### PR TITLE
KON-406 KoReturnTypeProvider Add `hasReturnTypeOf` And `hasReturnType(lambda)`

### DIFF
--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/api/ext/provider/koreceivertype/KoReceiverTypeProviderExtTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/api/ext/provider/koreceivertype/KoReceiverTypeProviderExtTest.kt
@@ -12,6 +12,20 @@ import org.junit.jupiter.api.Test
 
 class KoReceiverTypeProviderExtTest {
     @Test
+    fun `declaration-has-no-receiver-type`() {
+        // given
+        val sut = getSnippetFile("declaration-has-no-receiver-type")
+            .declarationsOf<KoReceiverTypeProvider>()
+            .first()
+
+        // then
+        assertSoftly(sut) {
+            hasReceiverTypeOf<Int>() shouldBeEqualTo false
+            hasReceiverTypeOf<SampleClass>() shouldBeEqualTo false
+        }
+    }
+
+    @Test
     fun `declaration-has-receiver-with-simple-type`() {
         // given
         val sut = getSnippetFile("declaration-has-receiver-with-simple-type")

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/api/ext/provider/koreceivertype/snippet/declaration-has-no-receiver-type.kttxt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/api/ext/provider/koreceivertype/snippet/declaration-has-no-receiver-type.kttxt
@@ -1,0 +1,1 @@
+fun sampleFunction() = ""

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/api/ext/provider/koreturntype/KoReturnTypeProviderExtTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/api/ext/provider/koreturntype/KoReturnTypeProviderExtTest.kt
@@ -2,10 +2,8 @@ package com.lemonappdev.konsist.api.ext.provider.koreturntype
 
 import com.lemonappdev.konsist.TestSnippetProvider
 import com.lemonappdev.konsist.api.ext.koscope.declarationsOf
-import com.lemonappdev.konsist.api.ext.provider.hasReceiverTypeOf
 import com.lemonappdev.konsist.api.ext.provider.hasReturnTypeOf
 import com.lemonappdev.konsist.api.ext.provider.hasValidKDocReturnTag
-import com.lemonappdev.konsist.api.provider.KoReceiverTypeProvider
 import com.lemonappdev.konsist.api.provider.KoReturnTypeProvider
 import com.lemonappdev.konsist.testdata.SampleClass
 import org.amshove.kluent.assertSoftly

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/api/ext/provider/koreturntype/KoReturnTypeProviderExtTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/api/ext/provider/koreturntype/KoReturnTypeProviderExtTest.kt
@@ -2,12 +2,59 @@ package com.lemonappdev.konsist.api.ext.provider.koreturntype
 
 import com.lemonappdev.konsist.TestSnippetProvider
 import com.lemonappdev.konsist.api.ext.koscope.declarationsOf
+import com.lemonappdev.konsist.api.ext.provider.hasReceiverTypeOf
+import com.lemonappdev.konsist.api.ext.provider.hasReturnTypeOf
 import com.lemonappdev.konsist.api.ext.provider.hasValidKDocReturnTag
+import com.lemonappdev.konsist.api.provider.KoReceiverTypeProvider
 import com.lemonappdev.konsist.api.provider.KoReturnTypeProvider
+import com.lemonappdev.konsist.testdata.SampleClass
+import org.amshove.kluent.assertSoftly
 import org.amshove.kluent.shouldBeEqualTo
 import org.junit.jupiter.api.Test
 
 class KoReturnTypeProviderExtTest {
+    @Test
+    fun `declaration-has-no-return-type`() {
+        // given
+        val sut = getSnippetFile("declaration-has-no-return-type")
+            .declarationsOf<KoReturnTypeProvider>()
+            .first()
+
+        // then
+        assertSoftly(sut) {
+            hasReturnTypeOf<String>() shouldBeEqualTo false
+            hasReturnTypeOf<SampleClass>() shouldBeEqualTo false
+        }
+    }
+
+    @Test
+    fun `declaration-has-return-type-with-simple-type`() {
+        // given
+        val sut = getSnippetFile("declaration-has-return-type-with-simple-type")
+            .declarationsOf<KoReturnTypeProvider>()
+            .first()
+
+        // then
+        assertSoftly(sut) {
+            hasReturnTypeOf<String>() shouldBeEqualTo true
+            hasReturnTypeOf<Int>() shouldBeEqualTo false
+        }
+    }
+
+    @Test
+    fun `declaration-has-return-type-with-complex-type`() {
+        // given
+        val sut = getSnippetFile("declaration-has-return-type-with-complex-type")
+            .declarationsOf<KoReturnTypeProvider>()
+            .first()
+
+        // then
+        assertSoftly(sut) {
+            hasReturnTypeOf<SampleClass>() shouldBeEqualTo true
+            hasReturnTypeOf<Int>() shouldBeEqualTo false
+        }
+    }
+
     @Test
     fun `declaration-with-return-type-has-valid-kdoc-return-tag`() {
         // given

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/api/ext/provider/koreturntype/snippet/declaration-has-no-return-type.kttxt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/api/ext/provider/koreturntype/snippet/declaration-has-no-return-type.kttxt
@@ -1,0 +1,1 @@
+fun sampleFunction() = ""

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/api/ext/provider/koreturntype/snippet/declaration-has-return-type-with-complex-type.kttxt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/api/ext/provider/koreturntype/snippet/declaration-has-return-type-with-complex-type.kttxt
@@ -1,0 +1,3 @@
+import com.lemonappdev.konsist.testdata.SampleClass
+
+fun sampleFunction(): SampleClass = SampleClass()

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/api/ext/provider/koreturntype/snippet/declaration-has-return-type-with-simple-type.kttxt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/api/ext/provider/koreturntype/snippet/declaration-has-return-type-with-simple-type.kttxt
@@ -1,0 +1,1 @@
+fun sampleFunction(): String = ""

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/kofunction/KoFunctionDeclarationForKoReturnTypeProviderTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/kofunction/KoFunctionDeclarationForKoReturnTypeProviderTest.kt
@@ -1,64 +1,13 @@
 package com.lemonappdev.konsist.core.declaration.kofunction
 
 import com.lemonappdev.konsist.TestSnippetProvider.getSnippetKoScope
+import com.lemonappdev.konsist.testdata.SampleType
+import net.bytebuddy.matcher.ElementMatchers.hasType
 import org.amshove.kluent.assertSoftly
 import org.amshove.kluent.shouldBeEqualTo
 import org.junit.jupiter.api.Test
 
 class KoFunctionDeclarationForKoReturnTypeProviderTest {
-    @Test
-    fun `function-return-type`() {
-        // given
-        val sut = getSnippetFile("function-return-type")
-            .functions()
-            .first()
-
-        // then
-        assertSoftly(sut) {
-            hasReturnType shouldBeEqualTo true
-            returnType?.sourceType shouldBeEqualTo "SampleType"
-            returnType?.aliasType shouldBeEqualTo null
-            returnType?.name shouldBeEqualTo "SampleType"
-            returnType?.isAlias shouldBeEqualTo false
-            returnType?.fullyQualifiedName shouldBeEqualTo "com.lemonappdev.konsist.testdata.SampleType"
-        }
-    }
-
-    @Test
-    fun `function-return-import-alias`() {
-        // given
-        val sut = getSnippetFile("function-return-import-alias")
-            .functions()
-            .first()
-
-        // then
-        assertSoftly(sut) {
-            hasReturnType shouldBeEqualTo true
-            returnType?.sourceType shouldBeEqualTo "SampleType"
-            returnType?.aliasType shouldBeEqualTo "ImportAlias"
-            returnType?.name shouldBeEqualTo "ImportAlias"
-            returnType?.isAlias shouldBeEqualTo true
-        }
-    }
-
-    @Test
-    fun `extension-function-return-type`() {
-        // given
-        val sut = getSnippetFile("extension-function-return-type")
-            .functions()
-            .first()
-
-        // then
-        assertSoftly(sut) {
-            hasReturnType shouldBeEqualTo true
-            returnType?.sourceType shouldBeEqualTo "SampleType"
-            returnType?.aliasType shouldBeEqualTo null
-            returnType?.name shouldBeEqualTo "SampleType"
-            returnType?.isAlias shouldBeEqualTo false
-            returnType?.fullyQualifiedName shouldBeEqualTo "com.lemonappdev.konsist.testdata.SampleType"
-        }
-    }
-
     @Test
     fun `function-not-return-type`() {
         // given
@@ -69,10 +18,10 @@ class KoFunctionDeclarationForKoReturnTypeProviderTest {
         // then
         assertSoftly(sut) {
             hasReturnType shouldBeEqualTo false
-            returnType?.sourceType shouldBeEqualTo null
-            returnType?.aliasType shouldBeEqualTo null
-            returnType?.name shouldBeEqualTo null
-            returnType?.isAlias shouldBeEqualTo null
+            returnType shouldBeEqualTo null
+            hasReturnType() shouldBeEqualTo false
+            hasReturnType { it.name == "String" } shouldBeEqualTo false
+            hasReturnTypeOf(String::class) shouldBeEqualTo false
         }
     }
 
@@ -86,10 +35,67 @@ class KoFunctionDeclarationForKoReturnTypeProviderTest {
         // then
         assertSoftly(sut) {
             hasReturnType shouldBeEqualTo false
-            returnType?.sourceType shouldBeEqualTo null
-            returnType?.aliasType shouldBeEqualTo null
-            returnType?.name shouldBeEqualTo null
-            returnType?.isAlias shouldBeEqualTo null
+            returnType shouldBeEqualTo null
+            hasReturnType() shouldBeEqualTo false
+            hasReturnType { it.name == "String" } shouldBeEqualTo false
+            hasReturnTypeOf(String::class) shouldBeEqualTo false
+        }
+    }
+
+    @Test
+    fun `function-return-type`() {
+        // given
+        val sut = getSnippetFile("function-return-type")
+            .functions()
+            .first()
+
+        // then
+        assertSoftly(sut) {
+            hasReturnType shouldBeEqualTo true
+            returnType?.name shouldBeEqualTo "SampleType"
+            hasReturnType() shouldBeEqualTo true
+            hasReturnType { it.name == "SampleType" } shouldBeEqualTo true
+            hasReturnType { it.name == "Int" } shouldBeEqualTo false
+            hasReturnTypeOf(SampleType::class) shouldBeEqualTo true
+            hasReturnTypeOf(Int::class) shouldBeEqualTo false
+        }
+    }
+
+    @Test
+    fun `function-return-import-alias`() {
+        // given
+        val sut = getSnippetFile("function-return-import-alias")
+            .functions()
+            .first()
+
+        // then
+        assertSoftly(sut) {
+            hasReturnType shouldBeEqualTo true
+            returnType?.name shouldBeEqualTo "ImportAlias"
+            hasReturnType() shouldBeEqualTo true
+            hasReturnType { it.name == "ImportAlias" } shouldBeEqualTo true
+            hasReturnType { it.name == "Int" } shouldBeEqualTo false
+            hasReturnTypeOf(SampleType::class) shouldBeEqualTo false
+            hasReturnTypeOf(Int::class) shouldBeEqualTo false
+        }
+    }
+
+    @Test
+    fun `extension-function-return-type`() {
+        // given
+        val sut = getSnippetFile("extension-function-return-type")
+            .functions()
+            .first()
+
+        // then
+        assertSoftly(sut) {
+            hasReturnType shouldBeEqualTo true
+            returnType?.name shouldBeEqualTo "SampleType"
+            hasReturnType() shouldBeEqualTo true
+            hasReturnType { it.name == "SampleType" } shouldBeEqualTo true
+            hasReturnType { it.name == "Int" } shouldBeEqualTo false
+            hasReturnTypeOf(SampleType::class) shouldBeEqualTo true
+            hasReturnTypeOf(Int::class) shouldBeEqualTo false
         }
     }
 

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/kofunction/KoFunctionDeclarationForKoReturnTypeProviderTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/kofunction/KoFunctionDeclarationForKoReturnTypeProviderTest.kt
@@ -2,7 +2,6 @@ package com.lemonappdev.konsist.core.declaration.kofunction
 
 import com.lemonappdev.konsist.TestSnippetProvider.getSnippetKoScope
 import com.lemonappdev.konsist.testdata.SampleType
-import net.bytebuddy.matcher.ElementMatchers.hasType
 import org.amshove.kluent.assertSoftly
 import org.amshove.kluent.shouldBeEqualTo
 import org.junit.jupiter.api.Test

--- a/lib/src/konsistTest/kotlin/com/lemonappdev/konsist/api/ApiKonsistTest.kt
+++ b/lib/src/konsistTest/kotlin/com/lemonappdev/konsist/api/ApiKonsistTest.kt
@@ -19,7 +19,7 @@ class ApiKonsistTest {
     fun `every api declaration has explicit return type`() {
         apiPackageScope
             .functions()
-            .assert { it.hasReturnType }
+            .assert { it.hasReturnType() }
     }
 
     @Test

--- a/lib/src/konsistTest/kotlin/com/lemonappdev/konsist/core/DeclarationKonsistTest.kt
+++ b/lib/src/konsistTest/kotlin/com/lemonappdev/konsist/core/DeclarationKonsistTest.kt
@@ -14,7 +14,7 @@ class DeclarationKonsistTest {
         declarationPackageScope
             .functions()
             .withoutName("print")
-            .assert { it.hasReturnType }
+            .assert { it.hasReturnType() }
     }
 
     @Test

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/api/ext/list/KoReturnTypeProviderListExt.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/api/ext/list/KoReturnTypeProviderListExt.kt
@@ -1,7 +1,6 @@
 package com.lemonappdev.konsist.api.ext.list
 
 import com.lemonappdev.konsist.api.declaration.KoTypeDeclaration
-import com.lemonappdev.konsist.api.provider.KoReceiverTypeProvider
 import com.lemonappdev.konsist.api.provider.KoReturnTypeProvider
 import kotlin.reflect.KClass
 
@@ -77,11 +76,11 @@ fun <T : KoReturnTypeProvider> List<T>.withoutReturnType(predicate: ((KoTypeDecl
 fun <T : KoReturnTypeProvider> List<T>.withReturnTypeOf(kClass: KClass<*>, vararg kClasses: KClass<*>): List<T> =
     filter {
         it.hasReturnTypeOf(kClass) ||
-                if (kClasses.isNotEmpty()) {
-                    kClasses.any { kClass -> it.hasReturnTypeOf(kClass) }
-                } else {
-                    false
-                }
+            if (kClasses.isNotEmpty()) {
+                kClasses.any { kClass -> it.hasReturnTypeOf(kClass) }
+            } else {
+                false
+            }
     }
 
 /**
@@ -94,9 +93,9 @@ fun <T : KoReturnTypeProvider> List<T>.withReturnTypeOf(kClass: KClass<*>, varar
 fun <T : KoReturnTypeProvider> List<T>.withoutReturnTypeOf(kClass: KClass<*>, vararg kClasses: KClass<*>): List<T> =
     filterNot {
         it.hasReturnTypeOf(kClass) ||
-                if (kClasses.isNotEmpty()) {
-                    kClasses.any { kClass -> it.hasReturnTypeOf(kClass) }
-                } else {
-                    false
-                }
+            if (kClasses.isNotEmpty()) {
+                kClasses.any { kClass -> it.hasReturnTypeOf(kClass) }
+            } else {
+                false
+            }
     }

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/api/ext/list/KoReturnTypeProviderListExt.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/api/ext/list/KoReturnTypeProviderListExt.kt
@@ -1,6 +1,7 @@
 package com.lemonappdev.konsist.api.ext.list
 
 import com.lemonappdev.konsist.api.declaration.KoTypeDeclaration
+import com.lemonappdev.konsist.api.provider.KoReceiverTypeProvider
 import com.lemonappdev.konsist.api.provider.KoReturnTypeProvider
 import kotlin.reflect.KClass
 
@@ -16,6 +17,7 @@ val <T : KoReturnTypeProvider> List<T>.returnTypes: List<KoTypeDeclaration>
  * @param names The return type name(s) to include.
  * @return A list containing declarations with the specified return type(s) (or any return type if [names] is empty).
  */
+@Deprecated("Will be removed in v1.0.0", ReplaceWith("withReturnType { it.name == ... }"))
 fun <T : KoReturnTypeProvider> List<T>.withReturnType(vararg names: String): List<T> = filter {
     when {
         names.isEmpty() -> it.hasReturnType
@@ -29,6 +31,7 @@ fun <T : KoReturnTypeProvider> List<T>.withReturnType(vararg names: String): Lis
  * @param names The return type name(s) to exclude.
  * @return A list containing declarations without specified return type(s) (or none return type if [names] is empty).
  */
+@Deprecated("Will be removed in v1.0.0", ReplaceWith("withoutReturnType { it.name != ... }"))
 fun <T : KoReturnTypeProvider> List<T>.withoutReturnType(vararg names: String): List<T> = filter {
     when {
         names.isEmpty() -> !it.hasReturnType
@@ -37,23 +40,49 @@ fun <T : KoReturnTypeProvider> List<T>.withoutReturnType(vararg names: String): 
 }
 
 /**
+ * List containing declarations with the specified return type.
+ *
+ * @param predicate The predicate function to determine if a declaration return type satisfies a condition.
+ * @return A list containing declarations with the specified return type (or any return type if [predicate] is null).
+ */
+fun <T : KoReturnTypeProvider> List<T>.withReturnType(predicate: ((KoTypeDeclaration) -> Boolean)? = null): List<T> =
+    filter {
+        when (predicate) {
+            null -> it.hasReturnType()
+            else -> it.returnType?.let { returnType -> predicate(returnType) } ?: false
+        }
+    }
+
+/**
+ * List containing declarations without the specified return type.
+ *
+ * @param predicate The predicate function to determine if a declaration return type satisfies a condition.
+ * @return A list containing declarations without the specified return type (or none return type if [predicate] is null).
+ */
+fun <T : KoReturnTypeProvider> List<T>.withoutReturnType(predicate: ((KoTypeDeclaration) -> Boolean)? = null): List<T> =
+    filterNot {
+        when (predicate) {
+            null -> it.hasReturnType()
+            else -> it.returnType?.let { returnType -> predicate(returnType) } ?: false
+        }
+    }
+
+/**
  * List containing declarations with return type.
  *
  * @param kClass The Kotlin class representing the return type to include.
  * @param kClasses The Kotlin class(es) representing the return type(s) to include.
  * @return A list containing declarations with the return type of the specified Kotlin class(es).
  */
-fun <T : KoReturnTypeProvider> List<T>.withReturnTypeOf(
-    kClass: KClass<*>,
-    vararg kClasses: KClass<*>,
-): List<T> = filter {
-    it.returnType?.name == kClass.simpleName ||
-        if (kClasses.isNotEmpty()) {
-            kClasses.any { kClass -> it.returnType?.name == kClass.simpleName }
-        } else {
-            false
-        }
-}
+fun <T : KoReturnTypeProvider> List<T>.withReturnTypeOf(kClass: KClass<*>, vararg kClasses: KClass<*>): List<T> =
+    filter {
+        it.hasReturnTypeOf(kClass) ||
+                if (kClasses.isNotEmpty()) {
+                    kClasses.any { kClass -> it.hasReturnTypeOf(kClass) }
+                } else {
+                    false
+                }
+    }
 
 /**
  * List containing declarations without return type.
@@ -62,14 +91,12 @@ fun <T : KoReturnTypeProvider> List<T>.withReturnTypeOf(
  * @param kClasses The Kotlin class(es) representing the return type(s) to exclude.
  * @return A list containing declarations without return type of the specified Kotlin class(es).
  */
-fun <T : KoReturnTypeProvider> List<T>.withoutReturnTypeOf(
-    kClass: KClass<*>,
-    vararg kClasses: KClass<*>,
-): List<T> = filter {
-    it.returnType?.name != kClass.simpleName &&
-        if (kClasses.isNotEmpty()) {
-            kClasses.none { kClass -> it.returnType?.name == kClass.simpleName }
-        } else {
-            true
-        }
-}
+fun <T : KoReturnTypeProvider> List<T>.withoutReturnTypeOf(kClass: KClass<*>, vararg kClasses: KClass<*>): List<T> =
+    filterNot {
+        it.hasReturnTypeOf(kClass) ||
+                if (kClasses.isNotEmpty()) {
+                    kClasses.any { kClass -> it.hasReturnTypeOf(kClass) }
+                } else {
+                    false
+                }
+    }

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/api/ext/provider/KoPropertyTypeProviderExt.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/api/ext/provider/KoPropertyTypeProviderExt.kt
@@ -5,4 +5,4 @@ import com.lemonappdev.konsist.api.provider.KoPropertyTypeProvider
  *
  * @return `true` if the declaration has type with the specified KClass name, `false` otherwise.
  */
-inline fun <reified T> KoPropertyTypeProvider.hasTypeOf(): Boolean = T::class.simpleName == type?.name
+inline fun <reified T> KoPropertyTypeProvider.hasTypeOf(): Boolean = hasTypeOf(T::class)

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/api/ext/provider/KoReturnTypeProviderExt.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/api/ext/provider/KoReturnTypeProviderExt.kt
@@ -2,7 +2,6 @@ package com.lemonappdev.konsist.api.ext.provider
 
 import com.lemonappdev.konsist.api.KoKDocTag
 import com.lemonappdev.konsist.api.provider.KoKDocProvider
-import com.lemonappdev.konsist.api.provider.KoPropertyTypeProvider
 import com.lemonappdev.konsist.api.provider.KoReturnTypeProvider
 
 /**

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/api/ext/provider/KoReturnTypeProviderExt.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/api/ext/provider/KoReturnTypeProviderExt.kt
@@ -10,7 +10,7 @@ import com.lemonappdev.konsist.api.provider.KoReturnTypeProvider
  *
  * @return `true` if the declaration has return type with the specified KClass name, `false` otherwise.
  */
-inline fun <reified T> KoReturnTypeProvider.hasTypeOf(): Boolean = hasReturnTypeOf(T::class)
+inline fun <reified T> KoReturnTypeProvider.hasReturnTypeOf(): Boolean = hasReturnTypeOf(T::class)
 
 /**
  * Whether declaration has a valid KDoc with a RETURN tag.

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/api/ext/provider/KoReturnTypeProviderExt.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/api/ext/provider/KoReturnTypeProviderExt.kt
@@ -2,7 +2,15 @@ package com.lemonappdev.konsist.api.ext.provider
 
 import com.lemonappdev.konsist.api.KoKDocTag
 import com.lemonappdev.konsist.api.provider.KoKDocProvider
+import com.lemonappdev.konsist.api.provider.KoPropertyTypeProvider
 import com.lemonappdev.konsist.api.provider.KoReturnTypeProvider
+
+/**
+ * Whether declaration has return type.
+ *
+ * @return `true` if the declaration has return type with the specified KClass name, `false` otherwise.
+ */
+inline fun <reified T> KoReturnTypeProvider.hasTypeOf(): Boolean = hasReturnTypeOf(T::class)
 
 /**
  * Whether declaration has a valid KDoc with a RETURN tag.

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/api/provider/KoReturnTypeProvider.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/api/provider/KoReturnTypeProvider.kt
@@ -1,6 +1,7 @@
 package com.lemonappdev.konsist.api.provider
 
 import com.lemonappdev.konsist.api.declaration.KoTypeDeclaration
+import kotlin.reflect.KClass
 
 /**
  * An interface representing a Kotlin declaration that provides access to the return type information.
@@ -14,5 +15,23 @@ interface KoReturnTypeProvider : KoBaseProvider {
     /**
      * Whether this declaration has a return type.
      */
+    @Deprecated("Will be removed in v1.0.0", ReplaceWith("hasReturnType()"))
     val hasReturnType: Boolean
+
+    /**
+     * Whether declaration has a specified return type.
+     *
+     * @param predicate The predicate function used to determine if a declaration return type satisfies a condition.
+     * @return `true` if the declaration has the specified return type (or any return type if [predicate] is `null`),
+     * `false` otherwise.
+     */
+    fun hasReturnType(predicate: ((KoTypeDeclaration) -> Boolean)? = null): Boolean
+
+    /**
+     * Whether declaration has a return type of the specified Kotlin class.
+     *
+     * @param kClass The Kotlin class representing the return type to check for.
+     * @return `true` if the declaration has a return type matching the specified KClass, `false` otherwise.
+     */
+    fun hasReturnTypeOf(kClass: KClass<*>): Boolean
 }

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/KoReturnTypeProviderCore.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/KoReturnTypeProviderCore.kt
@@ -6,6 +6,7 @@ import com.lemonappdev.konsist.core.util.ReceiverUtil
 import org.jetbrains.kotlin.psi.KtFunction
 import org.jetbrains.kotlin.psi.KtTypeReference
 import org.jetbrains.kotlin.psi.psiUtil.isExtensionDeclaration
+import kotlin.reflect.KClass
 
 internal interface KoReturnTypeProviderCore :
     KoReturnTypeProvider,
@@ -21,6 +22,15 @@ internal interface KoReturnTypeProviderCore :
     override val returnType: KoTypeDeclaration?
         get() = ReceiverUtil.getType(getTypeReferences(), ktFunction.isExtensionDeclaration(), this)
 
+    @Deprecated("Will be removed in v1.0.0", ReplaceWith("hasReturnType()"))
     override val hasReturnType: Boolean
         get() = ktFunction.hasDeclaredReturnType()
+
+    override fun hasReturnType(predicate: ((KoTypeDeclaration) -> Boolean)?): Boolean =
+        when (predicate) {
+            null -> ktFunction.hasDeclaredReturnType()
+            else -> returnType?.let { predicate(it) } ?: false
+        }
+
+    override fun hasReturnTypeOf(kClass: KClass<*>): Boolean = kClass.simpleName == returnType?.name
 }

--- a/lib/src/snippet/kotlin/com/lemonappdev/konsist/LibrarySnippets.kt
+++ b/lib/src/snippet/kotlin/com/lemonappdev/konsist/LibrarySnippets.kt
@@ -39,7 +39,7 @@ class LibrarySnippets {
         Konsist
             .scopeFromPackage("..api..")
             .functions()
-            .assert { it.hasReturnType }
+            .assert { it.hasReturnType() }
     }
 
     fun `every public property in api package must have specify type explicitly`() {

--- a/lib/src/test/kotlin/com/lemonappdev/konsist/api/ext/list/KoReturnTypeProviderListExtTest.kt
+++ b/lib/src/test/kotlin/com/lemonappdev/konsist/api/ext/list/KoReturnTypeProviderListExtTest.kt
@@ -1,6 +1,7 @@
 package com.lemonappdev.konsist.api.ext.list
 
 import com.lemonappdev.konsist.api.declaration.KoTypeDeclaration
+import com.lemonappdev.konsist.api.provider.KoReceiverTypeProvider
 import com.lemonappdev.konsist.api.provider.KoReturnTypeProvider
 import com.lemonappdev.konsist.testdata.SampleType1
 import com.lemonappdev.konsist.testdata.SampleType2
@@ -37,15 +38,44 @@ class KoReturnTypeProviderListExtTest {
     fun `withReturnType() returns declaration with any return type`() {
         // given
         val declaration1: KoReturnTypeProvider = mockk {
-            every { hasReturnType } returns true
+            every { hasReturnType() } returns true
         }
         val declaration2: KoReturnTypeProvider = mockk {
-            every { hasReturnType } returns false
+            every { hasReturnType() } returns false
         }
         val declarations = listOf(declaration1, declaration2)
 
         // when
         val sut = declarations.withReturnType()
+
+        // then
+        sut shouldBeEqualTo listOf(declaration1)
+    }
+
+    @Test
+    fun `withReturnType{} returns declaration which satisfy predicate`() {
+        // given
+        val name1 = "name1"
+        val name2 = "name2"
+        val type1: KoTypeDeclaration = mockk {
+            every { name } returns name1
+        }
+        val type2: KoTypeDeclaration = mockk {
+            every { name } returns name2
+        }
+        val declaration1: KoReturnTypeProvider = mockk {
+            every { returnType } returns type1
+        }
+        val declaration2: KoReturnTypeProvider = mockk {
+            every { returnType } returns type2
+        }
+        val declaration3: KoReturnTypeProvider = mockk {
+            every { returnType } returns null
+        }
+        val declarations = listOf(declaration1, declaration2, declaration3)
+
+        // when
+        val sut = declarations.withReturnType { it.name == name1 }
 
         // then
         sut shouldBeEqualTo listOf(declaration1)
@@ -79,10 +109,10 @@ class KoReturnTypeProviderListExtTest {
     fun `withoutReturnType() returns declaration without any return type`() {
         // given
         val declaration1: KoReturnTypeProvider = mockk {
-            every { hasReturnType } returns true
+            every { hasReturnType() } returns true
         }
         val declaration2: KoReturnTypeProvider = mockk {
-            every { hasReturnType } returns false
+            every { hasReturnType() } returns false
         }
         val declarations = listOf(declaration1, declaration2)
 
@@ -91,6 +121,35 @@ class KoReturnTypeProviderListExtTest {
 
         // then
         sut shouldBeEqualTo listOf(declaration2)
+    }
+
+    @Test
+    fun `withoutReturnType{} returns declarations which not satisfy predicate`() {
+        // given
+        val name1 = "name1"
+        val name2 = "name2"
+        val type1: KoTypeDeclaration = mockk {
+            every { name } returns name1
+        }
+        val type2: KoTypeDeclaration = mockk {
+            every { name } returns name2
+        }
+        val declaration1: KoReturnTypeProvider = mockk {
+            every { returnType } returns type1
+        }
+        val declaration2: KoReturnTypeProvider = mockk {
+            every { returnType } returns type2
+        }
+        val declaration3: KoReturnTypeProvider = mockk {
+            every { returnType } returns null
+        }
+        val declarations = listOf(declaration1, declaration2, declaration3)
+
+        // when
+        val sut = declarations.withoutReturnType { it.name == name1 }
+
+        // then
+        sut shouldBeEqualTo listOf(declaration2, declaration3)
     }
 
     @Test
@@ -120,15 +179,12 @@ class KoReturnTypeProviderListExtTest {
     @Test
     fun `withReturnTypeOf(KClass) returns declarations with given return types`() {
         // given
-        val typeName1 = "SampleType1"
-        val typeName2 = "SampleType2"
         val declaration1: KoReturnTypeProvider = mockk {
-            every { returnType?.name } returns typeName1
+            every { hasReturnTypeOf(SampleType1::class) } returns true
         }
         val declaration2: KoReturnTypeProvider = mockk {
-            every { returnType?.name } returns typeName2
+            every { hasReturnTypeOf(SampleType1::class) } returns false
         }
-
         val declarations = listOf(declaration1, declaration2)
 
         // when
@@ -141,17 +197,17 @@ class KoReturnTypeProviderListExtTest {
     @Test
     fun `withReturnTypeOf(KClass) returns declarations with one of given return types`() {
         // given
-        val typeName1 = "SampleType1"
-        val typeName2 = "SampleType2"
-        val typeName3 = "SampleType3"
         val declaration1: KoReturnTypeProvider = mockk {
-            every { returnType?.name } returns typeName1
+            every { hasReturnTypeOf(SampleType1::class) } returns true
+            every { hasReturnTypeOf(SampleType2::class) } returns false
         }
         val declaration2: KoReturnTypeProvider = mockk {
-            every { returnType?.name } returns typeName2
+            every { hasReturnTypeOf(SampleType1::class) } returns false
+            every { hasReturnTypeOf(SampleType2::class) } returns true
         }
         val declaration3: KoReturnTypeProvider = mockk {
-            every { returnType?.name } returns typeName3
+            every { hasReturnTypeOf(SampleType1::class) } returns false
+            every { hasReturnTypeOf(SampleType2::class) } returns false
         }
         val declarations = listOf(declaration1, declaration2, declaration3)
 
@@ -165,15 +221,12 @@ class KoReturnTypeProviderListExtTest {
     @Test
     fun `withoutReturnTypeOf(KClass) returns declaration without given return type`() {
         // given
-        val typeName1 = "SampleType1"
-        val typeName2 = "SampleType2"
         val declaration1: KoReturnTypeProvider = mockk {
-            every { returnType?.name } returns typeName1
+            every { hasReturnTypeOf(SampleType1::class) } returns true
         }
         val declaration2: KoReturnTypeProvider = mockk {
-            every { returnType?.name } returns typeName2
+            every { hasReturnTypeOf(SampleType1::class) } returns false
         }
-
         val declarations = listOf(declaration1, declaration2)
 
         // when
@@ -186,17 +239,17 @@ class KoReturnTypeProviderListExtTest {
     @Test
     fun `withoutReturnTypeOf(KClass) returns declaration without any of given return types`() {
         // given
-        val typeName1 = "SampleType1"
-        val typeName2 = "SampleType2"
-        val typeName3 = "SampleType3"
         val declaration1: KoReturnTypeProvider = mockk {
-            every { returnType?.name } returns typeName1
+            every { hasReturnTypeOf(SampleType1::class) } returns true
+            every { hasReturnTypeOf(SampleType2::class) } returns false
         }
         val declaration2: KoReturnTypeProvider = mockk {
-            every { returnType?.name } returns typeName2
+            every { hasReturnTypeOf(SampleType1::class) } returns false
+            every { hasReturnTypeOf(SampleType2::class) } returns true
         }
         val declaration3: KoReturnTypeProvider = mockk {
-            every { returnType?.name } returns typeName3
+            every { hasReturnTypeOf(SampleType1::class) } returns false
+            every { hasReturnTypeOf(SampleType2::class) } returns false
         }
         val declarations = listOf(declaration1, declaration2, declaration3)
 

--- a/lib/src/test/kotlin/com/lemonappdev/konsist/api/ext/list/KoReturnTypeProviderListExtTest.kt
+++ b/lib/src/test/kotlin/com/lemonappdev/konsist/api/ext/list/KoReturnTypeProviderListExtTest.kt
@@ -1,7 +1,6 @@
 package com.lemonappdev.konsist.api.ext.list
 
 import com.lemonappdev.konsist.api.declaration.KoTypeDeclaration
-import com.lemonappdev.konsist.api.provider.KoReceiverTypeProvider
 import com.lemonappdev.konsist.api.provider.KoReturnTypeProvider
 import com.lemonappdev.konsist.testdata.SampleType1
 import com.lemonappdev.konsist.testdata.SampleType2


### PR DESCRIPTION
1) Assume that we want to check if all functions in a scope has `String` return type.

Before the changes:
```kotlin
Konsist
   .scopeFromProject()
   .functions()
   .assert { it.returnType?.name == "String" } 
```

After the changes:
```kotlin
// First option
Konsist
   .scopeFromProject()
   .functions()
   .assert { it.hasReturnTypeOf<String>() } 
   
// Second option
Konsist
   .scopeFromProject()
   .functions()
   .assert { it.hasReturnTypeOf(String::class) } 
   
// Third option
Konsist
   .scopeFromProject()
   .functions()
   .assert { it.hasReturnType { type -> type.name == "String" } }
```


2) Similar, we may filter declarations using lambda predicate:

Before the changes:
```kotlin
Konsist
   .scopeFromProject()
   .functions()
   .withReturnType("SampleType1", "SampleType2")
   .assert { it.hasPrivateModifier } 
```

After the changes:
```kotlin
Konsist
   .scopeFromProject()
   .functions()
   .withReturnType { it.name == "SampleType1" || it.name == "SampleType2"}
   .assert { it.hasPrivateModifier } 
```

But in actual API we may specify more conditions than just a `name`, e.g.:
```kotlin
Konsist
   .scopeFromProject()
   .functions()
   .withReturnType { it.isKotlinType && it.name == "SampleType"}
   .assert { it.hasPrivateModifier } 
```