### PR TITLE
KON-362 Add Extensions To Expose Properties

### DIFF
--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/api/ext/provider/koannotation/KoAnnotationProviderExtTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/api/ext/provider/koannotation/KoAnnotationProviderExtTest.kt
@@ -2,6 +2,7 @@ package com.lemonappdev.konsist.api.ext.provider.koannotation
 
 import com.lemonappdev.konsist.TestSnippetProvider
 import com.lemonappdev.konsist.api.declaration.KoFileDeclaration
+import com.lemonappdev.konsist.api.ext.list.secondaryConstructors
 import com.lemonappdev.konsist.api.ext.provider.hasAnnotationOf
 import com.lemonappdev.konsist.api.provider.KoAnnotationProvider
 import com.lemonappdev.konsist.testdata.NonExistingAnnotation
@@ -119,7 +120,6 @@ class KoAnnotationProviderExtTest {
         // given
         val sut = getSnippetFile("secondary-constructor-has-two-annotations-of-type")
             .classes()
-            .first()
             .secondaryConstructors
             .first()
 
@@ -136,7 +136,6 @@ class KoAnnotationProviderExtTest {
         // given
         val sut = getSnippetFile("secondary-constructor-has-suppress-annotation-without-import")
             .classes()
-            .first()
             .secondaryConstructors
             .first()
 

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/api/ext/provider/korepresentstype/KoRepresentsTypeProviderExtTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/api/ext/provider/korepresentstype/KoRepresentsTypeProviderExtTest.kt
@@ -1,6 +1,8 @@
 package com.lemonappdev.konsist.api.ext.provider.korepresentstype
 
 import com.lemonappdev.konsist.TestSnippetProvider.getSnippetKoScope
+import com.lemonappdev.konsist.api.ext.list.annotations
+import com.lemonappdev.konsist.api.ext.list.parameters
 import com.lemonappdev.konsist.api.ext.provider.representsTypeOf
 import com.lemonappdev.konsist.api.provider.KoRepresentsTypeProvider
 import com.lemonappdev.konsist.testdata.NonExistingAnnotation
@@ -22,7 +24,6 @@ class KoRepresentsTypeProviderExtTest {
         // given
         val sut = getSnippetFile("parameter-represents-type-of-type")
             .functions()
-            .first()
             .parameters
             .first()
 
@@ -35,7 +36,6 @@ class KoRepresentsTypeProviderExtTest {
         // given
         val sut = getSnippetFile("annotation-represents-type")
             .functions()
-            .first()
             .annotations
             .first()
 
@@ -51,7 +51,6 @@ class KoRepresentsTypeProviderExtTest {
         // given
         val sut = getSnippetFile("annotation-represents-type-without-import")
             .functions()
-            .first()
             .annotations
             .first()
 

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koclass/KoClassDeclarationForKoTopLevelProviderTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koclass/KoClassDeclarationForKoTopLevelProviderTest.kt
@@ -1,6 +1,7 @@
 package com.lemonappdev.konsist.core.declaration.koclass
 
 import com.lemonappdev.konsist.TestSnippetProvider.getSnippetKoScope
+import com.lemonappdev.konsist.api.ext.list.classes
 import org.amshove.kluent.shouldBeEqualTo
 import org.junit.jupiter.api.Test
 
@@ -9,9 +10,8 @@ class KoClassDeclarationForKoTopLevelProviderTest {
     fun `class-is-not-top-level`() {
         // given
         val sut = getSnippetFile("class-is-not-top-level")
-            .classes()
-            .flatMap { it.classes() }
-            .first()
+            .classes(includeNested = true)
+            .first { it.name == "SampleNestedClass" }
 
         // then
         sut.isTopLevel shouldBeEqualTo false

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koclass/forkomodifier/KoClassDeclarationForKoVisibilityModifierProviderTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koclass/forkomodifier/KoClassDeclarationForKoVisibilityModifierProviderTest.kt
@@ -1,6 +1,7 @@
 package com.lemonappdev.konsist.core.declaration.koclass.forkomodifier
 
 import com.lemonappdev.konsist.TestSnippetProvider.getSnippetKoScope
+import com.lemonappdev.konsist.api.ext.list.classes
 import org.amshove.kluent.assertSoftly
 import org.amshove.kluent.shouldBeEqualTo
 import org.junit.jupiter.api.Test
@@ -63,9 +64,8 @@ class KoClassDeclarationForKoVisibilityModifierProviderTest {
     fun `protected-class`() {
         // given
         val sut = getSnippetFile("protected-class")
-            .classes()
-            .flatMap { it.classes() }
-            .first()
+            .classes(includeNested = true)
+            .first { it.name == "SampleClass" }
 
         // then
         sut.hasProtectedModifier shouldBeEqualTo true

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/kofunction/KoFunctionDeclarationForKoTopLevelProviderTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/kofunction/KoFunctionDeclarationForKoTopLevelProviderTest.kt
@@ -1,6 +1,7 @@
 package com.lemonappdev.konsist.core.declaration.kofunction
 
 import com.lemonappdev.konsist.TestSnippetProvider.getSnippetKoScope
+import com.lemonappdev.konsist.api.ext.list.functions
 import org.amshove.kluent.shouldBeEqualTo
 import org.junit.jupiter.api.Test
 
@@ -10,7 +11,7 @@ class KoFunctionDeclarationForKoTopLevelProviderTest {
         // given
         val sut = getSnippetFile("function-is-not-top-level")
             .classes()
-            .flatMap { it.functions() }
+            .functions()
             .first()
 
         // then

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koinitblock/KoInitBlockDeclarationForKoContainingDeclarationProviderTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koinitblock/KoInitBlockDeclarationForKoContainingDeclarationProviderTest.kt
@@ -1,6 +1,7 @@
 package com.lemonappdev.konsist.core.declaration.koinitblock
 
 import com.lemonappdev.konsist.TestSnippetProvider.getSnippetKoScope
+import com.lemonappdev.konsist.api.ext.list.initBlocks
 import com.lemonappdev.konsist.api.provider.KoNameProvider
 import org.amshove.kluent.assertSoftly
 import org.amshove.kluent.shouldBeEqualTo
@@ -13,7 +14,6 @@ class KoInitBlockDeclarationForKoContainingDeclarationProviderTest {
         // given
         val sut = getSnippetFile("init-block-parent-declaration")
             .classes()
-            .first()
             .initBlocks
             .first()
 

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koinitblock/KoInitBlockDeclarationForKoContainingFileProviderTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koinitblock/KoInitBlockDeclarationForKoContainingFileProviderTest.kt
@@ -1,6 +1,7 @@
 package com.lemonappdev.konsist.core.declaration.koinitblock
 
 import com.lemonappdev.konsist.TestSnippetProvider.getSnippetKoScope
+import com.lemonappdev.konsist.api.ext.list.initBlocks
 import org.amshove.kluent.shouldBeEqualTo
 import org.junit.jupiter.api.Test
 
@@ -10,7 +11,6 @@ class KoInitBlockDeclarationForKoContainingFileProviderTest {
         // given
         val sut = getSnippetFile("init-block-containing-file")
             .classes()
-            .first()
             .initBlocks
             .first()
 

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koinitblock/KoInitBlockDeclarationForKoLocalClassProviderTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koinitblock/KoInitBlockDeclarationForKoLocalClassProviderTest.kt
@@ -1,6 +1,7 @@
 package com.lemonappdev.konsist.core.declaration.koinitblock
 
 import com.lemonappdev.konsist.TestSnippetProvider.getSnippetKoScope
+import com.lemonappdev.konsist.api.ext.list.initBlocks
 import org.amshove.kluent.assertSoftly
 import org.amshove.kluent.shouldBeEqualTo
 import org.junit.jupiter.api.Test
@@ -11,7 +12,6 @@ class KoInitBlockDeclarationForKoLocalClassProviderTest {
         // given
         val sut = getSnippetFile("init-block-contains-no-local-classes")
             .classes()
-            .first()
             .initBlocks
             .first()
 
@@ -29,7 +29,6 @@ class KoInitBlockDeclarationForKoLocalClassProviderTest {
         // given
         val sut = getSnippetFile("init-block-contains-local-class")
             .classes()
-            .first()
             .initBlocks
             .first()
 

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koinitblock/KoInitBlockDeclarationForKoLocalDeclarationProviderTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koinitblock/KoInitBlockDeclarationForKoLocalDeclarationProviderTest.kt
@@ -1,6 +1,7 @@
 package com.lemonappdev.konsist.core.declaration.koinitblock
 
 import com.lemonappdev.konsist.TestSnippetProvider.getSnippetKoScope
+import com.lemonappdev.konsist.api.ext.list.initBlocks
 import com.lemonappdev.konsist.api.provider.KoNameProvider
 import org.amshove.kluent.assertSoftly
 import org.amshove.kluent.shouldBeEqualTo
@@ -12,7 +13,6 @@ class KoInitBlockDeclarationForKoLocalDeclarationProviderTest {
         // given
         val sut = getSnippetFile("init-block-contains-no-local-declarations")
             .classes()
-            .first()
             .initBlocks
             .first()
 
@@ -30,7 +30,6 @@ class KoInitBlockDeclarationForKoLocalDeclarationProviderTest {
         // given
         val sut = getSnippetFile("init-block-contains-local-declarations")
             .classes()
-            .first()
             .initBlocks
             .first()
 

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koinitblock/KoInitBlockDeclarationForKoLocalFunctionProviderTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koinitblock/KoInitBlockDeclarationForKoLocalFunctionProviderTest.kt
@@ -1,6 +1,7 @@
 package com.lemonappdev.konsist.core.declaration.koinitblock
 
 import com.lemonappdev.konsist.TestSnippetProvider.getSnippetKoScope
+import com.lemonappdev.konsist.api.ext.list.initBlocks
 import org.amshove.kluent.assertSoftly
 import org.amshove.kluent.shouldBeEqualTo
 import org.junit.jupiter.api.Test
@@ -11,7 +12,6 @@ class KoInitBlockDeclarationForKoLocalFunctionProviderTest {
         // given
         val sut = getSnippetFile("init-block-contains-no-local-function")
             .classes()
-            .first()
             .initBlocks
             .first()
 
@@ -29,7 +29,6 @@ class KoInitBlockDeclarationForKoLocalFunctionProviderTest {
         // given
         val sut = getSnippetFile("init-block-contains-local-function")
             .classes()
-            .first()
             .initBlocks
             .first()
 

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koinitblock/KoInitBlockDeclarationForKoLocationProviderTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koinitblock/KoInitBlockDeclarationForKoLocationProviderTest.kt
@@ -1,6 +1,7 @@
 package com.lemonappdev.konsist.core.declaration.koinitblock
 
 import com.lemonappdev.konsist.TestSnippetProvider.getSnippetKoScope
+import com.lemonappdev.konsist.api.ext.list.initBlocks
 import org.amshove.kluent.assertSoftly
 import org.amshove.kluent.shouldBeEqualTo
 import org.junit.jupiter.api.Test
@@ -11,7 +12,6 @@ class KoInitBlockDeclarationForKoLocationProviderTest {
         // given
         val sut = getSnippetFile("init-block-location-with-single-digit")
             .classes()
-            .first()
             .initBlocks
             .first()
 
@@ -24,14 +24,12 @@ class KoInitBlockDeclarationForKoLocationProviderTest {
         // given
         val projectPath = getSnippetFile("init-block-location-with-text")
             .classes()
-            .first()
             .initBlocks
             .first()
             .projectPath
 
         val sut = getSnippetFile("init-block-location-with-text")
             .classes()
-            .first()
             .initBlocks
             .first()
 

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koinitblock/KoInitBlockDeclarationForKoPathProviderTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koinitblock/KoInitBlockDeclarationForKoPathProviderTest.kt
@@ -1,6 +1,7 @@
 package com.lemonappdev.konsist.core.declaration.koinitblock
 
 import com.lemonappdev.konsist.TestSnippetProvider.getSnippetKoScope
+import com.lemonappdev.konsist.api.ext.list.initBlocks
 import org.amshove.kluent.assertSoftly
 import org.amshove.kluent.shouldBeEqualTo
 import org.junit.jupiter.api.Test
@@ -11,7 +12,6 @@ class KoInitBlockDeclarationForKoPathProviderTest {
         // given
         val sut = getSnippetFile("init-block-file-path")
             .classes()
-            .first()
             .initBlocks
             .first()
 
@@ -27,7 +27,6 @@ class KoInitBlockDeclarationForKoPathProviderTest {
         // given
         val sut = getSnippetFile("init-block-project-file-path")
             .classes()
-            .first()
             .initBlocks
             .first()
 
@@ -45,7 +44,6 @@ class KoInitBlockDeclarationForKoPathProviderTest {
         // given
         val sut = getSnippetFile("init-block-reside-in-file-path")
             .classes()
-            .first()
             .initBlocks
             .first()
 
@@ -63,7 +61,6 @@ class KoInitBlockDeclarationForKoPathProviderTest {
         // given
         val sut = getSnippetFile("init-block-reside-in-project-file-path")
             .classes()
-            .first()
             .initBlocks
             .first()
 

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koinitblock/KoInitBlockDeclarationForKoTextProviderTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koinitblock/KoInitBlockDeclarationForKoTextProviderTest.kt
@@ -1,6 +1,7 @@
 package com.lemonappdev.konsist.core.declaration.koinitblock
 
 import com.lemonappdev.konsist.TestSnippetProvider.getSnippetKoScope
+import com.lemonappdev.konsist.api.ext.list.initBlocks
 import org.amshove.kluent.shouldBeEqualTo
 import org.junit.jupiter.api.Test
 
@@ -10,7 +11,6 @@ class KoInitBlockDeclarationForKoTextProviderTest {
         // given
         val sut = getSnippetFile("init-block-text")
             .classes()
-            .first()
             .initBlocks
             .first()
 

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koinitblock/KoInitBlockDeclarationTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koinitblock/KoInitBlockDeclarationTest.kt
@@ -1,6 +1,7 @@
 package com.lemonappdev.konsist.core.declaration.koinitblock
 
 import com.lemonappdev.konsist.TestSnippetProvider
+import com.lemonappdev.konsist.api.ext.list.initBlocks
 import org.amshove.kluent.shouldBeEqualTo
 import org.junit.jupiter.api.Test
 
@@ -10,7 +11,6 @@ class KoInitBlockDeclarationTest {
         // given
         val sut = getSnippetFile("init-block-to-string")
             .classes()
-            .first()
             .initBlocks
             .first()
 

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/kointerface/KoInterfaceDeclarationForKoTopLevelProviderTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/kointerface/KoInterfaceDeclarationForKoTopLevelProviderTest.kt
@@ -1,6 +1,7 @@
 package com.lemonappdev.konsist.core.declaration.kointerface
 
 import com.lemonappdev.konsist.TestSnippetProvider.getSnippetKoScope
+import com.lemonappdev.konsist.api.ext.list.interfaces
 import org.amshove.kluent.shouldBeEqualTo
 import org.junit.jupiter.api.Test
 
@@ -10,7 +11,7 @@ class KoInterfaceDeclarationForKoTopLevelProviderTest {
         // given
         val sut = getSnippetFile("interface-is-not-top-level")
             .classes()
-            .flatMap { it.interfaces() }
+            .interfaces()
             .first()
 
         // then

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/kointerface/forkomodifier/KoInterfaceDeclarationForKoVisibilityModifierProviderTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/kointerface/forkomodifier/KoInterfaceDeclarationForKoVisibilityModifierProviderTest.kt
@@ -1,6 +1,7 @@
 package com.lemonappdev.konsist.core.declaration.kointerface.forkomodifier
 
 import com.lemonappdev.konsist.TestSnippetProvider.getSnippetKoScope
+import com.lemonappdev.konsist.api.ext.list.interfaces
 import org.amshove.kluent.assertSoftly
 import org.amshove.kluent.shouldBeEqualTo
 import org.junit.jupiter.api.Test
@@ -64,7 +65,7 @@ class KoInterfaceDeclarationForKoVisibilityModifierProviderTest {
         // given
         val sut = getSnippetFile("interface-has-protected-modifier")
             .classes()
-            .flatMap { it.interfaces() }
+            .interfaces()
             .first()
 
         // then

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koobject/KoObjectDeclarationForKoTopLevelProviderTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koobject/KoObjectDeclarationForKoTopLevelProviderTest.kt
@@ -1,6 +1,7 @@
 package com.lemonappdev.konsist.core.declaration.koobject
 
 import com.lemonappdev.konsist.TestSnippetProvider.getSnippetKoScope
+import com.lemonappdev.konsist.api.ext.list.objects
 import org.amshove.kluent.shouldBeEqualTo
 import org.junit.jupiter.api.Test
 
@@ -10,7 +11,7 @@ class KoObjectDeclarationForKoTopLevelProviderTest {
         // given
         val sut = getSnippetFile("object-is-not-top-level")
             .classes()
-            .flatMap { it.objects() }
+            .objects()
             .first()
 
         // then

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koparameter/KoParameterDeclarationForKoRepresentsTypeProviderTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koparameter/KoParameterDeclarationForKoRepresentsTypeProviderTest.kt
@@ -1,6 +1,7 @@
 package com.lemonappdev.konsist.core.declaration.koparameter
 
 import com.lemonappdev.konsist.TestSnippetProvider.getSnippetKoScope
+import com.lemonappdev.konsist.api.ext.list.parameters
 import org.amshove.kluent.assertSoftly
 import org.amshove.kluent.shouldBeEqualTo
 import org.junit.jupiter.api.Test
@@ -11,7 +12,6 @@ class KoParameterDeclarationForKoRepresentsTypeProviderTest {
         // given
         val sut = getSnippetFile("parameter-represents-type")
             .functions()
-            .first()
             .parameters
             .first()
 

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koparent/KoParentDeclarationForKoContainingFileProviderTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koparent/KoParentDeclarationForKoContainingFileProviderTest.kt
@@ -1,6 +1,7 @@
 package com.lemonappdev.konsist.core.declaration.koparent
 
 import com.lemonappdev.konsist.TestSnippetProvider.getSnippetKoScope
+import com.lemonappdev.konsist.api.ext.list.parents
 import org.amshove.kluent.shouldBeEqualTo
 import org.junit.jupiter.api.Test
 
@@ -10,7 +11,6 @@ class KoParentDeclarationForKoContainingFileProviderTest {
         // given
         val sut = getSnippetFile("parent-containing-file")
             .classes()
-            .first()
             .parents
             .first()
 

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koparent/KoParentDeclarationForKoFullyQualifiedNameProviderTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koparent/KoParentDeclarationForKoFullyQualifiedNameProviderTest.kt
@@ -1,6 +1,7 @@
 package com.lemonappdev.konsist.core.declaration.koparent
 
 import com.lemonappdev.konsist.TestSnippetProvider.getSnippetKoScope
+import com.lemonappdev.konsist.api.ext.list.parents
 import org.amshove.kluent.shouldBeEqualTo
 import org.junit.jupiter.api.Test
 
@@ -10,7 +11,6 @@ class KoParentDeclarationForKoFullyQualifiedNameProviderTest {
         // given
         val sut = getSnippetFile("parent-fully-qualified-name")
             .classes()
-            .first()
             .parents
             .first()
 
@@ -23,7 +23,6 @@ class KoParentDeclarationForKoFullyQualifiedNameProviderTest {
         // given
         val sut = getSnippetFile("parent-fully-qualified-name-without-import")
             .classes()
-            .first()
             .parents
             .first()
 

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koparent/KoParentDeclarationForKoLocationProviderTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koparent/KoParentDeclarationForKoLocationProviderTest.kt
@@ -1,6 +1,7 @@
 package com.lemonappdev.konsist.core.declaration.koparent
 
 import com.lemonappdev.konsist.TestSnippetProvider.getSnippetKoScope
+import com.lemonappdev.konsist.api.ext.list.parents
 import org.amshove.kluent.assertSoftly
 import org.amshove.kluent.shouldBeEqualTo
 import org.junit.jupiter.api.Test
@@ -11,7 +12,6 @@ class KoParentDeclarationForKoLocationProviderTest {
         // given
         val sut = getSnippetFile("parent-location")
             .classes()
-            .first()
             .parents
             .first()
 
@@ -24,14 +24,12 @@ class KoParentDeclarationForKoLocationProviderTest {
         // given
         val projectPath = getSnippetFile("parent-location-with-text")
             .classes()
-            .first()
             .parents
             .first()
             .projectPath
 
         val sut = getSnippetFile("parent-location-with-text")
             .classes()
-            .first()
             .parents
             .first()
 

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koparent/KoParentDeclarationForKoNameProviderTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koparent/KoParentDeclarationForKoNameProviderTest.kt
@@ -1,6 +1,7 @@
 package com.lemonappdev.konsist.core.declaration.koparent
 
 import com.lemonappdev.konsist.TestSnippetProvider
+import com.lemonappdev.konsist.api.ext.list.parents
 import org.amshove.kluent.shouldBeEqualTo
 import org.junit.jupiter.api.Test
 
@@ -10,7 +11,6 @@ class KoParentDeclarationForKoNameProviderTest {
         // given
         val sut = getSnippetFile("class-with-parent-class")
             .classes()
-            .first()
             .parents
             .first()
 
@@ -23,7 +23,6 @@ class KoParentDeclarationForKoNameProviderTest {
         // given
         val sut = getSnippetFile("class-with-generic-parent-class")
             .classes()
-            .first()
             .parents
             .first()
 
@@ -36,7 +35,6 @@ class KoParentDeclarationForKoNameProviderTest {
         // given
         val sut = getSnippetFile("class-with-parametrized-parent-class")
             .classes()
-            .first()
             .parents
             .first()
 
@@ -49,7 +47,6 @@ class KoParentDeclarationForKoNameProviderTest {
         // given
         val sut = getSnippetFile("class-with-parametrized-and-generic-parent-class")
             .classes()
-            .first()
             .parents
             .first()
 
@@ -62,7 +59,6 @@ class KoParentDeclarationForKoNameProviderTest {
         // given
         val sut = getSnippetFile("class-with-parent-interface")
             .classes()
-            .first()
             .parents
             .first()
 
@@ -75,7 +71,6 @@ class KoParentDeclarationForKoNameProviderTest {
         // given
         val sut = getSnippetFile("class-with-generic-parent-interface")
             .classes()
-            .first()
             .parents
             .first()
 
@@ -88,7 +83,6 @@ class KoParentDeclarationForKoNameProviderTest {
         // given
         val sut = getSnippetFile("class-with-parent-by-delegation")
             .classes()
-            .first()
             .parents
             .first()
 

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koparent/KoParentDeclarationForKoPackageProviderTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koparent/KoParentDeclarationForKoPackageProviderTest.kt
@@ -1,6 +1,7 @@
 package com.lemonappdev.konsist.core.declaration.koparent
 
 import com.lemonappdev.konsist.TestSnippetProvider.getSnippetKoScope
+import com.lemonappdev.konsist.api.ext.list.parents
 import org.amshove.kluent.shouldBeEqualTo
 import org.junit.jupiter.api.Test
 
@@ -10,7 +11,6 @@ class KoParentDeclarationForKoPackageProviderTest {
         // given
         val sut = getSnippetFile("parent-is-not-in-package")
             .classes()
-            .first()
             .parents
             .first()
 
@@ -23,7 +23,6 @@ class KoParentDeclarationForKoPackageProviderTest {
         // given
         val sut = getSnippetFile("parent-is-in-package")
             .classes()
-            .first()
             .parents
             .first()
 

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koparent/KoParentDeclarationForKoPathProviderTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koparent/KoParentDeclarationForKoPathProviderTest.kt
@@ -1,6 +1,7 @@
 package com.lemonappdev.konsist.core.declaration.koparent
 
 import com.lemonappdev.konsist.TestSnippetProvider.getSnippetKoScope
+import com.lemonappdev.konsist.api.ext.list.parents
 import org.amshove.kluent.assertSoftly
 import org.amshove.kluent.shouldBeEqualTo
 import org.junit.jupiter.api.Test
@@ -11,7 +12,6 @@ class KoParentDeclarationForKoPathProviderTest {
         // given
         val sut = getSnippetFile("parent-file-path")
             .classes()
-            .first()
             .parents
             .first()
 
@@ -27,7 +27,6 @@ class KoParentDeclarationForKoPathProviderTest {
         // given
         val sut = getSnippetFile("parent-project-file-path")
             .classes()
-            .first()
             .parents
             .first()
 
@@ -45,7 +44,6 @@ class KoParentDeclarationForKoPathProviderTest {
         // given
         val sut = getSnippetFile("parent-reside-in-file-path")
             .classes()
-            .first()
             .parents
             .first()
 
@@ -63,7 +61,6 @@ class KoParentDeclarationForKoPathProviderTest {
         // given
         val sut = getSnippetFile("parent-reside-in-project-file-path")
             .classes()
-            .first()
             .parents
             .first()
 

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koparent/KoParentDeclarationForKoResideInOrOutsidePackageProviderTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koparent/KoParentDeclarationForKoResideInOrOutsidePackageProviderTest.kt
@@ -1,6 +1,7 @@
 package com.lemonappdev.konsist.core.declaration.koparent
 
 import com.lemonappdev.konsist.TestSnippetProvider.getSnippetKoScope
+import com.lemonappdev.konsist.api.ext.list.parents
 import org.amshove.kluent.shouldBeEqualTo
 import org.junit.jupiter.api.Test
 
@@ -10,7 +11,6 @@ class KoParentDeclarationForKoResideInOrOutsidePackageProviderTest {
         // given
         val sut = getSnippetFile("parent-not-reside-in-file-package")
             .classes()
-            .first()
             .parents
             .first()
 
@@ -23,7 +23,6 @@ class KoParentDeclarationForKoResideInOrOutsidePackageProviderTest {
         // given
         val sut = getSnippetFile("parent-reside-in-file-package")
             .classes()
-            .first()
             .parents
             .first()
 
@@ -36,7 +35,6 @@ class KoParentDeclarationForKoResideInOrOutsidePackageProviderTest {
         // given
         val sut = getSnippetFile("parent-not-reside-outside-file-package")
             .classes()
-            .first()
             .parents
             .first()
 
@@ -49,7 +47,6 @@ class KoParentDeclarationForKoResideInOrOutsidePackageProviderTest {
         // given
         val sut = getSnippetFile("parent-reside-outside-file-package")
             .classes()
-            .first()
             .parents
             .first()
 

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/verify/kodeclarationassert/KoDeclarationAssertForDeclarationListTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/verify/kodeclarationassert/KoDeclarationAssertForDeclarationListTest.kt
@@ -1,6 +1,8 @@
 package com.lemonappdev.konsist.core.verify.kodeclarationassert
 
 import com.lemonappdev.konsist.TestSnippetProvider
+import com.lemonappdev.konsist.api.ext.list.initBlocks
+import com.lemonappdev.konsist.api.ext.list.localFunctions
 import com.lemonappdev.konsist.api.ext.list.withPrimaryConstructor
 import com.lemonappdev.konsist.api.verify.assert
 import com.lemonappdev.konsist.api.verify.assertNot
@@ -338,7 +340,6 @@ class KoDeclarationAssertForDeclarationListTest {
         val sut =
             getSnippetFile("assert-suppress-by-konsist-and-name-at-declaration-parent-level-when-it-is-not-KoAnnotationProvider")
                 .classes()
-                .first()
                 .initBlocks
 
         // then
@@ -351,7 +352,6 @@ class KoDeclarationAssertForDeclarationListTest {
         val sut =
             getSnippetFile("assert-suppress-by-name-at-declaration-parent-level-when-it-is-not-KoAnnotationProvider")
                 .classes()
-                .first()
                 .initBlocks
 
         // then
@@ -364,7 +364,6 @@ class KoDeclarationAssertForDeclarationListTest {
         val sut =
             getSnippetFile("assert-suppress-by-konsist-and-name-at-file-level-when-it-is-not-KoAnnotationProvider")
                 .classes()
-                .first()
                 .initBlocks
 
         // then
@@ -377,7 +376,6 @@ class KoDeclarationAssertForDeclarationListTest {
         val sut =
             getSnippetFile("assert-suppress-by-name-at-file-level-when-it-is-not-KoAnnotationProvider")
                 .classes()
-                .first()
                 .initBlocks
 
         // then
@@ -390,9 +388,7 @@ class KoDeclarationAssertForDeclarationListTest {
         val sut =
             getSnippetFile("assert-suppress-by-konsist-and-name-at-declaration-level-when-it-is-at-not-KoAnnotationProvider-declaration")
                 .classes()
-                .first()
                 .initBlocks
-                .first()
                 .localFunctions
 
         // then
@@ -405,9 +401,7 @@ class KoDeclarationAssertForDeclarationListTest {
         val sut =
             getSnippetFile("assert-suppress-by-name-at-declaration-level-when-it-is-at-not-KoAnnotationProvider-declaration")
                 .classes()
-                .first()
                 .initBlocks
-                .first()
                 .localFunctions
 
         // then
@@ -422,9 +416,7 @@ class KoDeclarationAssertForDeclarationListTest {
                 "assert-suppress-by-konsist-and-name-at-declaration-parent-level-when-it-is-at-not-KoAnnotationProvider-declaration",
             )
                 .classes()
-                .first()
                 .initBlocks
-                .first()
                 .localFunctions
 
         // then
@@ -437,9 +429,7 @@ class KoDeclarationAssertForDeclarationListTest {
         val sut =
             getSnippetFile("assert-suppress-by-name-at-declaration-parent-level-when-it-is-at-not-KoAnnotationProvider-declaration")
                 .classes()
-                .first()
                 .initBlocks
-                .first()
                 .localFunctions
 
         // then
@@ -452,9 +442,7 @@ class KoDeclarationAssertForDeclarationListTest {
         val sut =
             getSnippetFile("assert-suppress-by-konsist-and-name-at-file-level-when-it-is-at-not-KoAnnotationProvider-declaration")
                 .classes()
-                .first()
                 .initBlocks
-                .first()
                 .localFunctions
 
         // then
@@ -467,9 +455,7 @@ class KoDeclarationAssertForDeclarationListTest {
         val sut =
             getSnippetFile("assert-suppress-by-name-at-file-level-when-it-is-at-not-KoAnnotationProvider-declaration")
                 .classes()
-                .first()
                 .initBlocks
-                .first()
                 .localFunctions
 
         // then

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/verify/kodeclarationassert/KoDeclarationAssertForDeclarationSequenceTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/verify/kodeclarationassert/KoDeclarationAssertForDeclarationSequenceTest.kt
@@ -1,6 +1,8 @@
 package com.lemonappdev.konsist.core.verify.kodeclarationassert
 
 import com.lemonappdev.konsist.TestSnippetProvider
+import com.lemonappdev.konsist.api.ext.list.initBlocks
+import com.lemonappdev.konsist.api.ext.list.localFunctions
 import com.lemonappdev.konsist.api.verify.assert
 import com.lemonappdev.konsist.api.verify.assertNot
 import com.lemonappdev.konsist.core.exception.KoCheckFailedException
@@ -355,7 +357,6 @@ class KoDeclarationAssertForDeclarationSequenceTest {
         val sut =
             getSnippetFile("assert-suppress-by-konsist-and-name-at-declaration-parent-level-when-it-is-not-KoAnnotationProvider")
                 .classes()
-                .first()
                 .initBlocks
                 .asSequence()
 
@@ -369,7 +370,6 @@ class KoDeclarationAssertForDeclarationSequenceTest {
         val sut =
             getSnippetFile("assert-suppress-by-name-at-declaration-parent-level-when-it-is-not-KoAnnotationProvider")
                 .classes()
-                .first()
                 .initBlocks
                 .asSequence()
 
@@ -383,7 +383,6 @@ class KoDeclarationAssertForDeclarationSequenceTest {
         val sut =
             getSnippetFile("assert-suppress-by-konsist-and-name-at-file-level-when-it-is-not-KoAnnotationProvider")
                 .classes()
-                .first()
                 .initBlocks
                 .asSequence()
 
@@ -397,7 +396,6 @@ class KoDeclarationAssertForDeclarationSequenceTest {
         val sut =
             getSnippetFile("assert-suppress-by-name-at-file-level-when-it-is-not-KoAnnotationProvider")
                 .classes()
-                .first()
                 .initBlocks
                 .asSequence()
 
@@ -411,9 +409,7 @@ class KoDeclarationAssertForDeclarationSequenceTest {
         val sut =
             getSnippetFile("assert-suppress-by-konsist-and-name-at-declaration-level-when-it-is-at-not-KoAnnotationProvider-declaration")
                 .classes()
-                .first()
                 .initBlocks
-                .first()
                 .localFunctions
                 .asSequence()
 
@@ -427,9 +423,7 @@ class KoDeclarationAssertForDeclarationSequenceTest {
         val sut =
             getSnippetFile("assert-suppress-by-name-at-declaration-level-when-it-is-at-not-KoAnnotationProvider-declaration")
                 .classes()
-                .first()
                 .initBlocks
-                .first()
                 .localFunctions
                 .asSequence()
 
@@ -445,9 +439,7 @@ class KoDeclarationAssertForDeclarationSequenceTest {
                 "assert-suppress-by-konsist-and-name-at-declaration-parent-level-when-it-is-at-not-KoAnnotationProvider-declaration",
             )
                 .classes()
-                .first()
                 .initBlocks
-                .first()
                 .localFunctions
                 .asSequence()
 
@@ -461,9 +453,7 @@ class KoDeclarationAssertForDeclarationSequenceTest {
         val sut =
             getSnippetFile("assert-suppress-by-name-at-declaration-parent-level-when-it-is-at-not-KoAnnotationProvider-declaration")
                 .classes()
-                .first()
                 .initBlocks
-                .first()
                 .localFunctions
                 .asSequence()
 
@@ -477,9 +467,7 @@ class KoDeclarationAssertForDeclarationSequenceTest {
         val sut =
             getSnippetFile("assert-suppress-by-konsist-and-name-at-file-level-when-it-is-at-not-KoAnnotationProvider-declaration")
                 .classes()
-                .first()
                 .initBlocks
-                .first()
                 .localFunctions
                 .asSequence()
 
@@ -493,9 +481,7 @@ class KoDeclarationAssertForDeclarationSequenceTest {
         val sut =
             getSnippetFile("assert-suppress-by-name-at-file-level-when-it-is-at-not-KoAnnotationProvider-declaration")
                 .classes()
-                .first()
                 .initBlocks
-                .first()
                 .localFunctions
                 .asSequence()
 

--- a/lib/src/konsistTest/kotlin/com/lemonappdev/konsist/core/DeclarationKonsistTest.kt
+++ b/lib/src/konsistTest/kotlin/com/lemonappdev/konsist/core/DeclarationKonsistTest.kt
@@ -1,8 +1,8 @@
 package com.lemonappdev.konsist.core
 
 import com.lemonappdev.konsist.api.Konsist
-import com.lemonappdev.konsist.api.ext.list.withReturnType
-import com.lemonappdev.konsist.api.ext.list.withType
+import com.lemonappdev.konsist.api.ext.list.returnTypes
+import com.lemonappdev.konsist.api.ext.list.types
 import com.lemonappdev.konsist.api.ext.list.withoutName
 import com.lemonappdev.konsist.api.verify.assert
 import com.lemonappdev.konsist.api.verify.assertNot
@@ -28,8 +28,7 @@ class DeclarationKonsistTest {
     fun `none function return type has the 'Impl' suffix`() {
         declarationPackageScope
             .functions(includeNested = true)
-            .withReturnType()
-            .mapNotNull { it.returnType }
+            .returnTypes
             .assertNot { it.sourceType.endsWith("Impl") }
     }
 
@@ -37,8 +36,7 @@ class DeclarationKonsistTest {
     fun `none property type has the 'Impl' suffix`() {
         declarationPackageScope
             .properties(includeNested = true)
-            .withType()
-            .mapNotNull { it.type }
+            .types
             .assertNot { it.sourceType.endsWith("Impl") }
     }
 

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/api/ext/list/KoAnnotationProviderListExt.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/api/ext/list/KoAnnotationProviderListExt.kt
@@ -1,9 +1,7 @@
 package com.lemonappdev.konsist.api.ext.list
 
 import com.lemonappdev.konsist.api.declaration.KoAnnotationDeclaration
-import com.lemonappdev.konsist.api.declaration.KoClassDeclaration
 import com.lemonappdev.konsist.api.provider.KoAnnotationProvider
-import com.lemonappdev.konsist.api.provider.KoClassProvider
 import kotlin.reflect.KClass
 
 /**

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/api/ext/list/KoAnnotationProviderListExt.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/api/ext/list/KoAnnotationProviderListExt.kt
@@ -1,7 +1,16 @@
 package com.lemonappdev.konsist.api.ext.list
 
+import com.lemonappdev.konsist.api.declaration.KoAnnotationDeclaration
+import com.lemonappdev.konsist.api.declaration.KoClassDeclaration
 import com.lemonappdev.konsist.api.provider.KoAnnotationProvider
+import com.lemonappdev.konsist.api.provider.KoClassProvider
 import kotlin.reflect.KClass
+
+/**
+ * List containing annotation declarations.
+ */
+val <T : KoAnnotationProvider> List<T>.annotations: List<KoAnnotationDeclaration>
+    get() = flatMap { it.annotations }
 
 /**
  * List containing elements with any annotation.

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/api/ext/list/KoConstructorProviderListExt.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/api/ext/list/KoConstructorProviderListExt.kt
@@ -1,8 +1,6 @@
 package com.lemonappdev.konsist.api.ext.list
 
-import com.lemonappdev.konsist.api.declaration.KoAnnotationDeclaration
 import com.lemonappdev.konsist.api.declaration.KoConstructorDeclaration
-import com.lemonappdev.konsist.api.provider.KoAnnotationProvider
 import com.lemonappdev.konsist.api.provider.KoConstructorProvider
 
 /**

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/api/ext/list/KoConstructorProviderListExt.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/api/ext/list/KoConstructorProviderListExt.kt
@@ -1,6 +1,15 @@
 package com.lemonappdev.konsist.api.ext.list
 
+import com.lemonappdev.konsist.api.declaration.KoAnnotationDeclaration
+import com.lemonappdev.konsist.api.declaration.KoConstructorDeclaration
+import com.lemonappdev.konsist.api.provider.KoAnnotationProvider
 import com.lemonappdev.konsist.api.provider.KoConstructorProvider
+
+/**
+ * List containing constructor declarations.
+ */
+val <T : KoConstructorProvider> List<T>.constructors: List<KoConstructorDeclaration>
+    get() = flatMap { it.constructors }
 
 /**
  * List containing elements with constructor.

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/api/ext/list/KoContainingDeclarationProviderListExt.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/api/ext/list/KoContainingDeclarationProviderListExt.kt
@@ -1,0 +1,9 @@
+package com.lemonappdev.konsist.api.ext.list
+
+import com.lemonappdev.konsist.api.provider.KoContainingDeclarationProvider
+
+/**
+ * List of containing declarations for each element in the list.
+ */
+val <T : KoContainingDeclarationProvider> List<T>.containingDeclarations: List<KoContainingDeclarationProvider>
+    get() = mapNotNull { it.containingDeclaration }

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/api/ext/list/KoContainingFileProviderListExt.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/api/ext/list/KoContainingFileProviderListExt.kt
@@ -1,0 +1,10 @@
+package com.lemonappdev.konsist.api.ext.list
+
+import com.lemonappdev.konsist.api.declaration.KoFileDeclaration
+import com.lemonappdev.konsist.api.provider.KoContainingFileProvider
+
+/**
+ * List of containing files for each element in the list.
+ */
+val <T : KoContainingFileProvider> List<T>.containingFiles: List<KoFileDeclaration>
+    get() = map { it.containingFile }

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/api/ext/list/KoImportProviderListExt.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/api/ext/list/KoImportProviderListExt.kt
@@ -1,6 +1,15 @@
 package com.lemonappdev.konsist.api.ext.list
 
+import com.lemonappdev.konsist.api.declaration.KoConstructorDeclaration
+import com.lemonappdev.konsist.api.declaration.KoImportDeclaration
+import com.lemonappdev.konsist.api.provider.KoConstructorProvider
 import com.lemonappdev.konsist.api.provider.KoImportProvider
+
+/**
+ * List containing import declarations.
+ */
+val <T : KoImportProvider> List<T>.imports: List<KoImportDeclaration>
+    get() = flatMap { it.imports }
 
 /**
  * List containing elements with any import.

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/api/ext/list/KoImportProviderListExt.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/api/ext/list/KoImportProviderListExt.kt
@@ -1,8 +1,6 @@
 package com.lemonappdev.konsist.api.ext.list
 
-import com.lemonappdev.konsist.api.declaration.KoConstructorDeclaration
 import com.lemonappdev.konsist.api.declaration.KoImportDeclaration
-import com.lemonappdev.konsist.api.provider.KoConstructorProvider
 import com.lemonappdev.konsist.api.provider.KoImportProvider
 
 /**

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/api/ext/list/KoInitBlockProviderListExt.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/api/ext/list/KoInitBlockProviderListExt.kt
@@ -1,8 +1,6 @@
 package com.lemonappdev.konsist.api.ext.list
 
-import com.lemonappdev.konsist.api.declaration.KoImportDeclaration
 import com.lemonappdev.konsist.api.declaration.KoInitBlockDeclaration
-import com.lemonappdev.konsist.api.provider.KoImportProvider
 import com.lemonappdev.konsist.api.provider.KoInitBlockProvider
 
 /**

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/api/ext/list/KoInitBlockProviderListExt.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/api/ext/list/KoInitBlockProviderListExt.kt
@@ -1,6 +1,15 @@
 package com.lemonappdev.konsist.api.ext.list
 
+import com.lemonappdev.konsist.api.declaration.KoImportDeclaration
+import com.lemonappdev.konsist.api.declaration.KoInitBlockDeclaration
+import com.lemonappdev.konsist.api.provider.KoImportProvider
 import com.lemonappdev.konsist.api.provider.KoInitBlockProvider
+
+/**
+ * List containing init block declarations.
+ */
+val <T : KoInitBlockProvider> List<T>.initBlocks: List<KoInitBlockDeclaration>
+    get() = flatMap { it.initBlocks }
 
 /**
  * List containing elements that have init block(s).

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/api/ext/list/KoKDocProviderListExt.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/api/ext/list/KoKDocProviderListExt.kt
@@ -1,7 +1,14 @@
 package com.lemonappdev.konsist.api.ext.list
 
 import com.lemonappdev.konsist.api.KoKDocTag
+import com.lemonappdev.konsist.api.declaration.KoKDocDeclaration
 import com.lemonappdev.konsist.api.provider.KoKDocProvider
+
+/**
+ * List containing KDoc declarations.
+ */
+val <T : KoKDocProvider> List<T>.kDocs: List<KoKDocDeclaration>
+    get() = mapNotNull { it.kDoc }
 
 /**
  * List containing elements with KDoc.

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/api/ext/list/KoLocalClassProviderListExt.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/api/ext/list/KoLocalClassProviderListExt.kt
@@ -1,0 +1,12 @@
+package com.lemonappdev.konsist.api.ext.list
+
+import com.lemonappdev.konsist.api.declaration.KoClassDeclaration
+import com.lemonappdev.konsist.api.declaration.KoInitBlockDeclaration
+import com.lemonappdev.konsist.api.provider.KoInitBlockProvider
+import com.lemonappdev.konsist.api.provider.KoLocalClassProvider
+
+/**
+ * List containing local class declarations.
+ */
+val <T : KoLocalClassProvider> List<T>.localClasses: List<KoClassDeclaration>
+    get() = flatMap { it.localClasses }

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/api/ext/list/KoLocalClassProviderListExt.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/api/ext/list/KoLocalClassProviderListExt.kt
@@ -1,8 +1,6 @@
 package com.lemonappdev.konsist.api.ext.list
 
 import com.lemonappdev.konsist.api.declaration.KoClassDeclaration
-import com.lemonappdev.konsist.api.declaration.KoInitBlockDeclaration
-import com.lemonappdev.konsist.api.provider.KoInitBlockProvider
 import com.lemonappdev.konsist.api.provider.KoLocalClassProvider
 
 /**

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/api/ext/list/KoLocalDeclarationProviderListExt.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/api/ext/list/KoLocalDeclarationProviderListExt.kt
@@ -1,0 +1,14 @@
+package com.lemonappdev.konsist.api.ext.list
+
+import com.lemonappdev.konsist.api.declaration.KoBaseDeclaration
+import com.lemonappdev.konsist.api.declaration.KoClassDeclaration
+import com.lemonappdev.konsist.api.declaration.KoInitBlockDeclaration
+import com.lemonappdev.konsist.api.provider.KoInitBlockProvider
+import com.lemonappdev.konsist.api.provider.KoLocalClassProvider
+import com.lemonappdev.konsist.api.provider.KoLocalDeclarationProvider
+
+/**
+ * List containing local declarations.
+ */
+val <T : KoLocalDeclarationProvider> List<T>.localDeclarations: List<KoBaseDeclaration>
+    get() = flatMap { it.localDeclarations }

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/api/ext/list/KoLocalDeclarationProviderListExt.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/api/ext/list/KoLocalDeclarationProviderListExt.kt
@@ -1,10 +1,6 @@
 package com.lemonappdev.konsist.api.ext.list
 
 import com.lemonappdev.konsist.api.declaration.KoBaseDeclaration
-import com.lemonappdev.konsist.api.declaration.KoClassDeclaration
-import com.lemonappdev.konsist.api.declaration.KoInitBlockDeclaration
-import com.lemonappdev.konsist.api.provider.KoInitBlockProvider
-import com.lemonappdev.konsist.api.provider.KoLocalClassProvider
 import com.lemonappdev.konsist.api.provider.KoLocalDeclarationProvider
 
 /**

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/api/ext/list/KoLocalFunctionProviderListExt.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/api/ext/list/KoLocalFunctionProviderListExt.kt
@@ -1,0 +1,14 @@
+package com.lemonappdev.konsist.api.ext.list
+
+import com.lemonappdev.konsist.api.declaration.KoClassDeclaration
+import com.lemonappdev.konsist.api.declaration.KoFunctionDeclaration
+import com.lemonappdev.konsist.api.declaration.KoInitBlockDeclaration
+import com.lemonappdev.konsist.api.provider.KoInitBlockProvider
+import com.lemonappdev.konsist.api.provider.KoLocalClassProvider
+import com.lemonappdev.konsist.api.provider.KoLocalFunctionProvider
+
+/**
+ * List containing local function declarations.
+ */
+val <T : KoLocalFunctionProvider> List<T>.localFunctions: List<KoFunctionDeclaration>
+    get() = flatMap { it.localFunctions }

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/api/ext/list/KoLocalFunctionProviderListExt.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/api/ext/list/KoLocalFunctionProviderListExt.kt
@@ -1,10 +1,6 @@
 package com.lemonappdev.konsist.api.ext.list
 
-import com.lemonappdev.konsist.api.declaration.KoClassDeclaration
 import com.lemonappdev.konsist.api.declaration.KoFunctionDeclaration
-import com.lemonappdev.konsist.api.declaration.KoInitBlockDeclaration
-import com.lemonappdev.konsist.api.provider.KoInitBlockProvider
-import com.lemonappdev.konsist.api.provider.KoLocalClassProvider
 import com.lemonappdev.konsist.api.provider.KoLocalFunctionProvider
 
 /**

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/api/ext/list/KoPackageProviderListExt.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/api/ext/list/KoPackageProviderListExt.kt
@@ -1,0 +1,10 @@
+package com.lemonappdev.konsist.api.ext.list
+
+import com.lemonappdev.konsist.api.declaration.KoPackageDeclaration
+import com.lemonappdev.konsist.api.provider.KoPackageProvider
+
+/**
+ * List containing package declarations.
+ */
+val <T : KoPackageProvider> List<T>.packages: List<KoPackageDeclaration>
+    get() = mapNotNull { it.packagee }

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/api/ext/list/KoParametersProviderListExt.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/api/ext/list/KoParametersProviderListExt.kt
@@ -1,6 +1,15 @@
 package com.lemonappdev.konsist.api.ext.list
 
+import com.lemonappdev.konsist.api.declaration.KoImportDeclaration
+import com.lemonappdev.konsist.api.declaration.KoParameterDeclaration
+import com.lemonappdev.konsist.api.provider.KoImportProvider
 import com.lemonappdev.konsist.api.provider.KoParametersProvider
+
+/**
+ * List containing parameter declarations.
+ */
+val <T : KoParametersProvider> List<T>.parameters: List<KoParameterDeclaration>
+    get() = flatMap { it.parameters }
 
 /**
  * List containing elements with any parameter.

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/api/ext/list/KoParametersProviderListExt.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/api/ext/list/KoParametersProviderListExt.kt
@@ -1,8 +1,6 @@
 package com.lemonappdev.konsist.api.ext.list
 
-import com.lemonappdev.konsist.api.declaration.KoImportDeclaration
 import com.lemonappdev.konsist.api.declaration.KoParameterDeclaration
-import com.lemonappdev.konsist.api.provider.KoImportProvider
 import com.lemonappdev.konsist.api.provider.KoParametersProvider
 
 /**

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/api/ext/list/KoParentProviderListExt.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/api/ext/list/KoParentProviderListExt.kt
@@ -1,8 +1,6 @@
 package com.lemonappdev.konsist.api.ext.list
 
-import com.lemonappdev.konsist.api.declaration.KoParameterDeclaration
 import com.lemonappdev.konsist.api.declaration.KoParentDeclaration
-import com.lemonappdev.konsist.api.provider.KoParametersProvider
 import com.lemonappdev.konsist.api.provider.KoParentProvider
 import kotlin.reflect.KClass
 

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/api/ext/list/KoParentProviderListExt.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/api/ext/list/KoParentProviderListExt.kt
@@ -1,7 +1,16 @@
 package com.lemonappdev.konsist.api.ext.list
 
+import com.lemonappdev.konsist.api.declaration.KoParameterDeclaration
+import com.lemonappdev.konsist.api.declaration.KoParentDeclaration
+import com.lemonappdev.konsist.api.provider.KoParametersProvider
 import com.lemonappdev.konsist.api.provider.KoParentProvider
 import kotlin.reflect.KClass
+
+/**
+ * List containing parent declarations.
+ */
+val <T : KoParentProvider> List<T>.parents: List<KoParentDeclaration>
+    get() = flatMap { it.parents }
 
 /**
  * List containing elements with class or interface parent.

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/api/ext/list/KoPrimaryConstructorProviderListExt.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/api/ext/list/KoPrimaryConstructorProviderListExt.kt
@@ -1,6 +1,13 @@
 package com.lemonappdev.konsist.api.ext.list
 
+import com.lemonappdev.konsist.api.declaration.KoPrimaryConstructorDeclaration
 import com.lemonappdev.konsist.api.provider.KoPrimaryConstructorProvider
+
+/**
+ * List containing primary constructor declarations.
+ */
+val <T : KoPrimaryConstructorProvider> List<T>.primaryConstructors: List<KoPrimaryConstructorDeclaration>
+    get() = mapNotNull { it.primaryConstructor }
 
 /**
  * List containing elements that have primary constructor.

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/api/ext/list/KoPropertyTypeProviderListExt.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/api/ext/list/KoPropertyTypeProviderListExt.kt
@@ -1,7 +1,14 @@
 package com.lemonappdev.konsist.api.ext.list
 
+import com.lemonappdev.konsist.api.declaration.KoTypeDeclaration
 import com.lemonappdev.konsist.api.provider.KoPropertyTypeProvider
 import kotlin.reflect.KClass
+
+/**
+ * List containing type declarations.
+ */
+val <T : KoPropertyTypeProvider> List<T>.types: List<KoTypeDeclaration>
+    get() = mapNotNull { it.type }
 
 /**
  * List containing elements with type.

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/api/ext/list/KoReceiverTypeProviderListExt.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/api/ext/list/KoReceiverTypeProviderListExt.kt
@@ -1,7 +1,14 @@
 package com.lemonappdev.konsist.api.ext.list
 
+import com.lemonappdev.konsist.api.declaration.KoTypeDeclaration
 import com.lemonappdev.konsist.api.provider.KoReceiverTypeProvider
 import kotlin.reflect.KClass
+
+/**
+ * List containing receiver type declarations.
+ */
+val <T : KoReceiverTypeProvider> List<T>.receiverTypes: List<KoTypeDeclaration>
+    get() = mapNotNull { it.receiverType }
 
 /**
  * List containing elements with receiver type.

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/api/ext/list/KoReturnTypeProviderListExt.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/api/ext/list/KoReturnTypeProviderListExt.kt
@@ -1,7 +1,14 @@
 package com.lemonappdev.konsist.api.ext.list
 
+import com.lemonappdev.konsist.api.declaration.KoTypeDeclaration
 import com.lemonappdev.konsist.api.provider.KoReturnTypeProvider
 import kotlin.reflect.KClass
+
+/**
+ * List containing return type declarations.
+ */
+val <T : KoReturnTypeProvider> List<T>.returnTypes: List<KoTypeDeclaration>
+    get() = mapNotNull { it.returnType }
 
 /**
  * List containing elements with return type.

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/api/ext/list/KoSecondaryConstructorsProviderListExt.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/api/ext/list/KoSecondaryConstructorsProviderListExt.kt
@@ -1,6 +1,15 @@
 package com.lemonappdev.konsist.api.ext.list
 
+import com.lemonappdev.konsist.api.declaration.KoParentDeclaration
+import com.lemonappdev.konsist.api.declaration.KoSecondaryConstructorDeclaration
+import com.lemonappdev.konsist.api.provider.KoParentProvider
 import com.lemonappdev.konsist.api.provider.KoSecondaryConstructorsProvider
+
+/**
+ * List containing secondary constructor declarations.
+ */
+val <T : KoSecondaryConstructorsProvider> List<T>.secondaryConstructors: List<KoSecondaryConstructorDeclaration>
+    get() = flatMap { it.secondaryConstructors }
 
 /**
  * List containing elements that have secondary constructors.

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/api/ext/list/KoSecondaryConstructorsProviderListExt.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/api/ext/list/KoSecondaryConstructorsProviderListExt.kt
@@ -1,8 +1,6 @@
 package com.lemonappdev.konsist.api.ext.list
 
-import com.lemonappdev.konsist.api.declaration.KoParentDeclaration
 import com.lemonappdev.konsist.api.declaration.KoSecondaryConstructorDeclaration
-import com.lemonappdev.konsist.api.provider.KoParentProvider
 import com.lemonappdev.konsist.api.provider.KoSecondaryConstructorsProvider
 
 /**

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/api/ext/list/KoTypeAliasProviderListExt.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/api/ext/list/KoTypeAliasProviderListExt.kt
@@ -1,8 +1,6 @@
 package com.lemonappdev.konsist.api.ext.list
 
-import com.lemonappdev.konsist.api.declaration.KoSecondaryConstructorDeclaration
 import com.lemonappdev.konsist.api.declaration.KoTypeAliasDeclaration
-import com.lemonappdev.konsist.api.provider.KoSecondaryConstructorsProvider
 import com.lemonappdev.konsist.api.provider.KoTypeAliasProvider
 
 /**

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/api/ext/list/KoTypeAliasProviderListExt.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/api/ext/list/KoTypeAliasProviderListExt.kt
@@ -1,6 +1,15 @@
 package com.lemonappdev.konsist.api.ext.list
 
+import com.lemonappdev.konsist.api.declaration.KoSecondaryConstructorDeclaration
+import com.lemonappdev.konsist.api.declaration.KoTypeAliasDeclaration
+import com.lemonappdev.konsist.api.provider.KoSecondaryConstructorsProvider
 import com.lemonappdev.konsist.api.provider.KoTypeAliasProvider
+
+/**
+ * List containing type alias declarations.
+ */
+val <T : KoTypeAliasProvider> List<T>.typeAliases: List<KoTypeAliasDeclaration>
+    get() = flatMap { it.typeAliases }
 
 /**
  * List containing elements with any type alias.

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/api/ext/list/KoTypeProviderListExt.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/api/ext/list/KoTypeProviderListExt.kt
@@ -1,0 +1,10 @@
+package com.lemonappdev.konsist.api.ext.list
+
+import com.lemonappdev.konsist.api.declaration.KoTypeDeclaration
+import com.lemonappdev.konsist.api.provider.KoTypeProvider
+
+/**
+ * List containing type declarations.
+ */
+val <T : KoTypeProvider> List<T>.types: List<KoTypeDeclaration>
+    get() = map { it.type }

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/api/ext/list/modifierprovider/KoModifierProviderListExt.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/api/ext/list/modifierprovider/KoModifierProviderListExt.kt
@@ -3,8 +3,6 @@
 package com.lemonappdev.konsist.api.ext.list.modifierprovider
 
 import com.lemonappdev.konsist.api.KoModifier
-import com.lemonappdev.konsist.api.declaration.KoImportDeclaration
-import com.lemonappdev.konsist.api.provider.KoImportProvider
 import com.lemonappdev.konsist.api.provider.modifier.KoModifierProvider
 
 /**

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/api/ext/list/modifierprovider/KoModifierProviderListExt.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/api/ext/list/modifierprovider/KoModifierProviderListExt.kt
@@ -3,7 +3,15 @@
 package com.lemonappdev.konsist.api.ext.list.modifierprovider
 
 import com.lemonappdev.konsist.api.KoModifier
+import com.lemonappdev.konsist.api.declaration.KoImportDeclaration
+import com.lemonappdev.konsist.api.provider.KoImportProvider
 import com.lemonappdev.konsist.api.provider.modifier.KoModifierProvider
+
+/**
+ * List containing modifiers.
+ */
+val <T : KoModifierProvider> List<T>.modifiers: List<KoModifier>
+    get() = flatMap { it.modifiers }
 
 /**
  * List containing elements with any specified modifier.

--- a/lib/src/snippet/kotlin/com/lemonappdev/konsist/GeneralSnippets.kt
+++ b/lib/src/snippet/kotlin/com/lemonappdev/konsist/GeneralSnippets.kt
@@ -4,9 +4,11 @@ import com.lemonappdev.konsist.api.KoModifier
 import com.lemonappdev.konsist.api.Konsist
 import com.lemonappdev.konsist.api.declaration.KoFunctionDeclaration
 import com.lemonappdev.konsist.api.declaration.KoPropertyDeclaration
+import com.lemonappdev.konsist.api.ext.list.constructors
 import com.lemonappdev.konsist.api.ext.list.indexOfFirstInstance
 import com.lemonappdev.konsist.api.ext.list.indexOfLastInstance
 import com.lemonappdev.konsist.api.ext.list.modifierprovider.withValueModifier
+import com.lemonappdev.konsist.api.ext.list.parameters
 import com.lemonappdev.konsist.api.ext.list.properties
 import com.lemonappdev.konsist.api.ext.list.withPackage
 import com.lemonappdev.konsist.api.ext.provider.hasAnnotationOf
@@ -45,8 +47,8 @@ class GeneralSnippets {
         Konsist
             .scopeFromProject()
             .classes()
-            .flatMap { it.constructors }
-            .flatMap { it.parameters }
+            .constructors
+            .parameters
             .assert {
                 val nameTitleCase = it.name.replaceFirstChar { char -> char.titlecase(Locale.getDefault()) }
                 nameTitleCase == it.type.sourceType
@@ -57,7 +59,7 @@ class GeneralSnippets {
         Konsist
             .scopeFromProject()
             .classes()
-            .flatMap { it.constructors }
+            .constructors
             .assert {
                 val names = it.parameters.map { parameter -> parameter.name }
                 val sortedNames = names.sorted()

--- a/lib/src/snippet/kotlin/com/lemonappdev/konsist/GeneralSnippets.kt
+++ b/lib/src/snippet/kotlin/com/lemonappdev/konsist/GeneralSnippets.kt
@@ -9,6 +9,7 @@ import com.lemonappdev.konsist.api.ext.list.indexOfFirstInstance
 import com.lemonappdev.konsist.api.ext.list.indexOfLastInstance
 import com.lemonappdev.konsist.api.ext.list.modifierprovider.withValueModifier
 import com.lemonappdev.konsist.api.ext.list.parameters
+import com.lemonappdev.konsist.api.ext.list.primaryConstructors
 import com.lemonappdev.konsist.api.ext.list.properties
 import com.lemonappdev.konsist.api.ext.list.withPackage
 import com.lemonappdev.konsist.api.ext.provider.hasAnnotationOf
@@ -102,7 +103,7 @@ class GeneralSnippets {
             .scopeFromProject()
             .classes()
             .withValueModifier()
-            .mapNotNull { it.primaryConstructor }
+            .primaryConstructors
             .assert { it.hasParameterNamed("value") }
     }
 

--- a/lib/src/test/kotlin/com/lemonappdev/konsist/api/ext/list/KoAnnotationProviderListExtTest.kt
+++ b/lib/src/test/kotlin/com/lemonappdev/konsist/api/ext/list/KoAnnotationProviderListExtTest.kt
@@ -2,8 +2,6 @@ package com.lemonappdev.konsist.api.ext.list
 
 import com.lemonappdev.konsist.api.declaration.KoAnnotationDeclaration
 import com.lemonappdev.konsist.api.provider.KoAnnotationProvider
-import com.lemonappdev.konsist.api.provider.KoClassProvider
-import com.lemonappdev.konsist.core.declaration.KoClassDeclarationCore
 import com.lemonappdev.konsist.testdata.SampleAnnotation1
 import com.lemonappdev.konsist.testdata.SampleAnnotation2
 import io.mockk.every

--- a/lib/src/test/kotlin/com/lemonappdev/konsist/api/ext/list/KoAnnotationProviderListExtTest.kt
+++ b/lib/src/test/kotlin/com/lemonappdev/konsist/api/ext/list/KoAnnotationProviderListExtTest.kt
@@ -1,6 +1,9 @@
 package com.lemonappdev.konsist.api.ext.list
 
+import com.lemonappdev.konsist.api.declaration.KoAnnotationDeclaration
 import com.lemonappdev.konsist.api.provider.KoAnnotationProvider
+import com.lemonappdev.konsist.api.provider.KoClassProvider
+import com.lemonappdev.konsist.core.declaration.KoClassDeclarationCore
 import com.lemonappdev.konsist.testdata.SampleAnnotation1
 import com.lemonappdev.konsist.testdata.SampleAnnotation2
 import io.mockk.every
@@ -9,6 +12,30 @@ import org.amshove.kluent.shouldBeEqualTo
 import org.junit.jupiter.api.Test
 
 class KoAnnotationProviderListExtTest {
+    @Test
+    fun `annotations returns annotations from all declarations`() {
+        // given
+        val annotation1: KoAnnotationDeclaration = mockk()
+        val annotation2: KoAnnotationDeclaration = mockk()
+        val annotation3: KoAnnotationDeclaration = mockk()
+        val declaration1: KoAnnotationProvider = mockk {
+            every { annotations } returns listOf(annotation1, annotation2)
+        }
+        val declaration2: KoAnnotationProvider = mockk {
+            every { annotations } returns listOf(annotation3)
+        }
+        val declaration3: KoAnnotationProvider = mockk {
+            every { annotations } returns emptyList()
+        }
+        val declarations = listOf(declaration1, declaration2, declaration3)
+
+        // when
+        val sut = declarations.annotations
+
+        // then
+        sut shouldBeEqualTo listOf(annotation1, annotation2, annotation3)
+    }
+
     @Test
     fun `withAnnotations() returns declaration with any annotation`() {
         // given

--- a/lib/src/test/kotlin/com/lemonappdev/konsist/api/ext/list/KoConstructorProviderListExtTest.kt
+++ b/lib/src/test/kotlin/com/lemonappdev/konsist/api/ext/list/KoConstructorProviderListExtTest.kt
@@ -1,5 +1,7 @@
 package com.lemonappdev.konsist.api.ext.list
 
+import com.lemonappdev.konsist.api.declaration.KoConstructorDeclaration
+import com.lemonappdev.konsist.api.provider.KoAnnotationProvider
 import com.lemonappdev.konsist.api.provider.KoConstructorProvider
 import io.mockk.every
 import io.mockk.mockk
@@ -7,6 +9,30 @@ import org.amshove.kluent.shouldBeEqualTo
 import org.junit.jupiter.api.Test
 
 class KoConstructorProviderListExtTest {
+    @Test
+    fun `constructors returns constructors from all declarations`() {
+        // given
+        val constructor1: KoConstructorDeclaration = mockk()
+        val constructor2: KoConstructorDeclaration = mockk()
+        val constructor3: KoConstructorDeclaration = mockk()
+        val declaration1: KoConstructorProvider = mockk {
+            every { constructors } returns listOf(constructor1, constructor2)
+        }
+        val declaration2: KoConstructorProvider = mockk {
+            every { constructors } returns listOf(constructor3)
+        }
+        val declaration3: KoConstructorProvider = mockk {
+            every { constructors } returns emptyList()
+        }
+        val declarations = listOf(declaration1, declaration2, declaration3)
+
+        // when
+        val sut = declarations.constructors
+
+        // then
+        sut shouldBeEqualTo listOf(constructor1, constructor2, constructor3)
+    }
+
     @Test
     fun `withConstructor() returns declaration with constructor`() {
         // given

--- a/lib/src/test/kotlin/com/lemonappdev/konsist/api/ext/list/KoConstructorProviderListExtTest.kt
+++ b/lib/src/test/kotlin/com/lemonappdev/konsist/api/ext/list/KoConstructorProviderListExtTest.kt
@@ -1,7 +1,6 @@
 package com.lemonappdev.konsist.api.ext.list
 
 import com.lemonappdev.konsist.api.declaration.KoConstructorDeclaration
-import com.lemonappdev.konsist.api.provider.KoAnnotationProvider
 import com.lemonappdev.konsist.api.provider.KoConstructorProvider
 import io.mockk.every
 import io.mockk.mockk

--- a/lib/src/test/kotlin/com/lemonappdev/konsist/api/ext/list/KoContainingDeclarationProviderListExtTest.kt
+++ b/lib/src/test/kotlin/com/lemonappdev/konsist/api/ext/list/KoContainingDeclarationProviderListExtTest.kt
@@ -1,0 +1,34 @@
+package com.lemonappdev.konsist.api.ext.list
+
+import com.lemonappdev.konsist.api.declaration.KoClassDeclaration
+import com.lemonappdev.konsist.api.declaration.KoInterfaceDeclaration
+import com.lemonappdev.konsist.api.provider.KoContainingDeclarationProvider
+import io.mockk.every
+import io.mockk.mockk
+import org.amshove.kluent.shouldBeEqualTo
+import org.junit.jupiter.api.Test
+
+class KoContainingDeclarationProviderListExtTest {
+    @Test
+    fun `containingDeclarations returns containing declarations from all declarations`() {
+        // given
+        val containingDeclaration1: KoClassDeclaration = mockk()
+        val containingDeclaration2: KoInterfaceDeclaration = mockk()
+        val declaration1: KoContainingDeclarationProvider = mockk {
+            every { containingDeclaration } returns containingDeclaration1
+        }
+        val declaration2: KoContainingDeclarationProvider = mockk {
+            every { containingDeclaration } returns containingDeclaration2
+        }
+        val declaration3: KoContainingDeclarationProvider = mockk {
+            every { containingDeclaration } returns null
+        }
+        val declarations = listOf(declaration1, declaration2, declaration3)
+
+        // when
+        val sut = declarations.containingDeclarations
+
+        // then
+        sut shouldBeEqualTo listOf(containingDeclaration1, containingDeclaration2)
+    }
+}

--- a/lib/src/test/kotlin/com/lemonappdev/konsist/api/ext/list/KoContainingFileProviderListExtTest.kt
+++ b/lib/src/test/kotlin/com/lemonappdev/konsist/api/ext/list/KoContainingFileProviderListExtTest.kt
@@ -1,0 +1,30 @@
+package com.lemonappdev.konsist.api.ext.list
+
+import com.lemonappdev.konsist.api.declaration.KoFileDeclaration
+import com.lemonappdev.konsist.api.provider.KoContainingFileProvider
+import io.mockk.every
+import io.mockk.mockk
+import org.amshove.kluent.shouldBeEqualTo
+import org.junit.jupiter.api.Test
+
+class KoContainingFileProviderListExtTest {
+    @Test
+    fun `containingFiles returns containing files from all declarations`() {
+        // given
+        val containingFile1: KoFileDeclaration = mockk()
+        val containingFile2: KoFileDeclaration = mockk()
+        val declaration1: KoContainingFileProvider = mockk {
+            every { containingFile } returns containingFile1
+        }
+        val declaration2: KoContainingFileProvider = mockk {
+            every { containingFile } returns containingFile2
+        }
+        val declarations = listOf(declaration1, declaration2)
+
+        // when
+        val sut = declarations.containingFiles
+
+        // then
+        sut shouldBeEqualTo listOf(containingFile1, containingFile2)
+    }
+}

--- a/lib/src/test/kotlin/com/lemonappdev/konsist/api/ext/list/KoImportProviderListExtTest.kt
+++ b/lib/src/test/kotlin/com/lemonappdev/konsist/api/ext/list/KoImportProviderListExtTest.kt
@@ -1,5 +1,8 @@
 package com.lemonappdev.konsist.api.ext.list
 
+import com.lemonappdev.konsist.api.declaration.KoConstructorDeclaration
+import com.lemonappdev.konsist.api.declaration.KoImportDeclaration
+import com.lemonappdev.konsist.api.provider.KoConstructorProvider
 import com.lemonappdev.konsist.api.provider.KoImportProvider
 import io.mockk.every
 import io.mockk.mockk
@@ -8,6 +11,30 @@ import org.junit.jupiter.api.Test
 
 @Suppress("detekt.LargeClass")
 class KoImportProviderListExtTest {
+    @Test
+    fun `imports returns imports from all declarations`() {
+        // given
+        val import1: KoImportDeclaration = mockk()
+        val import2: KoImportDeclaration = mockk()
+        val import3: KoImportDeclaration = mockk()
+        val declaration1: KoImportProvider = mockk {
+            every { imports } returns listOf(import1, import2)
+        }
+        val declaration2: KoImportProvider = mockk {
+            every { imports } returns listOf(import3)
+        }
+        val declaration3: KoImportProvider = mockk {
+            every { imports } returns emptyList()
+        }
+        val declarations = listOf(declaration1, declaration2, declaration3)
+
+        // when
+        val sut = declarations.imports
+
+        // then
+        sut shouldBeEqualTo listOf(import1, import2, import3)
+    }
+
     @Test
     fun `withImports() returns declaration with any import`() {
         // given

--- a/lib/src/test/kotlin/com/lemonappdev/konsist/api/ext/list/KoImportProviderListExtTest.kt
+++ b/lib/src/test/kotlin/com/lemonappdev/konsist/api/ext/list/KoImportProviderListExtTest.kt
@@ -1,8 +1,6 @@
 package com.lemonappdev.konsist.api.ext.list
 
-import com.lemonappdev.konsist.api.declaration.KoConstructorDeclaration
 import com.lemonappdev.konsist.api.declaration.KoImportDeclaration
-import com.lemonappdev.konsist.api.provider.KoConstructorProvider
 import com.lemonappdev.konsist.api.provider.KoImportProvider
 import io.mockk.every
 import io.mockk.mockk

--- a/lib/src/test/kotlin/com/lemonappdev/konsist/api/ext/list/KoInitBlockProviderListExtTest.kt
+++ b/lib/src/test/kotlin/com/lemonappdev/konsist/api/ext/list/KoInitBlockProviderListExtTest.kt
@@ -1,5 +1,8 @@
 package com.lemonappdev.konsist.api.ext.list
 
+import com.lemonappdev.konsist.api.declaration.KoImportDeclaration
+import com.lemonappdev.konsist.api.declaration.KoInitBlockDeclaration
+import com.lemonappdev.konsist.api.provider.KoImportProvider
 import com.lemonappdev.konsist.api.provider.KoInitBlockProvider
 import io.mockk.every
 import io.mockk.mockk
@@ -8,6 +11,30 @@ import org.junit.jupiter.api.Test
 
 @Suppress("detekt.LargeClass")
 class KoInitBlockProviderListExtTest {
+    @Test
+    fun `initBlocks returns init blocks from all declarations`() {
+        // given
+        val initBlock1: KoInitBlockDeclaration = mockk()
+        val initBlock2: KoInitBlockDeclaration = mockk()
+        val initBlock3: KoInitBlockDeclaration = mockk()
+        val declaration1: KoInitBlockProvider = mockk {
+            every { initBlocks } returns listOf(initBlock1, initBlock2)
+        }
+        val declaration2: KoInitBlockProvider = mockk {
+            every { initBlocks } returns listOf(initBlock3)
+        }
+        val declaration3: KoInitBlockProvider = mockk {
+            every { initBlocks } returns emptyList()
+        }
+        val declarations = listOf(declaration1, declaration2, declaration3)
+
+        // when
+        val sut = declarations.initBlocks
+
+        // then
+        sut shouldBeEqualTo listOf(initBlock1, initBlock2, initBlock3)
+    }
+
     @Test
     fun `withInitBlocks() returns declaration with init blocks`() {
         // given

--- a/lib/src/test/kotlin/com/lemonappdev/konsist/api/ext/list/KoInitBlockProviderListExtTest.kt
+++ b/lib/src/test/kotlin/com/lemonappdev/konsist/api/ext/list/KoInitBlockProviderListExtTest.kt
@@ -1,8 +1,6 @@
 package com.lemonappdev.konsist.api.ext.list
 
-import com.lemonappdev.konsist.api.declaration.KoImportDeclaration
 import com.lemonappdev.konsist.api.declaration.KoInitBlockDeclaration
-import com.lemonappdev.konsist.api.provider.KoImportProvider
 import com.lemonappdev.konsist.api.provider.KoInitBlockProvider
 import io.mockk.every
 import io.mockk.mockk

--- a/lib/src/test/kotlin/com/lemonappdev/konsist/api/ext/list/KoKDocProviderListExtTest.kt
+++ b/lib/src/test/kotlin/com/lemonappdev/konsist/api/ext/list/KoKDocProviderListExtTest.kt
@@ -1,6 +1,7 @@
 package com.lemonappdev.konsist.api.ext.list
 
 import com.lemonappdev.konsist.api.KoKDocTag
+import com.lemonappdev.konsist.api.declaration.KoKDocDeclaration
 import com.lemonappdev.konsist.api.provider.KoKDocProvider
 import com.lemonappdev.konsist.core.declaration.KoKDocDeclarationCore
 import io.mockk.every
@@ -9,6 +10,29 @@ import org.amshove.kluent.shouldBeEqualTo
 import org.junit.jupiter.api.Test
 
 class KoKDocProviderListExtTest {
+    @Test
+    fun `kDocs returns kDocs from all declarations`() {
+        // given
+        val kDoc1: KoKDocDeclaration = mockk()
+        val kDoc2: KoKDocDeclaration = mockk()
+        val declaration1: KoKDocProvider = mockk {
+            every { kDoc } returns kDoc1
+        }
+        val declaration2: KoKDocProvider = mockk {
+            every { kDoc } returns kDoc2
+        }
+        val declaration3: KoKDocProvider = mockk {
+            every { kDoc } returns null
+        }
+        val declarations = listOf(declaration1, declaration2, declaration3)
+
+        // when
+        val sut = declarations.kDocs
+
+        // then
+        sut shouldBeEqualTo listOf(kDoc1, kDoc2)
+    }
+
     @Test
     fun `withKDoc() returns declaration with any kDoc`() {
         // given

--- a/lib/src/test/kotlin/com/lemonappdev/konsist/api/ext/list/KoLocalClassProviderListExtTest.kt
+++ b/lib/src/test/kotlin/com/lemonappdev/konsist/api/ext/list/KoLocalClassProviderListExtTest.kt
@@ -1,0 +1,36 @@
+package com.lemonappdev.konsist.api.ext.list
+
+import com.lemonappdev.konsist.api.declaration.KoClassDeclaration
+import com.lemonappdev.konsist.api.declaration.KoInitBlockDeclaration
+import com.lemonappdev.konsist.api.provider.KoInitBlockProvider
+import com.lemonappdev.konsist.api.provider.KoLocalClassProvider
+import io.mockk.every
+import io.mockk.mockk
+import org.amshove.kluent.shouldBeEqualTo
+import org.junit.jupiter.api.Test
+
+class KoLocalClassProviderListExtTest {
+    @Test
+    fun `localClasses returns local classes from all declarations`() {
+        // given
+        val localClass1: KoClassDeclaration = mockk()
+        val localClass2: KoClassDeclaration = mockk()
+        val localClass3: KoClassDeclaration = mockk()
+        val declaration1: KoLocalClassProvider = mockk {
+            every { localClasses } returns listOf(localClass1, localClass2)
+        }
+        val declaration2: KoLocalClassProvider = mockk {
+            every { localClasses } returns listOf(localClass3)
+        }
+        val declaration3: KoLocalClassProvider = mockk {
+            every { localClasses } returns emptyList()
+        }
+        val declarations = listOf(declaration1, declaration2, declaration3)
+
+        // when
+        val sut = declarations.localClasses
+
+        // then
+        sut shouldBeEqualTo listOf(localClass1, localClass2, localClass3)
+    }
+}

--- a/lib/src/test/kotlin/com/lemonappdev/konsist/api/ext/list/KoLocalClassProviderListExtTest.kt
+++ b/lib/src/test/kotlin/com/lemonappdev/konsist/api/ext/list/KoLocalClassProviderListExtTest.kt
@@ -1,8 +1,6 @@
 package com.lemonappdev.konsist.api.ext.list
 
 import com.lemonappdev.konsist.api.declaration.KoClassDeclaration
-import com.lemonappdev.konsist.api.declaration.KoInitBlockDeclaration
-import com.lemonappdev.konsist.api.provider.KoInitBlockProvider
 import com.lemonappdev.konsist.api.provider.KoLocalClassProvider
 import io.mockk.every
 import io.mockk.mockk

--- a/lib/src/test/kotlin/com/lemonappdev/konsist/api/ext/list/KoLocalDeclarationProviderListExtTest.kt
+++ b/lib/src/test/kotlin/com/lemonappdev/konsist/api/ext/list/KoLocalDeclarationProviderListExtTest.kt
@@ -1,10 +1,6 @@
 package com.lemonappdev.konsist.api.ext.list
 
 import com.lemonappdev.konsist.api.declaration.KoBaseDeclaration
-import com.lemonappdev.konsist.api.declaration.KoClassDeclaration
-import com.lemonappdev.konsist.api.declaration.KoInitBlockDeclaration
-import com.lemonappdev.konsist.api.provider.KoInitBlockProvider
-import com.lemonappdev.konsist.api.provider.KoLocalClassProvider
 import com.lemonappdev.konsist.api.provider.KoLocalDeclarationProvider
 import io.mockk.every
 import io.mockk.mockk

--- a/lib/src/test/kotlin/com/lemonappdev/konsist/api/ext/list/KoLocalDeclarationProviderListExtTest.kt
+++ b/lib/src/test/kotlin/com/lemonappdev/konsist/api/ext/list/KoLocalDeclarationProviderListExtTest.kt
@@ -1,0 +1,38 @@
+package com.lemonappdev.konsist.api.ext.list
+
+import com.lemonappdev.konsist.api.declaration.KoBaseDeclaration
+import com.lemonappdev.konsist.api.declaration.KoClassDeclaration
+import com.lemonappdev.konsist.api.declaration.KoInitBlockDeclaration
+import com.lemonappdev.konsist.api.provider.KoInitBlockProvider
+import com.lemonappdev.konsist.api.provider.KoLocalClassProvider
+import com.lemonappdev.konsist.api.provider.KoLocalDeclarationProvider
+import io.mockk.every
+import io.mockk.mockk
+import org.amshove.kluent.shouldBeEqualTo
+import org.junit.jupiter.api.Test
+
+class KoLocalDeclarationProviderListExtTest {
+    @Test
+    fun `localDeclarations returns local declarations from all declarations`() {
+        // given
+        val localDeclaration1: KoBaseDeclaration = mockk()
+        val localDeclaration2: KoBaseDeclaration = mockk()
+        val localDeclaration3: KoBaseDeclaration = mockk()
+        val declaration1: KoLocalDeclarationProvider = mockk {
+            every { localDeclarations } returns listOf(localDeclaration1, localDeclaration2)
+        }
+        val declaration2: KoLocalDeclarationProvider = mockk {
+            every { localDeclarations } returns listOf(localDeclaration3)
+        }
+        val declaration3: KoLocalDeclarationProvider = mockk {
+            every { localDeclarations } returns emptyList()
+        }
+        val declarations = listOf(declaration1, declaration2, declaration3)
+
+        // when
+        val sut = declarations.localDeclarations
+
+        // then
+        sut shouldBeEqualTo listOf(localDeclaration1, localDeclaration2, localDeclaration3)
+    }
+}

--- a/lib/src/test/kotlin/com/lemonappdev/konsist/api/ext/list/KoLocalFunctionProviderListExtTest.kt
+++ b/lib/src/test/kotlin/com/lemonappdev/konsist/api/ext/list/KoLocalFunctionProviderListExtTest.kt
@@ -1,0 +1,40 @@
+package com.lemonappdev.konsist.api.ext.list
+
+import com.lemonappdev.konsist.api.declaration.KoBaseDeclaration
+import com.lemonappdev.konsist.api.declaration.KoClassDeclaration
+import com.lemonappdev.konsist.api.declaration.KoFunctionDeclaration
+import com.lemonappdev.konsist.api.declaration.KoInitBlockDeclaration
+import com.lemonappdev.konsist.api.provider.KoInitBlockProvider
+import com.lemonappdev.konsist.api.provider.KoLocalClassProvider
+import com.lemonappdev.konsist.api.provider.KoLocalDeclarationProvider
+import com.lemonappdev.konsist.api.provider.KoLocalFunctionProvider
+import io.mockk.every
+import io.mockk.mockk
+import org.amshove.kluent.shouldBeEqualTo
+import org.junit.jupiter.api.Test
+
+class KoLocalFunctionProviderListExtTest {
+    @Test
+    fun `localFunctions returns local declarations from all declarations`() {
+        // given
+        val localFunction1: KoFunctionDeclaration = mockk()
+        val localFunction2: KoFunctionDeclaration = mockk()
+        val localFunction3: KoFunctionDeclaration = mockk()
+        val declaration1: KoLocalFunctionProvider = mockk {
+            every { localFunctions } returns listOf(localFunction1, localFunction2)
+        }
+        val declaration2: KoLocalFunctionProvider = mockk {
+            every { localFunctions } returns listOf(localFunction3)
+        }
+        val declaration3: KoLocalFunctionProvider = mockk {
+            every { localFunctions } returns emptyList()
+        }
+        val declarations = listOf(declaration1, declaration2, declaration3)
+
+        // when
+        val sut = declarations.localFunctions
+
+        // then
+        sut shouldBeEqualTo listOf(localFunction1, localFunction2, localFunction3)
+    }
+}

--- a/lib/src/test/kotlin/com/lemonappdev/konsist/api/ext/list/KoLocalFunctionProviderListExtTest.kt
+++ b/lib/src/test/kotlin/com/lemonappdev/konsist/api/ext/list/KoLocalFunctionProviderListExtTest.kt
@@ -1,12 +1,6 @@
 package com.lemonappdev.konsist.api.ext.list
 
-import com.lemonappdev.konsist.api.declaration.KoBaseDeclaration
-import com.lemonappdev.konsist.api.declaration.KoClassDeclaration
 import com.lemonappdev.konsist.api.declaration.KoFunctionDeclaration
-import com.lemonappdev.konsist.api.declaration.KoInitBlockDeclaration
-import com.lemonappdev.konsist.api.provider.KoInitBlockProvider
-import com.lemonappdev.konsist.api.provider.KoLocalClassProvider
-import com.lemonappdev.konsist.api.provider.KoLocalDeclarationProvider
 import com.lemonappdev.konsist.api.provider.KoLocalFunctionProvider
 import io.mockk.every
 import io.mockk.mockk

--- a/lib/src/test/kotlin/com/lemonappdev/konsist/api/ext/list/KoPackageProviderListExtTest.kt
+++ b/lib/src/test/kotlin/com/lemonappdev/konsist/api/ext/list/KoPackageProviderListExtTest.kt
@@ -1,0 +1,33 @@
+package com.lemonappdev.konsist.api.ext.list
+
+import com.lemonappdev.konsist.api.declaration.KoPackageDeclaration
+import com.lemonappdev.konsist.api.provider.KoPackageProvider
+import io.mockk.every
+import io.mockk.mockk
+import org.amshove.kluent.shouldBeEqualTo
+import org.junit.jupiter.api.Test
+
+class KoPackageProviderListExtTest {
+    @Test
+    fun `packages returns packages from all declarations`() {
+        // given
+        val packagee1: KoPackageDeclaration = mockk()
+        val packagee2: KoPackageDeclaration = mockk()
+        val declaration1: KoPackageProvider = mockk {
+            every { packagee } returns packagee1
+        }
+        val declaration2: KoPackageProvider = mockk {
+            every { packagee } returns packagee2
+        }
+        val declaration3: KoPackageProvider = mockk {
+            every { packagee } returns null
+        }
+        val declarations = listOf(declaration1, declaration2, declaration3)
+
+        // when
+        val sut = declarations.packages
+
+        // then
+        sut shouldBeEqualTo listOf(packagee1, packagee2)
+    }
+}

--- a/lib/src/test/kotlin/com/lemonappdev/konsist/api/ext/list/KoParametersProviderListExtTest.kt
+++ b/lib/src/test/kotlin/com/lemonappdev/konsist/api/ext/list/KoParametersProviderListExtTest.kt
@@ -1,7 +1,6 @@
 package com.lemonappdev.konsist.api.ext.list
 
 import com.lemonappdev.konsist.api.declaration.KoParameterDeclaration
-import com.lemonappdev.konsist.api.provider.KoImportProvider
 import com.lemonappdev.konsist.api.provider.KoParametersProvider
 import io.mockk.every
 import io.mockk.mockk

--- a/lib/src/test/kotlin/com/lemonappdev/konsist/api/ext/list/KoParametersProviderListExtTest.kt
+++ b/lib/src/test/kotlin/com/lemonappdev/konsist/api/ext/list/KoParametersProviderListExtTest.kt
@@ -1,6 +1,7 @@
 package com.lemonappdev.konsist.api.ext.list
 
 import com.lemonappdev.konsist.api.declaration.KoParameterDeclaration
+import com.lemonappdev.konsist.api.provider.KoImportProvider
 import com.lemonappdev.konsist.api.provider.KoParametersProvider
 import io.mockk.every
 import io.mockk.mockk
@@ -8,6 +9,30 @@ import org.amshove.kluent.shouldBeEqualTo
 import org.junit.jupiter.api.Test
 
 class KoParametersProviderListExtTest {
+    @Test
+    fun `parameters returns parameters from all declarations`() {
+        // given
+        val parameter1: KoParameterDeclaration = mockk()
+        val parameter2: KoParameterDeclaration = mockk()
+        val parameter3: KoParameterDeclaration = mockk()
+        val declaration1: KoParametersProvider = mockk {
+            every { parameters } returns listOf(parameter1, parameter2)
+        }
+        val declaration2: KoParametersProvider = mockk {
+            every { parameters } returns listOf(parameter3)
+        }
+        val declaration3: KoParametersProvider = mockk {
+            every { parameters } returns emptyList()
+        }
+        val declarations = listOf(declaration1, declaration2, declaration3)
+
+        // when
+        val sut = declarations.parameters
+
+        // then
+        sut shouldBeEqualTo listOf(parameter1, parameter2, parameter3)
+    }
+
     @Test
     fun `withParameters() returns declaration with any parameter`() {
         // given

--- a/lib/src/test/kotlin/com/lemonappdev/konsist/api/ext/list/KoParentProviderListExtTest.kt
+++ b/lib/src/test/kotlin/com/lemonappdev/konsist/api/ext/list/KoParentProviderListExtTest.kt
@@ -1,6 +1,8 @@
 package com.lemonappdev.konsist.api.ext.list
 
+import com.lemonappdev.konsist.api.declaration.KoParameterDeclaration
 import com.lemonappdev.konsist.api.declaration.KoParentDeclaration
+import com.lemonappdev.konsist.api.provider.KoParametersProvider
 import com.lemonappdev.konsist.api.provider.KoParentProvider
 import com.lemonappdev.konsist.testdata.SampleClass
 import com.lemonappdev.konsist.testdata.SampleInterface
@@ -11,6 +13,30 @@ import org.junit.jupiter.api.Test
 
 @Suppress("detekt.LargeClass")
 class KoParentProviderListExtTest {
+    @Test
+    fun `parents returns parents from all declarations`() {
+        // given
+        val parent1: KoParentDeclaration = mockk()
+        val parent2: KoParentDeclaration = mockk()
+        val parent3: KoParentDeclaration = mockk()
+        val declaration1: KoParentProvider = mockk {
+            every { parents } returns listOf(parent1, parent2)
+        }
+        val declaration2: KoParentProvider = mockk {
+            every { parents } returns listOf(parent3)
+        }
+        val declaration3: KoParentProvider = mockk {
+            every { parents } returns emptyList()
+        }
+        val declarations = listOf(declaration1, declaration2, declaration3)
+
+        // when
+        val sut = declarations.parents
+
+        // then
+        sut shouldBeEqualTo listOf(parent1, parent2, parent3)
+    }
+
     @Test
     fun `withParents() returns declaration with any parent`() {
         // given

--- a/lib/src/test/kotlin/com/lemonappdev/konsist/api/ext/list/KoParentProviderListExtTest.kt
+++ b/lib/src/test/kotlin/com/lemonappdev/konsist/api/ext/list/KoParentProviderListExtTest.kt
@@ -1,8 +1,6 @@
 package com.lemonappdev.konsist.api.ext.list
 
-import com.lemonappdev.konsist.api.declaration.KoParameterDeclaration
 import com.lemonappdev.konsist.api.declaration.KoParentDeclaration
-import com.lemonappdev.konsist.api.provider.KoParametersProvider
 import com.lemonappdev.konsist.api.provider.KoParentProvider
 import com.lemonappdev.konsist.testdata.SampleClass
 import com.lemonappdev.konsist.testdata.SampleInterface

--- a/lib/src/test/kotlin/com/lemonappdev/konsist/api/ext/list/KoPrimaryConstructorProviderListExtTest.kt
+++ b/lib/src/test/kotlin/com/lemonappdev/konsist/api/ext/list/KoPrimaryConstructorProviderListExtTest.kt
@@ -1,5 +1,6 @@
 package com.lemonappdev.konsist.api.ext.list
 
+import com.lemonappdev.konsist.api.declaration.KoPrimaryConstructorDeclaration
 import com.lemonappdev.konsist.api.provider.KoPrimaryConstructorProvider
 import io.mockk.every
 import io.mockk.mockk
@@ -7,6 +8,29 @@ import org.amshove.kluent.shouldBeEqualTo
 import org.junit.jupiter.api.Test
 
 class KoPrimaryConstructorProviderListExtTest {
+    @Test
+    fun `primaryConstructors returns primary constructors from all declarations`() {
+        // given
+        val primaryConstructor1: KoPrimaryConstructorDeclaration = mockk()
+        val primaryConstructor2: KoPrimaryConstructorDeclaration = mockk()
+        val declaration1: KoPrimaryConstructorProvider = mockk {
+            every { primaryConstructor } returns primaryConstructor1
+        }
+        val declaration2: KoPrimaryConstructorProvider = mockk {
+            every { primaryConstructor } returns primaryConstructor2
+        }
+        val declaration3: KoPrimaryConstructorProvider = mockk {
+            every { primaryConstructor } returns null
+        }
+        val declarations = listOf(declaration1, declaration2, declaration3)
+
+        // when
+        val sut = declarations.primaryConstructors
+
+        // then
+        sut shouldBeEqualTo listOf(primaryConstructor1, primaryConstructor2)
+    }
+
     @Test
     fun `withPrimaryConstructor() returns declaration with primary constructor`() {
         // given

--- a/lib/src/test/kotlin/com/lemonappdev/konsist/api/ext/list/KoPropertyTypeProviderListExtTest.kt
+++ b/lib/src/test/kotlin/com/lemonappdev/konsist/api/ext/list/KoPropertyTypeProviderListExtTest.kt
@@ -1,5 +1,6 @@
 package com.lemonappdev.konsist.api.ext.list
 
+import com.lemonappdev.konsist.api.declaration.KoTypeDeclaration
 import com.lemonappdev.konsist.api.provider.KoPropertyTypeProvider
 import com.lemonappdev.konsist.testdata.SampleType1
 import com.lemonappdev.konsist.testdata.SampleType2
@@ -9,6 +10,29 @@ import org.amshove.kluent.shouldBeEqualTo
 import org.junit.jupiter.api.Test
 
 class KoPropertyTypeProviderListExtTest {
+    @Test
+    fun `types returns types from all declarations`() {
+        // given
+        val type1: KoTypeDeclaration = mockk()
+        val type2: KoTypeDeclaration = mockk()
+        val declaration1: KoPropertyTypeProvider = mockk {
+            every { type } returns type1
+        }
+        val declaration2: KoPropertyTypeProvider = mockk {
+            every { type } returns type2
+        }
+        val declaration3: KoPropertyTypeProvider = mockk {
+            every { type } returns null
+        }
+        val declarations = listOf(declaration1, declaration2, declaration3)
+
+        // when
+        val sut = declarations.types
+
+        // then
+        sut shouldBeEqualTo listOf(type1, type2)
+    }
+
     @Test
     fun `withType() returns declaration with any type`() {
         // given

--- a/lib/src/test/kotlin/com/lemonappdev/konsist/api/ext/list/KoReceiverTypeProviderListExtTest.kt
+++ b/lib/src/test/kotlin/com/lemonappdev/konsist/api/ext/list/KoReceiverTypeProviderListExtTest.kt
@@ -1,5 +1,6 @@
 package com.lemonappdev.konsist.api.ext.list
 
+import com.lemonappdev.konsist.api.declaration.KoTypeDeclaration
 import com.lemonappdev.konsist.api.provider.KoReceiverTypeProvider
 import com.lemonappdev.konsist.testdata.SampleType1
 import com.lemonappdev.konsist.testdata.SampleType2
@@ -9,6 +10,29 @@ import org.amshove.kluent.shouldBeEqualTo
 import org.junit.jupiter.api.Test
 
 class KoReceiverTypeProviderListExtTest {
+    @Test
+    fun `receiverTypes returns receiver types from all declarations`() {
+        // given
+        val receiverType1: KoTypeDeclaration = mockk()
+        val receiverType2: KoTypeDeclaration = mockk()
+        val declaration1: KoReceiverTypeProvider = mockk {
+            every { receiverType } returns receiverType1
+        }
+        val declaration2: KoReceiverTypeProvider = mockk {
+            every { receiverType } returns receiverType2
+        }
+        val declaration3: KoReceiverTypeProvider = mockk {
+            every { receiverType } returns null
+        }
+        val declarations = listOf(declaration1, declaration2, declaration3)
+
+        // when
+        val sut = declarations.receiverTypes
+
+        // then
+        sut shouldBeEqualTo listOf(receiverType1, receiverType2)
+    }
+
     @Test
     fun `withReceiverType() returns declaration with any receiver`() {
         // given

--- a/lib/src/test/kotlin/com/lemonappdev/konsist/api/ext/list/KoReturnTypeProviderListExtTest.kt
+++ b/lib/src/test/kotlin/com/lemonappdev/konsist/api/ext/list/KoReturnTypeProviderListExtTest.kt
@@ -1,5 +1,6 @@
 package com.lemonappdev.konsist.api.ext.list
 
+import com.lemonappdev.konsist.api.declaration.KoTypeDeclaration
 import com.lemonappdev.konsist.api.provider.KoReturnTypeProvider
 import com.lemonappdev.konsist.testdata.SampleType1
 import com.lemonappdev.konsist.testdata.SampleType2
@@ -9,6 +10,29 @@ import org.amshove.kluent.shouldBeEqualTo
 import org.junit.jupiter.api.Test
 
 class KoReturnTypeProviderListExtTest {
+    @Test
+    fun `returnTypes returns return types from all declarations`() {
+        // given
+        val returnType1: KoTypeDeclaration = mockk()
+        val returnType2: KoTypeDeclaration = mockk()
+        val declaration1: KoReturnTypeProvider = mockk {
+            every { returnType } returns returnType1
+        }
+        val declaration2: KoReturnTypeProvider = mockk {
+            every { returnType } returns returnType2
+        }
+        val declaration3: KoReturnTypeProvider = mockk {
+            every { returnType } returns null
+        }
+        val declarations = listOf(declaration1, declaration2, declaration3)
+
+        // when
+        val sut = declarations.returnTypes
+
+        // then
+        sut shouldBeEqualTo listOf(returnType1, returnType2)
+    }
+
     @Test
     fun `withReturnType() returns declaration with any return type`() {
         // given

--- a/lib/src/test/kotlin/com/lemonappdev/konsist/api/ext/list/KoSecondaryConstructorsProviderListExtTest.kt
+++ b/lib/src/test/kotlin/com/lemonappdev/konsist/api/ext/list/KoSecondaryConstructorsProviderListExtTest.kt
@@ -1,5 +1,7 @@
 package com.lemonappdev.konsist.api.ext.list
 
+import com.lemonappdev.konsist.api.declaration.KoSecondaryConstructorDeclaration
+import com.lemonappdev.konsist.api.provider.KoParentProvider
 import com.lemonappdev.konsist.api.provider.KoSecondaryConstructorsProvider
 import io.mockk.every
 import io.mockk.mockk
@@ -8,6 +10,29 @@ import org.junit.jupiter.api.Test
 
 @Suppress("detekt.LargeClass")
 class KoSecondaryConstructorsProviderListExtTest {
+    @Test
+    fun `secondaryConstructors returns secondary constructors from all declarations`() {
+        // given
+        val secondaryConstructor1: KoSecondaryConstructorDeclaration = mockk()
+        val secondaryConstructor2: KoSecondaryConstructorDeclaration = mockk()
+        val secondaryConstructor3: KoSecondaryConstructorDeclaration = mockk()
+        val declaration1: KoSecondaryConstructorsProvider = mockk {
+            every { secondaryConstructors } returns listOf(secondaryConstructor1, secondaryConstructor2)
+        }
+        val declaration2: KoSecondaryConstructorsProvider = mockk {
+            every { secondaryConstructors } returns listOf(secondaryConstructor3)
+        }
+        val declaration3: KoSecondaryConstructorsProvider = mockk {
+            every { secondaryConstructors } returns emptyList()
+        }
+        val declarations = listOf(declaration1, declaration2, declaration3)
+
+        // when
+        val sut = declarations.secondaryConstructors
+
+        // then
+        sut shouldBeEqualTo listOf(secondaryConstructor1, secondaryConstructor2, secondaryConstructor3)
+    }
 
     @Test
     fun `withSecondaryConstructors() returns declaration with secondary constructor`() {

--- a/lib/src/test/kotlin/com/lemonappdev/konsist/api/ext/list/KoSecondaryConstructorsProviderListExtTest.kt
+++ b/lib/src/test/kotlin/com/lemonappdev/konsist/api/ext/list/KoSecondaryConstructorsProviderListExtTest.kt
@@ -1,7 +1,6 @@
 package com.lemonappdev.konsist.api.ext.list
 
 import com.lemonappdev.konsist.api.declaration.KoSecondaryConstructorDeclaration
-import com.lemonappdev.konsist.api.provider.KoParentProvider
 import com.lemonappdev.konsist.api.provider.KoSecondaryConstructorsProvider
 import io.mockk.every
 import io.mockk.mockk

--- a/lib/src/test/kotlin/com/lemonappdev/konsist/api/ext/list/KoTypeAliasProviderListExtTest.kt
+++ b/lib/src/test/kotlin/com/lemonappdev/konsist/api/ext/list/KoTypeAliasProviderListExtTest.kt
@@ -1,5 +1,8 @@
 package com.lemonappdev.konsist.api.ext.list
 
+import com.lemonappdev.konsist.api.declaration.KoParentDeclaration
+import com.lemonappdev.konsist.api.declaration.KoTypeAliasDeclaration
+import com.lemonappdev.konsist.api.provider.KoParentProvider
 import com.lemonappdev.konsist.api.provider.KoTypeAliasProvider
 import io.mockk.every
 import io.mockk.mockk
@@ -7,6 +10,30 @@ import org.amshove.kluent.shouldBeEqualTo
 import org.junit.jupiter.api.Test
 
 class KoTypeAliasProviderListExtTest {
+    @Test
+    fun `typeAliases returns type aliases from all declarations`() {
+        // given
+        val typeAlias1: KoTypeAliasDeclaration = mockk()
+        val typeAlias2: KoTypeAliasDeclaration = mockk()
+        val typeAlias3: KoTypeAliasDeclaration = mockk()
+        val declaration1: KoTypeAliasProvider = mockk {
+            every { typeAliases } returns listOf(typeAlias1, typeAlias2)
+        }
+        val declaration2: KoTypeAliasProvider = mockk {
+            every { typeAliases } returns listOf(typeAlias3)
+        }
+        val declaration3: KoTypeAliasProvider = mockk {
+            every { typeAliases } returns emptyList()
+        }
+        val declarations = listOf(declaration1, declaration2, declaration3)
+
+        // when
+        val sut = declarations.typeAliases
+
+        // then
+        sut shouldBeEqualTo listOf(typeAlias1, typeAlias2, typeAlias3)
+    }
+
     @Test
     fun `withTypeAlias() returns declaration with typealias`() {
         // given

--- a/lib/src/test/kotlin/com/lemonappdev/konsist/api/ext/list/KoTypeAliasProviderListExtTest.kt
+++ b/lib/src/test/kotlin/com/lemonappdev/konsist/api/ext/list/KoTypeAliasProviderListExtTest.kt
@@ -1,8 +1,6 @@
 package com.lemonappdev.konsist.api.ext.list
 
-import com.lemonappdev.konsist.api.declaration.KoParentDeclaration
 import com.lemonappdev.konsist.api.declaration.KoTypeAliasDeclaration
-import com.lemonappdev.konsist.api.provider.KoParentProvider
 import com.lemonappdev.konsist.api.provider.KoTypeAliasProvider
 import io.mockk.every
 import io.mockk.mockk

--- a/lib/src/test/kotlin/com/lemonappdev/konsist/api/ext/list/KoTypeProviderListExtTest.kt
+++ b/lib/src/test/kotlin/com/lemonappdev/konsist/api/ext/list/KoTypeProviderListExtTest.kt
@@ -1,0 +1,30 @@
+package com.lemonappdev.konsist.api.ext.list
+
+import com.lemonappdev.konsist.api.declaration.KoTypeDeclaration
+import com.lemonappdev.konsist.api.provider.KoTypeProvider
+import io.mockk.every
+import io.mockk.mockk
+import org.amshove.kluent.shouldBeEqualTo
+import org.junit.jupiter.api.Test
+
+class KoTypeProviderListExtTest {
+    @Test
+    fun `types returns types from all declarations`() {
+        // given
+        val type1: KoTypeDeclaration = mockk()
+        val type2: KoTypeDeclaration = mockk()
+        val declaration1: KoTypeProvider = mockk {
+            every { type } returns type1
+        }
+        val declaration2: KoTypeProvider = mockk {
+            every { type } returns type2
+        }
+        val declarations = listOf(declaration1, declaration2)
+
+        // when
+        val sut = declarations.types
+
+        // then
+        sut shouldBeEqualTo listOf(type1, type2)
+    }
+}

--- a/lib/src/test/kotlin/com/lemonappdev/konsist/api/ext/list/modifierprovider/KoModifierProviderListExtTest.kt
+++ b/lib/src/test/kotlin/com/lemonappdev/konsist/api/ext/list/modifierprovider/KoModifierProviderListExtTest.kt
@@ -3,9 +3,6 @@ package com.lemonappdev.konsist.api.ext.list.modifierprovider
 import com.lemonappdev.konsist.api.KoModifier
 import com.lemonappdev.konsist.api.KoModifier.OPEN
 import com.lemonappdev.konsist.api.KoModifier.PROTECTED
-import com.lemonappdev.konsist.api.declaration.KoImportDeclaration
-import com.lemonappdev.konsist.api.ext.list.imports
-import com.lemonappdev.konsist.api.provider.KoImportProvider
 import com.lemonappdev.konsist.api.provider.modifier.KoModifierProvider
 import io.mockk.every
 import io.mockk.mockk

--- a/lib/src/test/kotlin/com/lemonappdev/konsist/api/ext/list/modifierprovider/KoModifierProviderListExtTest.kt
+++ b/lib/src/test/kotlin/com/lemonappdev/konsist/api/ext/list/modifierprovider/KoModifierProviderListExtTest.kt
@@ -1,7 +1,11 @@
 package com.lemonappdev.konsist.api.ext.list.modifierprovider
 
+import com.lemonappdev.konsist.api.KoModifier
 import com.lemonappdev.konsist.api.KoModifier.OPEN
 import com.lemonappdev.konsist.api.KoModifier.PROTECTED
+import com.lemonappdev.konsist.api.declaration.KoImportDeclaration
+import com.lemonappdev.konsist.api.ext.list.imports
+import com.lemonappdev.konsist.api.provider.KoImportProvider
 import com.lemonappdev.konsist.api.provider.modifier.KoModifierProvider
 import io.mockk.every
 import io.mockk.mockk
@@ -10,6 +14,30 @@ import org.junit.jupiter.api.Test
 
 @Suppress("detekt.LargeClass")
 class KoModifierProviderListExtTest {
+    @Test
+    fun `modifiers returns modifiers from all declarations`() {
+        // given
+        val modifier1: KoModifier = mockk()
+        val modifier2: KoModifier = mockk()
+        val modifier3: KoModifier = mockk()
+        val declaration1: KoModifierProvider = mockk {
+            every { modifiers } returns listOf(modifier1, modifier2)
+        }
+        val declaration2: KoModifierProvider = mockk {
+            every { modifiers } returns listOf(modifier3)
+        }
+        val declaration3: KoModifierProvider = mockk {
+            every { modifiers } returns emptyList()
+        }
+        val declarations = listOf(declaration1, declaration2, declaration3)
+
+        // when
+        val sut = declarations.modifiers
+
+        // then
+        sut shouldBeEqualTo listOf(modifier1, modifier2, modifier3)
+    }
+
     @Test
     fun `withModifiers() returns declaration with modifier`() {
         // given


### PR DESCRIPTION
**Before:**
```kotlin
Konsist.scopeFromProject()
            .classes()
            .flatMap { it.constructors }
            .flatMap { it.parameters }
            .assert {
                it.hasAnnotationsOf(SerialName::class)
            }
```

**After**
```kotlin
Konsist.scopeFromProject()
            .classes()
            .constructors
            .parameters
            .assert {
                it.hasAnnotationsOf(SerialName::class)
            }
```