### PR TITLE
KON-410 KoReceiverTypeProvider Add `hasReceiverTypeOf` And `hasReceiverType(lambda)`

### DIFF
--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/kofunction/KoFunctionDeclarationForKoReceiverTypeProviderTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/kofunction/KoFunctionDeclarationForKoReceiverTypeProviderTest.kt
@@ -1,7 +1,6 @@
 package com.lemonappdev.konsist.core.declaration.kofunction
 
 import com.lemonappdev.konsist.TestSnippetProvider.getSnippetKoScope
-import net.bytebuddy.matcher.ElementMatchers.hasType
 import org.amshove.kluent.assertSoftly
 import org.amshove.kluent.shouldBeEqualTo
 import org.junit.jupiter.api.Test

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/kofunction/KoFunctionDeclarationForKoReceiverTypeProviderTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/kofunction/KoFunctionDeclarationForKoReceiverTypeProviderTest.kt
@@ -1,6 +1,7 @@
 package com.lemonappdev.konsist.core.declaration.kofunction
 
 import com.lemonappdev.konsist.TestSnippetProvider.getSnippetKoScope
+import net.bytebuddy.matcher.ElementMatchers.hasType
 import org.amshove.kluent.assertSoftly
 import org.amshove.kluent.shouldBeEqualTo
 import org.junit.jupiter.api.Test
@@ -17,6 +18,8 @@ class KoFunctionDeclarationForKoReceiverTypeProviderTest {
         assertSoftly(sut) {
             receiverType shouldBeEqualTo null
             hasReceiverType() shouldBeEqualTo false
+            hasReceiverType { it.name == "Int" } shouldBeEqualTo false
+            hasReceiverTypeOf(Int::class) shouldBeEqualTo false
             hasReceiverType("Int") shouldBeEqualTo false
         }
     }
@@ -32,6 +35,10 @@ class KoFunctionDeclarationForKoReceiverTypeProviderTest {
         assertSoftly(sut) {
             receiverType?.name shouldBeEqualTo "Int"
             hasReceiverType() shouldBeEqualTo true
+            hasReceiverType { it.name == "Int" } shouldBeEqualTo true
+            hasReceiverType { it.name == "String" } shouldBeEqualTo false
+            hasReceiverTypeOf(Int::class) shouldBeEqualTo true
+            hasReceiverTypeOf(String::class) shouldBeEqualTo false
             hasReceiverType("Int") shouldBeEqualTo true
             hasReceiverType("String") shouldBeEqualTo false
         }

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koproperty/KoPropertyDeclarationForKoReceiverTypeProviderTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koproperty/KoPropertyDeclarationForKoReceiverTypeProviderTest.kt
@@ -17,6 +17,8 @@ class KoPropertyDeclarationForKoReceiverTypeProviderTest {
         assertSoftly(sut) {
             receiverType shouldBeEqualTo null
             hasReceiverType() shouldBeEqualTo false
+            hasReceiverType { it.name == "Int" } shouldBeEqualTo false
+            hasReceiverTypeOf(Int::class) shouldBeEqualTo false
             hasReceiverType("Int") shouldBeEqualTo false
         }
     }
@@ -32,6 +34,10 @@ class KoPropertyDeclarationForKoReceiverTypeProviderTest {
         assertSoftly(sut) {
             receiverType?.name shouldBeEqualTo "Int"
             hasReceiverType() shouldBeEqualTo true
+            hasReceiverType { it.name == "Int" } shouldBeEqualTo true
+            hasReceiverType { it.name == "String" } shouldBeEqualTo false
+            hasReceiverTypeOf(Int::class) shouldBeEqualTo true
+            hasReceiverTypeOf(String::class) shouldBeEqualTo false
             hasReceiverType("Int") shouldBeEqualTo true
             hasReceiverType("String") shouldBeEqualTo false
         }

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/api/ext/list/KoPropertyTypeProviderListExt.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/api/ext/list/KoPropertyTypeProviderListExt.kt
@@ -75,9 +75,9 @@ fun <T : KoPropertyTypeProvider> List<T>.withoutType(predicate: ((KoTypeDeclarat
  */
 fun <T : KoPropertyTypeProvider> List<T>.withTypeOf(kClass: KClass<*>, vararg kClasses: KClass<*>): List<T> =
     filter {
-        it.type?.name == kClass.simpleName ||
+        it.hasTypeOf(kClass) ||
             if (kClasses.isNotEmpty()) {
-                kClasses.any { kClass -> it.type?.name == kClass.simpleName }
+                kClasses.any { kClass -> it.hasTypeOf(kClass) }
             } else {
                 false
             }
@@ -92,9 +92,9 @@ fun <T : KoPropertyTypeProvider> List<T>.withTypeOf(kClass: KClass<*>, vararg kC
  */
 fun <T : KoPropertyTypeProvider> List<T>.withoutTypeOf(kClass: KClass<*>, vararg kClasses: KClass<*>): List<T> =
     filter {
-        it.type?.name != kClass.simpleName &&
+        it.hasTypeOf(kClass) &&
             if (kClasses.isNotEmpty()) {
-                kClasses.none { kClass -> it.type?.name == kClass.simpleName }
+                kClasses.none { kClass -> it.hasTypeOf(kClass) }
             } else {
                 true
             }

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/api/ext/list/KoPropertyTypeProviderListExt.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/api/ext/list/KoPropertyTypeProviderListExt.kt
@@ -93,9 +93,9 @@ fun <T : KoPropertyTypeProvider> List<T>.withTypeOf(kClass: KClass<*>, vararg kC
 fun <T : KoPropertyTypeProvider> List<T>.withoutTypeOf(kClass: KClass<*>, vararg kClasses: KClass<*>): List<T> =
     filterNot {
         it.hasTypeOf(kClass) ||
-                if (kClasses.isNotEmpty()) {
-                    kClasses.any { kClass -> it.hasTypeOf(kClass) }
-                } else {
-                    false
-                }
+            if (kClasses.isNotEmpty()) {
+                kClasses.any { kClass -> it.hasTypeOf(kClass) }
+            } else {
+                false
+            }
     }

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/api/ext/list/KoPropertyTypeProviderListExt.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/api/ext/list/KoPropertyTypeProviderListExt.kt
@@ -91,11 +91,11 @@ fun <T : KoPropertyTypeProvider> List<T>.withTypeOf(kClass: KClass<*>, vararg kC
  * @return A list containing declarations without type of the specified Kotlin class(es).
  */
 fun <T : KoPropertyTypeProvider> List<T>.withoutTypeOf(kClass: KClass<*>, vararg kClasses: KClass<*>): List<T> =
-    filter {
-        it.hasTypeOf(kClass) &&
-            if (kClasses.isNotEmpty()) {
-                kClasses.none { kClass -> it.hasTypeOf(kClass) }
-            } else {
-                true
-            }
+    filterNot {
+        it.hasTypeOf(kClass) ||
+                if (kClasses.isNotEmpty()) {
+                    kClasses.any { kClass -> it.hasTypeOf(kClass) }
+                } else {
+                    false
+                }
     }

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/api/ext/list/KoReceiverTypeProviderListExt.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/api/ext/list/KoReceiverTypeProviderListExt.kt
@@ -94,11 +94,11 @@ fun <T : KoReceiverTypeProvider> List<T>.withReceiverTypeOf(kClass: KClass<*>, v
  * @return A list containing declarations without receiver type of the specified Kotlin class(es).
  */
 fun <T : KoReceiverTypeProvider> List<T>.withoutReceiverTypeOf(kClass: KClass<*>, vararg kClasses: KClass<*>): List<T> =
-    filter {
-        !it.hasReceiverTypeOf(kClass) &&
-            if (kClasses.isNotEmpty()) {
-                kClasses.none { kClass -> it.hasReceiverTypeOf(kClass) }
-            } else {
-                true
-            }
+    filterNot {
+        it.hasReceiverTypeOf(kClass) ||
+                if (kClasses.isNotEmpty()) {
+                    kClasses.any { kClass -> it.hasReceiverTypeOf(kClass) }
+                } else {
+                    false
+                }
     }

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/api/ext/list/KoReceiverTypeProviderListExt.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/api/ext/list/KoReceiverTypeProviderListExt.kt
@@ -1,6 +1,8 @@
 package com.lemonappdev.konsist.api.ext.list
 
 import com.lemonappdev.konsist.api.declaration.KoTypeDeclaration
+import com.lemonappdev.konsist.api.ext.provider.hasReceiverTypeOf
+import com.lemonappdev.konsist.api.provider.KoPropertyTypeProvider
 import com.lemonappdev.konsist.api.provider.KoReceiverTypeProvider
 import kotlin.reflect.KClass
 
@@ -16,6 +18,7 @@ val <T : KoReceiverTypeProvider> List<T>.receiverTypes: List<KoTypeDeclaration>
  * @param names The receiver type name(s) to include.
  * @return A list containing declarations with the specified receiver type(s) (or any receiver type if [names] is empty).
  */
+@Deprecated("Will be removed in v1.0.0", ReplaceWith("withReceiverType { it.name == ... }"))
 fun <T : KoReceiverTypeProvider> List<T>.withReceiverType(vararg names: String): List<T> = filter {
     when {
         names.isEmpty() -> it.hasReceiverType()
@@ -29,12 +32,42 @@ fun <T : KoReceiverTypeProvider> List<T>.withReceiverType(vararg names: String):
  * @param names The receiver type name(s) to exclude.
  * @return A list containing declarations without specified receiver type(s) (or none receiver type if [names] is empty).
  */
+@Deprecated("Will be removed in v1.0.0", ReplaceWith("withoutReceiverType { it.name != ... }"))
+
 fun <T : KoReceiverTypeProvider> List<T>.withoutReceiverType(vararg names: String): List<T> = filter {
     when {
         names.isEmpty() -> !it.hasReceiverType()
         else -> names.none { type -> it.hasReceiverType(type) }
     }
 }
+
+/**
+ * List containing declarations with the specified receiver type.
+ *
+ * @param predicate The predicate function to determine if a declaration receiver type satisfies a condition.
+ * @return A list containing declarations with the specified receiver type (or any receiver type if [predicate] is null).
+ */
+fun <T : KoReceiverTypeProvider> List<T>.withReceiverType(predicate: ((KoTypeDeclaration) -> Boolean)? = null): List<T> =
+    filter {
+        when (predicate) {
+            null -> it.hasReceiverType()
+            else -> it.receiverType?.let { receiverType -> predicate(receiverType) } ?: false
+        }
+    }
+
+/**
+ * List containing declarations without the specified receiver type.
+ *
+ * @param predicate The predicate function to determine if a declaration receiver type satisfies a condition.
+ * @return A list containing declarations without the specified receiver type (or none receiver type if [predicate] is null).
+ */
+fun <T : KoReceiverTypeProvider> List<T>.withoutReceiverType(predicate: ((KoTypeDeclaration) -> Boolean)? = null): List<T> =
+    filterNot {
+        when (predicate) {
+            null -> it.hasReceiverType()
+            else -> it.receiverType?.let { receiverType -> predicate(receiverType) } ?: false
+        }
+    }
 
 /**
  * List containing declarations with receiver type.
@@ -45,9 +78,9 @@ fun <T : KoReceiverTypeProvider> List<T>.withoutReceiverType(vararg names: Strin
  */
 fun <T : KoReceiverTypeProvider> List<T>.withReceiverTypeOf(kClass: KClass<*>, vararg kClasses: KClass<*>): List<T> =
     filter {
-        it.hasReceiverType(kClass.simpleName) ||
+        it.hasReceiverTypeOf(kClass) ||
             if (kClasses.isNotEmpty()) {
-                kClasses.any { kClass -> it.hasReceiverType(kClass.simpleName) }
+                kClasses.any { kClass -> it.hasReceiverTypeOf(kClass) }
             } else {
                 false
             }
@@ -62,9 +95,9 @@ fun <T : KoReceiverTypeProvider> List<T>.withReceiverTypeOf(kClass: KClass<*>, v
  */
 fun <T : KoReceiverTypeProvider> List<T>.withoutReceiverTypeOf(kClass: KClass<*>, vararg kClasses: KClass<*>): List<T> =
     filter {
-        !it.hasReceiverType(kClass.simpleName) &&
+        !it.hasReceiverTypeOf(kClass) &&
             if (kClasses.isNotEmpty()) {
-                kClasses.none { kClass -> it.hasReceiverType(kClass.simpleName) }
+                kClasses.none { kClass -> it.hasReceiverTypeOf(kClass) }
             } else {
                 true
             }

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/api/ext/list/KoReceiverTypeProviderListExt.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/api/ext/list/KoReceiverTypeProviderListExt.kt
@@ -2,7 +2,6 @@ package com.lemonappdev.konsist.api.ext.list
 
 import com.lemonappdev.konsist.api.declaration.KoTypeDeclaration
 import com.lemonappdev.konsist.api.ext.provider.hasReceiverTypeOf
-import com.lemonappdev.konsist.api.provider.KoPropertyTypeProvider
 import com.lemonappdev.konsist.api.provider.KoReceiverTypeProvider
 import kotlin.reflect.KClass
 
@@ -33,7 +32,6 @@ fun <T : KoReceiverTypeProvider> List<T>.withReceiverType(vararg names: String):
  * @return A list containing declarations without specified receiver type(s) (or none receiver type if [names] is empty).
  */
 @Deprecated("Will be removed in v1.0.0", ReplaceWith("withoutReceiverType { it.name != ... }"))
-
 fun <T : KoReceiverTypeProvider> List<T>.withoutReceiverType(vararg names: String): List<T> = filter {
     when {
         names.isEmpty() -> !it.hasReceiverType()
@@ -96,9 +94,9 @@ fun <T : KoReceiverTypeProvider> List<T>.withReceiverTypeOf(kClass: KClass<*>, v
 fun <T : KoReceiverTypeProvider> List<T>.withoutReceiverTypeOf(kClass: KClass<*>, vararg kClasses: KClass<*>): List<T> =
     filterNot {
         it.hasReceiverTypeOf(kClass) ||
-                if (kClasses.isNotEmpty()) {
-                    kClasses.any { kClass -> it.hasReceiverTypeOf(kClass) }
-                } else {
-                    false
-                }
+            if (kClasses.isNotEmpty()) {
+                kClasses.any { kClass -> it.hasReceiverTypeOf(kClass) }
+            } else {
+                false
+            }
     }

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/api/provider/KoPropertyTypeProvider.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/api/provider/KoPropertyTypeProvider.kt
@@ -15,8 +15,8 @@ interface KoPropertyTypeProvider : KoBaseProvider {
     /**
      * Whatever declaration has a type.
      *
-     * @param name the type name to check for (optional).
-     * @return `true` if the declaration has the specified type (or any type if [name] is `null`), `false` otherwise.
+     * @param name the type name to check for.
+     * @return `true` if the declaration has the specified type, `false` otherwise.
      */
     @Deprecated("Will be removed in v1.0.0", ReplaceWith("hasType { it.name == name }"))
     fun hasType(name: String): Boolean

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/api/provider/KoReceiverTypeProvider.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/api/provider/KoReceiverTypeProvider.kt
@@ -1,6 +1,7 @@
 package com.lemonappdev.konsist.api.provider
 
 import com.lemonappdev.konsist.api.declaration.KoTypeDeclaration
+import kotlin.reflect.KClass
 
 /**
  * An interface representing a Kotlin declaration that provides access to its receiver type information.
@@ -12,11 +13,27 @@ interface KoReceiverTypeProvider : KoBaseProvider {
     val receiverType: KoTypeDeclaration?
 
     /**
-     * Whether this declaration has receiver type.
+     * Whether declaration has receiver type.
      *
      * @param name the receiver type to check.
-     * @return `true` if the declaration has receiver type with the specified name (or any receiver type if [name] is null),
-     * `false` otherwise.
+     * @return `true` if the declaration has receiver type with the specified name, `false` otherwise.
      */
-    fun hasReceiverType(name: String? = null): Boolean
+    @Deprecated("Will be removed in v1.0.0", ReplaceWith("hasReceiverType { it.name == name }"))
+    fun hasReceiverType(name: String): Boolean
+
+    /**
+     * Whether declaration has a specified receiver type.
+     *
+     * @param predicate The predicate function used to determine if a declaration receiver type satisfies a condition.
+     * @return `true` if the declaration has the specified receiver type (or any receiver type if [predicate] is `null`), `false` otherwise.
+     */
+    fun hasReceiverType(predicate: ((KoTypeDeclaration) -> Boolean)? = null): Boolean
+
+    /**
+     * Whether declaration has a receiver type of the specified Kotlin class.
+     *
+     * @param kClass The Kotlin class representing the receiver type to check for.
+     * @return `true` if the declaration has a receiver type matching the specified KClass, `false` otherwise.
+     */
+    fun hasReceiverTypeOf(kClass: KClass<*>): Boolean
 }

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/KoReceiverTypeProviderCore.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/KoReceiverTypeProviderCore.kt
@@ -6,6 +6,7 @@ import com.lemonappdev.konsist.core.util.ReceiverUtil
 import org.jetbrains.kotlin.psi.KtCallableDeclaration
 import org.jetbrains.kotlin.psi.KtTypeReference
 import org.jetbrains.kotlin.psi.psiUtil.isExtensionDeclaration
+import kotlin.reflect.KClass
 
 internal interface KoReceiverTypeProviderCore :
     KoReceiverTypeProvider,
@@ -21,7 +22,16 @@ internal interface KoReceiverTypeProviderCore :
             this,
         )
 
-    override fun hasReceiverType(name: String?): Boolean = ReceiverUtil.hasReceiverType(receiverType, name)
+    @Deprecated("Will be removed in v1.0.0", ReplaceWith("hasReceiverType { it.name == name }"))
+    override fun hasReceiverType(name: String): Boolean = ReceiverUtil.hasReceiverType(receiverType, name)
+
+    override fun hasReceiverType(predicate: ((KoTypeDeclaration) -> Boolean)?): Boolean =
+        when (predicate) {
+            null -> receiverType != null
+            else -> receiverType?.let { predicate(it) } ?: false
+        }
+
+    override fun hasReceiverTypeOf(kClass: KClass<*>): Boolean = kClass.simpleName == receiverType?.name
 
     private fun getTypeReferences(): List<KtTypeReference> = ktCallableDeclaration
         .children

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/core/util/ReceiverUtil.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/core/util/ReceiverUtil.kt
@@ -25,7 +25,7 @@ object ReceiverUtil {
 
     /*
     1.0.0 CleanUp - When we remove KoReceiverTypeProviderCore.hasReceiverType it will be unused.
-    */
+     */
     internal fun getReceiverType(
         types: List<KtTypeReference>,
         isExtension: Boolean,
@@ -42,7 +42,7 @@ object ReceiverUtil {
 
     /*
     1.0.0 CleanUp - When we remove KoReceiverTypeProviderCore.hasReceiverType it will be unused.
-    */
+     */
     internal fun hasReceiverType(receiverType: KoTypeDeclaration?, name: String?): Boolean = when (name) {
         null -> receiverType != null
         else -> receiverType?.name == name

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/core/util/ReceiverUtil.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/core/util/ReceiverUtil.kt
@@ -23,6 +23,9 @@ object ReceiverUtil {
         return type?.let { KoTypeDeclarationCore.getInstance(it, parentDeclaration) }
     }
 
+    /*
+    1.0.0 CleanUp - When we remove KoReceiverTypeProviderCore.hasReceiverType it will be unused.
+    */
     internal fun getReceiverType(
         types: List<KtTypeReference>,
         isExtension: Boolean,
@@ -37,6 +40,9 @@ object ReceiverUtil {
         return type?.let { KoTypeDeclarationCore.getInstance(type, parentDeclaration) }
     }
 
+    /*
+    1.0.0 CleanUp - When we remove KoReceiverTypeProviderCore.hasReceiverType it will be unused.
+    */
     internal fun hasReceiverType(receiverType: KoTypeDeclaration?, name: String?): Boolean = when (name) {
         null -> receiverType != null
         else -> receiverType?.name == name

--- a/lib/src/test/kotlin/com/lemonappdev/konsist/api/ext/list/KoPropertyTypeProviderListExtTest.kt
+++ b/lib/src/test/kotlin/com/lemonappdev/konsist/api/ext/list/KoPropertyTypeProviderListExtTest.kt
@@ -2,6 +2,7 @@ package com.lemonappdev.konsist.api.ext.list
 
 import com.lemonappdev.konsist.api.declaration.KoTypeDeclaration
 import com.lemonappdev.konsist.api.provider.KoPropertyTypeProvider
+import com.lemonappdev.konsist.api.provider.KoReceiverTypeProvider
 import com.lemonappdev.konsist.testdata.SampleType1
 import com.lemonappdev.konsist.testdata.SampleType2
 import io.mockk.every
@@ -125,7 +126,7 @@ class KoPropertyTypeProviderListExtTest {
     }
 
     @Test
-    fun `withoutType){} returns declarations which not satisfy predicate`() {
+    fun `withoutType{} returns declarations which not satisfy predicate`() {
         // given
         val name1 = "name1"
         val name2 = "name2"
@@ -182,13 +183,11 @@ class KoPropertyTypeProviderListExtTest {
     @Test
     fun `withTypeOf(KClass) returns declaration with given return type`() {
         // given
-        val typeName1 = "SampleType1"
-        val typeName2 = "SampleType2"
         val declaration1: KoPropertyTypeProvider = mockk {
-            every { type?.name } returns typeName1
+            every { hasTypeOf(SampleType1::class) } returns true
         }
         val declaration2: KoPropertyTypeProvider = mockk {
-            every { type?.name } returns typeName2
+            every { hasTypeOf(SampleType1::class) } returns false
         }
         val declarations = listOf(declaration1, declaration2)
 
@@ -202,17 +201,17 @@ class KoPropertyTypeProviderListExtTest {
     @Test
     fun `withTypeOf(KClass) returns declarations with one of given return types`() {
         // given
-        val typeName1 = "SampleType1"
-        val typeName2 = "SampleType2"
-        val typeName3 = "SampleType3"
         val declaration1: KoPropertyTypeProvider = mockk {
-            every { type?.name } returns typeName1
+            every { hasTypeOf(SampleType1::class)  } returns true
+            every { hasTypeOf(SampleType2::class)  } returns false
         }
         val declaration2: KoPropertyTypeProvider = mockk {
-            every { type?.name } returns typeName2
+            every { hasTypeOf(SampleType1::class)  } returns false
+            every { hasTypeOf(SampleType2::class)  } returns true
         }
         val declaration3: KoPropertyTypeProvider = mockk {
-            every { type?.name } returns typeName3
+            every { hasTypeOf(SampleType1::class)  } returns false
+            every { hasTypeOf(SampleType2::class)  } returns false
         }
         val declarations = listOf(declaration1, declaration2, declaration3)
 
@@ -226,13 +225,11 @@ class KoPropertyTypeProviderListExtTest {
     @Test
     fun `withoutTypeOf(KClass) returns declaration without given return type`() {
         // given
-        val typeName1 = "SampleType1"
-        val typeName2 = "SampleType2"
         val declaration1: KoPropertyTypeProvider = mockk {
-            every { type?.name } returns typeName1
+            every { hasTypeOf(SampleType1::class) } returns true
         }
         val declaration2: KoPropertyTypeProvider = mockk {
-            every { type?.name } returns typeName2
+            every { hasTypeOf(SampleType1::class) } returns false
         }
         val declarations = listOf(declaration1, declaration2)
 
@@ -246,17 +243,17 @@ class KoPropertyTypeProviderListExtTest {
     @Test
     fun `withoutTypeOf(KClass) returns declaration without any of given return types`() {
         // given
-        val typeName1 = "SampleType1"
-        val typeName2 = "SampleType2"
-        val typeName3 = "SampleType3"
         val declaration1: KoPropertyTypeProvider = mockk {
-            every { type?.name } returns typeName1
+            every { hasTypeOf(SampleType1::class)  } returns true
+            every { hasTypeOf(SampleType2::class)  } returns false
         }
         val declaration2: KoPropertyTypeProvider = mockk {
-            every { type?.name } returns typeName2
+            every { hasTypeOf(SampleType1::class)  } returns false
+            every { hasTypeOf(SampleType2::class)  } returns true
         }
         val declaration3: KoPropertyTypeProvider = mockk {
-            every { type?.name } returns typeName3
+            every { hasTypeOf(SampleType1::class)  } returns false
+            every { hasTypeOf(SampleType2::class)  } returns false
         }
         val declarations = listOf(declaration1, declaration2, declaration3)
 

--- a/lib/src/test/kotlin/com/lemonappdev/konsist/api/ext/list/KoPropertyTypeProviderListExtTest.kt
+++ b/lib/src/test/kotlin/com/lemonappdev/konsist/api/ext/list/KoPropertyTypeProviderListExtTest.kt
@@ -2,7 +2,6 @@ package com.lemonappdev.konsist.api.ext.list
 
 import com.lemonappdev.konsist.api.declaration.KoTypeDeclaration
 import com.lemonappdev.konsist.api.provider.KoPropertyTypeProvider
-import com.lemonappdev.konsist.api.provider.KoReceiverTypeProvider
 import com.lemonappdev.konsist.testdata.SampleType1
 import com.lemonappdev.konsist.testdata.SampleType2
 import io.mockk.every
@@ -202,16 +201,16 @@ class KoPropertyTypeProviderListExtTest {
     fun `withTypeOf(KClass) returns declarations with one of given return types`() {
         // given
         val declaration1: KoPropertyTypeProvider = mockk {
-            every { hasTypeOf(SampleType1::class)  } returns true
-            every { hasTypeOf(SampleType2::class)  } returns false
+            every { hasTypeOf(SampleType1::class) } returns true
+            every { hasTypeOf(SampleType2::class) } returns false
         }
         val declaration2: KoPropertyTypeProvider = mockk {
-            every { hasTypeOf(SampleType1::class)  } returns false
-            every { hasTypeOf(SampleType2::class)  } returns true
+            every { hasTypeOf(SampleType1::class) } returns false
+            every { hasTypeOf(SampleType2::class) } returns true
         }
         val declaration3: KoPropertyTypeProvider = mockk {
-            every { hasTypeOf(SampleType1::class)  } returns false
-            every { hasTypeOf(SampleType2::class)  } returns false
+            every { hasTypeOf(SampleType1::class) } returns false
+            every { hasTypeOf(SampleType2::class) } returns false
         }
         val declarations = listOf(declaration1, declaration2, declaration3)
 
@@ -244,16 +243,16 @@ class KoPropertyTypeProviderListExtTest {
     fun `withoutTypeOf(KClass) returns declaration without any of given return types`() {
         // given
         val declaration1: KoPropertyTypeProvider = mockk {
-            every { hasTypeOf(SampleType1::class)  } returns true
-            every { hasTypeOf(SampleType2::class)  } returns false
+            every { hasTypeOf(SampleType1::class) } returns true
+            every { hasTypeOf(SampleType2::class) } returns false
         }
         val declaration2: KoPropertyTypeProvider = mockk {
-            every { hasTypeOf(SampleType1::class)  } returns false
-            every { hasTypeOf(SampleType2::class)  } returns true
+            every { hasTypeOf(SampleType1::class) } returns false
+            every { hasTypeOf(SampleType2::class) } returns true
         }
         val declaration3: KoPropertyTypeProvider = mockk {
-            every { hasTypeOf(SampleType1::class)  } returns false
-            every { hasTypeOf(SampleType2::class)  } returns false
+            every { hasTypeOf(SampleType1::class) } returns false
+            every { hasTypeOf(SampleType2::class) } returns false
         }
         val declarations = listOf(declaration1, declaration2, declaration3)
 

--- a/lib/src/test/kotlin/com/lemonappdev/konsist/api/ext/list/KoReceiverTypeProviderListExtTest.kt
+++ b/lib/src/test/kotlin/com/lemonappdev/konsist/api/ext/list/KoReceiverTypeProviderListExtTest.kt
@@ -1,7 +1,6 @@
 package com.lemonappdev.konsist.api.ext.list
 
 import com.lemonappdev.konsist.api.declaration.KoTypeDeclaration
-import com.lemonappdev.konsist.api.provider.KoPropertyTypeProvider
 import com.lemonappdev.konsist.api.provider.KoReceiverTypeProvider
 import com.lemonappdev.konsist.testdata.SampleType1
 import com.lemonappdev.konsist.testdata.SampleType2
@@ -187,7 +186,7 @@ class KoReceiverTypeProviderListExtTest {
             every { hasReceiverTypeOf(SampleType1::class) } returns true
         }
         val declaration2: KoReceiverTypeProvider = mockk {
-            every { hasReceiverTypeOf(SampleType1::class)  } returns false
+            every { hasReceiverTypeOf(SampleType1::class) } returns false
         }
         val declarations = listOf(declaration1, declaration2)
 
@@ -202,16 +201,16 @@ class KoReceiverTypeProviderListExtTest {
     fun `withReceiverTypeOf(KClass) returns declarations with one of given receivers`() {
         // given
         val declaration1: KoReceiverTypeProvider = mockk {
-            every { hasReceiverTypeOf(SampleType1::class)  } returns true
-            every { hasReceiverTypeOf(SampleType2::class)  } returns false
+            every { hasReceiverTypeOf(SampleType1::class) } returns true
+            every { hasReceiverTypeOf(SampleType2::class) } returns false
         }
         val declaration2: KoReceiverTypeProvider = mockk {
-            every { hasReceiverTypeOf(SampleType1::class)  } returns false
-            every { hasReceiverTypeOf(SampleType2::class)  } returns true
+            every { hasReceiverTypeOf(SampleType1::class) } returns false
+            every { hasReceiverTypeOf(SampleType2::class) } returns true
         }
         val declaration3: KoReceiverTypeProvider = mockk {
-            every { hasReceiverTypeOf(SampleType1::class)  } returns false
-            every { hasReceiverTypeOf(SampleType2::class)  } returns false
+            every { hasReceiverTypeOf(SampleType1::class) } returns false
+            every { hasReceiverTypeOf(SampleType2::class) } returns false
         }
         val declarations = listOf(declaration1, declaration2, declaration3)
 
@@ -226,10 +225,10 @@ class KoReceiverTypeProviderListExtTest {
     fun `withoutReceiverTypeOf(KClass) returns declaration without one of given receiver`() {
         // given
         val declaration1: KoReceiverTypeProvider = mockk {
-            every { hasReceiverTypeOf(SampleType1::class)  } returns true
+            every { hasReceiverTypeOf(SampleType1::class) } returns true
         }
         val declaration2: KoReceiverTypeProvider = mockk {
-            every { hasReceiverTypeOf(SampleType1::class)  } returns false
+            every { hasReceiverTypeOf(SampleType1::class) } returns false
         }
         val declarations = listOf(declaration1, declaration2)
 
@@ -244,16 +243,16 @@ class KoReceiverTypeProviderListExtTest {
     fun `withoutReceiverTypeOf(KClass) returns declaration without any of given receivers`() {
         // given
         val declaration1: KoReceiverTypeProvider = mockk {
-            every { hasReceiverTypeOf(SampleType1::class)  } returns true
-            every { hasReceiverTypeOf(SampleType2::class)  } returns false
+            every { hasReceiverTypeOf(SampleType1::class) } returns true
+            every { hasReceiverTypeOf(SampleType2::class) } returns false
         }
         val declaration2: KoReceiverTypeProvider = mockk {
-            every { hasReceiverTypeOf(SampleType1::class)  } returns false
-            every { hasReceiverTypeOf(SampleType2::class)  } returns true
+            every { hasReceiverTypeOf(SampleType1::class) } returns false
+            every { hasReceiverTypeOf(SampleType2::class) } returns true
         }
         val declaration3: KoReceiverTypeProvider = mockk {
-            every { hasReceiverTypeOf(SampleType1::class)  } returns false
-            every { hasReceiverTypeOf(SampleType2::class)  } returns false
+            every { hasReceiverTypeOf(SampleType1::class) } returns false
+            every { hasReceiverTypeOf(SampleType2::class) } returns false
         }
         val declarations = listOf(declaration1, declaration2, declaration3)
 

--- a/lib/src/test/kotlin/com/lemonappdev/konsist/api/ext/list/KoReceiverTypeProviderListExtTest.kt
+++ b/lib/src/test/kotlin/com/lemonappdev/konsist/api/ext/list/KoReceiverTypeProviderListExtTest.kt
@@ -1,6 +1,7 @@
 package com.lemonappdev.konsist.api.ext.list
 
 import com.lemonappdev.konsist.api.declaration.KoTypeDeclaration
+import com.lemonappdev.konsist.api.provider.KoPropertyTypeProvider
 import com.lemonappdev.konsist.api.provider.KoReceiverTypeProvider
 import com.lemonappdev.konsist.testdata.SampleType1
 import com.lemonappdev.konsist.testdata.SampleType2
@@ -52,6 +53,35 @@ class KoReceiverTypeProviderListExtTest {
     }
 
     @Test
+    fun `withReceiverType{} returns declaration which satisfy predicate`() {
+        // given
+        val name1 = "name1"
+        val name2 = "name2"
+        val type1: KoTypeDeclaration = mockk {
+            every { name } returns name1
+        }
+        val type2: KoTypeDeclaration = mockk {
+            every { name } returns name2
+        }
+        val declaration1: KoReceiverTypeProvider = mockk {
+            every { receiverType } returns type1
+        }
+        val declaration2: KoReceiverTypeProvider = mockk {
+            every { receiverType } returns type2
+        }
+        val declaration3: KoReceiverTypeProvider = mockk {
+            every { receiverType } returns null
+        }
+        val declarations = listOf(declaration1, declaration2, declaration3)
+
+        // when
+        val sut = declarations.withReceiverType { it.name == name1 }
+
+        // then
+        sut shouldBeEqualTo listOf(declaration1)
+    }
+
+    @Test
     fun `withReceiverType() returns declarations with one of given receivers`() {
         // given
         val typeName1 = "SampleType1"
@@ -96,6 +126,35 @@ class KoReceiverTypeProviderListExtTest {
     }
 
     @Test
+    fun `withoutReceiverType{} returns declarations which not satisfy predicate`() {
+        // given
+        val name1 = "name1"
+        val name2 = "name2"
+        val type1: KoTypeDeclaration = mockk {
+            every { name } returns name1
+        }
+        val type2: KoTypeDeclaration = mockk {
+            every { name } returns name2
+        }
+        val declaration1: KoReceiverTypeProvider = mockk {
+            every { receiverType } returns type1
+        }
+        val declaration2: KoReceiverTypeProvider = mockk {
+            every { receiverType } returns type2
+        }
+        val declaration3: KoReceiverTypeProvider = mockk {
+            every { receiverType } returns null
+        }
+        val declarations = listOf(declaration1, declaration2, declaration3)
+
+        // when
+        val sut = declarations.withoutReceiverType { it.name == name1 }
+
+        // then
+        sut shouldBeEqualTo listOf(declaration2, declaration3)
+    }
+
+    @Test
     fun `withoutReceiverType(name) returns declaration without any of given receivers`() {
         // given
         val typeName1 = "SampleType1"
@@ -124,12 +183,11 @@ class KoReceiverTypeProviderListExtTest {
     @Test
     fun `withReceiverTypeOf(KClass) returns declaration with one of given receiver`() {
         // given
-        val typeName = "SampleType1"
         val declaration1: KoReceiverTypeProvider = mockk {
-            every { hasReceiverType(typeName) } returns true
+            every { hasReceiverTypeOf(SampleType1::class) } returns true
         }
         val declaration2: KoReceiverTypeProvider = mockk {
-            every { hasReceiverType(typeName) } returns false
+            every { hasReceiverTypeOf(SampleType1::class)  } returns false
         }
         val declarations = listOf(declaration1, declaration2)
 
@@ -143,19 +201,17 @@ class KoReceiverTypeProviderListExtTest {
     @Test
     fun `withReceiverTypeOf(KClass) returns declarations with one of given receivers`() {
         // given
-        val typeName1 = "SampleType1"
-        val typeName2 = "SampleType2"
         val declaration1: KoReceiverTypeProvider = mockk {
-            every { hasReceiverType(typeName1) } returns true
-            every { hasReceiverType(typeName2) } returns false
+            every { hasReceiverTypeOf(SampleType1::class)  } returns true
+            every { hasReceiverTypeOf(SampleType2::class)  } returns false
         }
         val declaration2: KoReceiverTypeProvider = mockk {
-            every { hasReceiverType(typeName1) } returns false
-            every { hasReceiverType(typeName2) } returns true
+            every { hasReceiverTypeOf(SampleType1::class)  } returns false
+            every { hasReceiverTypeOf(SampleType2::class)  } returns true
         }
         val declaration3: KoReceiverTypeProvider = mockk {
-            every { hasReceiverType(typeName1) } returns false
-            every { hasReceiverType(typeName2) } returns false
+            every { hasReceiverTypeOf(SampleType1::class)  } returns false
+            every { hasReceiverTypeOf(SampleType2::class)  } returns false
         }
         val declarations = listOf(declaration1, declaration2, declaration3)
 
@@ -169,12 +225,11 @@ class KoReceiverTypeProviderListExtTest {
     @Test
     fun `withoutReceiverTypeOf(KClass) returns declaration without one of given receiver`() {
         // given
-        val typeName = "SampleType1"
         val declaration1: KoReceiverTypeProvider = mockk {
-            every { hasReceiverType(typeName) } returns true
+            every { hasReceiverTypeOf(SampleType1::class)  } returns true
         }
         val declaration2: KoReceiverTypeProvider = mockk {
-            every { hasReceiverType(typeName) } returns false
+            every { hasReceiverTypeOf(SampleType1::class)  } returns false
         }
         val declarations = listOf(declaration1, declaration2)
 
@@ -188,19 +243,17 @@ class KoReceiverTypeProviderListExtTest {
     @Test
     fun `withoutReceiverTypeOf(KClass) returns declaration without any of given receivers`() {
         // given
-        val typeName1 = "SampleType1"
-        val typeName2 = "SampleType2"
         val declaration1: KoReceiverTypeProvider = mockk {
-            every { hasReceiverType(typeName1) } returns true
-            every { hasReceiverType(typeName2) } returns false
+            every { hasReceiverTypeOf(SampleType1::class)  } returns true
+            every { hasReceiverTypeOf(SampleType2::class)  } returns false
         }
         val declaration2: KoReceiverTypeProvider = mockk {
-            every { hasReceiverType(typeName1) } returns false
-            every { hasReceiverType(typeName2) } returns true
+            every { hasReceiverTypeOf(SampleType1::class)  } returns false
+            every { hasReceiverTypeOf(SampleType2::class)  } returns true
         }
         val declaration3: KoReceiverTypeProvider = mockk {
-            every { hasReceiverType(typeName1) } returns false
-            every { hasReceiverType(typeName2) } returns false
+            every { hasReceiverTypeOf(SampleType1::class)  } returns false
+            every { hasReceiverTypeOf(SampleType2::class)  } returns false
         }
         val declarations = listOf(declaration1, declaration2, declaration3)
 


### PR DESCRIPTION
1) Assume that we want to check if all properties in a scope has `String` receiver type.

Before the changes:
```kotlin
Konsist
   .scopeFromProject()
   .properties()
   .assert { it.hasReceiverType("String") } 
```

After the changes:
```kotlin
// First option
Konsist
   .scopeFromProject()
   .properties()
   .assert { it.hasReceiverTypeOf<String>() } 
   
// Second option
Konsist
   .scopeFromProject()
   .properties()
   .assert { it.hasReceiverTypeOf(String::class) } 
   
// Third option
Konsist
   .scopeFromProject()
   .properties()
   .assert { it.hasReceiverType { type -> type.name == "String" } }
```


2) Similar, we may filter declarations using lambda predicate:

Before the changes:
```kotlin
Konsist
   .scopeFromProject()
   .properties()
   .withReceiverType("SampleType1", "SampleType2")
   .assert { it.hasPrivateModifier } 
```

After the changes:
```kotlin
Konsist
   .scopeFromProject()
   .properties()
   .withReceiverType { it.name == "SampleType1" || it.name == "SampleType2"}
   .assert { it.hasPrivateModifier } 
```

But in actual API we may specify more conditions than just a `name`, e.g.:
```kotlin
Konsist
   .scopeFromProject()
   .properties()
   .withReceiverType { it.isKotlinType && it.name == "SampleType"}
   .assert { it.hasPrivateModifier } 
```