### PR TITLE
KON-328 Fix Kotlin File Parsing When File Has CLRF Line Endings

### DIFF
--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/util/KotlinFileParserTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/util/KotlinFileParserTest.kt
@@ -1,0 +1,20 @@
+package com.lemonappdev.konsist.core.util
+
+import com.lemonappdev.konsist.TestSnippetProvider
+import com.lemonappdev.konsist.api.verify.assert
+import org.junit.jupiter.api.Test
+
+class KotlinFileParserTest {
+    @Test
+    fun `assert-suppress-with-few-parameters-on-declarations-which-items-have-null-parent`() {
+        // given
+        val sut = getSnippetFile("file-with-clrf-line-ending")
+            .classes()
+
+        // then
+        sut.assert { it.resideInPackage("..mapper") }
+    }
+
+    private fun getSnippetFile(fileName: String) =
+        TestSnippetProvider.getSnippetKoScope("core/util/snippet/", fileName)
+}

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/util/snippet/file-with-clrf-line-ending.kttxt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/util/snippet/file-with-clrf-line-ending.kttxt
@@ -1,0 +1,4 @@
+package com.sample.mapper
+
+class SampleClass {
+}

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/core/declaration/KoKDocDeclarationCore.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/core/declaration/KoKDocDeclarationCore.kt
@@ -5,6 +5,7 @@ import com.lemonappdev.konsist.api.declaration.KoKDocDeclaration
 import com.lemonappdev.konsist.core.provider.KoKDocDescriptionProviderCore
 import com.lemonappdev.konsist.core.provider.KoKDocTagsProviderCore
 import com.lemonappdev.konsist.core.provider.KoTextProviderCore
+import com.lemonappdev.konsist.core.util.EndOfLine
 import org.jetbrains.kotlin.kdoc.psi.api.KDocElement
 
 internal class KoKDocDeclarationCore(private val kDocElement: KDocElement) :
@@ -15,7 +16,10 @@ internal class KoKDocDeclarationCore(private val kDocElement: KDocElement) :
     override val psiElement: PsiElement by lazy { kDocElement }
 
     override val text: String by lazy {
-        val splitKDoc = kDocElement.text.split("\n").toMutableList()
+        val splitKDoc = kDocElement
+            .text
+            .split(EndOfLine.UNIX.value)
+            .toMutableList()
 
         if (splitKDoc.size == 1 && splitKDoc.first().startsWith("/**") && splitKDoc.first().endsWith("*/")) {
             splitKDoc

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/core/declaration/KoParentDeclarationCore.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/core/declaration/KoParentDeclarationCore.kt
@@ -6,6 +6,7 @@ import com.lemonappdev.konsist.core.provider.KoBaseProviderCore
 import com.lemonappdev.konsist.core.provider.KoLocationProviderCore
 import com.lemonappdev.konsist.core.provider.KoNameProviderCore
 import com.lemonappdev.konsist.core.provider.KoPathProviderCore
+import com.lemonappdev.konsist.core.util.EndOfLine
 import org.jetbrains.kotlin.psi.KtElement
 import org.jetbrains.kotlin.psi.KtSuperTypeListEntry
 
@@ -35,6 +36,6 @@ internal interface KoParentDeclarationCore :
              * Foo<UiState, Action>(Loading) -> Foo
              */
             .replace(Regex("<.*|\\(.*"), "")
-            .replace("\n", " ")
+            .replace(EndOfLine.UNIX.value, " ")
             .substringBefore(" by")
 }

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/core/declaration/KoPropertyDeclarationCore.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/core/declaration/KoPropertyDeclarationCore.kt
@@ -34,6 +34,7 @@ import com.lemonappdev.konsist.core.provider.modifier.KoValModifierProviderCore
 import com.lemonappdev.konsist.core.provider.modifier.KoVarModifierProviderCore
 import com.lemonappdev.konsist.core.provider.modifier.KoVisibilityModifierProviderCore
 import com.lemonappdev.konsist.core.provider.packagee.KoPackageDeclarationProviderCore
+import com.lemonappdev.konsist.core.util.EndOfLine
 import org.jetbrains.kotlin.psi.KtAnnotated
 import org.jetbrains.kotlin.psi.KtCallableDeclaration
 import org.jetbrains.kotlin.psi.KtElement
@@ -91,7 +92,7 @@ internal class KoPropertyDeclarationCore private constructor(
         ktProperty
             .delegateExpression
             ?.text
-            ?.replace("\n", " ")
+            ?.replace(EndOfLine.UNIX.value, " ")
             ?.substringAfter("by ")
             ?.substringBefore("{")
             ?.removeSuffix(" ")

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/KoKDocTagsProviderCore.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/KoKDocTagsProviderCore.kt
@@ -6,6 +6,7 @@ import com.lemonappdev.konsist.api.declaration.KoValuedKDocTagDeclaration
 import com.lemonappdev.konsist.api.provider.KoKDocTagsProvider
 import com.lemonappdev.konsist.core.declaration.KoKDocTagDeclarationCore
 import com.lemonappdev.konsist.core.declaration.KoValuedKDocTagDeclarationCore
+import com.lemonappdev.konsist.core.util.EndOfLine
 import java.util.*
 
 internal interface KoKDocTagsProviderCore : KoKDocTagsProvider, KoTextProviderCore, KoBaseProviderCore {
@@ -15,7 +16,7 @@ internal interface KoKDocTagsProviderCore : KoKDocTagsProvider, KoTextProviderCo
 
             val tagsAsStringList = text
                 .substringAfter("@", "")
-                .split("\n@")
+                .split("${EndOfLine.UNIX.value}@")
                 .map { ("@${it.replaceFirstChar { char -> char.lowercase(Locale.getDefault()) }}").trimEnd() }
 
             val tagsWithName = tagsAsStringList

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/modifier/KoModifierProviderCore.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/modifier/KoModifierProviderCore.kt
@@ -4,6 +4,7 @@ import com.lemonappdev.konsist.api.KoModifier
 import com.lemonappdev.konsist.api.provider.modifier.KoModifierProvider
 import com.lemonappdev.konsist.core.exception.KoInternalException
 import com.lemonappdev.konsist.core.provider.KoBaseProviderCore
+import com.lemonappdev.konsist.core.util.EndOfLine
 import org.jetbrains.kotlin.psi.KtTypeParameterListOwner
 
 internal interface KoModifierProviderCore : KoModifierProvider, KoBaseProviderCore {
@@ -13,7 +14,7 @@ internal interface KoModifierProviderCore : KoModifierProvider, KoBaseProviderCo
         get() = ktTypeParameterListOwner
             .modifierList
             ?.text
-            ?.split("\n")
+            ?.split(EndOfLine.UNIX.value)
             ?.map { it.substringBefore("//") }
             ?.flatMap { it.split(" ") }
             ?.takeLastWhile {

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/core/util/EndOfLine.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/core/util/EndOfLine.kt
@@ -1,0 +1,13 @@
+package com.lemonappdev.konsist.core.util
+
+internal enum class EndOfLine(val value: String) {
+    /**
+     * Unix-style end-of-line marker (LF)
+     */
+    UNIX("\n"),
+
+    /**
+     * Windows-style end-of-line marker (CRLF)
+     */
+    WINDOWS("\r\n"),
+}

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/core/util/KotlinFileParser.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/core/util/KotlinFileParser.kt
@@ -33,7 +33,9 @@ object KotlinFileParser {
     private fun getKtFile(file: File): KtFile {
         require(file.isKotlinFile || file.isKotlinSnippetFile) { "File must be a Kotlin file" }
 
-        val text = file.readText()
+        val text = file
+            .readText()
+            .replace(Regex(EndOfLine.WINDOWS.value), EndOfLine.UNIX.value)
 
         // Tests are using code snippets with txt extension that is messing up with Kotlin file parsing
         val filePath = file.path.replace(KOTLIN_SNIPPET_FILE_EXTENSION, KOTLIN_FILE_EXTENSION)


### PR DESCRIPTION
The Kotlin file parsing is crashing in `org.jetbrains.kotlin:kotlin-compiler` lib. 
Solution - before creating `KtFile` instance the `CLRF` line endings (win) are replaced with `LF` line endings (Unix).