### PR TITLE
KON-386 KoPropertyTypeProvider Add `hasTypeOf` And `hasType(lambda)`

### DIFF
--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/api/ext/provider/kopropertytype/KoPropertyTypeProviderExtTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/api/ext/provider/kopropertytype/KoPropertyTypeProviderExtTest.kt
@@ -2,8 +2,6 @@ package com.lemonappdev.konsist.api.ext.provider.kopropertytype
 
 import com.lemonappdev.konsist.TestSnippetProvider
 import com.lemonappdev.konsist.api.ext.koscope.declarationsOf
-import com.lemonappdev.konsist.api.ext.provider.hasReceiverTypeOf
-import com.lemonappdev.konsist.api.ext.provider.hasValidKDocReceiverTag
 import com.lemonappdev.konsist.api.provider.KoPropertyTypeProvider
 import com.lemonappdev.konsist.testdata.SampleClass
 import hasTypeOf

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/api/ext/provider/kopropertytype/KoPropertyTypeProviderExtTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/api/ext/provider/kopropertytype/KoPropertyTypeProviderExtTest.kt
@@ -1,0 +1,59 @@
+package com.lemonappdev.konsist.api.ext.provider.kopropertytype
+
+import com.lemonappdev.konsist.TestSnippetProvider
+import com.lemonappdev.konsist.api.ext.koscope.declarationsOf
+import com.lemonappdev.konsist.api.ext.provider.hasReceiverTypeOf
+import com.lemonappdev.konsist.api.ext.provider.hasValidKDocReceiverTag
+import com.lemonappdev.konsist.api.provider.KoPropertyTypeProvider
+import com.lemonappdev.konsist.testdata.SampleClass
+import hasTypeOf
+import org.amshove.kluent.assertSoftly
+import org.amshove.kluent.shouldBeEqualTo
+import org.junit.jupiter.api.Test
+
+class KoPropertyTypeProviderExtTest {
+    @Test
+    fun `declaration-has-no-type`() {
+        // given
+        val sut = getSnippetFile("declaration-has-no-type")
+            .declarationsOf<KoPropertyTypeProvider>()
+            .first()
+
+        // then
+        assertSoftly(sut) {
+            hasTypeOf<Int>() shouldBeEqualTo false
+            hasTypeOf<SampleClass>() shouldBeEqualTo false
+        }
+    }
+
+    @Test
+    fun `declaration-has-simple-type`() {
+        // given
+        val sut = getSnippetFile("declaration-has-simple-type")
+            .declarationsOf<KoPropertyTypeProvider>()
+            .first()
+
+        // then
+        assertSoftly(sut) {
+            hasTypeOf<Int>() shouldBeEqualTo true
+            hasTypeOf<SampleClass>() shouldBeEqualTo false
+        }
+    }
+
+    @Test
+    fun `declaration-has-complex-type`() {
+        // given
+        val sut = getSnippetFile("declaration-has-complex-type")
+            .declarationsOf<KoPropertyTypeProvider>()
+            .first()
+
+        // then
+        assertSoftly(sut) {
+            hasTypeOf<SampleClass>() shouldBeEqualTo true
+            hasTypeOf<Int>() shouldBeEqualTo false
+        }
+    }
+
+    private fun getSnippetFile(fileName: String) =
+        TestSnippetProvider.getSnippetKoScope("api/ext/provider/kopropertytype/snippet/", fileName)
+}

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/api/ext/provider/kopropertytype/snippet/declaration-has-complex-type.kttxt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/api/ext/provider/kopropertytype/snippet/declaration-has-complex-type.kttxt
@@ -1,0 +1,3 @@
+import com.lemonappdev.konsist.testdata.SampleClass
+
+val sampleProperty: SampleClass = SampleClass()

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/api/ext/provider/kopropertytype/snippet/declaration-has-no-type.kttxt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/api/ext/provider/kopropertytype/snippet/declaration-has-no-type.kttxt
@@ -1,0 +1,1 @@
+val sampleProperty = ""

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/api/ext/provider/kopropertytype/snippet/declaration-has-simple-type.kttxt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/api/ext/provider/kopropertytype/snippet/declaration-has-simple-type.kttxt
@@ -1,0 +1,1 @@
+val sampleProperty: Int = 0

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koproperty/KoPropertyDeclarationForKoPropertyTypeProviderTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koproperty/KoPropertyDeclarationForKoPropertyTypeProviderTest.kt
@@ -17,6 +17,8 @@ class KoPropertyDeclarationForKoPropertyTypeProviderTest {
         assertSoftly(sut) {
             type shouldBeEqualTo null
             hasType() shouldBeEqualTo false
+            hasType { it.name == "String" } shouldBeEqualTo false
+            hasTypeOf(String::class) shouldBeEqualTo false
             hasType("String") shouldBeEqualTo false
         }
     }
@@ -32,6 +34,10 @@ class KoPropertyDeclarationForKoPropertyTypeProviderTest {
         assertSoftly(sut) {
             type?.name shouldBeEqualTo "String"
             hasType() shouldBeEqualTo true
+            hasType { it.name == "String" } shouldBeEqualTo true
+            hasType { it.name == "Int" } shouldBeEqualTo false
+            hasTypeOf(String::class) shouldBeEqualTo true
+            hasTypeOf(Int::class) shouldBeEqualTo false
             hasType("String") shouldBeEqualTo true
             hasType("Int") shouldBeEqualTo false
         }

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/api/ext/list/KoPropertyTypeProviderListExt.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/api/ext/list/KoPropertyTypeProviderListExt.kt
@@ -30,7 +30,7 @@ fun <T : KoPropertyTypeProvider> List<T>.withType(vararg names: String): List<T>
  * @param names The type name(s) to exclude.
  * @return A list containing declarations without specified type (or none type if [names] is empty).
  */
-@Deprecated("Will be removed in v1.0.0", ReplaceWith("withoutType { it.name == ... }"))
+@Deprecated("Will be removed in v1.0.0", ReplaceWith("withoutType { it.name != ... }"))
 fun <T : KoPropertyTypeProvider> List<T>.withoutType(vararg names: String): List<T> = filter {
     when {
         names.isEmpty() -> !it.hasType()

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/api/ext/list/KoPropertyTypeProviderListExt.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/api/ext/list/KoPropertyTypeProviderListExt.kt
@@ -76,11 +76,11 @@ fun <T : KoPropertyTypeProvider> List<T>.withoutType(predicate: ((KoTypeDeclarat
 fun <T : KoPropertyTypeProvider> List<T>.withTypeOf(kClass: KClass<*>, vararg kClasses: KClass<*>): List<T> =
     filter {
         it.type?.name == kClass.simpleName ||
-                if (kClasses.isNotEmpty()) {
-                    kClasses.any { kClass -> it.type?.name == kClass.simpleName }
-                } else {
-                    false
-                }
+            if (kClasses.isNotEmpty()) {
+                kClasses.any { kClass -> it.type?.name == kClass.simpleName }
+            } else {
+                false
+            }
     }
 
 /**
@@ -93,9 +93,9 @@ fun <T : KoPropertyTypeProvider> List<T>.withTypeOf(kClass: KClass<*>, vararg kC
 fun <T : KoPropertyTypeProvider> List<T>.withoutTypeOf(kClass: KClass<*>, vararg kClasses: KClass<*>): List<T> =
     filter {
         it.type?.name != kClass.simpleName &&
-                if (kClasses.isNotEmpty()) {
-                    kClasses.none { kClass -> it.type?.name == kClass.simpleName }
-                } else {
-                    true
-                }
+            if (kClasses.isNotEmpty()) {
+                kClasses.none { kClass -> it.type?.name == kClass.simpleName }
+            } else {
+                true
+            }
     }

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/api/ext/list/KoPropertyTypeProviderListExt.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/api/ext/list/KoPropertyTypeProviderListExt.kt
@@ -16,6 +16,7 @@ val <T : KoPropertyTypeProvider> List<T>.types: List<KoTypeDeclaration>
  * @param names The type name(s) to include.
  * @return A list containing declarations with the specified type (or any type if [names] is empty).
  */
+@Deprecated("Will be removed in v1.0.0", ReplaceWith("withType { it.name == ... }"))
 fun <T : KoPropertyTypeProvider> List<T>.withType(vararg names: String): List<T> = filter {
     when {
         names.isEmpty() -> it.hasType()
@@ -29,10 +30,25 @@ fun <T : KoPropertyTypeProvider> List<T>.withType(vararg names: String): List<T>
  * @param names The type name(s) to exclude.
  * @return A list containing declarations without specified type (or none type if [names] is empty).
  */
+@Deprecated("Will be removed in v1.0.0", ReplaceWith("withoutType { it.name == ... }"))
 fun <T : KoPropertyTypeProvider> List<T>.withoutType(vararg names: String): List<T> = filter {
     when {
         names.isEmpty() -> !it.hasType()
         else -> names.none { type -> it.hasType(type) }
+    }
+}
+
+fun <T : KoPropertyTypeProvider> List<T>.withType(predicate: ((KoTypeDeclaration) -> Boolean)? = null) = filter {
+    when (predicate) {
+        null -> it.hasType()
+        else -> it.type?.let { type -> predicate(type) } ?: false
+    }
+}
+
+fun <T : KoPropertyTypeProvider> List<T>.withoutType(predicate: ((KoTypeDeclaration) -> Boolean)? = null) = filterNot {
+    when (predicate) {
+        null -> it.hasType()
+        else -> it.type?.let { type -> predicate(type) } ?: false
     }
 }
 
@@ -46,11 +62,11 @@ fun <T : KoPropertyTypeProvider> List<T>.withoutType(vararg names: String): List
 fun <T : KoPropertyTypeProvider> List<T>.withTypeOf(kClass: KClass<*>, vararg kClasses: KClass<*>): List<T> =
     filter {
         it.type?.name == kClass.simpleName ||
-            if (kClasses.isNotEmpty()) {
-                kClasses.any { kClass -> it.type?.name == kClass.simpleName }
-            } else {
-                false
-            }
+                if (kClasses.isNotEmpty()) {
+                    kClasses.any { kClass -> it.type?.name == kClass.simpleName }
+                } else {
+                    false
+                }
     }
 
 /**
@@ -63,9 +79,9 @@ fun <T : KoPropertyTypeProvider> List<T>.withTypeOf(kClass: KClass<*>, vararg kC
 fun <T : KoPropertyTypeProvider> List<T>.withoutTypeOf(kClass: KClass<*>, vararg kClasses: KClass<*>): List<T> =
     filter {
         it.type?.name != kClass.simpleName &&
-            if (kClasses.isNotEmpty()) {
-                kClasses.none { kClass -> it.type?.name == kClass.simpleName }
-            } else {
-                true
-            }
+                if (kClasses.isNotEmpty()) {
+                    kClasses.none { kClass -> it.type?.name == kClass.simpleName }
+                } else {
+                    true
+                }
     }

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/api/ext/list/KoPropertyTypeProviderListExt.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/api/ext/list/KoPropertyTypeProviderListExt.kt
@@ -38,19 +38,33 @@ fun <T : KoPropertyTypeProvider> List<T>.withoutType(vararg names: String): List
     }
 }
 
-fun <T : KoPropertyTypeProvider> List<T>.withType(predicate: ((KoTypeDeclaration) -> Boolean)? = null) = filter {
-    when (predicate) {
-        null -> it.hasType()
-        else -> it.type?.let { type -> predicate(type) } ?: false
+/**
+ * List containing declarations with the specified type.
+ *
+ * @param predicate The predicate function to determine if a declaration type satisfies a condition.
+ * @return A list containing declarations with the specified type (or any type if [predicate] is null).
+ */
+fun <T : KoPropertyTypeProvider> List<T>.withType(predicate: ((KoTypeDeclaration) -> Boolean)? = null): List<T> =
+    filter {
+        when (predicate) {
+            null -> it.hasType()
+            else -> it.type?.let { type -> predicate(type) } ?: false
+        }
     }
-}
 
-fun <T : KoPropertyTypeProvider> List<T>.withoutType(predicate: ((KoTypeDeclaration) -> Boolean)? = null) = filterNot {
-    when (predicate) {
-        null -> it.hasType()
-        else -> it.type?.let { type -> predicate(type) } ?: false
+/**
+ * List containing declarations without the specified type.
+ *
+ * @param predicate The predicate function to determine if a declaration type satisfies a condition.
+ * @return A list containing declarations without the specified type (or none type if [predicate] is null).
+ */
+fun <T : KoPropertyTypeProvider> List<T>.withoutType(predicate: ((KoTypeDeclaration) -> Boolean)? = null): List<T> =
+    filterNot {
+        when (predicate) {
+            null -> it.hasType()
+            else -> it.type?.let { type -> predicate(type) } ?: false
+        }
     }
-}
 
 /**
  * List containing declarations with type of.

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/api/ext/provider/KoPropertyTypeProviderExt.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/api/ext/provider/KoPropertyTypeProviderExt.kt
@@ -1,0 +1,8 @@
+import com.lemonappdev.konsist.api.provider.KoPropertyTypeProvider
+
+/**
+ * Whether declaration has type.
+ *
+ * @return `true` if the declaration has type with the specified KClass name, `false` otherwise.
+ */
+inline fun <reified T> KoPropertyTypeProvider.hasTypeOf(): Boolean = T::class.simpleName == type?.name

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/api/provider/KoPropertyTypeProvider.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/api/provider/KoPropertyTypeProvider.kt
@@ -21,7 +21,19 @@ interface KoPropertyTypeProvider : KoBaseProvider {
     @Deprecated("Will be removed in v1.0.0", ReplaceWith("hasType { it.name == name }"))
     fun hasType(name: String): Boolean
 
+    /**
+     * Whether declaration has a specified type.
+     *
+     * @param predicate The predicate function used to determine if a declaration type satisfies a condition.
+     * @return `true` if the declaration has the specified type (or any type if [predicate] is `null`), `false` otherwise.
+     */
     fun hasType(predicate: ((KoTypeDeclaration) -> Boolean)? = null): Boolean
 
+    /**
+     * Whether declaration has a type of the specified Kotlin class.
+     *
+     * @param kClass The Kotlin class representing the type to check for.
+     * @return `true` if the declaration has a type matching the specified KClass, `false` otherwise.
+     */
     fun hasTypeOf(kClass: KClass<*>): Boolean
 }

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/api/provider/KoPropertyTypeProvider.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/api/provider/KoPropertyTypeProvider.kt
@@ -1,6 +1,7 @@
 package com.lemonappdev.konsist.api.provider
 
 import com.lemonappdev.konsist.api.declaration.KoTypeDeclaration
+import kotlin.reflect.KClass
 
 /**
  * An interface representing a Kotlin declaration that provides access to the type information.
@@ -17,5 +18,10 @@ interface KoPropertyTypeProvider : KoBaseProvider {
      * @param name the type name to check for (optional).
      * @return `true` if the declaration has the specified type (or any type if [name] is `null`), `false` otherwise.
      */
-    fun hasType(name: String? = null): Boolean
+    @Deprecated("Will be removed in v1.0.0", ReplaceWith("hasType { it.name == name }"))
+    fun hasType(name: String): Boolean
+
+    fun hasType(predicate: ((KoTypeDeclaration) -> Boolean)? = null): Boolean
+
+    fun hasTypeOf(kClass: KClass<*>): Boolean
 }

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/KoPropertyTypeProviderCore.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/KoPropertyTypeProviderCore.kt
@@ -6,6 +6,7 @@ import com.lemonappdev.konsist.core.util.ReceiverUtil
 import org.jetbrains.kotlin.psi.KtCallableDeclaration
 import org.jetbrains.kotlin.psi.KtTypeReference
 import org.jetbrains.kotlin.psi.psiUtil.isExtensionDeclaration
+import kotlin.reflect.KClass
 
 internal interface KoPropertyTypeProviderCore :
     KoPropertyTypeProvider,
@@ -19,8 +20,14 @@ internal interface KoPropertyTypeProviderCore :
         .children
         .filterIsInstance<KtTypeReference>()
 
-    override fun hasType(name: String?): Boolean = when (name) {
-        null -> this.type != null
-        else -> this.type?.name == name
-    }
+    @Deprecated("Will be removed in v1.0.0", ReplaceWith("KoHasTestClassProvider"))
+    override fun hasType(name: String): Boolean = this.type?.name == name
+
+    override fun hasType(predicate: ((KoTypeDeclaration) -> Boolean)?): Boolean =
+        when (predicate) {
+            null -> type != null
+            else -> type?.let { predicate(it) } ?: false
+        }
+
+    override fun hasTypeOf(kClass: KClass<*>): Boolean = kClass.simpleName == type?.name
 }

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/KoPropertyTypeProviderCore.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/KoPropertyTypeProviderCore.kt
@@ -20,7 +20,7 @@ internal interface KoPropertyTypeProviderCore :
         .children
         .filterIsInstance<KtTypeReference>()
 
-    @Deprecated("Will be removed in v1.0.0", ReplaceWith("KoHasTestClassProvider"))
+    @Deprecated("Will be removed in v1.0.0", ReplaceWith("hasType { it.name == name }"))
     override fun hasType(name: String): Boolean = this.type?.name == name
 
     override fun hasType(predicate: ((KoTypeDeclaration) -> Boolean)?): Boolean =

--- a/lib/src/test/kotlin/com/lemonappdev/konsist/api/ext/list/KoPropertyTypeProviderListExtTest.kt
+++ b/lib/src/test/kotlin/com/lemonappdev/konsist/api/ext/list/KoPropertyTypeProviderListExtTest.kt
@@ -52,6 +52,35 @@ class KoPropertyTypeProviderListExtTest {
     }
 
     @Test
+    fun `withType{} returns declaration which satisfy predicate`() {
+        // given
+        val name1 = "name1"
+        val name2 = "name2"
+        val type1: KoTypeDeclaration = mockk {
+            every { name } returns name1
+        }
+        val type2: KoTypeDeclaration = mockk {
+            every { name } returns name2
+        }
+        val declaration1: KoPropertyTypeProvider = mockk {
+            every { type } returns type1
+        }
+        val declaration2: KoPropertyTypeProvider = mockk {
+            every { type } returns type2
+        }
+        val declaration3: KoPropertyTypeProvider = mockk {
+            every { type } returns null
+        }
+        val declarations = listOf(declaration1, declaration2, declaration3)
+
+        // when
+        val sut = declarations.withType { it.name == name1 }
+
+        // then
+        sut shouldBeEqualTo listOf(declaration1)
+    }
+
+    @Test
     fun `withType(name) returns declarations with one of given types`() {
         // given
         val typeName1 = "SampleType1"
@@ -93,6 +122,35 @@ class KoPropertyTypeProviderListExtTest {
 
         // then
         sut shouldBeEqualTo listOf(declaration2)
+    }
+
+    @Test
+    fun `withoutType){} returns declarations which not satisfy predicate`() {
+        // given
+        val name1 = "name1"
+        val name2 = "name2"
+        val type1: KoTypeDeclaration = mockk {
+            every { name } returns name1
+        }
+        val type2: KoTypeDeclaration = mockk {
+            every { name } returns name2
+        }
+        val declaration1: KoPropertyTypeProvider = mockk {
+            every { type } returns type1
+        }
+        val declaration2: KoPropertyTypeProvider = mockk {
+            every { type } returns type2
+        }
+        val declaration3: KoPropertyTypeProvider = mockk {
+            every { type } returns null
+        }
+        val declarations = listOf(declaration1, declaration2, declaration3)
+
+        // when
+        val sut = declarations.withoutType { it.name == name1 }
+
+        // then
+        sut shouldBeEqualTo listOf(declaration2, declaration3)
     }
 
     @Test


### PR DESCRIPTION
**Changes:**
1. **Deprecated** `KoPropertyTypeProvider.hasType(name = ...)` and extensions on `KoPropertyTypeProvider` list: `withType(vararg names: String)` and `withoutType(vararg names: String)`.

2. **Added** new methods on `KoPropertyTypeProvider`:
-`fun hasType(predicate: ((KoTypeDeclaration) -> Boolean)? = null): Boolean`
-`fun hasTypeOf(kClass: KClass<*>): Boolean`

3. **Added** new extension on `KoPropertyTypeProvider`: `fun <reified T> KoPropertyTypeProvider.hasTypeOf(): Boolean`

4. **Added** new extensions on `KoPropertyTypeProvider` list:
-`fun <T : KoPropertyTypeProvider> List<T>.withType(predicate: ((KoTypeDeclaration) -> Boolean)? = null): List<T>`
-`fun <T : KoPropertyTypeProvider> List<T>.withoutType(predicate: ((KoTypeDeclaration) -> Boolean)? = null): List<T>`

**Examples:**
Assume that we want to check if all properties in a scope has `String` type.

Before the changes:
```kotlin
Konsist
   .scopeFromProject()
   .properties()
   .assert { it.hasType("String") } 
```

After the changes:
```kotlin
// First option
Konsist
   .scopeFromProject()
   .properties()
   .assert { it.hasTypeOf<String>() } 
   
// Second option
Konsist
   .scopeFromProject()
   .properties()
   .assert { it.hasTypeOf(String::class) } 
   
// Third option
Konsist
   .scopeFromProject()
   .properties()
   .assert { it.hasType { type -> type.name == "String" } 
```


Similar, we may filter declarations using lambda predicate:

Before the changes:
```kotlin
Konsist
   .scopeFromProject()
   .properties()
   .withType("SampleType1", "SampleType2")
   .assert { it.hasPrivateModifier } 
```

After the changes:
```kotlin
Konsist
   .scopeFromProject()
   .properties()
   .withType { it.name == "SampleType1" || it.name == "SampleType2"}
   .assert { it.hasPrivateModifier } 
```

But in actual API we may specify more conditions than just a `name`, e.g.:
```kotlin
Konsist
   .scopeFromProject()
   .properties()
   .withType { it.isKotlinType && it.name == "SampleType"}
   .assert { it.hasPrivateModifier } 
```