### PR TITLE
KON-388 Add `countX { ... }` methods

### DIFF
--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koclass/KoClassDeclarationForKoAnnotationProviderTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koclass/KoClassDeclarationForKoAnnotationProviderTest.kt
@@ -20,6 +20,7 @@ class KoClassDeclarationForKoAnnotationProviderTest {
         assertSoftly(sut) {
             annotations shouldBeEqualTo emptyList()
             numAnnotations shouldBeEqualTo 0
+            countAnnotations { it.name == "NonExistingAnnotation" } shouldBeEqualTo 0
             hasAnnotations() shouldBeEqualTo false
         }
     }
@@ -34,6 +35,8 @@ class KoClassDeclarationForKoAnnotationProviderTest {
         // then
         assertSoftly(sut) {
             numAnnotations shouldBeEqualTo 1
+            countAnnotations { it.name == "SampleAnnotation" } shouldBeEqualTo 1
+            countAnnotations { it.name == "NonExistingAnnotation" } shouldBeEqualTo 0
             hasAnnotations("SampleAnnotation") shouldBeEqualTo true
             hasAnnotations("NonExistingAnnotation") shouldBeEqualTo false
             hasAnnotations("com.lemonappdev.konsist.testdata.SampleAnnotation") shouldBeEqualTo true
@@ -53,6 +56,8 @@ class KoClassDeclarationForKoAnnotationProviderTest {
         // then
         assertSoftly(sut) {
             numAnnotations shouldBeEqualTo 2
+            countAnnotations { it.hasNameStartingWith("Sample") } shouldBeEqualTo 2
+            countAnnotations { it.name == "SampleAnnotation1" } shouldBeEqualTo 1
             hasAnnotations("SampleAnnotation1") shouldBeEqualTo true
             hasAnnotations("SampleAnnotation2") shouldBeEqualTo true
             hasAnnotations("NonExistingAnnotation") shouldBeEqualTo false

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koclass/KoClassDeclarationForKoConstructorProviderTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koclass/KoClassDeclarationForKoConstructorProviderTest.kt
@@ -18,6 +18,7 @@ class KoClassDeclarationForKoConstructorProviderTest {
         assertSoftly(sut) {
             constructors shouldBeEqualTo emptyList()
             numConstructors shouldBeEqualTo 0
+            countConstructors { it.hasModifiers() } shouldBeEqualTo 0
         }
     }
 
@@ -32,6 +33,8 @@ class KoClassDeclarationForKoConstructorProviderTest {
         assertSoftly(sut) {
             constructors shouldNotBeEqualTo emptyList()
             numConstructors shouldBeEqualTo 3
+            countConstructors { it.hasPublicOrDefaultModifier } shouldBeEqualTo 3
+            countConstructors { it.hasPublicModifier } shouldBeEqualTo 1
         }
     }
 

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koclass/KoClassDeclarationForKoEnumConstantProviderTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koclass/KoClassDeclarationForKoEnumConstantProviderTest.kt
@@ -17,6 +17,7 @@ class KoClassDeclarationForKoEnumConstantProviderTest {
         assertSoftly(sut) {
             enumConstants shouldBeEqualTo emptyList()
             numEnumConstants shouldBeEqualTo 0
+            countEnumConstants { it.hasNameStartingWith("SAMPLE") } shouldBeEqualTo 0
             hasEnumConstants() shouldBeEqualTo false
             hasEnumConstants("SAMPLE_CONSTANT") shouldBeEqualTo false
         }
@@ -43,6 +44,8 @@ class KoClassDeclarationForKoEnumConstantProviderTest {
         // then
         assertSoftly(sut) {
             numEnumConstants shouldBeEqualTo 2
+            countEnumConstants { it.hasNameStartingWith("SAMPLE") } shouldBeEqualTo 2
+            countEnumConstants { it.name == "SAMPLE_CONSTANT_1" } shouldBeEqualTo 1
             hasEnumConstants() shouldBeEqualTo true
             hasEnumConstants("SAMPLE_CONSTANT_1") shouldBeEqualTo true
             hasEnumConstants("SAMPLE_CONSTANT_1", "SAMPLE_CONSTANT_2") shouldBeEqualTo true

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koclass/KoClassDeclarationForKoInitBlockProviderTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koclass/KoClassDeclarationForKoInitBlockProviderTest.kt
@@ -18,6 +18,7 @@ class KoClassDeclarationForKoInitBlockProviderTest {
         assertSoftly(sut) {
             initBlocks shouldBeEqualTo emptyList()
             numInitBlocks shouldBeEqualTo 0
+            countInitBlocks { it.localFunctions.isEmpty() } shouldBeEqualTo 0
             hasInitBlocks shouldBeEqualTo false
         }
     }
@@ -33,6 +34,7 @@ class KoClassDeclarationForKoInitBlockProviderTest {
         assertSoftly(sut) {
             initBlocks shouldNotBeEqualTo emptyList()
             numInitBlocks shouldBeEqualTo 1
+            countInitBlocks { it.localFunctions.isEmpty() } shouldBeEqualTo 1
             hasInitBlocks shouldBeEqualTo true
         }
     }
@@ -48,6 +50,8 @@ class KoClassDeclarationForKoInitBlockProviderTest {
         assertSoftly(sut) {
             initBlocks shouldNotBeEqualTo emptyList()
             numInitBlocks shouldBeEqualTo 2
+            countInitBlocks { it.localDeclarations.isNotEmpty() } shouldBeEqualTo 2
+            countInitBlocks { it.localFunctions.isNotEmpty() } shouldBeEqualTo 1
             hasInitBlocks shouldBeEqualTo true
         }
     }

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koclass/KoClassDeclarationForKoParentProviderTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koclass/KoClassDeclarationForKoParentProviderTest.kt
@@ -17,6 +17,7 @@ class KoClassDeclarationForKoParentProviderTest {
         assertSoftly(sut) {
             parents shouldBeEqualTo emptyList()
             numParents shouldBeEqualTo 0
+            countParents { it.name == "SampleParentClass" } shouldBeEqualTo 0
             hasParents() shouldBeEqualTo false
             hasParents("SampleClass") shouldBeEqualTo false
         }
@@ -37,6 +38,8 @@ class KoClassDeclarationForKoParentProviderTest {
                 "SampleParentInterface2",
             )
             numParents shouldBeEqualTo 3
+            countParents { it.name == "SampleParentClass" } shouldBeEqualTo 1
+            countParents { it.hasNameStartingWith("SampleParentInterface") } shouldBeEqualTo 2
             hasParents() shouldBeEqualTo true
             hasParents("SampleParentClass") shouldBeEqualTo true
             hasParents("OtherInterface") shouldBeEqualTo false

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koclass/KoClassDeclarationForKoSecondaryConstructorsProviderTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koclass/KoClassDeclarationForKoSecondaryConstructorsProviderTest.kt
@@ -18,6 +18,7 @@ class KoClassDeclarationForKoSecondaryConstructorsProviderTest {
         assertSoftly(sut) {
             secondaryConstructors.isEmpty() shouldBeEqualTo true
             numSecondaryConstructors shouldBeEqualTo 0
+            countSecondaryConstructors { it.hasPublicModifier } shouldBeEqualTo 0
             hasSecondaryConstructors shouldBeEqualTo false
         }
     }
@@ -33,6 +34,8 @@ class KoClassDeclarationForKoSecondaryConstructorsProviderTest {
         assertSoftly(sut) {
             secondaryConstructors.isNotEmpty() shouldBeEqualTo true
             numSecondaryConstructors shouldBeEqualTo 1
+            countSecondaryConstructors { it.hasPrivateModifier } shouldBeEqualTo 1
+            countSecondaryConstructors { it.hasPublicModifier } shouldBeEqualTo 0
             hasSecondaryConstructors shouldBeEqualTo true
         }
     }
@@ -48,6 +51,8 @@ class KoClassDeclarationForKoSecondaryConstructorsProviderTest {
         assertSoftly(sut) {
             secondaryConstructors shouldHaveSize 1
             numSecondaryConstructors shouldBeEqualTo 1
+            countSecondaryConstructors { it.hasPublicOrDefaultModifier } shouldBeEqualTo 1
+            countSecondaryConstructors { it.hasPublicModifier } shouldBeEqualTo 0
             hasSecondaryConstructors shouldBeEqualTo true
         }
     }

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koclass/forkomodifier/KoClassDeclarationForKoModifierProviderTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koclass/forkomodifier/KoClassDeclarationForKoModifierProviderTest.kt
@@ -25,6 +25,7 @@ class KoClassDeclarationForKoModifierProviderTest {
         assertSoftly(sut) {
             modifiers shouldBeEqualTo emptyList()
             numModifiers shouldBeEqualTo 0
+            countModifiers { it.type == "private" } shouldBeEqualTo 0
             hasModifiers() shouldBeEqualTo false
             hasModifiers(OPEN) shouldBeEqualTo false
             hasModifiers(OPEN, DATA) shouldBeEqualTo false
@@ -42,6 +43,7 @@ class KoClassDeclarationForKoModifierProviderTest {
         assertSoftly(sut) {
             hasModifiers() shouldBeEqualTo true
             numModifiers shouldBeEqualTo 2
+            countModifiers { it.type == "private" } shouldBeEqualTo 1
             hasModifiers(PRIVATE) shouldBeEqualTo true
             hasModifiers(OPEN) shouldBeEqualTo true
             hasModifiers(PROTECTED) shouldBeEqualTo false

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koclass/snippet/forkoconstructorsprovider/class-has-primary-and-secondary-constructors.kttxt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koclass/snippet/forkoconstructorsprovider/class-has-primary-and-secondary-constructors.kttxt
@@ -1,5 +1,5 @@
 class SampleClass(val sampleProperty1: Int) {
-    constructor(sampleProperty1: Int, sampleProperty2: Int) : this(sampleProperty1)
+    public constructor(sampleProperty1: Int, sampleProperty2: Int) : this(sampleProperty1)
 
     constructor(sampleProperty1: Int, sampleProperty2: Int, sampleProperty3: String): this(sampleProperty1)
 }

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koclass/snippet/forkoinitblockprovider/class-with-two-init-blocks.kttxt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koclass/snippet/forkoinitblockprovider/class-with-two-init-blocks.kttxt
@@ -4,6 +4,8 @@ class SampleClass {
     }
 
     init {
+        fun localFunction() {}
+
         println("Sample text")
     }
 }

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koclass/snippet/forkosecondaryconstructorsprovider/class-has-secondary-constructor.kttxt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koclass/snippet/forkosecondaryconstructorsprovider/class-has-secondary-constructor.kttxt
@@ -1,4 +1,4 @@
 class SampleClass {
-    constructor() {
+    private constructor() {
     }
 }

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koconstructor/KoConstructorDeclarationForKoAnnotationProviderTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koconstructor/KoConstructorDeclarationForKoAnnotationProviderTest.kt
@@ -22,6 +22,7 @@ class KoConstructorDeclarationForKoAnnotationProviderTest {
         assertSoftly(sut) {
             annotations shouldBeEqualTo emptyList()
             numAnnotations shouldBeEqualTo 0
+            countAnnotations { it.name == "NonExistingAnnotation" } shouldBeEqualTo 0
             hasAnnotations() shouldBeEqualTo false
         }
     }
@@ -38,6 +39,8 @@ class KoConstructorDeclarationForKoAnnotationProviderTest {
         // then
         assertSoftly(sut) {
             numAnnotations shouldBeEqualTo 1
+            countAnnotations { it.name == "SampleAnnotation" } shouldBeEqualTo 1
+            countAnnotations { it.name == "NonExistingAnnotation" } shouldBeEqualTo 0
             hasAnnotations("SampleAnnotation") shouldBeEqualTo true
             hasAnnotations("NonExistingAnnotation") shouldBeEqualTo false
             hasAnnotations("com.lemonappdev.konsist.testdata.SampleAnnotation") shouldBeEqualTo true
@@ -59,6 +62,8 @@ class KoConstructorDeclarationForKoAnnotationProviderTest {
         // then
         assertSoftly(sut) {
             numAnnotations shouldBeEqualTo 2
+            countAnnotations { it.hasNameStartingWith("Sample") } shouldBeEqualTo 2
+            countAnnotations { it.name == "SampleAnnotation1" } shouldBeEqualTo 1
             hasAnnotations("SampleAnnotation1") shouldBeEqualTo true
             hasAnnotations("SampleAnnotation2") shouldBeEqualTo true
             hasAnnotations("NonExistingAnnotation") shouldBeEqualTo false

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koconstructor/KoConstructorDeclarationForKoParametersProviderTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koconstructor/KoConstructorDeclarationForKoParametersProviderTest.kt
@@ -19,6 +19,7 @@ class KoConstructorDeclarationForKoParametersProviderTest {
         assertSoftly(sut) {
             parameters shouldBeEqualTo emptyList()
             numParameters shouldBeEqualTo 0
+            countParameters { it.hasPublicOrDefaultModifier } shouldBeEqualTo 0
         }
     }
 
@@ -35,6 +36,7 @@ class KoConstructorDeclarationForKoParametersProviderTest {
         assertSoftly(sut) {
             parameters.size shouldBeEqualTo 1
             numParameters shouldBeEqualTo 1
+            countParameters { it.hasPublicOrDefaultModifier } shouldBeEqualTo 1
             parameters.first().name shouldBeEqualTo "sampleParameter"
         }
     }

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koconstructor/forkomodifier/KoConstructorDeclarationForKoModifierProviderTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koconstructor/forkomodifier/KoConstructorDeclarationForKoModifierProviderTest.kt
@@ -23,11 +23,12 @@ class KoConstructorDeclarationForKoModifierProviderTest {
 
         // then
         assertSoftly(sut) {
-            it.modifiers shouldBeEqualTo emptyList()
-            it.numModifiers shouldBeEqualTo 0
-            it.hasModifiers() shouldBeEqualTo false
-            it.hasModifiers(OPEN) shouldBeEqualTo false
-            it.hasModifiers(OPEN, DATA) shouldBeEqualTo false
+            modifiers shouldBeEqualTo emptyList()
+            numModifiers shouldBeEqualTo 0
+            countModifiers { it.type == "private" } shouldBeEqualTo 0
+            hasModifiers() shouldBeEqualTo false
+            hasModifiers(OPEN) shouldBeEqualTo false
+            hasModifiers(OPEN, DATA) shouldBeEqualTo false
         }
     }
 
@@ -43,8 +44,9 @@ class KoConstructorDeclarationForKoModifierProviderTest {
 
         // then
         assertSoftly(sut) {
-            it.modifiers shouldBeEqualTo listOf(PRIVATE)
-            it.numModifiers shouldBeEqualTo 1
+            modifiers shouldBeEqualTo listOf(PRIVATE)
+            numModifiers shouldBeEqualTo 1
+            countModifiers { it.type == "private" } shouldBeEqualTo 1
         }
     }
 

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koenumconstant/KoEnumConstantDeclarationForKoAnnotationProviderTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koenumconstant/KoEnumConstantDeclarationForKoAnnotationProviderTest.kt
@@ -22,6 +22,7 @@ class KoEnumConstantDeclarationForKoAnnotationProviderTest {
         assertSoftly(sut) {
             annotations shouldBeEqualTo emptyList()
             numAnnotations shouldBeEqualTo 0
+            countAnnotations { it.name == "NonExistingAnnotation" } shouldBeEqualTo 0
             hasAnnotations() shouldBeEqualTo false
         }
     }
@@ -38,6 +39,8 @@ class KoEnumConstantDeclarationForKoAnnotationProviderTest {
         // then
         assertSoftly(sut) {
             numAnnotations shouldBeEqualTo 1
+            countAnnotations { it.name == "SampleAnnotation" } shouldBeEqualTo 1
+            countAnnotations { it.name == "NonExistingAnnotation" } shouldBeEqualTo 0
             hasAnnotations("SampleAnnotation") shouldBeEqualTo true
             hasAnnotations("NonExistingAnnotation") shouldBeEqualTo false
             hasAnnotations("com.lemonappdev.konsist.testdata.SampleAnnotation") shouldBeEqualTo true
@@ -59,6 +62,8 @@ class KoEnumConstantDeclarationForKoAnnotationProviderTest {
         // then
         assertSoftly(sut) {
             numAnnotations shouldBeEqualTo 2
+            countAnnotations { it.hasNameStartingWith("Sample") } shouldBeEqualTo 2
+            countAnnotations { it.name == "SampleAnnotation1" } shouldBeEqualTo 1
             hasAnnotations("SampleAnnotation1") shouldBeEqualTo true
             hasAnnotations("SampleAnnotation2") shouldBeEqualTo true
             hasAnnotations("NonExistingAnnotation") shouldBeEqualTo false

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/kofile/KoFileDeclarationForKoAnnotationProviderTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/kofile/KoFileDeclarationForKoAnnotationProviderTest.kt
@@ -18,8 +18,9 @@ class KoFileDeclarationForKoAnnotationProviderTest {
 
         // then
         assertSoftly(sut) {
-            annotations.isEmpty() shouldBeEqualTo true
+            annotations shouldBeEqualTo emptyList()
             numAnnotations shouldBeEqualTo 0
+            countAnnotations { it.name == "NonExistingAnnotation" } shouldBeEqualTo 0
             hasAnnotations("SampleAnnotation") shouldBeEqualTo false
             hasAnnotations("com.lemonappdev.konsist.testdata.SampleAnnotation") shouldBeEqualTo false
         }
@@ -36,6 +37,8 @@ class KoFileDeclarationForKoAnnotationProviderTest {
         assertSoftly(sut) {
             annotations.map { it.name } shouldBeEqualTo listOf("SampleAnnotation1", "SampleAnnotation2")
             numAnnotations shouldBeEqualTo 2
+            countAnnotations { it.hasNameStartingWith("Sample") } shouldBeEqualTo 2
+            countAnnotations { it.name == "SampleAnnotation1" } shouldBeEqualTo 1
             hasAnnotations("SampleAnnotation1") shouldBeEqualTo true
             hasAnnotations("SampleAnnotation1", "SampleAnnotation2") shouldBeEqualTo true
             hasAnnotations("OtherAnnotation") shouldBeEqualTo false

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/kofile/KoFileDeclarationForKoImportProviderTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/kofile/KoFileDeclarationForKoImportProviderTest.kt
@@ -17,6 +17,7 @@ class KoFileDeclarationForKoImportProviderTest {
         assertSoftly(sut) {
             imports.isEmpty() shouldBeEqualTo true
             numImports shouldBeEqualTo 0
+            countImports { it.name == "com.lemonappdev.konsist.testdata.OtherImport" } shouldBeEqualTo 0
             hasImports() shouldBeEqualTo false
             hasImports("com.lemonappdev.konsist.testdata.OtherImport") shouldBeEqualTo false
         }
@@ -51,6 +52,8 @@ class KoFileDeclarationForKoImportProviderTest {
         // then
         assertSoftly(sut) {
             numImports shouldBeEqualTo 2
+            countImports { it.hasNameStartingWith("com.lemonappdev") } shouldBeEqualTo 2
+            countImports { it.name == "com.lemonappdev.konsist.testdata.SampleType" } shouldBeEqualTo 1
             hasImports() shouldBeEqualTo true
             hasImports("com..") shouldBeEqualTo true
             hasImports("com..", "..testdata..") shouldBeEqualTo true

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/kofile/KoFileDeclarationForKoTypeAliasProviderTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/kofile/KoFileDeclarationForKoTypeAliasProviderTest.kt
@@ -17,6 +17,7 @@ class KoFileDeclarationForKoTypeAliasProviderTest {
         assertSoftly(sut) {
             typeAliases shouldBeEqualTo emptyList()
             numTypeAliases shouldBeEqualTo 0
+            countTypeAliases { it.hasPrivateModifier } shouldBeEqualTo 0
             hasTypeAliases() shouldBeEqualTo false
             hasTypeAliases("SampleTypeAlias") shouldBeEqualTo false
         }
@@ -46,6 +47,8 @@ class KoFileDeclarationForKoTypeAliasProviderTest {
         // then
         assertSoftly(sut) {
             numTypeAliases shouldBeEqualTo 2
+            countTypeAliases { it.hasNameStartingWith("Sample") } shouldBeEqualTo 2
+            countTypeAliases { it.name == "SampleTypeAlias1" } shouldBeEqualTo 1
             hasTypeAliases() shouldBeEqualTo true
             hasTypeAliases("SampleTypeAlias1") shouldBeEqualTo true
             hasTypeAliases("SampleTypeAlias1", "SampleTypeAlias2") shouldBeEqualTo true

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/kofunction/KoFunctionDeclarationForKoAnnotationProviderTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/kofunction/KoFunctionDeclarationForKoAnnotationProviderTest.kt
@@ -20,6 +20,7 @@ class KoFunctionDeclarationForKoAnnotationProviderTest {
         assertSoftly(sut) {
             annotations shouldBeEqualTo emptyList()
             numAnnotations shouldBeEqualTo 0
+            countAnnotations { it.name == "NonExistingAnnotation" } shouldBeEqualTo 0
             hasAnnotations() shouldBeEqualTo false
         }
     }
@@ -34,6 +35,8 @@ class KoFunctionDeclarationForKoAnnotationProviderTest {
         // then
         assertSoftly(sut) {
             numAnnotations shouldBeEqualTo 1
+            countAnnotations { it.name == "SampleAnnotation" } shouldBeEqualTo 1
+            countAnnotations { it.name == "NonExistingAnnotation" } shouldBeEqualTo 0
             hasAnnotations("SampleAnnotation") shouldBeEqualTo true
             hasAnnotations("NonExistingAnnotation") shouldBeEqualTo false
             hasAnnotations("com.lemonappdev.konsist.testdata.SampleAnnotation") shouldBeEqualTo true
@@ -53,6 +56,8 @@ class KoFunctionDeclarationForKoAnnotationProviderTest {
         // then
         assertSoftly(sut) {
             numAnnotations shouldBeEqualTo 2
+            countAnnotations { it.hasNameStartingWith("Sample") } shouldBeEqualTo 2
+            countAnnotations { it.name == "SampleAnnotation1" } shouldBeEqualTo 1
             hasAnnotations("SampleAnnotation1") shouldBeEqualTo true
             hasAnnotations("SampleAnnotation2") shouldBeEqualTo true
             hasAnnotations("NonExistingAnnotation") shouldBeEqualTo false

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/kofunction/KoFunctionDeclarationForKoParametersProviderTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/kofunction/KoFunctionDeclarationForKoParametersProviderTest.kt
@@ -17,6 +17,7 @@ class KoFunctionDeclarationForKoParametersProviderTest {
         assertSoftly(sut) {
             parameters shouldBeEqualTo emptyList()
             numParameters shouldBeEqualTo 0
+            countParameters { it.hasPublicOrDefaultModifier } shouldBeEqualTo 0
         }
     }
 
@@ -31,6 +32,7 @@ class KoFunctionDeclarationForKoParametersProviderTest {
         assertSoftly(sut) {
             parameters.size shouldBeEqualTo 1
             numParameters shouldBeEqualTo 1
+            countParameters { it.hasPublicOrDefaultModifier } shouldBeEqualTo 1
             parameters.first().name shouldBeEqualTo "sampleParameter"
         }
     }

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/kofunction/forkomodifier/KoFunctionDeclarationForKoModifierProviderTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/kofunction/forkomodifier/KoFunctionDeclarationForKoModifierProviderTest.kt
@@ -24,6 +24,7 @@ class KoFunctionDeclarationForKoModifierProviderTest {
         assertSoftly(sut) {
             modifiers shouldBeEqualTo emptyList()
             numModifiers shouldBeEqualTo 0
+            countModifiers { it.type == "private" } shouldBeEqualTo 0
             hasModifiers() shouldBeEqualTo false
             hasModifiers(OPEN) shouldBeEqualTo false
             hasModifiers(OPEN, KoModifier.DATA) shouldBeEqualTo false
@@ -40,6 +41,7 @@ class KoFunctionDeclarationForKoModifierProviderTest {
         // then
         assertSoftly(sut) {
             numModifiers shouldBeEqualTo 2
+            countModifiers { it.type == "protected" } shouldBeEqualTo 1
             hasModifiers() shouldBeEqualTo true
             hasModifiers(PROTECTED) shouldBeEqualTo true
             hasModifiers(SUSPEND) shouldBeEqualTo true

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/kointerface/KoInterfaceDeclarationForKoAnnotationProviderTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/kointerface/KoInterfaceDeclarationForKoAnnotationProviderTest.kt
@@ -20,6 +20,7 @@ class KoInterfaceDeclarationForKoAnnotationProviderTest {
         assertSoftly(sut) {
             annotations shouldBeEqualTo emptyList()
             numAnnotations shouldBeEqualTo 0
+            countAnnotations { it.name == "NonExistingAnnotation" } shouldBeEqualTo 0
             hasAnnotations() shouldBeEqualTo false
         }
     }
@@ -34,6 +35,8 @@ class KoInterfaceDeclarationForKoAnnotationProviderTest {
         // then
         assertSoftly(sut) {
             numAnnotations shouldBeEqualTo 1
+            countAnnotations { it.name == "SampleAnnotation" } shouldBeEqualTo 1
+            countAnnotations { it.name == "NonExistingAnnotation" } shouldBeEqualTo 0
             hasAnnotations("SampleAnnotation") shouldBeEqualTo true
             hasAnnotations("NonExistingAnnotation") shouldBeEqualTo false
             hasAnnotations("com.lemonappdev.konsist.testdata.SampleAnnotation") shouldBeEqualTo true
@@ -53,6 +56,8 @@ class KoInterfaceDeclarationForKoAnnotationProviderTest {
         // then
         assertSoftly(sut) {
             numAnnotations shouldBeEqualTo 2
+            countAnnotations { it.hasNameStartingWith("Sample") } shouldBeEqualTo 2
+            countAnnotations { it.name == "SampleAnnotation1" } shouldBeEqualTo 1
             hasAnnotations("SampleAnnotation1") shouldBeEqualTo true
             hasAnnotations("SampleAnnotation2") shouldBeEqualTo true
             hasAnnotations("NonExistingAnnotation") shouldBeEqualTo false

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/kointerface/KoInterfaceDeclarationForKoParentProviderTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/kointerface/KoInterfaceDeclarationForKoParentProviderTest.kt
@@ -17,6 +17,7 @@ class KoInterfaceDeclarationForKoParentProviderTest {
         assertSoftly(sut) {
             parents shouldBeEqualTo emptyList()
             numParents shouldBeEqualTo 0
+            countParents { it.name == "SampleParentClass" } shouldBeEqualTo 0
             hasParents() shouldBeEqualTo false
             hasParents("SampleInterface") shouldBeEqualTo false
         }
@@ -33,6 +34,8 @@ class KoInterfaceDeclarationForKoParentProviderTest {
         assertSoftly(sut) {
             parents.map { it.name } shouldBeEqualTo listOf("SampleParentInterface1", "SampleParentInterface2")
             numParents shouldBeEqualTo 2
+            countParents { it.name == "SampleParentInterface1" } shouldBeEqualTo 1
+            countParents { it.hasNameStartingWith("SampleParentInterface") } shouldBeEqualTo 2
             hasParents() shouldBeEqualTo true
             hasParents("SampleParentInterface1") shouldBeEqualTo true
             hasParents("OtherInterface") shouldBeEqualTo false

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/kointerface/forkomodifier/KoInterfaceDeclarationForKoModifierProviderTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/kointerface/forkomodifier/KoInterfaceDeclarationForKoModifierProviderTest.kt
@@ -26,6 +26,7 @@ class KoInterfaceDeclarationForKoModifierProviderTest {
         assertSoftly(sut) {
             modifiers shouldBeEqualTo emptyList()
             numModifiers shouldBeEqualTo 0
+            countModifiers { it.type == "private" } shouldBeEqualTo 0
             hasModifiers() shouldBeEqualTo false
             hasModifiers(OPEN) shouldBeEqualTo false
             hasModifiers(OPEN, DATA) shouldBeEqualTo false
@@ -45,6 +46,7 @@ class KoInterfaceDeclarationForKoModifierProviderTest {
         // then
         assertSoftly(sut) {
             numModifiers shouldBeEqualTo 2
+            countModifiers { it.type == "public" } shouldBeEqualTo 1
             hasModifiers() shouldBeEqualTo true
             hasModifiers(PUBLIC) shouldBeEqualTo true
             hasModifiers(ABSTRACT) shouldBeEqualTo true

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koobject/KoObjectDeclarationForKoAnnotationProviderTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koobject/KoObjectDeclarationForKoAnnotationProviderTest.kt
@@ -20,6 +20,7 @@ class KoObjectDeclarationForKoAnnotationProviderTest {
         assertSoftly(sut) {
             annotations shouldBeEqualTo emptyList()
             numAnnotations shouldBeEqualTo 0
+            countAnnotations { it.name == "NonExistingAnnotation" } shouldBeEqualTo 0
             hasAnnotations() shouldBeEqualTo false
         }
     }
@@ -34,6 +35,8 @@ class KoObjectDeclarationForKoAnnotationProviderTest {
         // then
         assertSoftly(sut) {
             numAnnotations shouldBeEqualTo 1
+            countAnnotations { it.name == "SampleAnnotation" } shouldBeEqualTo 1
+            countAnnotations { it.name == "NonExistingAnnotation" } shouldBeEqualTo 0
             hasAnnotations("SampleAnnotation") shouldBeEqualTo true
             hasAnnotations("NonExistingAnnotation") shouldBeEqualTo false
             hasAnnotations("com.lemonappdev.konsist.testdata.SampleAnnotation") shouldBeEqualTo true
@@ -53,6 +56,8 @@ class KoObjectDeclarationForKoAnnotationProviderTest {
         // then
         assertSoftly(sut) {
             numAnnotations shouldBeEqualTo 2
+            countAnnotations { it.hasNameStartingWith("Sample") } shouldBeEqualTo 2
+            countAnnotations { it.name == "SampleAnnotation1" } shouldBeEqualTo 1
             hasAnnotations("SampleAnnotation1") shouldBeEqualTo true
             hasAnnotations("SampleAnnotation2") shouldBeEqualTo true
             hasAnnotations("NonExistingAnnotation") shouldBeEqualTo false

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koobject/KoObjectDeclarationForKoInitBlockProviderTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koobject/KoObjectDeclarationForKoInitBlockProviderTest.kt
@@ -18,6 +18,7 @@ class KoObjectDeclarationForKoInitBlockProviderTest {
         assertSoftly(sut) {
             initBlocks shouldBeEqualTo emptyList()
             numInitBlocks shouldBeEqualTo 0
+            countInitBlocks { it.localFunctions.isEmpty() } shouldBeEqualTo 0
             hasInitBlocks shouldBeEqualTo false
         }
     }
@@ -33,6 +34,7 @@ class KoObjectDeclarationForKoInitBlockProviderTest {
         assertSoftly(sut) {
             initBlocks shouldNotBeEqualTo emptyList()
             numInitBlocks shouldBeEqualTo 1
+            countInitBlocks { it.localFunctions.isEmpty() } shouldBeEqualTo 1
             hasInitBlocks shouldBeEqualTo true
         }
     }
@@ -48,6 +50,8 @@ class KoObjectDeclarationForKoInitBlockProviderTest {
         assertSoftly(sut) {
             initBlocks shouldNotBeEqualTo emptyList()
             numInitBlocks shouldBeEqualTo 2
+            countInitBlocks { it.localDeclarations.isNotEmpty() } shouldBeEqualTo 2
+            countInitBlocks { it.localFunctions.isNotEmpty() } shouldBeEqualTo 1
             hasInitBlocks shouldBeEqualTo true
         }
     }

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koobject/KoObjectDeclarationForKoParentProviderTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koobject/KoObjectDeclarationForKoParentProviderTest.kt
@@ -17,6 +17,7 @@ class KoObjectDeclarationForKoParentProviderTest {
         assertSoftly(sut) {
             parents shouldBeEqualTo emptyList()
             numParents shouldBeEqualTo 0
+            countParents { it.name == "SampleParentClass" } shouldBeEqualTo 0
             hasParents() shouldBeEqualTo false
             hasParents("SampleClass") shouldBeEqualTo false
         }
@@ -37,6 +38,8 @@ class KoObjectDeclarationForKoParentProviderTest {
                 "SampleParentInterface2",
             )
             numParents shouldBeEqualTo 3
+            countParents { it.name == "SampleParentClass" } shouldBeEqualTo 1
+            countParents { it.hasNameStartingWith("SampleParentInterface") } shouldBeEqualTo 2
             hasParents() shouldBeEqualTo true
             hasParents("SampleParentClass") shouldBeEqualTo true
             hasParents("OtherInterface") shouldBeEqualTo false

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koobject/forkomodifier/KoObjectDeclarationForKoModifierProviderTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koobject/forkomodifier/KoObjectDeclarationForKoModifierProviderTest.kt
@@ -24,6 +24,7 @@ class KoObjectDeclarationForKoModifierProviderTest {
         assertSoftly(sut) {
             modifiers shouldBeEqualTo emptyList()
             numModifiers shouldBeEqualTo 0
+            countModifiers { it.type == "private" } shouldBeEqualTo 0
             hasModifiers() shouldBeEqualTo false
             hasModifiers(OPEN) shouldBeEqualTo false
             hasModifiers(OPEN, DATA) shouldBeEqualTo false
@@ -42,6 +43,7 @@ class KoObjectDeclarationForKoModifierProviderTest {
         // then
         assertSoftly(sut) {
             numModifiers shouldBeEqualTo 2
+            countModifiers { it.type == "private" } shouldBeEqualTo 1
             hasModifiers() shouldBeEqualTo true
             hasModifiers(PRIVATE) shouldBeEqualTo true
             hasModifiers(DATA) shouldBeEqualTo true

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koobject/snippet/forkoinitblockprovider/object-with-two-init-blocks.kttxt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koobject/snippet/forkoinitblockprovider/object-with-two-init-blocks.kttxt
@@ -4,6 +4,8 @@ object SampleObject {
     }
 
     init {
+        fun localFunction() {}
+
         println("Sample text")
     }
 }

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koparameter/KoParameterDeclarationForKoAnnotationProviderTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koparameter/KoParameterDeclarationForKoAnnotationProviderTest.kt
@@ -23,6 +23,7 @@ class KoParameterDeclarationForKoAnnotationProviderTest {
         assertSoftly(sut) {
             it?.annotations shouldBeEqualTo emptyList()
             it?.numAnnotations shouldBeEqualTo 0
+            it?.countAnnotations { annotation -> annotation.name == "NonExistingAnnotation" } shouldBeEqualTo 0
             it?.hasAnnotations() shouldBeEqualTo false
         }
     }
@@ -40,6 +41,8 @@ class KoParameterDeclarationForKoAnnotationProviderTest {
         // then
         assertSoftly(sut) {
             it?.numAnnotations shouldBeEqualTo 1
+            it?.countAnnotations { annotation -> annotation.name == "SampleAnnotation" } shouldBeEqualTo 1
+            it?.countAnnotations { annotation -> annotation.name == "NonExistingAnnotation" } shouldBeEqualTo 0
             it?.hasAnnotations("SampleAnnotation") shouldBeEqualTo true
             it?.hasAnnotations("NonExistingAnnotation") shouldBeEqualTo false
             it?.hasAnnotations("com.lemonappdev.konsist.testdata.SampleAnnotation") shouldBeEqualTo true
@@ -62,6 +65,8 @@ class KoParameterDeclarationForKoAnnotationProviderTest {
         // then
         assertSoftly(sut) {
             it?.numAnnotations shouldBeEqualTo 2
+            it?.countAnnotations { annotation -> annotation.hasNameStartingWith("Sample") } shouldBeEqualTo 2
+            it?.countAnnotations { annotation -> annotation.name == "SampleAnnotation1" } shouldBeEqualTo 1
             it?.hasAnnotations("SampleAnnotation1") shouldBeEqualTo true
             it?.hasAnnotations("SampleAnnotation2") shouldBeEqualTo true
             it?.hasAnnotations("NonExistingAnnotation") shouldBeEqualTo false

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koparameter/forkomodifier/KoParameterDeclarationForKoModifierProviderTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koparameter/forkomodifier/KoParameterDeclarationForKoModifierProviderTest.kt
@@ -25,6 +25,7 @@ class KoParameterDeclarationForKoModifierProviderTest {
         assertSoftly(sut) {
             it?.modifiers shouldBeEqualTo emptyList()
             it?.numModifiers shouldBeEqualTo 0
+            it?.countModifiers { modifier -> modifier.type == "private" } shouldBeEqualTo 0
             it?.hasModifiers() shouldBeEqualTo false
             it?.hasModifiers(OPEN) shouldBeEqualTo false
             it?.hasModifiers(OPEN, DATA) shouldBeEqualTo false
@@ -45,6 +46,7 @@ class KoParameterDeclarationForKoModifierProviderTest {
         assertSoftly(sut) {
             it?.modifiers shouldNotBeEqualTo emptyList()
             it?.numModifiers shouldBeEqualTo 1
+            it?.countModifiers { modifier -> modifier.type == "public" } shouldBeEqualTo 1
             it?.hasModifiers() shouldBeEqualTo true
             it?.hasModifiers(PUBLIC) shouldBeEqualTo true
             it?.hasModifiers(PRIVATE) shouldBeEqualTo false

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koproperty/KoPropertyDeclarationForKoAnnotationProviderTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koproperty/KoPropertyDeclarationForKoAnnotationProviderTest.kt
@@ -20,6 +20,7 @@ class KoPropertyDeclarationForKoAnnotationProviderTest {
         assertSoftly(sut) {
             annotations shouldBeEqualTo emptyList()
             numAnnotations shouldBeEqualTo 0
+            countAnnotations { it.name == "NonExistingAnnotation" } shouldBeEqualTo 0
             hasAnnotations() shouldBeEqualTo false
         }
     }
@@ -34,6 +35,8 @@ class KoPropertyDeclarationForKoAnnotationProviderTest {
         // then
         assertSoftly(sut) {
             numAnnotations shouldBeEqualTo 1
+            countAnnotations { it.name == "SampleAnnotation" } shouldBeEqualTo 1
+            countAnnotations { it.name == "NonExistingAnnotation" } shouldBeEqualTo 0
             hasAnnotations("SampleAnnotation") shouldBeEqualTo true
             hasAnnotations("NonExistingAnnotation") shouldBeEqualTo false
             hasAnnotations("com.lemonappdev.konsist.testdata.SampleAnnotation") shouldBeEqualTo true
@@ -53,6 +56,8 @@ class KoPropertyDeclarationForKoAnnotationProviderTest {
         // then
         assertSoftly(sut) {
             numAnnotations shouldBeEqualTo 2
+            countAnnotations { it.hasNameStartingWith("Sample") } shouldBeEqualTo 2
+            countAnnotations { it.name == "SampleAnnotation1" } shouldBeEqualTo 1
             hasAnnotations("SampleAnnotation1") shouldBeEqualTo true
             hasAnnotations("SampleAnnotation2") shouldBeEqualTo true
             hasAnnotations("NonExistingAnnotation") shouldBeEqualTo false

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koproperty/forkomodifier/KoPropertyDeclarationForKoModifierProviderTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koproperty/forkomodifier/KoPropertyDeclarationForKoModifierProviderTest.kt
@@ -25,6 +25,7 @@ class KoPropertyDeclarationForKoModifierProviderTest {
         assertSoftly(sut) {
             modifiers shouldBeEqualTo emptyList()
             numModifiers shouldBeEqualTo 0
+            countModifiers { it.type == "private" } shouldBeEqualTo 0
             hasModifiers() shouldBeEqualTo false
             hasModifiers(OPEN) shouldBeEqualTo false
             hasModifiers(OPEN, DATA) shouldBeEqualTo false
@@ -41,6 +42,7 @@ class KoPropertyDeclarationForKoModifierProviderTest {
         // then
         assertSoftly(sut) {
             numModifiers shouldBeEqualTo 2
+            countModifiers { it.type == "protected" } shouldBeEqualTo 1
             hasModifiers() shouldBeEqualTo true
             hasModifiers(PROTECTED) shouldBeEqualTo true
             hasModifiers(OPEN) shouldBeEqualTo true

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/kotypealias/KoTypeAliasDeclarationForKoAnnotationProviderTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/kotypealias/KoTypeAliasDeclarationForKoAnnotationProviderTest.kt
@@ -20,6 +20,7 @@ class KoTypeAliasDeclarationForKoAnnotationProviderTest {
         assertSoftly(sut) {
             annotations shouldBeEqualTo emptyList()
             numAnnotations shouldBeEqualTo 0
+            countAnnotations { it.name == "NonExistingAnnotation" } shouldBeEqualTo 0
             hasAnnotations() shouldBeEqualTo false
         }
     }
@@ -34,6 +35,8 @@ class KoTypeAliasDeclarationForKoAnnotationProviderTest {
         // then
         assertSoftly(sut) {
             numAnnotations shouldBeEqualTo 1
+            countAnnotations { it.name == "SampleAnnotation" } shouldBeEqualTo 1
+            countAnnotations { it.name == "NonExistingAnnotation" } shouldBeEqualTo 0
             hasAnnotations("SampleAnnotation") shouldBeEqualTo true
             hasAnnotations("NonExistingAnnotation") shouldBeEqualTo false
             hasAnnotations("com.lemonappdev.konsist.testdata.SampleAnnotation") shouldBeEqualTo true
@@ -53,6 +56,8 @@ class KoTypeAliasDeclarationForKoAnnotationProviderTest {
         // then
         assertSoftly(sut) {
             numAnnotations shouldBeEqualTo 2
+            countAnnotations { it.hasNameStartingWith("Sample") } shouldBeEqualTo 2
+            countAnnotations { it.name == "SampleAnnotation1" } shouldBeEqualTo 1
             hasAnnotations("SampleAnnotation1") shouldBeEqualTo true
             hasAnnotations("SampleAnnotation2") shouldBeEqualTo true
             hasAnnotations("NonExistingAnnotation") shouldBeEqualTo false

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/kotypealias/forkomodifier/KoTypeAliasDeclarationForKoModifierProviderTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/kotypealias/forkomodifier/KoTypeAliasDeclarationForKoModifierProviderTest.kt
@@ -22,6 +22,7 @@ class KoTypeAliasDeclarationForKoModifierProviderTest {
         assertSoftly(sut) {
             modifiers shouldBeEqualTo emptyList()
             numModifiers shouldBeEqualTo 0
+            countModifiers { it.type == "private" } shouldBeEqualTo 0
             hasModifiers() shouldBeEqualTo false
             hasModifiers(KoModifier.OPEN) shouldBeEqualTo false
             hasModifiers(KoModifier.OPEN, KoModifier.DATA) shouldBeEqualTo false
@@ -42,6 +43,7 @@ class KoTypeAliasDeclarationForKoModifierProviderTest {
         assertSoftly(sut) {
             modifiers shouldBeEqualTo listOf(PRIVATE)
             numModifiers shouldBeEqualTo 1
+            countModifiers { it.type == "private" } shouldBeEqualTo 1
         }
     }
 

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/api/provider/KoAnnotationProvider.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/api/provider/KoAnnotationProvider.kt
@@ -1,6 +1,7 @@
 package com.lemonappdev.konsist.api.provider
 
 import com.lemonappdev.konsist.api.declaration.KoAnnotationDeclaration
+import com.lemonappdev.konsist.api.declaration.KoClassDeclaration
 import kotlin.reflect.KClass
 
 /**
@@ -16,6 +17,14 @@ interface KoAnnotationProvider : KoBaseProvider {
      * The number of annotations.
      */
     val numAnnotations: Int
+
+    /**
+     * Gets the number of annotations that satisfies the specified predicate present in the declaration.
+     *
+     * @param predicate The predicate function to determine if an annotation satisfies a condition.
+     * @return The number of annotations in the declaration.
+     */
+    fun countAnnotations(predicate: (KoAnnotationDeclaration) -> Boolean): Int
 
     /**
      * Whether the declaration has annotations.

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/api/provider/KoAnnotationProvider.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/api/provider/KoAnnotationProvider.kt
@@ -1,7 +1,6 @@
 package com.lemonappdev.konsist.api.provider
 
 import com.lemonappdev.konsist.api.declaration.KoAnnotationDeclaration
-import com.lemonappdev.konsist.api.declaration.KoClassDeclaration
 import kotlin.reflect.KClass
 
 /**

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/api/provider/KoConstructorProvider.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/api/provider/KoConstructorProvider.kt
@@ -1,5 +1,6 @@
 package com.lemonappdev.konsist.api.provider
 
+import com.lemonappdev.konsist.api.declaration.KoAnnotationDeclaration
 import com.lemonappdev.konsist.api.declaration.KoConstructorDeclaration
 
 /**
@@ -15,4 +16,12 @@ interface KoConstructorProvider : KoBaseProvider {
      * The number of constructors.
      */
     val numConstructors: Int
+
+    /**
+     * Gets the number of constructors that satisfies the specified predicate present in the declaration.
+     *
+     * @param predicate The predicate function to determine if a constructor satisfies a condition.
+     * @return The number of constructors in the declaration.
+     */
+    fun countConstructors(predicate: (KoConstructorDeclaration) -> Boolean): Int
 }

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/api/provider/KoConstructorProvider.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/api/provider/KoConstructorProvider.kt
@@ -1,6 +1,5 @@
 package com.lemonappdev.konsist.api.provider
 
-import com.lemonappdev.konsist.api.declaration.KoAnnotationDeclaration
 import com.lemonappdev.konsist.api.declaration.KoConstructorDeclaration
 
 /**

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/api/provider/KoEnumConstantProvider.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/api/provider/KoEnumConstantProvider.kt
@@ -1,6 +1,5 @@
 package com.lemonappdev.konsist.api.provider
 
-import com.lemonappdev.konsist.api.declaration.KoClassDeclaration
 import com.lemonappdev.konsist.api.declaration.KoEnumConstantDeclaration
 
 /**

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/api/provider/KoEnumConstantProvider.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/api/provider/KoEnumConstantProvider.kt
@@ -1,5 +1,6 @@
 package com.lemonappdev.konsist.api.provider
 
+import com.lemonappdev.konsist.api.declaration.KoClassDeclaration
 import com.lemonappdev.konsist.api.declaration.KoEnumConstantDeclaration
 
 /**
@@ -16,6 +17,14 @@ interface KoEnumConstantProvider : KoBaseProvider {
      * The number of enum constants.
      */
     val numEnumConstants: Int
+
+    /**
+     * Gets the number of enum constants that satisfies the specified predicate present in the declaration.
+     *
+     * @param predicate The predicate function to determine if an enum constant satisfies a condition.
+     * @return The number of enum constants in the declaration.
+     */
+    fun countEnumConstants(predicate: (KoEnumConstantDeclaration) -> Boolean): Int
 
     /**
      * Whether the declaration has enum constants.

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/api/provider/KoImportProvider.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/api/provider/KoImportProvider.kt
@@ -1,6 +1,5 @@
 package com.lemonappdev.konsist.api.provider
 
-import com.lemonappdev.konsist.api.declaration.KoAnnotationDeclaration
 import com.lemonappdev.konsist.api.declaration.KoImportDeclaration
 
 /**

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/api/provider/KoImportProvider.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/api/provider/KoImportProvider.kt
@@ -1,5 +1,6 @@
 package com.lemonappdev.konsist.api.provider
 
+import com.lemonappdev.konsist.api.declaration.KoAnnotationDeclaration
 import com.lemonappdev.konsist.api.declaration.KoImportDeclaration
 
 /**
@@ -15,6 +16,14 @@ interface KoImportProvider : KoBaseProvider {
      * The number of imports.
      */
     val numImports: Int
+
+    /**
+     * Gets the number of imports that satisfies the specified predicate present in the declaration.
+     *
+     * @param predicate The predicate function to determine if an import satisfies a condition.
+     * @return The number of imports in the declaration.
+     */
+    fun countImports(predicate: (KoImportDeclaration) -> Boolean): Int
 
     /**
      * Whether the declaration has imports.

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/api/provider/KoInitBlockProvider.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/api/provider/KoInitBlockProvider.kt
@@ -1,6 +1,5 @@
 package com.lemonappdev.konsist.api.provider
 
-import com.lemonappdev.konsist.api.declaration.KoAnnotationDeclaration
 import com.lemonappdev.konsist.api.declaration.KoInitBlockDeclaration
 
 /**

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/api/provider/KoInitBlockProvider.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/api/provider/KoInitBlockProvider.kt
@@ -1,5 +1,6 @@
 package com.lemonappdev.konsist.api.provider
 
+import com.lemonappdev.konsist.api.declaration.KoAnnotationDeclaration
 import com.lemonappdev.konsist.api.declaration.KoInitBlockDeclaration
 
 /**
@@ -20,4 +21,12 @@ interface KoInitBlockProvider : KoBaseProvider {
      * Whatever declaration has init blocks.
      */
     val hasInitBlocks: Boolean
+
+    /**
+     * Gets the number of init blocks that satisfies the specified predicate present in the declaration.
+     *
+     * @param predicate The predicate function to determine if an init block satisfies a condition.
+     * @return The number of init blocks in the declaration.
+     */
+    fun countInitBlocks(predicate: (KoInitBlockDeclaration) -> Boolean): Int
 }

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/api/provider/KoParametersProvider.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/api/provider/KoParametersProvider.kt
@@ -1,5 +1,6 @@
 package com.lemonappdev.konsist.api.provider
 
+import com.lemonappdev.konsist.api.declaration.KoAnnotationDeclaration
 import com.lemonappdev.konsist.api.declaration.KoParameterDeclaration
 
 /**
@@ -15,6 +16,14 @@ interface KoParametersProvider : KoBaseProvider {
      * The number of parameters.
      */
     val numParameters: Int
+
+    /**
+     * Gets the number of parameters that satisfies the specified predicate present in the declaration.
+     *
+     * @param predicate The predicate function to determine if a parameter satisfies a condition.
+     * @return The number of parameters in the declaration.
+     */
+    fun countParameters(predicate: (KoParameterDeclaration) -> Boolean): Int
 
     /**
      * Whatever declaration has a parameter with given name.

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/api/provider/KoParametersProvider.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/api/provider/KoParametersProvider.kt
@@ -1,6 +1,5 @@
 package com.lemonappdev.konsist.api.provider
 
-import com.lemonappdev.konsist.api.declaration.KoAnnotationDeclaration
 import com.lemonappdev.konsist.api.declaration.KoParameterDeclaration
 
 /**

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/api/provider/KoParentProvider.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/api/provider/KoParentProvider.kt
@@ -1,5 +1,6 @@
 package com.lemonappdev.konsist.api.provider
 
+import com.lemonappdev.konsist.api.declaration.KoAnnotationDeclaration
 import com.lemonappdev.konsist.api.declaration.KoParentDeclaration
 
 /**
@@ -16,6 +17,14 @@ interface KoParentProvider : KoBaseProvider {
      * The number of parents.
      */
     val numParents: Int
+
+    /**
+     * Gets the number of parents that satisfies the specified predicate present in the declaration.
+     *
+     * @param predicate The predicate function to determine if an parent satisfies a condition.
+     * @return The number of parents in the declaration.
+     */
+    fun countParents(predicate: (KoParentDeclaration) -> Boolean): Int
 
     /**
      * Whatever class has parents (parent class and parent interfaces) defined directly in the Kotlin file.

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/api/provider/KoParentProvider.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/api/provider/KoParentProvider.kt
@@ -1,6 +1,5 @@
 package com.lemonappdev.konsist.api.provider
 
-import com.lemonappdev.konsist.api.declaration.KoAnnotationDeclaration
 import com.lemonappdev.konsist.api.declaration.KoParentDeclaration
 
 /**

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/api/provider/KoSecondaryConstructorsProvider.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/api/provider/KoSecondaryConstructorsProvider.kt
@@ -1,5 +1,6 @@
 package com.lemonappdev.konsist.api.provider
 
+import com.lemonappdev.konsist.api.declaration.KoAnnotationDeclaration
 import com.lemonappdev.konsist.api.declaration.KoSecondaryConstructorDeclaration
 
 /**
@@ -20,4 +21,12 @@ interface KoSecondaryConstructorsProvider : KoBaseProvider {
      * Whatever declaration has secondary constructors.
      */
     val hasSecondaryConstructors: Boolean
+
+    /**
+     * Gets the number of secondary constructors that satisfies the specified predicate present in the declaration.
+     *
+     * @param predicate The predicate function to determine if a secondary constructor satisfies a condition.
+     * @return The number of secondary constructors in the declaration.
+     */
+    fun countSecondaryConstructors(predicate: (KoSecondaryConstructorDeclaration) -> Boolean): Int
 }

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/api/provider/KoSecondaryConstructorsProvider.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/api/provider/KoSecondaryConstructorsProvider.kt
@@ -1,6 +1,5 @@
 package com.lemonappdev.konsist.api.provider
 
-import com.lemonappdev.konsist.api.declaration.KoAnnotationDeclaration
 import com.lemonappdev.konsist.api.declaration.KoSecondaryConstructorDeclaration
 
 /**

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/api/provider/KoTypeAliasProvider.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/api/provider/KoTypeAliasProvider.kt
@@ -1,5 +1,6 @@
 package com.lemonappdev.konsist.api.provider
 
+import com.lemonappdev.konsist.api.declaration.KoAnnotationDeclaration
 import com.lemonappdev.konsist.api.declaration.KoTypeAliasDeclaration
 
 /**
@@ -16,6 +17,14 @@ interface KoTypeAliasProvider : KoBaseProvider {
      * The number of type aliases.
      */
     val numTypeAliases: Int
+
+    /**
+     * Gets the number of type aliases that satisfies the specified predicate present in the declaration.
+     *
+     * @param predicate The predicate function to determine if a type alias satisfies a condition.
+     * @return The number of type aliases in the declaration.
+     */
+    fun countTypeAliases(predicate: (KoTypeAliasDeclaration) -> Boolean): Int
 
     /**
      * Whether the declaration has type aliases.

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/api/provider/KoTypeAliasProvider.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/api/provider/KoTypeAliasProvider.kt
@@ -1,6 +1,5 @@
 package com.lemonappdev.konsist.api.provider
 
-import com.lemonappdev.konsist.api.declaration.KoAnnotationDeclaration
 import com.lemonappdev.konsist.api.declaration.KoTypeAliasDeclaration
 
 /**

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/api/provider/modifier/KoModifierProvider.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/api/provider/modifier/KoModifierProvider.kt
@@ -6,7 +6,6 @@ import com.lemonappdev.konsist.api.provider.KoBaseProvider
 /**
  * An interface representing a Kotlin declaration that provides access to its modifiers.
  */
-@Suppress("detekt.TooManyFunctions")
 interface KoModifierProvider : KoBaseProvider {
     /**
      * List of modifiers.

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/api/provider/modifier/KoModifierProvider.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/api/provider/modifier/KoModifierProvider.kt
@@ -1,6 +1,7 @@
 package com.lemonappdev.konsist.api.provider.modifier
 
 import com.lemonappdev.konsist.api.KoModifier
+import com.lemonappdev.konsist.api.declaration.KoAnnotationDeclaration
 import com.lemonappdev.konsist.api.provider.KoBaseProvider
 
 /**
@@ -16,6 +17,14 @@ interface KoModifierProvider : KoBaseProvider {
      * The number of modifiers.
      */
     val numModifiers: Int
+
+    /**
+     * Gets the number of modifiers that satisfies the specified predicate present in the declaration.
+     *
+     * @param predicate The predicate function to determine if a modifier satisfies a condition.
+     * @return The number of modifiers in the declaration.
+     */
+    fun countModifiers(predicate: (KoModifier) -> Boolean): Int
 
     /**
      * Whether the declaration has modifiers.

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/api/provider/modifier/KoModifierProvider.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/api/provider/modifier/KoModifierProvider.kt
@@ -1,7 +1,6 @@
 package com.lemonappdev.konsist.api.provider.modifier
 
 import com.lemonappdev.konsist.api.KoModifier
-import com.lemonappdev.konsist.api.declaration.KoAnnotationDeclaration
 import com.lemonappdev.konsist.api.provider.KoBaseProvider
 
 /**

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/core/declaration/KoFunctionDeclarationCore.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/core/declaration/KoFunctionDeclarationCore.kt
@@ -46,7 +46,6 @@ import org.jetbrains.kotlin.psi.KtElement
 import org.jetbrains.kotlin.psi.KtFunction
 import org.jetbrains.kotlin.psi.KtTypeParameterListOwner
 
-@Suppress("detekt.TooManyFunctions")
 internal class KoFunctionDeclarationCore private constructor(
     override val ktFunction: KtFunction,
     override val containingDeclaration: KoContainingDeclarationProvider,

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/KoAnnotationProviderCore.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/KoAnnotationProviderCore.kt
@@ -1,7 +1,6 @@
 package com.lemonappdev.konsist.core.provider
 
 import com.lemonappdev.konsist.api.declaration.KoAnnotationDeclaration
-import com.lemonappdev.konsist.api.declaration.KoEnumConstantDeclaration
 import com.lemonappdev.konsist.api.provider.KoAnnotationProvider
 import com.lemonappdev.konsist.core.declaration.KoAnnotationDeclarationCore
 import org.jetbrains.kotlin.psi.KtAnnotated

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/KoAnnotationProviderCore.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/KoAnnotationProviderCore.kt
@@ -1,6 +1,7 @@
 package com.lemonappdev.konsist.core.provider
 
 import com.lemonappdev.konsist.api.declaration.KoAnnotationDeclaration
+import com.lemonappdev.konsist.api.declaration.KoEnumConstantDeclaration
 import com.lemonappdev.konsist.api.provider.KoAnnotationProvider
 import com.lemonappdev.konsist.core.declaration.KoAnnotationDeclarationCore
 import org.jetbrains.kotlin.psi.KtAnnotated
@@ -19,6 +20,9 @@ internal interface KoAnnotationProviderCore :
 
     override val numAnnotations: Int
         get() = annotations.size
+
+    override fun countAnnotations(predicate: (KoAnnotationDeclaration) -> Boolean): Int =
+        annotations.count { predicate(it) }
 
     override fun hasAnnotations(vararg names: String): Boolean = when {
         names.isEmpty() -> annotations.isNotEmpty()

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/KoConstructorProviderCore.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/KoConstructorProviderCore.kt
@@ -1,6 +1,5 @@
 package com.lemonappdev.konsist.core.provider
 
-import com.lemonappdev.konsist.api.declaration.KoAnnotationDeclaration
 import com.lemonappdev.konsist.api.declaration.KoConstructorDeclaration
 import com.lemonappdev.konsist.api.provider.KoConstructorProvider
 

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/KoConstructorProviderCore.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/KoConstructorProviderCore.kt
@@ -1,5 +1,6 @@
 package com.lemonappdev.konsist.core.provider
 
+import com.lemonappdev.konsist.api.declaration.KoAnnotationDeclaration
 import com.lemonappdev.konsist.api.declaration.KoConstructorDeclaration
 import com.lemonappdev.konsist.api.provider.KoConstructorProvider
 
@@ -13,4 +14,7 @@ internal interface KoConstructorProviderCore :
 
     override val numConstructors: Int
         get() = constructors.size
+
+    override fun countConstructors(predicate: (KoConstructorDeclaration) -> Boolean): Int =
+        constructors.count { predicate(it) }
 }

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/KoEnumConstantProviderCore.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/KoEnumConstantProviderCore.kt
@@ -8,7 +8,8 @@ import org.jetbrains.kotlin.psi.KtClassBody
 import org.jetbrains.kotlin.psi.KtEnumEntry
 import org.jetbrains.kotlin.utils.addToStdlib.firstIsInstanceOrNull
 
-internal interface KoEnumConstantProviderCore : KoEnumConstantProvider, KoBaseProviderCore, KoContainingDeclarationProviderCore {
+internal interface KoEnumConstantProviderCore : KoEnumConstantProvider, KoBaseProviderCore,
+    KoContainingDeclarationProviderCore {
     val ktClass: KtClass
 
     override val enumConstants: List<KoEnumConstantDeclaration>
@@ -21,6 +22,9 @@ internal interface KoEnumConstantProviderCore : KoEnumConstantProvider, KoBasePr
 
     override val numEnumConstants: Int
         get() = enumConstants.size
+
+    override fun countEnumConstants(predicate: (KoEnumConstantDeclaration) -> Boolean): Int =
+        enumConstants.count { predicate(it) }
 
     override fun hasEnumConstants(vararg names: String): Boolean = when {
         names.isEmpty() -> enumConstants.isNotEmpty()

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/KoEnumConstantProviderCore.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/KoEnumConstantProviderCore.kt
@@ -8,7 +8,9 @@ import org.jetbrains.kotlin.psi.KtClassBody
 import org.jetbrains.kotlin.psi.KtEnumEntry
 import org.jetbrains.kotlin.utils.addToStdlib.firstIsInstanceOrNull
 
-internal interface KoEnumConstantProviderCore : KoEnumConstantProvider, KoBaseProviderCore,
+internal interface KoEnumConstantProviderCore :
+    KoEnumConstantProvider,
+    KoBaseProviderCore,
     KoContainingDeclarationProviderCore {
     val ktClass: KtClass
 

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/KoImportProviderCore.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/KoImportProviderCore.kt
@@ -1,5 +1,6 @@
 package com.lemonappdev.konsist.core.provider
 
+import com.lemonappdev.konsist.api.declaration.KoAnnotationDeclaration
 import com.lemonappdev.konsist.api.declaration.KoImportDeclaration
 import com.lemonappdev.konsist.api.provider.KoImportProvider
 import com.lemonappdev.konsist.core.declaration.KoImportDeclarationCore
@@ -26,6 +27,9 @@ internal interface KoImportProviderCore : KoImportProvider, KoContainingDeclarat
 
     override val numImports: Int
         get() = imports.size
+
+    override fun countImports(predicate: (KoImportDeclaration) -> Boolean): Int =
+        imports.count { predicate(it) }
 
     override fun hasImports(vararg names: String): Boolean = when {
         names.isEmpty() -> imports.isNotEmpty()

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/KoImportProviderCore.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/KoImportProviderCore.kt
@@ -1,6 +1,5 @@
 package com.lemonappdev.konsist.core.provider
 
-import com.lemonappdev.konsist.api.declaration.KoAnnotationDeclaration
 import com.lemonappdev.konsist.api.declaration.KoImportDeclaration
 import com.lemonappdev.konsist.api.provider.KoImportProvider
 import com.lemonappdev.konsist.core.declaration.KoImportDeclarationCore

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/KoInitBlockProviderCore.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/KoInitBlockProviderCore.kt
@@ -1,5 +1,6 @@
 package com.lemonappdev.konsist.core.provider
 
+import com.lemonappdev.konsist.api.declaration.KoAnnotationDeclaration
 import com.lemonappdev.konsist.api.declaration.KoInitBlockDeclaration
 import com.lemonappdev.konsist.api.provider.KoInitBlockProvider
 import com.lemonappdev.konsist.core.declaration.KoInitBlockDeclarationCore
@@ -31,4 +32,7 @@ internal interface KoInitBlockProviderCore :
 
     override val hasInitBlocks: Boolean
         get() = initBlocks.isNotEmpty()
+
+    override fun countInitBlocks(predicate: (KoInitBlockDeclaration) -> Boolean): Int =
+        initBlocks.count { predicate(it) }
 }

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/KoInitBlockProviderCore.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/KoInitBlockProviderCore.kt
@@ -1,6 +1,5 @@
 package com.lemonappdev.konsist.core.provider
 
-import com.lemonappdev.konsist.api.declaration.KoAnnotationDeclaration
 import com.lemonappdev.konsist.api.declaration.KoInitBlockDeclaration
 import com.lemonappdev.konsist.api.provider.KoInitBlockProvider
 import com.lemonappdev.konsist.core.declaration.KoInitBlockDeclarationCore

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/KoParametersProviderCore.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/KoParametersProviderCore.kt
@@ -1,5 +1,6 @@
 package com.lemonappdev.konsist.core.provider
 
+import com.lemonappdev.konsist.api.declaration.KoAnnotationDeclaration
 import com.lemonappdev.konsist.api.declaration.KoParameterDeclaration
 import com.lemonappdev.konsist.api.provider.KoParametersProvider
 import com.lemonappdev.konsist.core.declaration.KoParameterDeclarationCore
@@ -19,6 +20,9 @@ internal interface KoParametersProviderCore :
 
     override val numParameters: Int
         get() = parameters.size
+
+    override fun countParameters(predicate: (KoParameterDeclaration) -> Boolean): Int =
+        parameters.count { predicate(it) }
 
     override fun hasParameterNamed(name: String): Boolean = parameters.any { it.name == name }
 }

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/KoParametersProviderCore.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/KoParametersProviderCore.kt
@@ -1,6 +1,5 @@
 package com.lemonappdev.konsist.core.provider
 
-import com.lemonappdev.konsist.api.declaration.KoAnnotationDeclaration
 import com.lemonappdev.konsist.api.declaration.KoParameterDeclaration
 import com.lemonappdev.konsist.api.provider.KoParametersProvider
 import com.lemonappdev.konsist.core.declaration.KoParameterDeclarationCore

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/KoParentProviderCore.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/KoParentProviderCore.kt
@@ -1,5 +1,6 @@
 package com.lemonappdev.konsist.core.provider
 
+import com.lemonappdev.konsist.api.declaration.KoAnnotationDeclaration
 import com.lemonappdev.konsist.api.declaration.KoParentDeclaration
 import com.lemonappdev.konsist.api.provider.KoParentProvider
 import com.lemonappdev.konsist.core.declaration.KoParentDeclarationCore
@@ -22,6 +23,9 @@ internal interface KoParentProviderCore :
 
     override val numParents: Int
         get() = parents.size
+
+    override fun countParents(predicate: (KoParentDeclaration) -> Boolean): Int =
+        parents.count { predicate(it) }
 
     override fun hasParents(vararg names: String): Boolean = when {
         names.isEmpty() -> parents.isNotEmpty()

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/KoParentProviderCore.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/KoParentProviderCore.kt
@@ -1,6 +1,5 @@
 package com.lemonappdev.konsist.core.provider
 
-import com.lemonappdev.konsist.api.declaration.KoAnnotationDeclaration
 import com.lemonappdev.konsist.api.declaration.KoParentDeclaration
 import com.lemonappdev.konsist.api.provider.KoParentProvider
 import com.lemonappdev.konsist.core.declaration.KoParentDeclarationCore

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/KoSecondaryConstructorsProviderCore.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/KoSecondaryConstructorsProviderCore.kt
@@ -1,5 +1,6 @@
 package com.lemonappdev.konsist.core.provider
 
+import com.lemonappdev.konsist.api.declaration.KoAnnotationDeclaration
 import com.lemonappdev.konsist.api.declaration.KoSecondaryConstructorDeclaration
 import com.lemonappdev.konsist.api.provider.KoSecondaryConstructorsProvider
 import com.lemonappdev.konsist.core.declaration.KoSecondaryConstructorDeclarationCore
@@ -22,4 +23,7 @@ internal interface KoSecondaryConstructorsProviderCore :
 
     override val hasSecondaryConstructors: Boolean
         get() = ktClass.hasSecondaryConstructors()
+
+    override fun countSecondaryConstructors(predicate: (KoSecondaryConstructorDeclaration) -> Boolean): Int =
+        secondaryConstructors.count { predicate(it) }
 }

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/KoSecondaryConstructorsProviderCore.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/KoSecondaryConstructorsProviderCore.kt
@@ -1,6 +1,5 @@
 package com.lemonappdev.konsist.core.provider
 
-import com.lemonappdev.konsist.api.declaration.KoAnnotationDeclaration
 import com.lemonappdev.konsist.api.declaration.KoSecondaryConstructorDeclaration
 import com.lemonappdev.konsist.api.provider.KoSecondaryConstructorsProvider
 import com.lemonappdev.konsist.core.declaration.KoSecondaryConstructorDeclarationCore

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/KoTypeAliasProviderCore.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/KoTypeAliasProviderCore.kt
@@ -6,7 +6,9 @@ import com.lemonappdev.konsist.core.declaration.KoTypeAliasDeclarationCore
 import org.jetbrains.kotlin.psi.KtFile
 import org.jetbrains.kotlin.psi.KtTypeAlias
 
-internal interface KoTypeAliasProviderCore : KoTypeAliasProvider, KoBaseProviderCore,
+internal interface KoTypeAliasProviderCore :
+    KoTypeAliasProvider,
+    KoBaseProviderCore,
     KoContainingDeclarationProviderCore {
     val ktFile: KtFile
 

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/KoTypeAliasProviderCore.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/KoTypeAliasProviderCore.kt
@@ -6,7 +6,8 @@ import com.lemonappdev.konsist.core.declaration.KoTypeAliasDeclarationCore
 import org.jetbrains.kotlin.psi.KtFile
 import org.jetbrains.kotlin.psi.KtTypeAlias
 
-internal interface KoTypeAliasProviderCore : KoTypeAliasProvider, KoBaseProviderCore, KoContainingDeclarationProviderCore {
+internal interface KoTypeAliasProviderCore : KoTypeAliasProvider, KoBaseProviderCore,
+    KoContainingDeclarationProviderCore {
     val ktFile: KtFile
 
     override val typeAliases: List<KoTypeAliasDeclaration>
@@ -17,6 +18,9 @@ internal interface KoTypeAliasProviderCore : KoTypeAliasProvider, KoBaseProvider
 
     override val numTypeAliases: Int
         get() = typeAliases.size
+
+    override fun countTypeAliases(predicate: (KoTypeAliasDeclaration) -> Boolean): Int =
+        typeAliases.count { predicate(it) }
 
     override fun hasTypeAliases(vararg names: String): Boolean = when {
         names.isEmpty() -> typeAliases.isNotEmpty()

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/modifier/KoModifierProviderCore.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/modifier/KoModifierProviderCore.kt
@@ -1,7 +1,6 @@
 package com.lemonappdev.konsist.core.provider.modifier
 
 import com.lemonappdev.konsist.api.KoModifier
-import com.lemonappdev.konsist.api.declaration.KoAnnotationDeclaration
 import com.lemonappdev.konsist.api.provider.modifier.KoModifierProvider
 import com.lemonappdev.konsist.core.exception.KoInternalException
 import com.lemonappdev.konsist.core.provider.KoBaseProviderCore

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/modifier/KoModifierProviderCore.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/modifier/KoModifierProviderCore.kt
@@ -1,6 +1,7 @@
 package com.lemonappdev.konsist.core.provider.modifier
 
 import com.lemonappdev.konsist.api.KoModifier
+import com.lemonappdev.konsist.api.declaration.KoAnnotationDeclaration
 import com.lemonappdev.konsist.api.provider.modifier.KoModifierProvider
 import com.lemonappdev.konsist.core.exception.KoInternalException
 import com.lemonappdev.konsist.core.provider.KoBaseProviderCore
@@ -39,6 +40,9 @@ internal interface KoModifierProviderCore : KoModifierProvider, KoBaseProviderCo
 
     override val numModifiers: Int
         get() = modifiers.size
+
+    override fun countModifiers(predicate: (KoModifier) -> Boolean): Int =
+        modifiers.count { predicate(it) }
 
     override fun hasModifiers(vararg koModifiers: KoModifier): Boolean = when {
         koModifiers.isEmpty() -> modifiers.isNotEmpty()


### PR DESCRIPTION
Added `countX` methods for `KoAnnotationProvider`, `KoConstructorProvider`, `KoEnumConstantProvider`, `KoImportProvider`, `KoInitBlockProvider`, `KoParametersProvider`, `KoParentProvider`, `KoSecondaryConstructorProvider`, `KoTypeAliasProvider` and `KoModifierProvider`.

`countX` gets the number of elements that satisfies the specified predicate. 

E.g.
```kotlin
Konsist
  .scopeFromProject()
  .classes()
  .withEnumModifier()
  .assert {
      it.countEnumConstants { const -> const.hasAnnotations() } == 0
  }
```