### PR TITLE
KON-309 Improve Architecture Assertion Error Messages

### DIFF
--- a/lib/src/apiTest/kotlin/com/lemonappdev/konsist/architecture/assertarchitecture/architecture2/Architecture2Test.kt
+++ b/lib/src/apiTest/kotlin/com/lemonappdev/konsist/architecture/assertarchitecture/architecture2/Architecture2Test.kt
@@ -11,9 +11,13 @@ import org.junit.jupiter.api.Test
 
 class Architecture2Test {
     private val rootPath = PathProvider.getInstance().rootProjectPath
-    private val domain = Layer("Domain", "com.lemonappdev.konsist.architecture.assertarchitecture.architecture2.project.domain..")
+    private val domain =
+        Layer("Domain", "com.lemonappdev.konsist.architecture.assertarchitecture.architecture2.project.domain..")
     private val presentation =
-        Layer("Presentation", "com.lemonappdev.konsist.architecture.assertarchitecture.architecture2.project.presentation..")
+        Layer(
+            "Presentation",
+            "com.lemonappdev.konsist.architecture.assertarchitecture.architecture2.project.presentation..",
+        )
     private val scope = Konsist.scopeFromDirectory(
         "lib/src/apiTest/kotlin/com/lemonappdev/konsist/architecture/assertarchitecture/architecture2/project",
     )
@@ -50,11 +54,10 @@ class Architecture2Test {
             }
         } catch (e: KoCheckFailedException) {
             e.message?.shouldBeEqualTo(
-                """
-                'fails when dependency is set that domain layer is depend on presentation layer' test has failed.
-                Presentation depends on nothing assertion failure:
-                $rootPath/lib/src/apiTest/kotlin/com/lemonappdev/konsist/architecture/assertarchitecture/architecture2/project/presentation/sample/PresentationThirdClass.kt
-                """.trimIndent(),
+                "'fails when dependency is set that domain layer is depend on presentation layer' test has failed.\n" +
+                "Presentation depends on nothing assertion failure:\n" +
+                "A file $rootPath/lib/src/apiTest/kotlin/com/lemonappdev/konsist/architecture/assertarchitecture/architecture2/project/presentation/sample/PresentationThirdClass.kt in a Presentation layer depends on Domain layer, imports:\n" +
+                "\tcom.lemonappdev.konsist.architecture.assertarchitecture.architecture2.project.domain.DomainFirstClass ($rootPath/lib/src/apiTest/kotlin/com/lemonappdev/konsist/architecture/assertarchitecture/architecture2/project/presentation/sample/PresentationThirdClass.kt:3:1)"
             ) ?: throw e
         }
     }
@@ -72,11 +75,10 @@ class Architecture2Test {
             scope.assertArchitecture(architecture)
         } catch (e: KoCheckFailedException) {
             e.message?.shouldBeEqualTo(
-                """
-                'fails when dependency is set that domain layer is depend on presentation layer and architecture is passed as parameter' test has failed.
-                Presentation depends on nothing assertion failure:
-                $rootPath/lib/src/apiTest/kotlin/com/lemonappdev/konsist/architecture/assertarchitecture/architecture2/project/presentation/sample/PresentationThirdClass.kt
-                """.trimIndent(),
+                "'fails when dependency is set that domain layer is depend on presentation layer and architecture is passed as parameter' test has failed.\n" +
+                        "Presentation depends on nothing assertion failure:\n" +
+                        "A file $rootPath/lib/src/apiTest/kotlin/com/lemonappdev/konsist/architecture/assertarchitecture/architecture2/project/presentation/sample/PresentationThirdClass.kt in a Presentation layer depends on Domain layer, imports:\n" +
+                        "\tcom.lemonappdev.konsist.architecture.assertarchitecture.architecture2.project.domain.DomainFirstClass ($rootPath/lib/src/apiTest/kotlin/com/lemonappdev/konsist/architecture/assertarchitecture/architecture2/project/presentation/sample/PresentationThirdClass.kt:3:1)"
             ) ?: throw e
         }
     }

--- a/lib/src/apiTest/kotlin/com/lemonappdev/konsist/architecture/assertarchitecture/architecture2/Architecture2Test.kt
+++ b/lib/src/apiTest/kotlin/com/lemonappdev/konsist/architecture/assertarchitecture/architecture2/Architecture2Test.kt
@@ -55,9 +55,13 @@ class Architecture2Test {
         } catch (e: KoCheckFailedException) {
             e.message?.shouldBeEqualTo(
                 "'fails when dependency is set that domain layer is depend on presentation layer' test has failed.\n" +
-                "Presentation depends on nothing assertion failure:\n" +
-                "A file $rootPath/lib/src/apiTest/kotlin/com/lemonappdev/konsist/architecture/assertarchitecture/architecture2/project/presentation/sample/PresentationThirdClass.kt in a Presentation layer depends on Domain layer, imports:\n" +
-                "\tcom.lemonappdev.konsist.architecture.assertarchitecture.architecture2.project.domain.DomainFirstClass ($rootPath/lib/src/apiTest/kotlin/com/lemonappdev/konsist/architecture/assertarchitecture/architecture2/project/presentation/sample/PresentationThirdClass.kt:3:1)"
+                    "Presentation depends on nothing assertion failure:\n" +
+                    "A file $rootPath/lib/src/apiTest/kotlin/com/lemonappdev/konsist/architecture/assertarchitecture" +
+                    "/architecture2/project/presentation/sample/PresentationThirdClass.kt in a Presentation layer " +
+                    "depends on Domain layer, imports:\n" +
+                    "\tcom.lemonappdev.konsist.architecture.assertarchitecture.architecture2.project.domain." +
+                    "DomainFirstClass ($rootPath/lib/src/apiTest/kotlin/com/lemonappdev/konsist/architecture/" +
+                    "assertarchitecture/architecture2/project/presentation/sample/PresentationThirdClass.kt:3:1)",
             ) ?: throw e
         }
     }
@@ -75,10 +79,15 @@ class Architecture2Test {
             scope.assertArchitecture(architecture)
         } catch (e: KoCheckFailedException) {
             e.message?.shouldBeEqualTo(
-                "'fails when dependency is set that domain layer is depend on presentation layer and architecture is passed as parameter' test has failed.\n" +
-                        "Presentation depends on nothing assertion failure:\n" +
-                        "A file $rootPath/lib/src/apiTest/kotlin/com/lemonappdev/konsist/architecture/assertarchitecture/architecture2/project/presentation/sample/PresentationThirdClass.kt in a Presentation layer depends on Domain layer, imports:\n" +
-                        "\tcom.lemonappdev.konsist.architecture.assertarchitecture.architecture2.project.domain.DomainFirstClass ($rootPath/lib/src/apiTest/kotlin/com/lemonappdev/konsist/architecture/assertarchitecture/architecture2/project/presentation/sample/PresentationThirdClass.kt:3:1)"
+                "'fails when dependency is set that domain layer is depend on presentation layer and " +
+                    "architecture is passed as parameter' test has failed.\n" +
+                    "Presentation depends on nothing assertion failure:\n" +
+                    "A file $rootPath/lib/src/apiTest/kotlin/com/lemonappdev/konsist/architecture/assertarchitecture" +
+                    "/architecture2/project/presentation/sample/PresentationThirdClass.kt in a Presentation layer " +
+                    "depends on Domain layer, imports:\n" +
+                    "\tcom.lemonappdev.konsist.architecture.assertarchitecture.architecture2.project.domain." +
+                    "DomainFirstClass ($rootPath/lib/src/apiTest/kotlin/com/lemonappdev/konsist/architecture/" +
+                    "assertarchitecture/architecture2/project/presentation/sample/PresentationThirdClass.kt:3:1)",
             ) ?: throw e
         }
     }

--- a/lib/src/apiTest/kotlin/com/lemonappdev/konsist/architecture/assertarchitecture/architecture3/Architecture3Test.kt
+++ b/lib/src/apiTest/kotlin/com/lemonappdev/konsist/architecture/assertarchitecture/architecture3/Architecture3Test.kt
@@ -5,14 +5,20 @@ import com.lemonappdev.konsist.api.architecture.KoArchitectureCreator.architectu
 import com.lemonappdev.konsist.api.architecture.KoArchitectureCreator.assertArchitecture
 import com.lemonappdev.konsist.api.architecture.Layer
 import com.lemonappdev.konsist.core.exception.KoCheckFailedException
-import org.amshove.kluent.shouldThrow
+import org.amshove.kluent.assertSoftly
+import org.amshove.kluent.shouldContain
 import org.junit.jupiter.api.Test
 
 class Architecture3Test {
-    private val domain = Layer("Domain", "com.lemonappdev.konsist.architecture.assertarchitecture.architecture3.project.domain..")
+    private val domain =
+        Layer("Domain", "com.lemonappdev.konsist.architecture.assertarchitecture.architecture3.project.domain..")
     private val presentation =
-        Layer("Presentation", "com.lemonappdev.konsist.architecture.assertarchitecture.architecture3.project.presentation..")
-    private val data = Layer("Data", "com.lemonappdev.konsist.architecture.assertarchitecture.architecture3.project.data..")
+        Layer(
+            "Presentation",
+            "com.lemonappdev.konsist.architecture.assertarchitecture.architecture3.project.presentation..",
+        )
+    private val data =
+        Layer("Data", "com.lemonappdev.konsist.architecture.assertarchitecture.architecture3.project.data..")
     private val scope = Konsist.scopeFromDirectory(
         "lib/src/apiTest/kotlin/com/lemonappdev/konsist/architecture/assertarchitecture/architecture3/project",
     )
@@ -43,18 +49,20 @@ class Architecture3Test {
 
     @Test
     fun `fails when bad dependency is set`() {
-        // given
-        val sut = {
+        // then
+        try {
             scope
                 .assertArchitecture {
                     data.dependsOnNothing()
                     presentation.dependsOn(data)
                     domain.dependsOn(data)
                 }
+        } catch (e: KoCheckFailedException) {
+            assertSoftly {
+                e.message?.shouldContain("'fails when bad dependency is set' test has failed.\n")
+                e.message?.shouldContain("Presentation depends on Data assertion failure:\n")
+            }
         }
-
-        // then
-        sut shouldThrow KoCheckFailedException::class
     }
 
     @Test
@@ -66,11 +74,15 @@ class Architecture3Test {
             domain.dependsOn(data)
         }
 
-        val sut = {
-            scope.assertArchitecture(architecture)
-        }
-
         // then
-        sut shouldThrow KoCheckFailedException::class
+        try {
+            scope
+                .assertArchitecture(architecture)
+        } catch (e: KoCheckFailedException) {
+            assertSoftly {
+                e.message?.shouldContain("'fails when bad dependency is set and architecture is passed as parameter' test has failed.\n")
+                e.message?.shouldContain("Presentation depends on Data assertion failure:\n")
+            }
+        }
     }
 }

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/core/verify/KoArchitectureAssert.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/core/verify/KoArchitectureAssert.kt
@@ -119,7 +119,7 @@ private fun getCheckFailedMessages(
                 }
             }
 
-            layer.name + " " + message + "\n" + details
+            "${layer.name} $message\n$details"
         }
 
     return "'${getTestMethodNameFromSeventhIndex()}' test has failed.\n$failedDeclarationsMessage"


### PR DESCRIPTION
When we have such dependencies in the project:
<img width="685" alt="image" src="https://github.com/LemonAppDev/konsist/assets/111683562/e3c8f7d3-d093-496f-9420-52dad24059ac">
and we add this test:
<img width="297" alt="image" src="https://github.com/LemonAppDev/konsist/assets/111683562/3978bc55-769b-48d9-a865-f04429766a49">
there will be errors.

Error message before PR changes:
<img width="1109" alt="image" src="https://github.com/LemonAppDev/konsist/assets/111683562/b2c8fd81-2fb6-4139-b212-bf66e445a8e9">

Error message after PR changes:
<img width="1794" alt="image" src="https://github.com/LemonAppDev/konsist/assets/111683562/9dae7043-f44f-4a05-a1f9-c87b3af76a1d">
