### PR TITLE
KON-361 Deprecate `hasTest`

### DIFF
--- a/lib/src/main/kotlin/com/lemonappdev/konsist/api/declaration/KoClassDeclaration.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/api/declaration/KoClassDeclaration.kt
@@ -10,6 +10,7 @@ import com.lemonappdev.konsist.api.provider.KoDeclarationProvider
 import com.lemonappdev.konsist.api.provider.KoFullyQualifiedNameProvider
 import com.lemonappdev.konsist.api.provider.KoFunctionProvider
 import com.lemonappdev.konsist.api.provider.KoHasTestClassProvider
+import com.lemonappdev.konsist.api.provider.KoHasTestProvider
 import com.lemonappdev.konsist.api.provider.KoInitBlockProvider
 import com.lemonappdev.konsist.api.provider.KoInterfaceProvider
 import com.lemonappdev.konsist.api.provider.KoKDocProvider
@@ -54,6 +55,7 @@ interface KoClassDeclaration :
     KoFullyQualifiedNameProvider,
     KoFunctionProvider,
     KoHasTestClassProvider,
+    KoHasTestProvider,
     KoInitBlockProvider,
     KoInterfaceProvider,
     KoKDocProvider,

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/api/ext/list/KoHasTestProviderListExt.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/api/ext/list/KoHasTestProviderListExt.kt
@@ -1,0 +1,33 @@
+package com.lemonappdev.konsist.api.ext.list
+
+import com.lemonappdev.konsist.api.provider.KoHasTestProvider
+
+/**
+ * List containing elements with a test.
+ *
+ * @param testFileNameSuffix the suffix of the test file name. By default, "Test".
+ * @param moduleName         the name of the module to check (optional).
+ * @param sourceSetName      the name of the source set to check (optional).
+ * @return A list containing elements with a test.
+ */
+@Deprecated("Will be removed from v1.0.0", ReplaceWith("withTestClass"))
+fun <T : KoHasTestProvider> List<T>.withTest(
+    testFileNameSuffix: String = "Test",
+    moduleName: String? = null,
+    sourceSetName: String? = null,
+): List<T> = filter { it.hasTest(testFileNameSuffix, moduleName, sourceSetName) }
+
+/**
+ * List containing elements without a test.
+ *
+ * @param testFileNameSuffix the suffix of the test file name. By default, "Test".
+ * @param moduleName         the name of the module to check (optional).
+ * @param sourceSetName      the name of the source set to check (optional).
+ * @return A list containing elements without a test.
+ */
+@Deprecated("Will be removed from v1.0.0", ReplaceWith("withoutTestClass"))
+fun <T : KoHasTestProvider> List<T>.withoutTest(
+    testFileNameSuffix: String = "Test",
+    moduleName: String? = null,
+    sourceSetName: String? = null,
+): List<T> = filterNot { it.hasTest(testFileNameSuffix, moduleName, sourceSetName) }

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/api/ext/list/KoHasTestProviderListExt.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/api/ext/list/KoHasTestProviderListExt.kt
@@ -10,7 +10,7 @@ import com.lemonappdev.konsist.api.provider.KoHasTestProvider
  * @param sourceSetName      the name of the source set to check (optional).
  * @return A list containing elements with a test.
  */
-@Deprecated("Will be removed from v1.0.0", ReplaceWith("withTestClass"))
+@Deprecated("Will be removed in v1.0.0", ReplaceWith("withTestClass"))
 fun <T : KoHasTestProvider> List<T>.withTest(
     testFileNameSuffix: String = "Test",
     moduleName: String? = null,
@@ -25,7 +25,7 @@ fun <T : KoHasTestProvider> List<T>.withTest(
  * @param sourceSetName      the name of the source set to check (optional).
  * @return A list containing elements without a test.
  */
-@Deprecated("Will be removed from v1.0.0", ReplaceWith("withoutTestClass"))
+@Deprecated("Will be removed in v1.0.0", ReplaceWith("withoutTestClass"))
 fun <T : KoHasTestProvider> List<T>.withoutTest(
     testFileNameSuffix: String = "Test",
     moduleName: String? = null,

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/api/provider/KoHasTestProvider.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/api/provider/KoHasTestProvider.kt
@@ -3,7 +3,7 @@ package com.lemonappdev.konsist.api.provider
 /**
  * An interface representing a Kotlin declaration that provides information about whether it has a test.
  */
-@Deprecated("Will be removed from v1.0.0", ReplaceWith("KoHasTestClassProvider"))
+@Deprecated("Will be removed in v1.0.0", ReplaceWith("KoHasTestClassProvider"))
 interface KoHasTestProvider : KoBaseProvider {
     /**
      * Whatever declaration has a Test.
@@ -13,7 +13,7 @@ interface KoHasTestProvider : KoBaseProvider {
      * @param sourceSetName      the name of the source set to check (optional).
      * @return `true` if the declaration has a test, `false` otherwise.
      */
-    @Deprecated("Will be removed from v1.0.0", ReplaceWith("hasTestClass()"))
+    @Deprecated("Will be removed in v1.0.0", ReplaceWith("hasTestClass()"))
     fun hasTest(
         testFileNameSuffix: String = "Test",
         moduleName: String? = null,

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/api/provider/KoHasTestProvider.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/api/provider/KoHasTestProvider.kt
@@ -1,0 +1,22 @@
+package com.lemonappdev.konsist.api.provider
+
+/**
+ * An interface representing a Kotlin declaration that provides information about whether it has a test.
+ */
+@Deprecated("Will be removed from v1.0.0", ReplaceWith("KoHasTestClassProvider"))
+interface KoHasTestProvider : KoBaseProvider {
+    /**
+     * Whatever declaration has a Test.
+     *
+     * @param testFileNameSuffix the suffix of the test file name. By default, "Test".
+     * @param moduleName         the name of the module to check (optional).
+     * @param sourceSetName      the name of the source set to check (optional).
+     * @return `true` if the declaration has a test, `false` otherwise.
+     */
+    @Deprecated("Will be removed from v1.0.0", ReplaceWith("hasTestClass()"))
+    fun hasTest(
+        testFileNameSuffix: String = "Test",
+        moduleName: String? = null,
+        sourceSetName: String? = null,
+    ): Boolean
+}

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/core/declaration/KoClassDeclarationCore.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/core/declaration/KoClassDeclarationCore.kt
@@ -15,6 +15,7 @@ import com.lemonappdev.konsist.core.provider.KoDeclarationFullyQualifiedNameProv
 import com.lemonappdev.konsist.core.provider.KoDeclarationProviderCore
 import com.lemonappdev.konsist.core.provider.KoFunctionProviderCore
 import com.lemonappdev.konsist.core.provider.KoHasTestClassProviderCore
+import com.lemonappdev.konsist.core.provider.KoHasTestProviderCore
 import com.lemonappdev.konsist.core.provider.KoInitBlockProviderCore
 import com.lemonappdev.konsist.core.provider.KoInterfaceProviderCore
 import com.lemonappdev.konsist.core.provider.KoKDocProviderCore
@@ -64,6 +65,7 @@ internal class KoClassDeclarationCore private constructor(
     KoDeclarationProviderCore,
     KoFunctionProviderCore,
     KoHasTestClassProviderCore,
+    KoHasTestProviderCore,
     KoInitBlockProviderCore,
     KoInterfaceProviderCore,
     KoKDocProviderCore,

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/KoHasTestProviderCore.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/KoHasTestProviderCore.kt
@@ -1,9 +1,9 @@
 package com.lemonappdev.konsist.core.provider
 
 import com.lemonappdev.konsist.api.provider.KoHasTestProvider
-@Deprecated("Will be removed from v1.0.0", ReplaceWith("KoHasTestClassProviderCore"))
+@Deprecated("Will be removed in v1.0.0", ReplaceWith("KoHasTestClassProviderCore"))
 internal interface KoHasTestProviderCore : KoHasTestProvider, KoHasTestClassProviderCore {
-    @Deprecated("Will be removed from v1.0.0", replaceWith = ReplaceWith("hasTestClass()"))
+    @Deprecated("Will be removed in v1.0.0", replaceWith = ReplaceWith("hasTestClass()"))
     override fun hasTest(testFileNameSuffix: String, moduleName: String?, sourceSetName: String?): Boolean =
         hasTestClass(testFileNameSuffix, moduleName, sourceSetName)
 }

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/KoHasTestProviderCore.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/KoHasTestProviderCore.kt
@@ -1,0 +1,9 @@
+package com.lemonappdev.konsist.core.provider
+
+import com.lemonappdev.konsist.api.provider.KoHasTestProvider
+@Deprecated("Will be removed from v1.0.0", ReplaceWith("KoHasTestClassProviderCore"))
+internal interface KoHasTestProviderCore : KoHasTestProvider, KoHasTestClassProviderCore {
+    @Deprecated("Will be removed from v1.0.0", replaceWith = ReplaceWith("hasTestClass()"))
+    override fun hasTest(testFileNameSuffix: String, moduleName: String?, sourceSetName: String?): Boolean =
+        hasTestClass(testFileNameSuffix, moduleName, sourceSetName)
+}


### PR DESCRIPTION
Continue to https://github.com/LemonAppDev/konsist/pull/397

We decided to deprecate previous methods, not remove this. 