### PR TITLE
KON-373 Update KoFullyQualifiedNameProvider.fullyQualifiedName Implementation To Not Return Empty String

### DIFF
--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koannotation/KoAnnotationDeclarationForKoFullyQualifiedNameProviderTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koannotation/KoAnnotationDeclarationForKoFullyQualifiedNameProviderTest.kt
@@ -28,7 +28,7 @@ class KoAnnotationDeclarationForKoFullyQualifiedNameProviderTest {
             .first()
 
         // then
-        sut.fullyQualifiedName shouldBeEqualTo ""
+        sut.fullyQualifiedName shouldBeEqualTo "SampleAnnotationWithoutImport"
     }
 
     private fun getSnippetFile(fileName: String) =

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koparent/KoParentDeclarationForKoFullyQualifiedNameProviderTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koparent/KoParentDeclarationForKoFullyQualifiedNameProviderTest.kt
@@ -27,7 +27,7 @@ class KoParentDeclarationForKoFullyQualifiedNameProviderTest {
             .first()
 
         // then
-        sut.fullyQualifiedName shouldBeEqualTo ""
+        sut.fullyQualifiedName shouldBeEqualTo "SampleParentClass"
     }
 
     private fun getSnippetFile(fileName: String) =

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koparent/snippet/forkofullyqualifiednameprovider/parent-fully-qualified-name-without-import.kttxt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koparent/snippet/forkofullyqualifiednameprovider/parent-fully-qualified-name-without-import.kttxt
@@ -1,3 +1,3 @@
-class SampleBaseClass: SampleClass()
+class SampleBaseClass: SampleParentClass()
 
-open class SampleClass
+open class SampleParentClass

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/kotype/KoTypeDeclarationForKoFullyQualifiedNameProviderTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/kotype/KoTypeDeclarationForKoFullyQualifiedNameProviderTest.kt
@@ -35,8 +35,8 @@ class KoTypeDeclarationForKoFullyQualifiedNameProviderTest {
         fun provideValues() = listOf(
             arguments("simple-type", "com.lemonappdev.konsist.testdata.SampleType"),
             arguments("simple-nullable-type", "com.lemonappdev.konsist.testdata.SampleType"),
-            arguments("simple-list-type", ""),
-            arguments("simple-nullable-list-type", ""),
+            arguments("simple-list-type", "List<SampleType?>"),
+            arguments("simple-nullable-list-type", "List<SampleType?>?"),
             arguments("import-alias", "com.lemonappdev.konsist.testdata.SampleType"),
             arguments("nullable-import-alias", "com.lemonappdev.konsist.testdata.SampleType"),
         )

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/core/declaration/KoAnnotationDeclarationCore.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/core/declaration/KoAnnotationDeclarationCore.kt
@@ -36,7 +36,7 @@ internal class KoAnnotationDeclarationCore private constructor(
         containingFile
             .imports
             .firstOrNull { it.text.endsWith(".$name") }
-            ?.name ?: ""
+            ?.name ?: name
     }
 
     override fun toString(): String {

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/core/declaration/KoPackageDeclarationCore.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/core/declaration/KoPackageDeclarationCore.kt
@@ -34,7 +34,7 @@ internal class KoPackageDeclarationCore private constructor(private val ktPackag
         if (ktPackageDirective.fqName != FqName.ROOT) {
             ktPackageDirective.fqName.toString()
         } else {
-            ""
+            name
         }
     }
 

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/core/declaration/KoParentDeclarationCore.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/core/declaration/KoParentDeclarationCore.kt
@@ -53,7 +53,7 @@ internal open class KoParentDeclarationCore private constructor(private val ktSu
         containingFile
             .imports
             .firstOrNull { it.text.endsWith(".$name") }
-            ?.name ?: ""
+            ?.name ?: name
     }
 
     override fun toString(): String {

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/core/declaration/KoTypeDeclarationCore.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/core/declaration/KoTypeDeclarationCore.kt
@@ -48,7 +48,7 @@ internal class KoTypeDeclarationCore private constructor(
         containingFile
             .imports
             .map { it.name }
-            .firstOrNull { it.contains(sourceType) } ?: ""
+            .firstOrNull { it.contains(sourceType) } ?: name
     }
 
     override fun toString(): String {


### PR DESCRIPTION
Assume we have such snippet code:
```kotlin
@SampleAnnotationWithoutImport
fun sampleFunction() {
}

annotation class SampleAnnotationWithoutImport
```
```kotlin
Konsist
       .scopeFromProject()
       .functions()
       .withName("sampleFunction")
       .annotations
       .first()
       .fullyQualifiedName // Before it returns empty string, now returns "SampleAnnotationWithoutImport"
```