### PR TITLE
KON-423 KoArgumentProvider Add `hasArgument(lambda)` `hasAllArguments(lambda)` And `countArguments(lambda)`

### DIFF
--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koannotation/KoAnnotationDeclarationForKoArgumentProviderTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koannotation/KoAnnotationDeclarationForKoArgumentProviderTest.kt
@@ -19,7 +19,10 @@ class KoAnnotationDeclarationForKoArgumentProviderTest {
         assertSoftly(sut) {
             arguments shouldBeEqualTo emptyList()
             numArguments shouldBeEqualTo 0
+            countArguments { it.value == "text" } shouldBeEqualTo 0
             hasArguments() shouldBeEqualTo false
+            hasArgument { it.value == "text" } shouldBeEqualTo false
+            hasAllArguments { it.value == "text" } shouldBeEqualTo true
         }
     }
 
@@ -35,7 +38,10 @@ class KoAnnotationDeclarationForKoArgumentProviderTest {
         assertSoftly(sut) {
             arguments shouldBeEqualTo emptyList()
             numArguments shouldBeEqualTo 0
+            countArguments { it.value == "text" } shouldBeEqualTo 0
             hasArguments() shouldBeEqualTo false
+            hasArgument { it.value == "text" } shouldBeEqualTo false
+            hasAllArguments { it.value == "text" } shouldBeEqualTo true
         }
     }
 
@@ -51,7 +57,13 @@ class KoAnnotationDeclarationForKoArgumentProviderTest {
         assertSoftly(sut) {
             arguments.map { it.value } shouldBeEqualTo listOf("text")
             numArguments shouldBeEqualTo 1
+            countArguments { it.value == "text" } shouldBeEqualTo 1
+            countArguments { it.value == "other" } shouldBeEqualTo 0
             hasArguments() shouldBeEqualTo true
+            hasArgument { it.value == "text" } shouldBeEqualTo true
+            hasArgument { it.value == "other" } shouldBeEqualTo false
+            hasAllArguments { it.value == "text" } shouldBeEqualTo true
+            hasAllArguments { it.value == "other" } shouldBeEqualTo false
         }
     }
 
@@ -67,7 +79,13 @@ class KoAnnotationDeclarationForKoArgumentProviderTest {
         assertSoftly(sut) {
             arguments.map { it.value } shouldBeEqualTo listOf("text", "true")
             numArguments shouldBeEqualTo 2
+            countArguments { it.value.startsWith("t") } shouldBeEqualTo 2
+            countArguments { it.value == "text" } shouldBeEqualTo 1
             hasArguments() shouldBeEqualTo true
+            hasArgument { it.value == "text" } shouldBeEqualTo true
+            hasArgument { it.value == "other" } shouldBeEqualTo false
+            hasAllArguments { it.value.startsWith("t") } shouldBeEqualTo true
+            hasAllArguments { it.value.startsWith("k") } shouldBeEqualTo false
         }
     }
 

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koenumconstant/KoEnumConstantDeclarationForKoArgumentProviderTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koenumconstant/KoEnumConstantDeclarationForKoArgumentProviderTest.kt
@@ -22,7 +22,8 @@ class KoEnumConstantDeclarationForKoArgumentProviderTest {
             countArguments { it.value == "text" } shouldBeEqualTo 0
             hasArguments() shouldBeEqualTo false
             hasArgument { it.value == "text" } shouldBeEqualTo false
-            hasAllArguments { it.value == "text" } shouldBeEqualTo true        }
+            hasAllArguments { it.value == "text" } shouldBeEqualTo true
+        }
     }
 
     @Test
@@ -40,7 +41,8 @@ class KoEnumConstantDeclarationForKoArgumentProviderTest {
             countArguments { it.value == "text" } shouldBeEqualTo 0
             hasArguments() shouldBeEqualTo false
             hasArgument { it.value == "text" } shouldBeEqualTo false
-            hasAllArguments { it.value == "text" } shouldBeEqualTo true        }
+            hasAllArguments { it.value == "text" } shouldBeEqualTo true
+        }
     }
 
     @Test
@@ -61,7 +63,8 @@ class KoEnumConstantDeclarationForKoArgumentProviderTest {
             hasArgument { it.value == "0" } shouldBeEqualTo true
             hasArgument { it.value == "1" } shouldBeEqualTo false
             hasAllArguments { it.value == "0" } shouldBeEqualTo true
-            hasAllArguments { it.value == "1" } shouldBeEqualTo false        }
+            hasAllArguments { it.value == "1" } shouldBeEqualTo false
+        }
     }
 
     @Test
@@ -82,7 +85,8 @@ class KoEnumConstantDeclarationForKoArgumentProviderTest {
             hasArgument { it.value == "0" } shouldBeEqualTo true
             hasArgument { it.value == "1" } shouldBeEqualTo false
             hasAllArguments { it.value.startsWith("fal") || it.value == "0" } shouldBeEqualTo true
-            hasAllArguments { it.value.startsWith("k") } shouldBeEqualTo false        }
+            hasAllArguments { it.value.startsWith("k") } shouldBeEqualTo false
+        }
     }
 
     @Test

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koenumconstant/KoEnumConstantDeclarationForKoArgumentProviderTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koenumconstant/KoEnumConstantDeclarationForKoArgumentProviderTest.kt
@@ -19,8 +19,10 @@ class KoEnumConstantDeclarationForKoArgumentProviderTest {
         assertSoftly(sut) {
             arguments shouldBeEqualTo emptyList()
             numArguments shouldBeEqualTo 0
+            countArguments { it.value == "text" } shouldBeEqualTo 0
             hasArguments() shouldBeEqualTo false
-        }
+            hasArgument { it.value == "text" } shouldBeEqualTo false
+            hasAllArguments { it.value == "text" } shouldBeEqualTo true        }
     }
 
     @Test
@@ -35,8 +37,10 @@ class KoEnumConstantDeclarationForKoArgumentProviderTest {
         assertSoftly(sut) {
             arguments shouldBeEqualTo emptyList()
             numArguments shouldBeEqualTo 0
+            countArguments { it.value == "text" } shouldBeEqualTo 0
             hasArguments() shouldBeEqualTo false
-        }
+            hasArgument { it.value == "text" } shouldBeEqualTo false
+            hasAllArguments { it.value == "text" } shouldBeEqualTo true        }
     }
 
     @Test
@@ -51,8 +55,13 @@ class KoEnumConstantDeclarationForKoArgumentProviderTest {
         assertSoftly(sut) {
             arguments.map { it.value } shouldBeEqualTo listOf("0")
             numArguments shouldBeEqualTo 1
+            countArguments { it.value == "0" } shouldBeEqualTo 1
+            countArguments { it.value == "1" } shouldBeEqualTo 0
             hasArguments() shouldBeEqualTo true
-        }
+            hasArgument { it.value == "0" } shouldBeEqualTo true
+            hasArgument { it.value == "1" } shouldBeEqualTo false
+            hasAllArguments { it.value == "0" } shouldBeEqualTo true
+            hasAllArguments { it.value == "1" } shouldBeEqualTo false        }
     }
 
     @Test
@@ -67,8 +76,13 @@ class KoEnumConstantDeclarationForKoArgumentProviderTest {
         assertSoftly(sut) {
             arguments.map { it.value } shouldBeEqualTo listOf("0", "false")
             numArguments shouldBeEqualTo 2
+            countArguments { it.value.startsWith("fal") || it.value == "0" } shouldBeEqualTo 2
+            countArguments { it.value == "0" } shouldBeEqualTo 1
             hasArguments() shouldBeEqualTo true
-        }
+            hasArgument { it.value == "0" } shouldBeEqualTo true
+            hasArgument { it.value == "1" } shouldBeEqualTo false
+            hasAllArguments { it.value.startsWith("fal") || it.value == "0" } shouldBeEqualTo true
+            hasAllArguments { it.value.startsWith("k") } shouldBeEqualTo false        }
     }
 
     @Test

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/api/ext/list/KoArgumentProviderListExt.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/api/ext/list/KoArgumentProviderListExt.kt
@@ -17,8 +17,48 @@ val <T : KoArgumentProvider> List<T>.arguments: List<KoArgumentDeclaration>
 fun <T : KoArgumentProvider> List<T>.withArguments(): List<T> = filter { it.hasArguments() }
 
 /**
+ * List containing declarations whose all arguments match the given predicate.
+ *
+ * @param predicate The predicate function to determine if a declaration argument satisfies a condition.
+ * @return A list containing declarations with the specified argument(s).
+ */
+fun <T : KoArgumentProvider> List<T>.withAllArguments(predicate: (KoArgumentDeclaration) -> Boolean): List<T> = filter {
+    it.hasAllArguments(predicate)
+}
+
+/**
+ * List containing declarations whose at least one argument matches the given predicate.
+ *
+ * @param predicate The predicate function to determine if a declaration argument satisfies a condition.
+ * @return A list containing declarations with the specified argument(s).
+ */
+fun <T : KoArgumentProvider> List<T>.withArgument(predicate: (KoArgumentDeclaration) -> Boolean): List<T> = filter {
+    it.hasArgument(predicate)
+}
+
+/**
  * List containing elements with no argument.
  *
  * @return A list containing elements with no argument.
  */
 fun <T : KoArgumentProvider> List<T>.withoutArguments(): List<T> = filterNot { it.hasArguments() }
+
+/**
+ * List containing declarations whose all arguments do not match the predicate.
+ *
+ * @param predicate The predicate function to determine if a declaration argument satisfies a condition.
+ * @return A list containing declarations without the specified argument(s).
+ */
+fun <T : KoArgumentProvider> List<T>.withoutAllArguments(predicate: (KoArgumentDeclaration) -> Boolean): List<T> = filterNot {
+    it.hasAllArguments(predicate)
+}
+
+/**
+ * List containing declarations whose at least one argument does not match the predicate.
+ *
+ * @param predicate The predicate function to determine if a declaration argument satisfies a condition.
+ * @return A list containing declarations with the specified argument(s).
+ */
+fun <T : KoArgumentProvider> List<T>.withoutArgument(predicate: (KoArgumentDeclaration) -> Boolean): List<T> = filterNot {
+    it.hasArgument(predicate)
+}

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/api/provider/KoArgumentProvider.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/api/provider/KoArgumentProvider.kt
@@ -1,6 +1,7 @@
 package com.lemonappdev.konsist.api.provider
 
 import com.lemonappdev.konsist.api.declaration.KoArgumentDeclaration
+import com.lemonappdev.konsist.api.declaration.KoImportDeclaration
 
 /**
  * An interface representing a Kotlin declaration that provides access to arguments.
@@ -18,9 +19,37 @@ interface KoArgumentProvider : KoBaseProvider {
     val numArguments: Int
 
     /**
+     * Gets the number of arguments that satisfies the specified predicate present in the declaration.
+     *
+     * @param predicate The predicate function to determine if an argument satisfies a condition.
+     * @return The number of arguments in the declaration.
+     */
+    fun countArguments(predicate: (KoArgumentDeclaration) -> Boolean): Int
+
+    /**
      * Whether the declaration has arguments.
      *
      * @return `true` if the declaration has any argument, `false` otherwise.
      */
     fun hasArguments(): Boolean
+
+    /**
+     * Whether the declaration has any argument with the specified predicate.
+     *
+     * @param predicate The predicate function to determine if an argument satisfies a condition.
+     * @return `true` if the declaration has arguments with the specified predicate, `false` otherwise.
+     */
+    fun hasArgument(predicate: (KoArgumentDeclaration) -> Boolean): Boolean
+
+    /**
+     * Whether the declaration has all arguments with the specified predicate.
+     *
+     * Note that if the arguments contains no elements, the function returns `true` because there are no elements in it
+     * that do not match the predicate. See a more detailed explanation of this logic concept in
+     * ["Vacuous truth"](https://en.wikipedia.org/wiki/Vacuous_truth) article.
+     *
+     * @param predicate The predicate function to determine if an argument satisfies a condition.
+     * @return `true` if the declaration has all arguments with the specified predicate, `false` otherwise.
+     */
+    fun hasAllArguments(predicate: (KoArgumentDeclaration) -> Boolean): Boolean
 }

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/api/provider/KoArgumentProvider.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/api/provider/KoArgumentProvider.kt
@@ -1,7 +1,6 @@
 package com.lemonappdev.konsist.api.provider
 
 import com.lemonappdev.konsist.api.declaration.KoArgumentDeclaration
-import com.lemonappdev.konsist.api.declaration.KoImportDeclaration
 
 /**
  * An interface representing a Kotlin declaration that provides access to arguments.

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/KoArgumentProviderCore.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/KoArgumentProviderCore.kt
@@ -1,10 +1,19 @@
 package com.lemonappdev.konsist.core.provider
 
+import com.lemonappdev.konsist.api.declaration.KoArgumentDeclaration
 import com.lemonappdev.konsist.api.provider.KoArgumentProvider
 
-internal interface KoArgumentProviderCore : KoArgumentProvider, KoBaseProviderCore, KoContainingDeclarationProviderCore {
+internal interface KoArgumentProviderCore : KoArgumentProvider, KoBaseProviderCore,
+    KoContainingDeclarationProviderCore {
     override val numArguments: Int
         get() = arguments.size
 
+    override fun countArguments(predicate: (KoArgumentDeclaration) -> Boolean): Int =
+        arguments.count { predicate(it) }
+
     override fun hasArguments(): Boolean = arguments.isNotEmpty()
+
+    override fun hasArgument(predicate: (KoArgumentDeclaration) -> Boolean): Boolean = arguments.any(predicate)
+
+    override fun hasAllArguments(predicate: (KoArgumentDeclaration) -> Boolean): Boolean = arguments.all(predicate)
 }

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/KoArgumentProviderCore.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/KoArgumentProviderCore.kt
@@ -3,7 +3,9 @@ package com.lemonappdev.konsist.core.provider
 import com.lemonappdev.konsist.api.declaration.KoArgumentDeclaration
 import com.lemonappdev.konsist.api.provider.KoArgumentProvider
 
-internal interface KoArgumentProviderCore : KoArgumentProvider, KoBaseProviderCore,
+internal interface KoArgumentProviderCore :
+    KoArgumentProvider,
+    KoBaseProviderCore,
     KoContainingDeclarationProviderCore {
     override val numArguments: Int
         get() = arguments.size

--- a/lib/src/test/kotlin/com/lemonappdev/konsist/api/ext/list/KoArgumentProviderListExtTest.kt
+++ b/lib/src/test/kotlin/com/lemonappdev/konsist/api/ext/list/KoArgumentProviderListExtTest.kt
@@ -1,9 +1,7 @@
 package com.lemonappdev.konsist.api.ext.list
 
 import com.lemonappdev.konsist.api.declaration.KoArgumentDeclaration
-import com.lemonappdev.konsist.api.declaration.KoImportDeclaration
 import com.lemonappdev.konsist.api.provider.KoArgumentProvider
-import com.lemonappdev.konsist.api.provider.KoImportProvider
 import io.mockk.every
 import io.mockk.mockk
 import org.amshove.kluent.shouldBeEqualTo

--- a/lib/src/test/kotlin/com/lemonappdev/konsist/api/ext/list/KoArgumentProviderListExtTest.kt
+++ b/lib/src/test/kotlin/com/lemonappdev/konsist/api/ext/list/KoArgumentProviderListExtTest.kt
@@ -1,7 +1,9 @@
 package com.lemonappdev.konsist.api.ext.list
 
 import com.lemonappdev.konsist.api.declaration.KoArgumentDeclaration
+import com.lemonappdev.konsist.api.declaration.KoImportDeclaration
 import com.lemonappdev.konsist.api.provider.KoArgumentProvider
+import com.lemonappdev.konsist.api.provider.KoImportProvider
 import io.mockk.every
 import io.mockk.mockk
 import org.amshove.kluent.shouldBeEqualTo
@@ -63,6 +65,86 @@ class KoArgumentProviderListExtTest {
 
         // when
         val sut = declarations.withoutArguments()
+
+        // then
+        sut shouldBeEqualTo listOf(declaration2)
+    }
+
+    @Test
+    fun `withAllArguments{} returns declaration with all imports satisfy predicate`() {
+        // given
+        val suffix = "Name"
+        val predicate: (KoArgumentDeclaration) -> Boolean = { it.hasNameEndingWith(suffix) }
+        val declaration1: KoArgumentProvider = mockk {
+            every { hasAllArguments(predicate) } returns true
+        }
+        val declaration2: KoArgumentProvider = mockk {
+            every { hasAllArguments(predicate) } returns false
+        }
+        val declarations = listOf(declaration1, declaration2)
+
+        // when
+        val sut = declarations.withAllArguments(predicate)
+
+        // then
+        sut shouldBeEqualTo listOf(declaration1)
+    }
+
+    @Test
+    fun `withArgument{} returns declaration with import which satisfy predicate`() {
+        // given
+        val suffix = "Name"
+        val predicate: (KoArgumentDeclaration) -> Boolean = { it.hasNameEndingWith(suffix) }
+        val declaration1: KoArgumentProvider = mockk {
+            every { hasArgument(predicate) } returns true
+        }
+        val declaration2: KoArgumentProvider = mockk {
+            every { hasArgument(predicate) } returns false
+        }
+        val declarations = listOf(declaration1, declaration2)
+
+        // when
+        val sut = declarations.withArgument(predicate)
+
+        // then
+        sut shouldBeEqualTo listOf(declaration1)
+    }
+
+    @Test
+    fun `withoutAllArguments{} returns declaration with all imports which not satisfy predicate`() {
+        // given
+        val suffix = "Name"
+        val predicate: (KoArgumentDeclaration) -> Boolean = { it.hasNameEndingWith(suffix) }
+        val declaration1: KoArgumentProvider = mockk {
+            every { hasAllArguments(predicate) } returns true
+        }
+        val declaration2: KoArgumentProvider = mockk {
+            every { hasAllArguments(predicate) } returns false
+        }
+        val declarations = listOf(declaration1, declaration2)
+
+        // when
+        val sut = declarations.withoutAllArguments(predicate)
+
+        // then
+        sut shouldBeEqualTo listOf(declaration2)
+    }
+
+    @Test
+    fun `withoutArgument{} returns declaration without import which satisfy predicate`() {
+        // given
+        val suffix = "Name"
+        val predicate: (KoArgumentDeclaration) -> Boolean = { it.hasNameEndingWith(suffix) }
+        val declaration1: KoArgumentProvider = mockk {
+            every { hasArgument(predicate) } returns true
+        }
+        val declaration2: KoArgumentProvider = mockk {
+            every { hasArgument(predicate) } returns false
+        }
+        val declarations = listOf(declaration1, declaration2)
+
+        // when
+        val sut = declarations.withoutArgument(predicate)
 
         // then
         sut shouldBeEqualTo listOf(declaration2)


### PR DESCRIPTION

After the changes we may:
 - count arguments which specify given predicate
```kotlin
Konsist
   .scopeFromProject()
   .functions()
   .annotations
   .assert {
    it.countArguments { argument -> argument.value.startsWith("value") } == 0
    }
```

 - check if declaration has argument which specified given predicate
```kotlin
Konsist
   .scopeFromProject()
   .functions()
   .annotations
   .assert {
    it.hasArgument { argument -> argument.value == "value" }
    }
```

 - check if declaration has all arguments which specified given predicate
```kotlin
Konsist
   .scopeFromProject()
   .functions()
   .annotations
   .assert {
    it.hasAllArguments { argument -> argument.value.startsWith("value") }
    }
```

 - filter declaration using lambda predicate
```kotlin
Konsist
   .scopeFromProject()
   .functions()
   .annotations
   .withArgument { it.value == "value" }
   ...

Konsist
   .scopeFromProject()
   .functions()
   .annotations
   .withAllArguments { it.value.startsWith("value") }
   ...

Konsist
   .scopeFromProject()
   .functions()
   .annotations
   .withoutArgument { it.value == "value" }
   ...

Konsist
   .scopeFromProject()
   .functions()
   .annotations
   .withoutAllArguments { it.value.startsWith("value") }
   ...
```
