### PR TITLE
KON-392 Add `withName()` And `withoutName()` Extensions On KoNameProvider List

### DIFF
--- a/lib/src/main/kotlin/com/lemonappdev/konsist/api/ext/list/KoNameProviderListExt.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/api/ext/list/KoNameProviderListExt.kt
@@ -3,25 +3,29 @@ package com.lemonappdev.konsist.api.ext.list
 import com.lemonappdev.konsist.api.provider.KoNameProvider
 
 /**
- * List containing elements with any of the specified names.
+ * List containing elements with name.
  *
- * @param name The name to include.
- * @param names The names to include.
- * @return A list containing elements with the specified names.
+ * @param names The name(s) to include.
+ * @return A list containing elements with the specified names (or any name if [names] is empty).
  */
-fun <T : KoNameProvider> List<T>.withName(name: String, vararg names: String): List<T> = filter {
-    it.name == name || names.any { name -> it.name == name }
+fun <T : KoNameProvider> List<T>.withName(vararg names: String): List<T> = filter {
+    when {
+        names.isEmpty() -> it.name != ""
+        else -> names.any { name -> it.name == name }
+    }
 }
 
 /**
- * List containing elements without any of the specified names.
+ * List containing elements without name.
  *
- * @param name The name to exclude.
- * @param names The names to exclude.
- * @return A list containing elements without the specified names.
+ * @param names The name(s) to exclude.
+ * @return A list containing elements without the specified names (or none name if [names] is empty).
  */
-fun <T : KoNameProvider> List<T>.withoutName(name: String, vararg names: String): List<T> = filter {
-    it.name != name && names.none { name -> it.name == name }
+fun <T : KoNameProvider> List<T>.withoutName(vararg names: String): List<T> = filter {
+    when {
+        names.isEmpty() -> it.name == ""
+        else -> names.none { name -> it.name == name }
+    }
 }
 
 /**

--- a/lib/src/test/kotlin/com/lemonappdev/konsist/api/ext/list/KoNameProviderListExtTest.kt
+++ b/lib/src/test/kotlin/com/lemonappdev/konsist/api/ext/list/KoNameProviderListExtTest.kt
@@ -8,6 +8,46 @@ import org.junit.jupiter.api.Test
 
 class KoNameProviderListExtTest {
     @Test
+    fun `withName() returns declaration with any name`() {
+        // given
+        val name1 = "sampleName"
+        val name2 = ""
+        val declaration1: KoNameProvider = mockk {
+            every { name } returns name1
+        }
+        val declaration2: KoNameProvider = mockk {
+            every { name } returns name2
+        }
+        val declarations = listOf(declaration1, declaration2)
+
+        // when
+        val sut = declarations.withName()
+
+        // then
+        sut shouldBeEqualTo listOf(declaration1)
+    }
+
+    @Test
+    fun `withoutName() returns declaration without name`() {
+        // given
+        val name1 = "sampleName"
+        val name2 = ""
+        val declaration1: KoNameProvider = mockk {
+            every { name } returns name1
+        }
+        val declaration2: KoNameProvider = mockk {
+            every { name } returns name2
+        }
+        val declarations = listOf(declaration1, declaration2)
+
+        // when
+        val sut = declarations.withoutName()
+
+        // then
+        sut shouldBeEqualTo listOf(declaration2)
+    }
+
+    @Test
     fun `withName() returns declaration with given name`() {
         // given
         val name1 = "sampleName1"


### PR DESCRIPTION
In `KoNameProvider` we have a property `name` which returns a name - if exists - or an empty string otherwise.
An example of such situation may have `KoArgumentDeclaration` instance:
```kotlin
@SampleAnnotation(sampleParameter = "text") // this annotation has argument with "sampleParameter" name
@SampleAnnotation("text") // this annotation has argument with empty string name 
```

Because of this we improve two extensions:

- `withName()` - we may call this without any argument. It returns list containing elements with non-empty string name.
- `withoutName()` - we may call this without any argument. It returns list containing elements with empty string name.

Before:
<img width="298" alt="image" src="https://github.com/LemonAppDev/konsist/assets/111683562/9b7aaca0-b12c-41f6-a502-9289dda45288">

After:
<img width="361" alt="image" src="https://github.com/LemonAppDev/konsist/assets/111683562/9f2193b0-b316-4ad0-9dd1-c53e50c62b15">
