### PR TITLE
KON-339 Refactor KoDeclarationAndProviderAssertCore To Not Display `XCore` In A Failed Declaration Type

### DIFF
--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/verify/kodeclarationassert/KoDeclarationAssertForDeclarationListTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/verify/kodeclarationassert/KoDeclarationAssertForDeclarationListTest.kt
@@ -43,6 +43,36 @@ class KoDeclarationAssertForDeclarationListTest {
     }
 
     @Test
+    fun `declaration-assert-displaying-correct-failed-declaration-type`() {
+        // given
+        val sut = getSnippetFile("declaration-assert-displaying-correct-failed-declaration-type")
+            .classes()
+
+        // then
+        try {
+            sut.assert { false }
+        } catch (e: Exception) {
+            e.message?.shouldContain("(SampleClass ClassDeclaration)")
+                ?: throw e
+        }
+    }
+
+    @Test
+    fun `file-declaration-assert-displaying-correct-failed-declaration-type`() {
+        // given
+        val sut = getSnippetFile("file-declaration-assert-displaying-correct-failed-declaration-type")
+            .files
+
+        // then
+        try {
+            sut.assert { false }
+        } catch (e: Exception) {
+            e.message?.shouldContain("(file-declaration-assert-displaying-correct-failed-declaration-type FileDeclaration)")
+                ?: throw e
+        }
+    }
+
+    @Test
     fun `declaration-assert-fails-when-declaration-list-is-empty`() {
         // given
         val sut = getSnippetFile("declaration-assert-fails-when-declaration-list-is-empty")

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/verify/kodeclarationassert/KoDeclarationAssertForDeclarationSequenceTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/verify/kodeclarationassert/KoDeclarationAssertForDeclarationSequenceTest.kt
@@ -42,6 +42,38 @@ class KoDeclarationAssertForDeclarationSequenceTest {
     }
 
     @Test
+    fun `declaration-assert-displaying-correct-failed-declaration-type`() {
+        // given
+        val sut = getSnippetFile("declaration-assert-displaying-correct-failed-declaration-type")
+            .classes()
+            .asSequence()
+
+        // then
+        try {
+            sut.assert { false }
+        } catch (e: Exception) {
+            e.message?.shouldContain("(SampleClass ClassDeclaration)")
+                ?: throw e
+        }
+    }
+
+    @Test
+    fun `file-declaration-assert-displaying-correct-failed-declaration-type`() {
+        // given
+        val sut = getSnippetFile("file-declaration-assert-displaying-correct-failed-declaration-type")
+            .files
+            .asSequence()
+
+        // then
+        try {
+            sut.assert { false }
+        } catch (e: Exception) {
+            e.message?.shouldContain("(file-declaration-assert-displaying-correct-failed-declaration-type FileDeclaration)")
+                ?: throw e
+        }
+    }
+
+    @Test
     fun `declaration-assert-fails-when-declaration-list-is-empty`() {
         // given
         val sut = getSnippetFile("declaration-assert-fails-when-declaration-list-is-empty")

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/verify/kodeclarationassert/snippet/declaration-assert-displaying-correct-failed-declaration-type.kttxt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/verify/kodeclarationassert/snippet/declaration-assert-displaying-correct-failed-declaration-type.kttxt
@@ -1,0 +1,1 @@
+class SampleClass

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/verify/kodeclarationassert/snippet/file-declaration-assert-displaying-correct-failed-declaration-type.kttxt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/verify/kodeclarationassert/snippet/file-declaration-assert-displaying-correct-failed-declaration-type.kttxt
@@ -1,0 +1,1 @@
+class SampleClass

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/verify/koproviderassert/KoDeclarationAssertForProviderListTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/verify/koproviderassert/KoDeclarationAssertForProviderListTest.kt
@@ -28,7 +28,25 @@ class KoDeclarationAssertForProviderListTest {
         try {
             sut.assert { false }
         } catch (e: Exception) {
-            e.message?.shouldContain("Assert 'provider-assert-test-method-name' has failed. Invalid declarations (2)") ?: throw e
+            e.message?.shouldContain("Assert 'provider-assert-test-method-name' has failed. Invalid declarations (2)")
+                ?: throw e
+        }
+    }
+
+    @Test
+    fun `provider-assert-displaying-correct-failed-declaration-type`() {
+        // given
+        val sut = getSnippetFile("provider-assert-displaying-correct-failed-declaration-type")
+            .declarations()
+            .filterNot { it is KoFileDeclaration }
+            .filterIsInstance<KoNameProvider>()
+
+        // then
+        try {
+            sut.assert { false }
+        } catch (e: Exception) {
+            e.message?.shouldContain("(SampleClass ClassDeclaration)")
+                ?: throw e
         }
     }
 

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/verify/koproviderassert/snippet/provider-assert-displaying-correct-failed-declaration-type.kttxt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/verify/koproviderassert/snippet/provider-assert-displaying-correct-failed-declaration-type.kttxt
@@ -1,0 +1,1 @@
+class SampleClass


### PR DESCRIPTION
Before:
<img width="1273" alt="image" src="https://github.com/LemonAppDev/konsist/assets/111683562/6dc79086-a43d-40ac-81d6-9c67cda1c7ca">

After:
<img width="1256" alt="image" src="https://github.com/LemonAppDev/konsist/assets/111683562/5ab8406d-a71b-44a1-8dac-2eb567c50dd7">

