### PR TITLE
KON-393 Change Return Type Of `print` From Unit To Declaration Instance

### DIFF
--- a/lib/src/main/kotlin/com/lemonappdev/konsist/api/container/KoScope.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/api/container/KoScope.kt
@@ -161,7 +161,7 @@ interface KoScope {
      * @param prefix An optional string to be printed before the scope content. Default is null.
      * @return The original scope.
      */
-    fun print(prefix: String? = null): KoScope
+    fun print(prefix: String? = null, predicate: ((KoScope) -> String)? = null): KoScope
 
     /**
      * Indicates whether some other object is "equal to" this one.

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/api/container/KoScope.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/api/container/KoScope.kt
@@ -159,6 +159,8 @@ interface KoScope {
      * Print the scope.
      *
      * @param prefix An optional string to be printed before the scope content. Default is null.
+     * @param predicate An optional function that generates the string representation of the scope.
+     *                  If predicate is not provided (default is `null`), the function uses `toString` method.
      * @return The original scope.
      */
     fun print(prefix: String? = null, predicate: ((KoScope) -> String)? = null): KoScope

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/api/container/KoScope.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/api/container/KoScope.kt
@@ -159,9 +159,9 @@ interface KoScope {
      * Print the scope.
      *
      * @param prefix An optional string to be printed before the scope content. Default is null.
-     *
+     * @return The original scope.
      */
-    fun print(prefix: String? = null): Unit
+    fun print(prefix: String? = null): KoScope
 
     /**
      * Indicates whether some other object is "equal to" this one.

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/api/ext/list/KoBaseProviderListExt.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/api/ext/list/KoBaseProviderListExt.kt
@@ -1,5 +1,6 @@
 package com.lemonappdev.konsist.api.ext.list
 
+import com.lemonappdev.konsist.api.ext.provider.print
 import com.lemonappdev.konsist.api.provider.KoBaseProvider
 
 /**
@@ -13,12 +14,7 @@ import com.lemonappdev.konsist.api.provider.KoBaseProvider
 fun <T : KoBaseProvider> List<T>.print(prefix: String? = null, predicate: ((T) -> String)? = null): List<T> {
     prefix?.let { println(it) }
 
-    forEach {
-        if (predicate != null) {
-            println(predicate(it))
-        } else {
-            it.print()
-        }
-    }
+    forEach { it.print(predicate = predicate) }
+
     return this
 }

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/api/ext/list/KoBaseProviderListExt.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/api/ext/list/KoBaseProviderListExt.kt
@@ -8,7 +8,7 @@ import com.lemonappdev.konsist.api.provider.KoBaseProvider
  *
  * @param prefix An optional string to be printed before each element. Default is null.
  * @param predicate An optional function that generates the string representation of each element.
- *                  Default is null, which means the default `toString` method is used.
+ *                  If predicate is not provided (default is `null`), the function uses `toString` method.
  * @return The original list of elements.
  */
 fun <T : KoBaseProvider> List<T>.print(prefix: String? = null, predicate: ((T) -> String)? = null): List<T> {

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/api/ext/provider/KoBaseProviderExt.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/api/ext/provider/KoBaseProviderExt.kt
@@ -1,0 +1,18 @@
+package com.lemonappdev.konsist.api.ext.provider
+
+import com.lemonappdev.konsist.api.provider.KoBaseProvider
+import com.lemonappdev.konsist.api.provider.KoConstructorProvider
+import com.lemonappdev.konsist.api.provider.KoNameProvider
+
+/**
+ * Print declaration.
+ *
+ * @param prefix An optional string to be printed before the declaration content. Default is null.
+ */
+fun <T : KoBaseProvider> T.print(prefix: String? = null): T {
+    prefix?.let { println(it) }
+
+    val text = if (this is KoNameProvider && name != "") name else toString()
+    println(text)
+    return this
+}

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/api/ext/provider/KoBaseProviderExt.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/api/ext/provider/KoBaseProviderExt.kt
@@ -6,7 +6,11 @@ import com.lemonappdev.konsist.api.provider.KoNameProvider
 /**
  * Print declaration.
  *
- * @param prefix An optional string to be printed before the declaration content. Default is null.
+ * @param prefix An optional string to be printed before the declaration content. Default is `null`.
+ * @param predicate An optional function that generates the string representation of the declaration.
+ *                  If predicate is not provided (default is `null`), the function uses the declaration's
+ *                  name (if available) or`toString` method otherwise.
+ * @return The original declaration.
  */
 fun <T : KoBaseProvider> T.print(prefix: String? = null, predicate: ((T) -> String)? = null): T {
     prefix?.let { println(it) }

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/api/ext/provider/KoBaseProviderExt.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/api/ext/provider/KoBaseProviderExt.kt
@@ -9,10 +9,15 @@ import com.lemonappdev.konsist.api.provider.KoNameProvider
  *
  * @param prefix An optional string to be printed before the declaration content. Default is null.
  */
-fun <T : KoBaseProvider> T.print(prefix: String? = null): T {
+fun <T : KoBaseProvider> T.print(prefix: String? = null, predicate: ((T) -> String)? = null): T {
     prefix?.let { println(it) }
 
-    val text = if (this is KoNameProvider && name != "") name else toString()
-    println(text)
+    if (predicate != null) {
+        println(predicate(this))
+    } else {
+        val text = if (this is KoNameProvider && name != "") name else toString()
+        println(text)
+    }
+
     return this
 }

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/api/ext/provider/KoBaseProviderExt.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/api/ext/provider/KoBaseProviderExt.kt
@@ -1,7 +1,6 @@
 package com.lemonappdev.konsist.api.ext.provider
 
 import com.lemonappdev.konsist.api.provider.KoBaseProvider
-import com.lemonappdev.konsist.api.provider.KoConstructorProvider
 import com.lemonappdev.konsist.api.provider.KoNameProvider
 
 /**

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/api/provider/KoBaseProvider.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/api/provider/KoBaseProvider.kt
@@ -3,11 +3,4 @@ package com.lemonappdev.konsist.api.provider
 /**
  * An interface representing a Kotlin declaration.
  */
-interface KoBaseProvider {
-    /**
-     * Print declaration.
-     *
-     * @param prefix An optional string to be printed before the declaration content. Default is null.
-     */
-    fun print(prefix: String? = null): Unit
-}
+interface KoBaseProvider

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/core/container/KoScopeCore.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/core/container/KoScopeCore.kt
@@ -63,7 +63,8 @@ class KoScopeCore(
     ): List<KoPropertyDeclaration> =
         koFiles.flatMap { it.properties(includeNested, includeLocal) }
 
-    override fun slice(predicate: (KoFileDeclaration) -> Boolean): KoScope = KoScopeCore(koFiles.filter { predicate(it) })
+    override fun slice(predicate: (KoFileDeclaration) -> Boolean): KoScope =
+        KoScopeCore(koFiles.filter { predicate(it) })
 
     override operator fun plus(scope: KoScope): KoScope = KoScopeCore(files + scope.files)
 
@@ -81,9 +82,15 @@ class KoScopeCore(
         .toList()
         .joinToString("\n") { it.path }
 
-    override fun print(prefix: String?): KoScope {
+    override fun print(prefix: String?, predicate: ((KoScope) -> String)?): KoScope {
         prefix?.let { println(it) }
-        println(toString())
+
+        if (predicate != null) {
+            println(predicate(this))
+        } else {
+            println(toString())
+        }
+
         return this
     }
 

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/core/container/KoScopeCore.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/core/container/KoScopeCore.kt
@@ -81,9 +81,10 @@ class KoScopeCore(
         .toList()
         .joinToString("\n") { it.path }
 
-    override fun print(prefix: String?) {
+    override fun print(prefix: String?): KoScope {
         prefix?.let { println(it) }
         println(toString())
+        return this
     }
 
     override fun equals(other: Any?): Boolean = other is KoScope && files.toList() == other.files.toList()

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/KoBaseProviderCore.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/KoBaseProviderCore.kt
@@ -1,6 +1,5 @@
 package com.lemonappdev.konsist.core.provider
 
 import com.lemonappdev.konsist.api.provider.KoBaseProvider
-import com.lemonappdev.konsist.api.provider.KoNameProvider
 
 internal interface KoBaseProviderCore : KoBaseProvider

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/KoBaseProviderCore.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/KoBaseProviderCore.kt
@@ -3,11 +3,4 @@ package com.lemonappdev.konsist.core.provider
 import com.lemonappdev.konsist.api.provider.KoBaseProvider
 import com.lemonappdev.konsist.api.provider.KoNameProvider
 
-internal interface KoBaseProviderCore : KoBaseProvider {
-    override fun print(prefix: String?) {
-        prefix?.let { println(it) }
-
-        val text = if (this is KoNameProvider && name != "") name else toString()
-        println(text)
-    }
-}
+internal interface KoBaseProviderCore : KoBaseProvider


### PR DESCRIPTION
1. Changed return types of `print` method in `KoScope` and `KoBaseProvider` to original element.  Before print() was returning `Unit` which made it impossible to use chain calls.

Before:
<img width="226" alt="image" src="https://github.com/LemonAppDev/konsist/assets/111683562/5884af8c-8369-4167-a28d-91dfacb72c86">
<img width="240" alt="image" src="https://github.com/LemonAppDev/konsist/assets/111683562/813dcba5-94f1-4678-92f7-e6e7ff0da4bc">

After:
<img width="238" alt="image" src="https://github.com/LemonAppDev/konsist/assets/111683562/af735971-5913-4bb3-ad57-11e5e6c3c8ad">
<img width="236" alt="image" src="https://github.com/LemonAppDev/konsist/assets/111683562/85740963-1d0a-48d0-8f31-6833f6597fbe">

2. Add lambda `predicate` parameter to above functions (like in https://github.com/LemonAppDev/konsist/pull/442)
