### PR TITLE
KON-335 Add Lambda Param To KoLocalXProvider

### DIFF
--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/kofunction/KoFunctionDeclarationForKoLocalClassProviderTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/kofunction/KoFunctionDeclarationForKoLocalClassProviderTest.kt
@@ -33,11 +33,11 @@ class KoFunctionDeclarationForKoLocalClassProviderTest {
         assertSoftly(sut) {
             numLocalClasses shouldBeEqualTo 2
             countLocalClasses { it.name == "SampleClass1" } shouldBeEqualTo 1
-            containsLocalClass { it.name == "SampleClass1"} shouldBeEqualTo true
-            containsLocalClass { it.name == "OtherClass"} shouldBeEqualTo false
+            containsLocalClass { it.name == "SampleClass1" } shouldBeEqualTo true
+            containsLocalClass { it.name == "OtherClass" } shouldBeEqualTo false
             localClasses
                 .map { it.name }
-                .shouldBeEqualTo(listOf("SampleClass1", "SampleClass2" ))
+                .shouldBeEqualTo(listOf("SampleClass1", "SampleClass2"))
         }
     }
 

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/kofunction/KoFunctionDeclarationForKoLocalClassProviderTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/kofunction/KoFunctionDeclarationForKoLocalClassProviderTest.kt
@@ -6,38 +6,40 @@ import org.amshove.kluent.shouldBeEqualTo
 import org.junit.jupiter.api.Test
 
 class KoFunctionDeclarationForKoLocalClassProviderTest {
-//    @Test
-//    fun `function-contains-no-local-classes`() {
-//        // given
-//        val sut = getSnippetFile("function-contains-no-local-classes")
-//            .functions()
-//            .first()
-//
-//        // then
-//        assertSoftly(sut) {
-//            numLocalClasses shouldBeEqualTo 0
-//            containsLocalClass("SampleClass") shouldBeEqualTo false
-//            localClasses
-//                .shouldBeEqualTo(emptyList())
-//        }
-//    }
-//
-//    @Test
-//    fun `function-contains-local-class`() {
-//        // given
-//        val sut = getSnippetFile("function-contains-local-class")
-//            .functions()
-//            .first()
-//
-//        // then
-//        assertSoftly(sut) {
-//            numLocalClasses shouldBeEqualTo 1
-//            containsLocalClass("SampleClass") shouldBeEqualTo true
-//            localClasses
-//                .map { it.name }
-//                .shouldBeEqualTo(listOf("SampleClass"))
-//        }
-//    }
+    @Test
+    fun `function-contains-no-local-classes`() {
+        // given
+        val sut = getSnippetFile("function-contains-no-local-classes")
+            .functions()
+            .first()
+
+        // then
+        assertSoftly(sut) {
+            numLocalClasses shouldBeEqualTo 0
+            countLocalClasses { it.name == "SampleClass" } shouldBeEqualTo 0
+            containsLocalClass { it.name == "SampleClass" } shouldBeEqualTo false
+            localClasses shouldBeEqualTo emptyList()
+        }
+    }
+
+    @Test
+    fun `function-contains-local-class`() {
+        // given
+        val sut = getSnippetFile("function-contains-local-class")
+            .functions()
+            .first()
+
+        // then
+        assertSoftly(sut) {
+            numLocalClasses shouldBeEqualTo 2
+            countLocalClasses { it.name == "SampleClass1" } shouldBeEqualTo 1
+            containsLocalClass { it.name == "SampleClass1"} shouldBeEqualTo true
+            containsLocalClass { it.name == "OtherClass"} shouldBeEqualTo false
+            localClasses
+                .map { it.name }
+                .shouldBeEqualTo(listOf("SampleClass1", "SampleClass2" ))
+        }
+    }
 
     private fun getSnippetFile(fileName: String) =
         getSnippetKoScope("core/declaration/kofunction/snippet/forkolocalclassprovider/", fileName)

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/kofunction/KoFunctionDeclarationForKoLocalClassProviderTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/kofunction/KoFunctionDeclarationForKoLocalClassProviderTest.kt
@@ -6,38 +6,38 @@ import org.amshove.kluent.shouldBeEqualTo
 import org.junit.jupiter.api.Test
 
 class KoFunctionDeclarationForKoLocalClassProviderTest {
-    @Test
-    fun `function-contains-no-local-classes`() {
-        // given
-        val sut = getSnippetFile("function-contains-no-local-classes")
-            .functions()
-            .first()
-
-        // then
-        assertSoftly(sut) {
-            numLocalClasses shouldBeEqualTo 0
-            containsLocalClass("SampleClass") shouldBeEqualTo false
-            localClasses
-                .shouldBeEqualTo(emptyList())
-        }
-    }
-
-    @Test
-    fun `function-contains-local-class`() {
-        // given
-        val sut = getSnippetFile("function-contains-local-class")
-            .functions()
-            .first()
-
-        // then
-        assertSoftly(sut) {
-            numLocalClasses shouldBeEqualTo 1
-            containsLocalClass("SampleClass") shouldBeEqualTo true
-            localClasses
-                .map { it.name }
-                .shouldBeEqualTo(listOf("SampleClass"))
-        }
-    }
+//    @Test
+//    fun `function-contains-no-local-classes`() {
+//        // given
+//        val sut = getSnippetFile("function-contains-no-local-classes")
+//            .functions()
+//            .first()
+//
+//        // then
+//        assertSoftly(sut) {
+//            numLocalClasses shouldBeEqualTo 0
+//            containsLocalClass("SampleClass") shouldBeEqualTo false
+//            localClasses
+//                .shouldBeEqualTo(emptyList())
+//        }
+//    }
+//
+//    @Test
+//    fun `function-contains-local-class`() {
+//        // given
+//        val sut = getSnippetFile("function-contains-local-class")
+//            .functions()
+//            .first()
+//
+//        // then
+//        assertSoftly(sut) {
+//            numLocalClasses shouldBeEqualTo 1
+//            containsLocalClass("SampleClass") shouldBeEqualTo true
+//            localClasses
+//                .map { it.name }
+//                .shouldBeEqualTo(listOf("SampleClass"))
+//        }
+//    }
 
     private fun getSnippetFile(fileName: String) =
         getSnippetKoScope("core/declaration/kofunction/snippet/forkolocalclassprovider/", fileName)

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/kofunction/KoFunctionDeclarationForKoLocalDeclarationProviderTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/kofunction/KoFunctionDeclarationForKoLocalDeclarationProviderTest.kt
@@ -17,10 +17,9 @@ class KoFunctionDeclarationForKoLocalDeclarationProviderTest {
         // then
         assertSoftly(sut) {
             numLocalDeclarations shouldBeEqualTo 0
-            containsLocalDeclaration("sampleLocalProperty") shouldBeEqualTo false
-            localDeclarations
-                .filterIsInstance<KoNameProvider>()
-                .shouldBeEqualTo(emptyList())
+            countLocalClasses { it.name == "sampleOtherDeclaration" } shouldBeEqualTo 0
+            containsLocalDeclaration { (it as KoNameProvider).name == "sampleLocalProperty" } shouldBeEqualTo false
+            localDeclarations shouldBeEqualTo emptyList()
         }
     }
 
@@ -34,10 +33,11 @@ class KoFunctionDeclarationForKoLocalDeclarationProviderTest {
         // then
         assertSoftly(sut) {
             numLocalDeclarations shouldBeEqualTo 3
-            containsLocalDeclaration("sampleLocalProperty") shouldBeEqualTo true
-            containsLocalDeclaration("sampleLocalFunction") shouldBeEqualTo true
-            containsLocalDeclaration("SampleLocalClass") shouldBeEqualTo true
-            containsLocalDeclaration("sampleOtherDeclaration") shouldBeEqualTo false
+            countLocalDeclarations { (it as KoNameProvider).hasNameStartingWith("sampleLocal") } shouldBeEqualTo 2
+            containsLocalDeclaration { (it as KoNameProvider).name == "sampleLocalProperty" } shouldBeEqualTo true
+            containsLocalDeclaration { (it as KoNameProvider).name == "sampleLocalFunction" } shouldBeEqualTo true
+            containsLocalDeclaration { (it as KoNameProvider).name == "SampleLocalClass" } shouldBeEqualTo true
+            containsLocalDeclaration { (it as KoNameProvider).name == "sampleOtherDeclaration" } shouldBeEqualTo false
             localDeclarations
                 .filterIsInstance<KoNameProvider>()
                 .map { it.name }

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/kofunction/KoFunctionDeclarationForKoLocalFunctionProviderTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/kofunction/KoFunctionDeclarationForKoLocalFunctionProviderTest.kt
@@ -16,9 +16,9 @@ class KoFunctionDeclarationForKoLocalFunctionProviderTest {
         // then
         assertSoftly(sut) {
             numLocalFunctions shouldBeEqualTo 0
-            containsLocalFunction("sampleLocalFunction") shouldBeEqualTo false
-            localFunctions
-                .shouldBeEqualTo(emptyList())
+            countLocalFunctions { it.name == "sampleLocalFunction" } shouldBeEqualTo 0
+            containsLocalFunction { it.name == "sampleLocalFunction" } shouldBeEqualTo false
+            localFunctions shouldBeEqualTo emptyList()
         }
     }
 
@@ -31,11 +31,13 @@ class KoFunctionDeclarationForKoLocalFunctionProviderTest {
 
         // then
         assertSoftly(sut) {
-            numLocalFunctions shouldBeEqualTo 1
-            containsLocalFunction("sampleLocalFunction") shouldBeEqualTo true
+            numLocalFunctions shouldBeEqualTo 2
+            countLocalFunctions { it.name == "sampleLocalFunction1" } shouldBeEqualTo 1
+            containsLocalFunction { it.name == "sampleLocalFunction1" } shouldBeEqualTo true
+            containsLocalFunction { it.name == "otherLocalFunction1" } shouldBeEqualTo false
             localFunctions
                 .map { it.name }
-                .shouldBeEqualTo(listOf("sampleLocalFunction"))
+                .shouldBeEqualTo(listOf("sampleLocalFunction1", "sampleLocalFunction2"))
         }
     }
 

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/kofunction/KoFunctionDeclarationForKoLocalPropertyProviderTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/kofunction/KoFunctionDeclarationForKoLocalPropertyProviderTest.kt
@@ -16,9 +16,9 @@ class KoFunctionDeclarationForKoLocalPropertyProviderTest {
         // then
         assertSoftly(sut) {
             numLocalProperties shouldBeEqualTo 0
-            containsLocalProperty("sampleLocalProperty") shouldBeEqualTo false
-            localProperties
-                .shouldBeEqualTo(emptyList())
+            countLocalProperties { it.name == "sampleLocalProperty" } shouldBeEqualTo 0
+            containsLocalProperty { it.name == "sampleLocalProperty"} shouldBeEqualTo false
+            localProperties shouldBeEqualTo emptyList()
         }
     }
 
@@ -31,11 +31,13 @@ class KoFunctionDeclarationForKoLocalPropertyProviderTest {
 
         // then
         assertSoftly(sut) {
-            numLocalProperties shouldBeEqualTo 1
-            containsLocalProperty("sampleLocalProperty") shouldBeEqualTo true
+            numLocalProperties shouldBeEqualTo 2
+            countLocalProperties { it.name == "sampleLocalProperty1" } shouldBeEqualTo 1
+            containsLocalProperty { it.name == "sampleLocalProperty1"} shouldBeEqualTo true
+            containsLocalProperty { it.name == "otherLocalProperty"} shouldBeEqualTo false
             localProperties
                 .map { it.name }
-                .shouldBeEqualTo(listOf("sampleLocalProperty"))
+                .shouldBeEqualTo(listOf("sampleLocalProperty1", "sampleLocalProperty2"))
         }
     }
 

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/kofunction/KoFunctionDeclarationForKoLocalPropertyProviderTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/kofunction/KoFunctionDeclarationForKoLocalPropertyProviderTest.kt
@@ -17,7 +17,7 @@ class KoFunctionDeclarationForKoLocalPropertyProviderTest {
         assertSoftly(sut) {
             numLocalProperties shouldBeEqualTo 0
             countLocalProperties { it.name == "sampleLocalProperty" } shouldBeEqualTo 0
-            containsLocalProperty { it.name == "sampleLocalProperty"} shouldBeEqualTo false
+            containsLocalProperty { it.name == "sampleLocalProperty" } shouldBeEqualTo false
             localProperties shouldBeEqualTo emptyList()
         }
     }
@@ -33,8 +33,8 @@ class KoFunctionDeclarationForKoLocalPropertyProviderTest {
         assertSoftly(sut) {
             numLocalProperties shouldBeEqualTo 2
             countLocalProperties { it.name == "sampleLocalProperty1" } shouldBeEqualTo 1
-            containsLocalProperty { it.name == "sampleLocalProperty1"} shouldBeEqualTo true
-            containsLocalProperty { it.name == "otherLocalProperty"} shouldBeEqualTo false
+            containsLocalProperty { it.name == "sampleLocalProperty1" } shouldBeEqualTo true
+            containsLocalProperty { it.name == "otherLocalProperty" } shouldBeEqualTo false
             localProperties
                 .map { it.name }
                 .shouldBeEqualTo(listOf("sampleLocalProperty1", "sampleLocalProperty2"))

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/kofunction/snippet/forkolocalclassprovider/function-contains-local-class.kttxt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/kofunction/snippet/forkolocalclassprovider/function-contains-local-class.kttxt
@@ -1,3 +1,5 @@
 fun sampleFunction() {
-    class SampleClass
+    class SampleClass1
+
+    class SampleClass2
 }

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/kofunction/snippet/forkolocalfunctionprovider/function-contains-local-function.kttxt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/kofunction/snippet/forkolocalfunctionprovider/function-contains-local-function.kttxt
@@ -1,4 +1,7 @@
 fun sampleFunction() {
-    fun sampleLocalFunction() {
+    fun sampleLocalFunction1() {
+    }
+
+    fun sampleLocalFunction2() {
     }
 }

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/kofunction/snippet/forkolocalpropertyprovider/function-contains-local-property.kttxt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/kofunction/snippet/forkolocalpropertyprovider/function-contains-local-property.kttxt
@@ -1,3 +1,5 @@
 fun sampleFunction() {
-    val sampleLocalProperty: Boolean = true
+    val sampleLocalProperty1: Boolean = true
+
+    val sampleLocalProperty2: Boolean = true
 }

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koinitblock/KoInitBlockDeclarationForKoLocalClassProviderTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koinitblock/KoInitBlockDeclarationForKoLocalClassProviderTest.kt
@@ -6,42 +6,42 @@ import org.amshove.kluent.shouldBeEqualTo
 import org.junit.jupiter.api.Test
 
 class KoInitBlockDeclarationForKoLocalClassProviderTest {
-    @Test
-    fun `init-block-contains-no-local-classes`() {
-        // given
-        val sut = getSnippetFile("init-block-contains-no-local-classes")
-            .classes()
-            .first()
-            .initBlocks
-            .first()
-
-        // then
-        assertSoftly(sut) {
-            numLocalClasses shouldBeEqualTo 0
-            containsLocalClass("SampleLocalClass") shouldBeEqualTo false
-            localClasses
-                .shouldBeEqualTo(emptyList())
-        }
-    }
-
-    @Test
-    fun `init-block-contains-local-class`() {
-        // given
-        val sut = getSnippetFile("init-block-contains-local-class")
-            .classes()
-            .first()
-            .initBlocks
-            .first()
-
-        // then
-        assertSoftly(sut) {
-            numLocalClasses shouldBeEqualTo 1
-            containsLocalClass("SampleLocalClass") shouldBeEqualTo true
-            localClasses
-                .map { it.name }
-                .shouldBeEqualTo(listOf("SampleLocalClass"))
-        }
-    }
+//    @Test
+//    fun `init-block-contains-no-local-classes`() {
+//        // given
+//        val sut = getSnippetFile("init-block-contains-no-local-classes")
+//            .classes()
+//            .first()
+//            .initBlocks
+//            .first()
+//
+//        // then
+//        assertSoftly(sut) {
+//            numLocalClasses shouldBeEqualTo 0
+//            containsLocalClass("SampleLocalClass") shouldBeEqualTo false
+//            localClasses
+//                .shouldBeEqualTo(emptyList())
+//        }
+//    }
+//
+//    @Test
+//    fun `init-block-contains-local-class`() {
+//        // given
+//        val sut = getSnippetFile("init-block-contains-local-class")
+//            .classes()
+//            .first()
+//            .initBlocks
+//            .first()
+//
+//        // then
+//        assertSoftly(sut) {
+//            numLocalClasses shouldBeEqualTo 1
+//            containsLocalClass("SampleLocalClass") shouldBeEqualTo true
+//            localClasses
+//                .map { it.name }
+//                .shouldBeEqualTo(listOf("SampleLocalClass"))
+//        }
+//    }
 
     private fun getSnippetFile(fileName: String) =
         getSnippetKoScope("core/declaration/koinitblock/snippet/forkolocalclassprovider/", fileName)

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koinitblock/KoInitBlockDeclarationForKoLocalClassProviderTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koinitblock/KoInitBlockDeclarationForKoLocalClassProviderTest.kt
@@ -37,8 +37,8 @@ class KoInitBlockDeclarationForKoLocalClassProviderTest {
         assertSoftly(sut) {
             numLocalClasses shouldBeEqualTo 2
             countLocalClasses { it.name == "SampleLocalClass1" } shouldBeEqualTo 1
-            containsLocalClass { it.name == "SampleLocalClass1"} shouldBeEqualTo true
-            containsLocalClass { it.name == "OtherClass"} shouldBeEqualTo false
+            containsLocalClass { it.name == "SampleLocalClass1" } shouldBeEqualTo true
+            containsLocalClass { it.name == "OtherClass" } shouldBeEqualTo false
             localClasses
                 .map { it.name }
                 .shouldBeEqualTo(listOf("SampleLocalClass1", "SampleLocalClass2"))

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koinitblock/KoInitBlockDeclarationForKoLocalClassProviderTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koinitblock/KoInitBlockDeclarationForKoLocalClassProviderTest.kt
@@ -6,42 +6,44 @@ import org.amshove.kluent.shouldBeEqualTo
 import org.junit.jupiter.api.Test
 
 class KoInitBlockDeclarationForKoLocalClassProviderTest {
-//    @Test
-//    fun `init-block-contains-no-local-classes`() {
-//        // given
-//        val sut = getSnippetFile("init-block-contains-no-local-classes")
-//            .classes()
-//            .first()
-//            .initBlocks
-//            .first()
-//
-//        // then
-//        assertSoftly(sut) {
-//            numLocalClasses shouldBeEqualTo 0
-//            containsLocalClass("SampleLocalClass") shouldBeEqualTo false
-//            localClasses
-//                .shouldBeEqualTo(emptyList())
-//        }
-//    }
-//
-//    @Test
-//    fun `init-block-contains-local-class`() {
-//        // given
-//        val sut = getSnippetFile("init-block-contains-local-class")
-//            .classes()
-//            .first()
-//            .initBlocks
-//            .first()
-//
-//        // then
-//        assertSoftly(sut) {
-//            numLocalClasses shouldBeEqualTo 1
-//            containsLocalClass("SampleLocalClass") shouldBeEqualTo true
-//            localClasses
-//                .map { it.name }
-//                .shouldBeEqualTo(listOf("SampleLocalClass"))
-//        }
-//    }
+    @Test
+    fun `init-block-contains-no-local-classes`() {
+        // given
+        val sut = getSnippetFile("init-block-contains-no-local-classes")
+            .classes()
+            .first()
+            .initBlocks
+            .first()
+
+        // then
+        assertSoftly(sut) {
+            numLocalClasses shouldBeEqualTo 0
+            countLocalClasses { it.name == "SampleLocalClass" } shouldBeEqualTo 0
+            containsLocalClass { it.name == "SampleLocalClass" } shouldBeEqualTo false
+            localClasses shouldBeEqualTo emptyList()
+        }
+    }
+
+    @Test
+    fun `init-block-contains-local-class`() {
+        // given
+        val sut = getSnippetFile("init-block-contains-local-class")
+            .classes()
+            .first()
+            .initBlocks
+            .first()
+
+        // then
+        assertSoftly(sut) {
+            numLocalClasses shouldBeEqualTo 2
+            countLocalClasses { it.name == "SampleLocalClass1" } shouldBeEqualTo 1
+            containsLocalClass { it.name == "SampleLocalClass1"} shouldBeEqualTo true
+            containsLocalClass { it.name == "OtherClass"} shouldBeEqualTo false
+            localClasses
+                .map { it.name }
+                .shouldBeEqualTo(listOf("SampleLocalClass1", "SampleLocalClass2"))
+        }
+    }
 
     private fun getSnippetFile(fileName: String) =
         getSnippetKoScope("core/declaration/koinitblock/snippet/forkolocalclassprovider/", fileName)

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koinitblock/KoInitBlockDeclarationForKoLocalDeclarationProviderTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koinitblock/KoInitBlockDeclarationForKoLocalDeclarationProviderTest.kt
@@ -19,10 +19,9 @@ class KoInitBlockDeclarationForKoLocalDeclarationProviderTest {
         // then
         assertSoftly(sut) {
             numLocalDeclarations shouldBeEqualTo 0
-            containsLocalDeclaration("sampleLocalProperty") shouldBeEqualTo false
-            localDeclarations
-                .filterIsInstance<KoNameProvider>()
-                .shouldBeEqualTo(emptyList())
+            countLocalClasses { it.name == "sampleOtherDeclaration" } shouldBeEqualTo 0
+            containsLocalDeclaration { (it as KoNameProvider).name == "sampleLocalProperty" } shouldBeEqualTo false
+            localDeclarations shouldBeEqualTo emptyList()
         }
     }
 
@@ -38,10 +37,11 @@ class KoInitBlockDeclarationForKoLocalDeclarationProviderTest {
         // then
         assertSoftly(sut) {
             numLocalDeclarations shouldBeEqualTo 3
-            containsLocalDeclaration("sampleLocalProperty") shouldBeEqualTo true
-            containsLocalDeclaration("sampleLocalFunction") shouldBeEqualTo true
-            containsLocalDeclaration("SampleLocalClass") shouldBeEqualTo true
-            containsLocalDeclaration("sampleOtherDeclaration") shouldBeEqualTo false
+            countLocalDeclarations { (it as KoNameProvider).hasNameStartingWith("sampleLocal") } shouldBeEqualTo 2
+            containsLocalDeclaration { (it as KoNameProvider).name == "sampleLocalProperty" } shouldBeEqualTo true
+            containsLocalDeclaration { (it as KoNameProvider).name == "sampleLocalFunction" } shouldBeEqualTo true
+            containsLocalDeclaration { (it as KoNameProvider).name == "SampleLocalClass" } shouldBeEqualTo true
+            containsLocalDeclaration { (it as KoNameProvider).name == "sampleOtherDeclaration" } shouldBeEqualTo false
             localDeclarations
                 .filterIsInstance<KoNameProvider>()
                 .map { it.name }

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koinitblock/KoInitBlockDeclarationForKoLocalFunctionProviderTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koinitblock/KoInitBlockDeclarationForKoLocalFunctionProviderTest.kt
@@ -18,9 +18,9 @@ class KoInitBlockDeclarationForKoLocalFunctionProviderTest {
         // then
         assertSoftly(sut) {
             numLocalFunctions shouldBeEqualTo 0
-            containsLocalFunction("sampleLocalFunction") shouldBeEqualTo false
-            localFunctions
-                .shouldBeEqualTo(emptyList())
+            countLocalFunctions { it.name == "sampleLocalFunction" } shouldBeEqualTo 0
+            containsLocalFunction { it.name == "sampleLocalFunction" } shouldBeEqualTo false
+            localFunctions shouldBeEqualTo emptyList()
         }
     }
 
@@ -35,11 +35,13 @@ class KoInitBlockDeclarationForKoLocalFunctionProviderTest {
 
         // then
         assertSoftly(sut) {
-            numLocalFunctions shouldBeEqualTo 1
-            containsLocalFunction("sampleLocalFunction") shouldBeEqualTo true
+            numLocalFunctions shouldBeEqualTo 2
+            countLocalFunctions { it.name == "sampleLocalFunction1" } shouldBeEqualTo 1
+            containsLocalFunction { it.name == "sampleLocalFunction1" } shouldBeEqualTo true
+            containsLocalFunction { it.name == "otherLocalFunction1" } shouldBeEqualTo false
             localFunctions
                 .map { it.name }
-                .shouldBeEqualTo(listOf("sampleLocalFunction"))
+                .shouldBeEqualTo(listOf("sampleLocalFunction1", "sampleLocalFunction2"))
         }
     }
 

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koinitblock/KoInitBlockDeclarationForKoLocalPropertyProviderTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koinitblock/KoInitBlockDeclarationForKoLocalPropertyProviderTest.kt
@@ -19,7 +19,7 @@ class KoInitBlockDeclarationForKoLocalPropertyProviderTest {
         assertSoftly(sut) {
             numLocalProperties shouldBeEqualTo 0
             countLocalProperties { it.name == "sampleLocalProperty" } shouldBeEqualTo 0
-            containsLocalProperty { it.name == "sampleLocalProperty"} shouldBeEqualTo false
+            containsLocalProperty { it.name == "sampleLocalProperty" } shouldBeEqualTo false
             localProperties shouldBeEqualTo emptyList()
         }
     }
@@ -37,8 +37,8 @@ class KoInitBlockDeclarationForKoLocalPropertyProviderTest {
         assertSoftly(sut) {
             numLocalProperties shouldBeEqualTo 2
             countLocalProperties { it.name == "sampleLocalProperty1" } shouldBeEqualTo 1
-            containsLocalProperty { it.name == "sampleLocalProperty1"} shouldBeEqualTo true
-            containsLocalProperty { it.name == "otherLocalProperty"} shouldBeEqualTo false
+            containsLocalProperty { it.name == "sampleLocalProperty1" } shouldBeEqualTo true
+            containsLocalProperty { it.name == "otherLocalProperty" } shouldBeEqualTo false
             localProperties
                 .map { it.name }
                 .shouldBeEqualTo(listOf("sampleLocalProperty1", "sampleLocalProperty2"))

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koinitblock/KoInitBlockDeclarationForKoLocalPropertyProviderTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koinitblock/KoInitBlockDeclarationForKoLocalPropertyProviderTest.kt
@@ -18,9 +18,9 @@ class KoInitBlockDeclarationForKoLocalPropertyProviderTest {
         // then
         assertSoftly(sut) {
             numLocalProperties shouldBeEqualTo 0
-            containsLocalProperty("sampleLocalProperty") shouldBeEqualTo false
-            localProperties
-                .shouldBeEqualTo(emptyList())
+            countLocalProperties { it.name == "sampleLocalProperty" } shouldBeEqualTo 0
+            containsLocalProperty { it.name == "sampleLocalProperty"} shouldBeEqualTo false
+            localProperties shouldBeEqualTo emptyList()
         }
     }
 
@@ -35,11 +35,13 @@ class KoInitBlockDeclarationForKoLocalPropertyProviderTest {
 
         // then
         assertSoftly(sut) {
-            numLocalProperties shouldBeEqualTo 1
-            containsLocalProperty("sampleLocalProperty") shouldBeEqualTo true
+            numLocalProperties shouldBeEqualTo 2
+            countLocalProperties { it.name == "sampleLocalProperty1" } shouldBeEqualTo 1
+            containsLocalProperty { it.name == "sampleLocalProperty1"} shouldBeEqualTo true
+            containsLocalProperty { it.name == "otherLocalProperty"} shouldBeEqualTo false
             localProperties
                 .map { it.name }
-                .shouldBeEqualTo(listOf("sampleLocalProperty"))
+                .shouldBeEqualTo(listOf("sampleLocalProperty1", "sampleLocalProperty2"))
         }
     }
 

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koinitblock/snippet/forkolocalclassprovider/init-block-contains-local-class.kttxt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koinitblock/snippet/forkolocalclassprovider/init-block-contains-local-class.kttxt
@@ -1,5 +1,7 @@
 class SampleClass {
     init {
-        class SampleLocalClass
+        class SampleLocalClass1
+
+        class SampleLocalClass2
     }
 }

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koinitblock/snippet/forkolocalfunctionprovider/init-block-contains-local-function.kttxt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koinitblock/snippet/forkolocalfunctionprovider/init-block-contains-local-function.kttxt
@@ -1,5 +1,7 @@
 class SampleClass {
     init {
-        fun sampleLocalFunction() { }
+        fun sampleLocalFunction1() { }
+
+        fun sampleLocalFunction2() { }
     }
 }

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koinitblock/snippet/forkolocalpropertyprovider/init-block-contains-local-property.kttxt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koinitblock/snippet/forkolocalpropertyprovider/init-block-contains-local-property.kttxt
@@ -1,5 +1,7 @@
 class SampleClass {
     init {
-        val sampleLocalProperty: Boolean = true
+        val sampleLocalProperty1: Boolean = true
+
+        val sampleLocalProperty2: Boolean = true
     }
 }

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/verify/kodeclarationassert/KoDeclarationAssertForDeclarationListTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/verify/kodeclarationassert/KoDeclarationAssertForDeclarationListTest.kt
@@ -312,7 +312,7 @@ class KoDeclarationAssertForDeclarationListTest {
                 .initBlocks
 
         // then
-        sut.assert { it.containsLocalProperty("otherProperty") }
+        sut.assert { it.containsLocalProperty { property -> property.name == "otherProperty"} }
     }
 
     @Test
@@ -325,7 +325,7 @@ class KoDeclarationAssertForDeclarationListTest {
                 .initBlocks
 
         // then
-        sut.assert { it.containsLocalProperty("otherProperty") }
+        sut.assert { it.containsLocalProperty { property -> property.name == "otherProperty"} }
     }
 
     @Test
@@ -338,7 +338,7 @@ class KoDeclarationAssertForDeclarationListTest {
                 .initBlocks
 
         // then
-        sut.assert { it.containsLocalProperty("otherProperty") }
+        sut.assert { it.containsLocalProperty { property -> property.name == "otherProperty"} }
     }
 
     @Test
@@ -351,7 +351,7 @@ class KoDeclarationAssertForDeclarationListTest {
                 .initBlocks
 
         // then
-        sut.assert { it.containsLocalProperty("otherProperty") }
+        sut.assert { it.containsLocalProperty { property -> property.name == "otherProperty"} }
     }
 
     @Test

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/verify/kodeclarationassert/KoDeclarationAssertForDeclarationListTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/verify/kodeclarationassert/KoDeclarationAssertForDeclarationListTest.kt
@@ -312,7 +312,7 @@ class KoDeclarationAssertForDeclarationListTest {
                 .initBlocks
 
         // then
-        sut.assert { it.containsLocalProperty { property -> property.name == "otherProperty"} }
+        sut.assert { it.containsLocalProperty { property -> property.name == "otherProperty" } }
     }
 
     @Test
@@ -325,7 +325,7 @@ class KoDeclarationAssertForDeclarationListTest {
                 .initBlocks
 
         // then
-        sut.assert { it.containsLocalProperty { property -> property.name == "otherProperty"} }
+        sut.assert { it.containsLocalProperty { property -> property.name == "otherProperty" } }
     }
 
     @Test
@@ -338,7 +338,7 @@ class KoDeclarationAssertForDeclarationListTest {
                 .initBlocks
 
         // then
-        sut.assert { it.containsLocalProperty { property -> property.name == "otherProperty"} }
+        sut.assert { it.containsLocalProperty { property -> property.name == "otherProperty" } }
     }
 
     @Test
@@ -351,7 +351,7 @@ class KoDeclarationAssertForDeclarationListTest {
                 .initBlocks
 
         // then
-        sut.assert { it.containsLocalProperty { property -> property.name == "otherProperty"} }
+        sut.assert { it.containsLocalProperty { property -> property.name == "otherProperty" } }
     }
 
     @Test

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/verify/kodeclarationassert/KoDeclarationAssertForDeclarationSequenceTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/verify/kodeclarationassert/KoDeclarationAssertForDeclarationSequenceTest.kt
@@ -328,7 +328,7 @@ class KoDeclarationAssertForDeclarationSequenceTest {
                 .asSequence()
 
         // then
-        sut.assert { it.containsLocalProperty{ property -> property.name == "otherProperty"} }
+        sut.assert { it.containsLocalProperty { property -> property.name == "otherProperty" } }
     }
 
     @Test
@@ -342,7 +342,7 @@ class KoDeclarationAssertForDeclarationSequenceTest {
                 .asSequence()
 
         // then
-        sut.assert { it.containsLocalProperty{ property -> property.name == "otherProperty"} }
+        sut.assert { it.containsLocalProperty { property -> property.name == "otherProperty" } }
     }
 
     @Test
@@ -356,7 +356,7 @@ class KoDeclarationAssertForDeclarationSequenceTest {
                 .asSequence()
 
         // then
-        sut.assert { it.containsLocalProperty{ property -> property.name == "otherProperty"} }
+        sut.assert { it.containsLocalProperty { property -> property.name == "otherProperty" } }
     }
 
     @Test
@@ -370,7 +370,7 @@ class KoDeclarationAssertForDeclarationSequenceTest {
                 .asSequence()
 
         // then
-        sut.assert { it.containsLocalProperty{ property -> property.name == "otherProperty"} }
+        sut.assert { it.containsLocalProperty { property -> property.name == "otherProperty" } }
     }
 
     @Test

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/verify/kodeclarationassert/KoDeclarationAssertForDeclarationSequenceTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/verify/kodeclarationassert/KoDeclarationAssertForDeclarationSequenceTest.kt
@@ -328,7 +328,7 @@ class KoDeclarationAssertForDeclarationSequenceTest {
                 .asSequence()
 
         // then
-        sut.assert { it.containsLocalProperty("otherProperty") }
+        sut.assert { it.containsLocalProperty{ property -> property.name == "otherProperty"} }
     }
 
     @Test
@@ -342,7 +342,7 @@ class KoDeclarationAssertForDeclarationSequenceTest {
                 .asSequence()
 
         // then
-        sut.assert { it.containsLocalProperty("otherProperty") }
+        sut.assert { it.containsLocalProperty{ property -> property.name == "otherProperty"} }
     }
 
     @Test
@@ -356,7 +356,7 @@ class KoDeclarationAssertForDeclarationSequenceTest {
                 .asSequence()
 
         // then
-        sut.assert { it.containsLocalProperty("otherProperty") }
+        sut.assert { it.containsLocalProperty{ property -> property.name == "otherProperty"} }
     }
 
     @Test
@@ -370,7 +370,7 @@ class KoDeclarationAssertForDeclarationSequenceTest {
                 .asSequence()
 
         // then
-        sut.assert { it.containsLocalProperty("otherProperty") }
+        sut.assert { it.containsLocalProperty{ property -> property.name == "otherProperty"} }
     }
 
     @Test

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/api/provider/KoLocalClassProvider.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/api/provider/KoLocalClassProvider.kt
@@ -17,10 +17,18 @@ interface KoLocalClassProvider : KoBaseProvider {
     val numLocalClasses: Int
 
     /**
+     * Gets the number of local classes that satisfies the specified predicate present in the declaration.
+     *
+     * @param predicate The predicate function to determine if a local class satisfies a condition.
+     * @return The number of local classes in the declaration.
+     */
+    fun countLocalClasses(predicate: (KoClassDeclaration) -> Boolean): Int
+
+    /**
      * Checks whether the declaration contains a local class with the specified name.
      *
-     * @param name The name of the local class to check.
-     * @return `true` if the declaration contains a local class with the specified name, `false` otherwise.
+     * @param predicate The predicate function to determine if a local class satisfies a condition.
+     * @return `true` if the declaration contains a local class with the specified predicate, `false` otherwise.
      */
-    fun containsLocalClass(name: String): Boolean
+    fun containsLocalClass(predicate: (KoClassDeclaration) -> Boolean): Boolean
 }

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/api/provider/KoLocalDeclarationProvider.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/api/provider/KoLocalDeclarationProvider.kt
@@ -1,7 +1,6 @@
 package com.lemonappdev.konsist.api.provider
 
 import com.lemonappdev.konsist.api.declaration.KoBaseDeclaration
-import com.lemonappdev.konsist.api.declaration.KoClassDeclaration
 
 /**
  * An interface representing a Kotlin declaration that provides information about local declarations.

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/api/provider/KoLocalDeclarationProvider.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/api/provider/KoLocalDeclarationProvider.kt
@@ -1,6 +1,7 @@
 package com.lemonappdev.konsist.api.provider
 
 import com.lemonappdev.konsist.api.declaration.KoBaseDeclaration
+import com.lemonappdev.konsist.api.declaration.KoClassDeclaration
 
 /**
  * An interface representing a Kotlin declaration that provides information about local declarations.
@@ -17,10 +18,18 @@ interface KoLocalDeclarationProvider : KoBaseProvider {
     val numLocalDeclarations: Int
 
     /**
+     * Gets the number of local declarations that satisfies the specified predicate present in the declaration.
+     *
+     * @param predicate The predicate function to determine if a local declaration satisfies a condition.
+     * @return The number of local declarations in the declaration.
+     */
+    fun countLocalDeclarations(predicate: (KoBaseDeclaration) -> Boolean): Int
+
+    /**
      * Checks whether the declaration contains a local declaration with the specified name.
      *
-     * @param name The name of the local declaration to check.
+     * @param predicate The predicate function to determine if a local declaration satisfies a condition.
      * @return `true` if the declaration contains a local declaration with the specified name, `false` otherwise.
      */
-    fun containsLocalDeclaration(name: String): Boolean
+    fun containsLocalDeclaration(predicate: (KoBaseDeclaration) -> Boolean): Boolean
 }

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/api/provider/KoLocalFunctionProvider.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/api/provider/KoLocalFunctionProvider.kt
@@ -1,5 +1,6 @@
 package com.lemonappdev.konsist.api.provider
 
+import com.lemonappdev.konsist.api.declaration.KoClassDeclaration
 import com.lemonappdev.konsist.api.declaration.KoFunctionDeclaration
 
 /**
@@ -17,10 +18,18 @@ interface KoLocalFunctionProvider : KoBaseProvider {
     val numLocalFunctions: Int
 
     /**
+     * Gets the number of local functions that satisfies the specified predicate present in the declaration.
+     *
+     * @param predicate The predicate function to determine if a local function satisfies a condition.
+     * @return The number of local functions in the declaration.
+     */
+    fun countLocalFunctions(predicate: (KoFunctionDeclaration) -> Boolean): Int
+
+    /**
      * Checks whether the declaration contains a local function with the specified name.
      *
-     * @param name The name of the local function to check.
+     * @param predicate The predicate function to determine if a local function satisfies a condition.
      * @return `true` if the declaration contains a local function with the specified name, `false` otherwise.
      */
-    fun containsLocalFunction(name: String): Boolean
+    fun containsLocalFunction(predicate: (KoFunctionDeclaration) -> Boolean): Boolean
 }

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/api/provider/KoLocalFunctionProvider.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/api/provider/KoLocalFunctionProvider.kt
@@ -1,6 +1,5 @@
 package com.lemonappdev.konsist.api.provider
 
-import com.lemonappdev.konsist.api.declaration.KoClassDeclaration
 import com.lemonappdev.konsist.api.declaration.KoFunctionDeclaration
 
 /**

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/api/provider/KoLocalPropertyProvider.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/api/provider/KoLocalPropertyProvider.kt
@@ -1,6 +1,5 @@
 package com.lemonappdev.konsist.api.provider
 
-import com.lemonappdev.konsist.api.declaration.KoFunctionDeclaration
 import com.lemonappdev.konsist.api.declaration.KoPropertyDeclaration
 
 /**

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/api/provider/KoLocalPropertyProvider.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/api/provider/KoLocalPropertyProvider.kt
@@ -1,5 +1,6 @@
 package com.lemonappdev.konsist.api.provider
 
+import com.lemonappdev.konsist.api.declaration.KoFunctionDeclaration
 import com.lemonappdev.konsist.api.declaration.KoPropertyDeclaration
 
 /**
@@ -17,10 +18,18 @@ interface KoLocalPropertyProvider : KoBaseProvider {
     val numLocalProperties: Int
 
     /**
+     * Gets the number of local properties that satisfies the specified predicate present in the declaration.
+     *
+     * @param predicate The predicate function to determine if a local property satisfies a condition.
+     * @return The number of local properties in the declaration.
+     */
+    fun countLocalProperties(predicate: (KoPropertyDeclaration) -> Boolean): Int
+
+    /**
      * Checks whether the declaration contains a local property with the specified name.
      *
-     * @param name The name of the local property to check.
+     * @param predicate The predicate function to determine if a local property satisfies a condition.
      * @return `true` if the declaration contains a local property with the specified name, `false` otherwise.
      */
-    fun containsLocalProperty(name: String): Boolean
+    fun containsLocalProperty(predicate: (KoPropertyDeclaration) -> Boolean): Boolean
 }

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/KoClassProviderCore.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/KoClassProviderCore.kt
@@ -25,5 +25,5 @@ internal interface KoClassProviderCore : KoClassProvider, KoDeclarationProviderC
         includeNested: Boolean,
         includeLocal: Boolean,
         predicate: (KoClassDeclaration) -> Boolean,
-    ): Int = classes(includeNested, includeLocal).filter { predicate(it) }.size
+    ): Int = classes(includeNested, includeLocal).count { predicate(it) }
 }

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/KoDeclarationProviderCore.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/KoDeclarationProviderCore.kt
@@ -21,7 +21,7 @@ internal interface KoDeclarationProviderCore : KoDeclarationProvider, KoBaseProv
         includeNested: Boolean,
         includeLocal: Boolean,
         predicate: (KoBaseDeclaration) -> Boolean,
-    ): Int = declarations(includeNested, includeLocal).filter { predicate(it) }.size
+    ): Int = declarations(includeNested, includeLocal).count { predicate(it) }
 
     override fun numPublicDeclarations(includeNested: Boolean, includeLocal: Boolean): Int =
         declarations(includeNested, includeLocal)

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/KoFunctionProviderCore.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/KoFunctionProviderCore.kt
@@ -24,5 +24,5 @@ internal interface KoFunctionProviderCore : KoFunctionProvider, KoDeclarationPro
         includeNested: Boolean,
         includeLocal: Boolean,
         predicate: (KoFunctionDeclaration) -> Boolean,
-    ): Int = functions(includeNested, includeLocal).filter { predicate(it) }.size
+    ): Int = functions(includeNested, includeLocal).count { predicate(it) }
 }

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/KoInterfaceProviderCore.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/KoInterfaceProviderCore.kt
@@ -21,5 +21,5 @@ internal interface KoInterfaceProviderCore : KoInterfaceProvider, KoDeclarationP
     override fun countInterfaces(
         includeNested: Boolean,
         predicate: (KoInterfaceDeclaration) -> Boolean,
-    ): Int = interfaces(includeNested).filter { predicate(it) }.size
+    ): Int = interfaces(includeNested).count { predicate(it) }
 }

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/KoLocalClassProviderCore.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/KoLocalClassProviderCore.kt
@@ -10,5 +10,9 @@ internal interface KoLocalClassProviderCore : KoLocalClassProvider, KoLocalDecla
     override val numLocalClasses: Int
         get() = localClasses.size
 
-    override fun containsLocalClass(name: String): Boolean = localClasses.any { it.name == name }
+    override fun countLocalClasses(predicate: (KoClassDeclaration) -> Boolean): Int =
+        localClasses.count { predicate(it) }
+
+    override fun containsLocalClass(predicate: (KoClassDeclaration) -> Boolean): Boolean =
+        localClasses.any { predicate(it) }
 }

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/KoLocalDeclarationProviderCore.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/KoLocalDeclarationProviderCore.kt
@@ -1,9 +1,7 @@
 package com.lemonappdev.konsist.core.provider
 
 import com.lemonappdev.konsist.api.declaration.KoBaseDeclaration
-import com.lemonappdev.konsist.api.declaration.KoClassDeclaration
 import com.lemonappdev.konsist.api.provider.KoLocalDeclarationProvider
-import com.lemonappdev.konsist.api.provider.KoNameProvider
 
 internal interface KoLocalDeclarationProviderCore : KoLocalDeclarationProvider, KoBaseProviderCore {
     override val numLocalDeclarations: Int

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/KoLocalDeclarationProviderCore.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/KoLocalDeclarationProviderCore.kt
@@ -1,5 +1,7 @@
 package com.lemonappdev.konsist.core.provider
 
+import com.lemonappdev.konsist.api.declaration.KoBaseDeclaration
+import com.lemonappdev.konsist.api.declaration.KoClassDeclaration
 import com.lemonappdev.konsist.api.provider.KoLocalDeclarationProvider
 import com.lemonappdev.konsist.api.provider.KoNameProvider
 
@@ -7,5 +9,9 @@ internal interface KoLocalDeclarationProviderCore : KoLocalDeclarationProvider, 
     override val numLocalDeclarations: Int
         get() = localDeclarations.size
 
-    override fun containsLocalDeclaration(name: String): Boolean = localDeclarations.any { (it as? KoNameProvider)?.name == name }
+    override fun countLocalDeclarations(predicate: (KoBaseDeclaration) -> Boolean): Int =
+        localDeclarations.count { predicate(it) }
+
+    override fun containsLocalDeclaration(predicate: (KoBaseDeclaration) -> Boolean): Boolean =
+        localDeclarations.any { predicate(it) }
 }

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/KoLocalFunctionProviderCore.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/KoLocalFunctionProviderCore.kt
@@ -1,10 +1,11 @@
 package com.lemonappdev.konsist.core.provider
 
-import com.lemonappdev.konsist.api.declaration.KoClassDeclaration
 import com.lemonappdev.konsist.api.declaration.KoFunctionDeclaration
 import com.lemonappdev.konsist.api.provider.KoLocalFunctionProvider
 
-internal interface KoLocalFunctionProviderCore : KoLocalFunctionProvider, KoLocalDeclarationProviderCore,
+internal interface KoLocalFunctionProviderCore :
+    KoLocalFunctionProvider,
+    KoLocalDeclarationProviderCore,
     KoBaseProviderCore {
     override val localFunctions: List<KoFunctionDeclaration>
         get() = localDeclarations.filterIsInstance<KoFunctionDeclaration>()

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/KoLocalFunctionProviderCore.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/KoLocalFunctionProviderCore.kt
@@ -1,14 +1,20 @@
 package com.lemonappdev.konsist.core.provider
 
+import com.lemonappdev.konsist.api.declaration.KoClassDeclaration
 import com.lemonappdev.konsist.api.declaration.KoFunctionDeclaration
 import com.lemonappdev.konsist.api.provider.KoLocalFunctionProvider
 
-internal interface KoLocalFunctionProviderCore : KoLocalFunctionProvider, KoLocalDeclarationProviderCore, KoBaseProviderCore {
+internal interface KoLocalFunctionProviderCore : KoLocalFunctionProvider, KoLocalDeclarationProviderCore,
+    KoBaseProviderCore {
     override val localFunctions: List<KoFunctionDeclaration>
         get() = localDeclarations.filterIsInstance<KoFunctionDeclaration>()
 
     override val numLocalFunctions: Int
         get() = localFunctions.size
 
-    override fun containsLocalFunction(name: String): Boolean = localFunctions.any { it.name == name }
+    override fun countLocalFunctions(predicate: (KoFunctionDeclaration) -> Boolean): Int =
+        localFunctions.count { predicate(it) }
+
+    override fun containsLocalFunction(predicate: (KoFunctionDeclaration) -> Boolean): Boolean =
+        localFunctions.any { predicate(it) }
 }

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/KoLocalPropertyProviderCore.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/KoLocalPropertyProviderCore.kt
@@ -1,14 +1,20 @@
 package com.lemonappdev.konsist.core.provider
 
+import com.lemonappdev.konsist.api.declaration.KoFunctionDeclaration
 import com.lemonappdev.konsist.api.declaration.KoPropertyDeclaration
 import com.lemonappdev.konsist.api.provider.KoLocalPropertyProvider
 
-internal interface KoLocalPropertyProviderCore : KoLocalPropertyProvider, KoLocalDeclarationProviderCore, KoBaseProviderCore {
+internal interface KoLocalPropertyProviderCore : KoLocalPropertyProvider, KoLocalDeclarationProviderCore,
+    KoBaseProviderCore {
     override val localProperties: List<KoPropertyDeclaration>
         get() = localDeclarations.filterIsInstance<KoPropertyDeclaration>()
 
     override val numLocalProperties: Int
         get() = localProperties.size
 
-    override fun containsLocalProperty(name: String): Boolean = localProperties.any { it.name == name }
+    override fun countLocalProperties(predicate: (KoPropertyDeclaration) -> Boolean): Int =
+        localProperties.count { predicate(it) }
+
+    override fun containsLocalProperty(predicate: (KoPropertyDeclaration) -> Boolean): Boolean =
+        localProperties.any { predicate(it) }
 }

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/KoLocalPropertyProviderCore.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/KoLocalPropertyProviderCore.kt
@@ -1,10 +1,11 @@
 package com.lemonappdev.konsist.core.provider
 
-import com.lemonappdev.konsist.api.declaration.KoFunctionDeclaration
 import com.lemonappdev.konsist.api.declaration.KoPropertyDeclaration
 import com.lemonappdev.konsist.api.provider.KoLocalPropertyProvider
 
-internal interface KoLocalPropertyProviderCore : KoLocalPropertyProvider, KoLocalDeclarationProviderCore,
+internal interface KoLocalPropertyProviderCore :
+    KoLocalPropertyProvider,
+    KoLocalDeclarationProviderCore,
     KoBaseProviderCore {
     override val localProperties: List<KoPropertyDeclaration>
         get() = localDeclarations.filterIsInstance<KoPropertyDeclaration>()

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/KoObjectProviderCore.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/KoObjectProviderCore.kt
@@ -19,5 +19,5 @@ internal interface KoObjectProviderCore : KoObjectProvider, KoDeclarationProvide
     override fun countObjects(
         includeNested: Boolean,
         predicate: (KoObjectDeclaration) -> Boolean,
-    ): Int = objects(includeNested).filter { predicate(it) }.size
+    ): Int = objects(includeNested).count { predicate(it) }
 }

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/KoPropertyProviderCore.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/KoPropertyProviderCore.kt
@@ -25,5 +25,5 @@ internal interface KoPropertyProviderCore : KoPropertyProvider, KoDeclarationPro
         includeNested: Boolean,
         includeLocal: Boolean,
         predicate: (KoPropertyDeclaration) -> Boolean,
-    ): Int = properties(includeNested, includeLocal).filter { predicate(it) }.size
+    ): Int = properties(includeNested, includeLocal).count { predicate(it) }
 }


### PR DESCRIPTION
Added for all KoLocalXProviders `countLocalX(predicate: (KoXDeclaration) -> Boolean)` and changed `containsLocalX` method to pass predicate function instead of name of declaration.