### PR TITLE
KON-381 Add Lambda As Last Argument Of `print` Function

### DIFF
--- a/lib/src/main/kotlin/com/lemonappdev/konsist/api/container/KoScope.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/api/container/KoScope.kt
@@ -158,10 +158,10 @@ interface KoScope {
     /**
      * Print the scope.
      *
-     * @param prefix An optional string to be printed before the scope content. Default is an empty string.
+     * @param prefix An optional string to be printed before the scope content. Default is null.
      *
      */
-    fun print(prefix: String = ""): Unit
+    fun print(prefix: String? = null): Unit
 
     /**
      * Indicates whether some other object is "equal to" this one.

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/api/ext/list/KoBaseProviderListExt.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/api/ext/list/KoBaseProviderListExt.kt
@@ -5,13 +5,14 @@ import com.lemonappdev.konsist.api.provider.KoBaseProvider
 /**
  * Print the elements.
  *
- * @param prefix An optional string to be printed before each element. Default is an empty string.
+ * @param prefix An optional string to be printed before each element. Default is null.
  * @param predicate An optional function that generates the string representation of each element.
  *                  Default is null, which means the default `toString` method is used.
  * @return The original list of elements.
  */
-fun <T : KoBaseProvider> List<T>.print(prefix: String = "", predicate: ((T) -> String)? = null): List<T> {
-    println(prefix)
+fun <T : KoBaseProvider> List<T>.print(prefix: String? = null, predicate: ((T) -> String)? = null): List<T> {
+    prefix?.let { println(it) }
+
     forEach {
         if (predicate == null) {
             println(it.toString())

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/api/ext/list/KoBaseProviderListExt.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/api/ext/list/KoBaseProviderListExt.kt
@@ -6,6 +6,8 @@ import com.lemonappdev.konsist.api.provider.KoBaseProvider
  * Print the elements.
  *
  * @param prefix An optional string to be printed before each element. Default is an empty string.
+ * @param predicate An optional function that generates the string representation of each element.
+ *                  Default is null, which means the default `toString` method is used.
  * @return The original list of elements.
  */
 fun <T : KoBaseProvider> List<T>.print(prefix: String = "", predicate: ((T) -> String)? = null): List<T> {

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/api/ext/list/KoBaseProviderListExt.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/api/ext/list/KoBaseProviderListExt.kt
@@ -8,8 +8,14 @@ import com.lemonappdev.konsist.api.provider.KoBaseProvider
  * @param prefix An optional string to be printed before each element. Default is an empty string.
  * @return The original list of elements.
  */
-fun <T : KoBaseProvider> List<T>.print(prefix: String = ""): List<T> {
+fun <T : KoBaseProvider> List<T>.print(prefix: String = "", predicate: ((T) -> String)? = null): List<T> {
     println(prefix)
-    forEach { println(it.toString()) }
+    forEach {
+        if (predicate == null) {
+            println(it.toString())
+        } else {
+            println(predicate(it))
+        }
+    }
     return this
 }

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/api/provider/KoTextProvider.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/api/provider/KoTextProvider.kt
@@ -12,7 +12,7 @@ interface KoTextProvider : KoBaseProvider {
     /**
      * Print declaration.
      *
-     * @param prefix An optional string to be printed before the declaration content. Default is an empty string.
+     * @param prefix An optional string to be printed before the declaration content. Default is null.
      */
-    fun print(prefix: String = ""): Unit
+    fun print(prefix: String? = null): Unit
 }

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/core/container/KoScopeCore.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/core/container/KoScopeCore.kt
@@ -81,8 +81,9 @@ class KoScopeCore(
         .toList()
         .joinToString("\n") { it.path }
 
-    override fun print(prefix: String) {
-        println(prefix + toString())
+    override fun print(prefix: String?) {
+        prefix?.let { println(it) }
+        println(toString())
     }
 
     override fun equals(other: Any?): Boolean = other is KoScope && files.toList() == other.files.toList()

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/KoTextProviderCore.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/KoTextProviderCore.kt
@@ -9,7 +9,8 @@ internal interface KoTextProviderCore : KoTextProvider, KoBaseProviderCore {
     override val text: String
         get() = psiElement.text
 
-    override fun print(prefix: String) {
-        kotlin.io.print(prefix + toString())
+    override fun print(prefix: String?) {
+        prefix?.let { println(it) }
+        kotlin.io.print(toString())
     }
 }


### PR DESCRIPTION
Before:
```kotlin
...
  .classes()
  .print() // prints text and location of all declarations (this causes a mess in the log)
```

After:
```kotlin
...
  .classes()
  .print { it.name }  // We may choose what we want to display 
                      // (if we don't pass the predicate in lambda, 
                      // it prints the declarations as before changes).
```
log to the above:
```kotlin
SampleClass1
SampleClass2
...
```