### PR TITLE
KON-382 Change Default Behaviour Of `print`

### DIFF
--- a/lib/src/main/kotlin/com/lemonappdev/konsist/api/ext/list/KoBaseProviderListExt.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/api/ext/list/KoBaseProviderListExt.kt
@@ -1,7 +1,7 @@
 package com.lemonappdev.konsist.api.ext.list
 
 import com.lemonappdev.konsist.api.provider.KoBaseProvider
-import com.lemonappdev.konsist.api.provider.KoNameProvider
+import com.lemonappdev.konsist.api.provider.KoTextProvider
 
 /**
  * Print the elements.
@@ -17,10 +17,8 @@ fun <T : KoBaseProvider> List<T>.print(prefix: String? = null, predicate: ((T) -
     forEach {
         if (predicate != null) {
             println(predicate(it))
-        } else if (it is KoNameProvider) {
-            println(it.name)
         } else {
-            println(toString())
+            it.print()
         }
     }
     return this

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/api/ext/list/KoBaseProviderListExt.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/api/ext/list/KoBaseProviderListExt.kt
@@ -1,6 +1,7 @@
 package com.lemonappdev.konsist.api.ext.list
 
 import com.lemonappdev.konsist.api.provider.KoBaseProvider
+import com.lemonappdev.konsist.api.provider.KoNameProvider
 
 /**
  * Print the elements.
@@ -14,10 +15,12 @@ fun <T : KoBaseProvider> List<T>.print(prefix: String? = null, predicate: ((T) -
     prefix?.let { println(it) }
 
     forEach {
-        if (predicate == null) {
-            println(it.toString())
-        } else {
+        if (predicate != null) {
             println(predicate(it))
+        } else if (it is KoNameProvider) {
+            println(it.name)
+        } else {
+            println(toString())
         }
     }
     return this

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/api/ext/list/KoBaseProviderListExt.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/api/ext/list/KoBaseProviderListExt.kt
@@ -1,7 +1,6 @@
 package com.lemonappdev.konsist.api.ext.list
 
 import com.lemonappdev.konsist.api.provider.KoBaseProvider
-import com.lemonappdev.konsist.api.provider.KoTextProvider
 
 /**
  * Print the elements.

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/api/provider/KoBaseProvider.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/api/provider/KoBaseProvider.kt
@@ -3,4 +3,11 @@ package com.lemonappdev.konsist.api.provider
 /**
  * An interface representing a Kotlin declaration.
  */
-interface KoBaseProvider
+interface KoBaseProvider {
+    /**
+     * Print declaration.
+     *
+     * @param prefix An optional string to be printed before the declaration content. Default is null.
+     */
+    fun print(prefix: String? = null): Unit
+}

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/api/provider/KoTextProvider.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/api/provider/KoTextProvider.kt
@@ -8,11 +8,4 @@ interface KoTextProvider : KoBaseProvider {
      * Text of the declaration.
      */
     val text: String
-
-    /**
-     * Print declaration.
-     *
-     * @param prefix An optional string to be printed before the declaration content. Default is null.
-     */
-    fun print(prefix: String? = null): Unit
 }

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/KoBaseProviderCore.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/KoBaseProviderCore.kt
@@ -1,5 +1,13 @@
 package com.lemonappdev.konsist.core.provider
 
 import com.lemonappdev.konsist.api.provider.KoBaseProvider
+import com.lemonappdev.konsist.api.provider.KoNameProvider
 
-internal interface KoBaseProviderCore : KoBaseProvider
+internal interface KoBaseProviderCore : KoBaseProvider {
+    override fun print(prefix: String?) {
+        prefix?.let { println(it) }
+
+        val text = if (this is KoNameProvider && name != "") name else toString()
+        println(text)
+    }
+}

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/KoTextProviderCore.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/KoTextProviderCore.kt
@@ -9,11 +9,4 @@ internal interface KoTextProviderCore : KoTextProvider, KoBaseProviderCore {
 
     override val text: String
         get() = psiElement.text
-
-    override fun print(prefix: String?) {
-        prefix?.let { println(it) }
-
-        val text = if (this is KoNameProvider) name else toString()
-        println(text)
-    }
 }

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/KoTextProviderCore.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/KoTextProviderCore.kt
@@ -1,7 +1,6 @@
 package com.lemonappdev.konsist.core.provider
 
 import com.intellij.psi.PsiElement
-import com.lemonappdev.konsist.api.provider.KoNameProvider
 import com.lemonappdev.konsist.api.provider.KoTextProvider
 
 internal interface KoTextProviderCore : KoTextProvider, KoBaseProviderCore {

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/KoTextProviderCore.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/KoTextProviderCore.kt
@@ -1,6 +1,7 @@
 package com.lemonappdev.konsist.core.provider
 
 import com.intellij.psi.PsiElement
+import com.lemonappdev.konsist.api.provider.KoNameProvider
 import com.lemonappdev.konsist.api.provider.KoTextProvider
 
 internal interface KoTextProviderCore : KoTextProvider, KoBaseProviderCore {
@@ -11,6 +12,8 @@ internal interface KoTextProviderCore : KoTextProvider, KoBaseProviderCore {
 
     override fun print(prefix: String?) {
         prefix?.let { println(it) }
-        kotlin.io.print(toString())
+
+        val text = if (this is KoNameProvider) name else toString()
+        println(text)
     }
 }


### PR DESCRIPTION
Previously, the `print()` function printed the `toString()` method, which made the log very long, especially for long classes and nested classes.

After change, `print()` prints the `name` declaration (if not available, it prints `toString()`).

Before changes, below snippet code:
```kotlin
Konsist
  .scopeFromProject()
  .classes()
  .print("Before changes:")
```
prints:

<img width="1209" alt="image" src="https://github.com/LemonAppDev/konsist/assets/111683562/e7d25305-e939-4fb2-83eb-5ce2edb54de8">

After changes, below snippet code:
```kotlin
Konsist
  .scopeFromProject()
  .classes()
  .print("After changes:")
```
prints:
<img width="122" alt="image" src="https://github.com/LemonAppDev/konsist/assets/111683562/b5c7eaf6-e93d-4c75-915a-8802674da39e">

Developers will be able to print text and other properties by using https://github.com/LemonAppDev/konsist/pull/442.
