### PR TITLE
KON-418 Add Message To `assert` And `assertNot`

### DIFF
--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/verify/kodeclarationassert/KoDeclarationAssertForDeclarationListTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/verify/kodeclarationassert/KoDeclarationAssertForDeclarationListTest.kt
@@ -45,6 +45,40 @@ class KoDeclarationAssertForDeclarationListTest {
     }
 
     @Test
+    fun `declaration-assert-error-with-custom-message`() {
+        // given
+        val message = "CUSTOM ASSERT MESSAGE"
+        val sut = getSnippetFile("declaration-assert-error-with-custom-message")
+            .classes()
+
+        // then
+        try {
+            sut.assert(message) { false }
+        } catch (e: Exception) {
+            e.message?.shouldContain("Assert 'declaration-assert-error-with-custom-message' has failed." +
+                    "\n$message\nInvalid declarations (1)")
+                ?: throw e
+        }
+    }
+
+    @Test
+    fun `file-declaration-assert-error-with-custom-message`() {
+        // given
+        val message = "CUSTOM ASSERT MESSAGE"
+        val sut = getSnippetFile("file-declaration-assert-error-with-custom-message")
+            .files
+
+        // then
+        try {
+            sut.assert(message) { false }
+        } catch (e: Exception) {
+            e.message?.shouldContain("Assert 'file-declaration-assert-error-with-custom-message' has failed." +
+                    "\n$message\nInvalid files (1)")
+                ?: throw e
+        }
+    }
+
+    @Test
     fun `declaration-assert-displaying-correct-failed-declaration-type`() {
         // given
         val sut = getSnippetFile("declaration-assert-displaying-correct-failed-declaration-type")
@@ -87,7 +121,7 @@ class KoDeclarationAssertForDeclarationListTest {
 
         // then
         func shouldThrow KoPreconditionFailedException::class withMessage
-            "Declaration list is empty. Please make sure that list of declarations contain items before calling the 'assert' method."
+                "Declaration list is empty. Please make sure that list of declarations contain items before calling the 'assert' method."
     }
 
     @Test
@@ -103,7 +137,7 @@ class KoDeclarationAssertForDeclarationListTest {
 
         // then
         func shouldThrow KoPreconditionFailedException::class withMessage
-            "Declaration list is empty. Please make sure that list of declarations contain items before calling the 'assertNot' method."
+                "Declaration list is empty. Please make sure that list of declarations contain items before calling the 'assertNot' method."
     }
 
     @Test

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/verify/kodeclarationassert/KoDeclarationAssertForDeclarationListTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/verify/kodeclarationassert/KoDeclarationAssertForDeclarationListTest.kt
@@ -55,8 +55,10 @@ class KoDeclarationAssertForDeclarationListTest {
         try {
             sut.assert(message) { false }
         } catch (e: Exception) {
-            e.message?.shouldContain("Assert 'declaration-assert-error-with-custom-message' has failed." +
-                    "\n$message\nInvalid declarations (1)")
+            e.message?.shouldContain(
+                "Assert 'declaration-assert-error-with-custom-message' has failed." +
+                    "\n$message\nInvalid declarations (1)",
+            )
                 ?: throw e
         }
     }
@@ -72,8 +74,10 @@ class KoDeclarationAssertForDeclarationListTest {
         try {
             sut.assert(message) { false }
         } catch (e: Exception) {
-            e.message?.shouldContain("Assert 'file-declaration-assert-error-with-custom-message' has failed." +
-                    "\n$message\nInvalid files (1)")
+            e.message?.shouldContain(
+                "Assert 'file-declaration-assert-error-with-custom-message' has failed." +
+                    "\n$message\nInvalid files (1)",
+            )
                 ?: throw e
         }
     }
@@ -121,7 +125,7 @@ class KoDeclarationAssertForDeclarationListTest {
 
         // then
         func shouldThrow KoPreconditionFailedException::class withMessage
-                "Declaration list is empty. Please make sure that list of declarations contain items before calling the 'assert' method."
+            "Declaration list is empty. Please make sure that list of declarations contain items before calling the 'assert' method."
     }
 
     @Test
@@ -137,7 +141,7 @@ class KoDeclarationAssertForDeclarationListTest {
 
         // then
         func shouldThrow KoPreconditionFailedException::class withMessage
-                "Declaration list is empty. Please make sure that list of declarations contain items before calling the 'assertNot' method."
+            "Declaration list is empty. Please make sure that list of declarations contain items before calling the 'assertNot' method."
     }
 
     @Test

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/verify/kodeclarationassert/KoDeclarationAssertForDeclarationSequenceTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/verify/kodeclarationassert/KoDeclarationAssertForDeclarationSequenceTest.kt
@@ -55,8 +55,10 @@ class KoDeclarationAssertForDeclarationSequenceTest {
         try {
             sut.assert(message) { false }
         } catch (e: Exception) {
-            e.message?.shouldContain("Assert 'declaration-assert-error-with-custom-message' has failed." +
-                    "\n$message\nInvalid declarations (1)")
+            e.message?.shouldContain(
+                "Assert 'declaration-assert-error-with-custom-message' has failed." +
+                    "\n$message\nInvalid declarations (1)",
+            )
                 ?: throw e
         }
     }
@@ -73,8 +75,10 @@ class KoDeclarationAssertForDeclarationSequenceTest {
         try {
             sut.assert(message) { false }
         } catch (e: Exception) {
-            e.message?.shouldContain("Assert 'file-declaration-assert-error-with-custom-message' has failed." +
-                    "\n$message\nInvalid files (1)")
+            e.message?.shouldContain(
+                "Assert 'file-declaration-assert-error-with-custom-message' has failed." +
+                    "\n$message\nInvalid files (1)",
+            )
                 ?: throw e
         }
     }

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/verify/kodeclarationassert/KoDeclarationAssertForDeclarationSequenceTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/verify/kodeclarationassert/KoDeclarationAssertForDeclarationSequenceTest.kt
@@ -44,6 +44,42 @@ class KoDeclarationAssertForDeclarationSequenceTest {
     }
 
     @Test
+    fun `declaration-assert-error-with-custom-message`() {
+        // given
+        val message = "CUSTOM ASSERT MESSAGE"
+        val sut = getSnippetFile("declaration-assert-error-with-custom-message")
+            .classes()
+            .asSequence()
+
+        // then
+        try {
+            sut.assert(message) { false }
+        } catch (e: Exception) {
+            e.message?.shouldContain("Assert 'declaration-assert-error-with-custom-message' has failed." +
+                    "\n$message\nInvalid declarations (1)")
+                ?: throw e
+        }
+    }
+
+    @Test
+    fun `file-declaration-assert-error-with-custom-message`() {
+        // given
+        val message = "CUSTOM ASSERT MESSAGE"
+        val sut = getSnippetFile("file-declaration-assert-error-with-custom-message")
+            .files
+            .asSequence()
+
+        // then
+        try {
+            sut.assert(message) { false }
+        } catch (e: Exception) {
+            e.message?.shouldContain("Assert 'file-declaration-assert-error-with-custom-message' has failed." +
+                    "\n$message\nInvalid files (1)")
+                ?: throw e
+        }
+    }
+
+    @Test
     fun `declaration-assert-displaying-correct-failed-declaration-type`() {
         // given
         val sut = getSnippetFile("declaration-assert-displaying-correct-failed-declaration-type")

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/verify/kodeclarationassert/snippet/declaration-assert-error-with-custom-message.kttxt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/verify/kodeclarationassert/snippet/declaration-assert-error-with-custom-message.kttxt
@@ -1,0 +1,1 @@
+class SampleClass

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/verify/kodeclarationassert/snippet/file-declaration-assert-error-with-custom-message.kttxt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/verify/kodeclarationassert/snippet/file-declaration-assert-error-with-custom-message.kttxt
@@ -1,0 +1,1 @@
+class SampleCless

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/verify/koproviderassert/KoDeclarationAssertForProviderListTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/verify/koproviderassert/KoDeclarationAssertForProviderListTest.kt
@@ -34,6 +34,24 @@ class KoDeclarationAssertForProviderListTest {
     }
 
     @Test
+    fun `provider-assert-error-with-custom-message`() {
+        // given
+        val message = "CUSTOM ASSERT MESSAGE"
+        val sut = getSnippetFile("provider-assert-error-with-custom-message")
+            .declarations()
+            .filterIsInstance<KoNameProvider>()
+
+        // then
+        try {
+            sut.assert(message) { false }
+        } catch (e: Exception) {
+            e.message?.shouldContain("Assert 'provider-assert-error-with-custom-message' has failed." +
+                    "\n$message\nInvalid declarations (2)")
+                ?: throw e
+        }
+    }
+
+    @Test
     fun `provider-assert-displaying-correct-failed-declaration-type`() {
         // given
         val sut = getSnippetFile("provider-assert-displaying-correct-failed-declaration-type")

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/verify/koproviderassert/KoDeclarationAssertForProviderListTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/verify/koproviderassert/KoDeclarationAssertForProviderListTest.kt
@@ -45,8 +45,10 @@ class KoDeclarationAssertForProviderListTest {
         try {
             sut.assert(message) { false }
         } catch (e: Exception) {
-            e.message?.shouldContain("Assert 'provider-assert-error-with-custom-message' has failed." +
-                    "\n$message\nInvalid declarations (2)")
+            e.message?.shouldContain(
+                "Assert 'provider-assert-error-with-custom-message' has failed." +
+                    "\n$message\nInvalid declarations (2)",
+            )
                 ?: throw e
         }
     }

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/verify/koproviderassert/KoDeclarationAssertForProviderSequenceTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/verify/koproviderassert/KoDeclarationAssertForProviderSequenceTest.kt
@@ -47,8 +47,10 @@ class KoDeclarationAssertForProviderSequenceTest {
         try {
             sut.assert(message) { false }
         } catch (e: Exception) {
-            e.message?.shouldContain("Assert 'provider-assert-error-with-custom-message' has failed." +
-                    "\n$message\nInvalid declarations (2)")
+            e.message?.shouldContain(
+                "Assert 'provider-assert-error-with-custom-message' has failed." +
+                    "\n$message\nInvalid declarations (2)",
+            )
                 ?: throw e
         }
     }

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/verify/koproviderassert/KoDeclarationAssertForProviderSequenceTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/verify/koproviderassert/KoDeclarationAssertForProviderSequenceTest.kt
@@ -35,6 +35,25 @@ class KoDeclarationAssertForProviderSequenceTest {
     }
 
     @Test
+    fun `provider-assert-error-with-custom-message`() {
+        // given
+        val message = "CUSTOM ASSERT MESSAGE"
+        val sut = getSnippetFile("provider-assert-error-with-custom-message")
+            .declarations()
+            .filterIsInstance<KoNameProvider>()
+            .asSequence()
+
+        // then
+        try {
+            sut.assert(message) { false }
+        } catch (e: Exception) {
+            e.message?.shouldContain("Assert 'provider-assert-error-with-custom-message' has failed." +
+                    "\n$message\nInvalid declarations (2)")
+                ?: throw e
+        }
+    }
+
+    @Test
     fun `provider-assert-fails-when-declaration-list-is-empty`() {
         // given
         val sut = getSnippetFile("provider-assert-fails-when-declaration-list-is-empty")

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/verify/koproviderassert/snippet/provider-assert-error-with-custom-message.kttxt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/verify/koproviderassert/snippet/provider-assert-error-with-custom-message.kttxt
@@ -1,0 +1,1 @@
+class SampleClass

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/api/verify/KoDeclarationAndProviderAssert.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/api/verify/KoDeclarationAndProviderAssert.kt
@@ -9,8 +9,8 @@ import com.lemonappdev.konsist.core.verify.assert
  * @param function The predicate function that takes an element of type [E] and returns a [Boolean] value.
  *                If the function returns `true`, the element is considered valid; otherwise, it's considered invalid.
  */
-fun <E : KoBaseProvider> List<E>.assert(function: (E) -> Boolean?): Unit {
-    assert(function, positiveCheck = true)
+fun <E : KoBaseProvider> List<E>.assert(message: String? = null, function: (E) -> Boolean?): Unit {
+    assert(message, function, positiveCheck = true)
 }
 
 /**
@@ -19,8 +19,8 @@ fun <E : KoBaseProvider> List<E>.assert(function: (E) -> Boolean?): Unit {
  * @param function The predicate function that takes an element of type [E] and returns a [Boolean] value.
  *                If the function returns `true`, the element is considered invalid; otherwise, it's considered valid.
  */
-fun <E : KoBaseProvider> List<E>.assertNot(function: (E) -> Boolean?): Unit {
-    assert(function, positiveCheck = false)
+fun <E : KoBaseProvider> List<E>.assertNot(message: String? = null, function: (E) -> Boolean?): Unit {
+    assert(message, function, positiveCheck = false)
 }
 
 /**
@@ -29,8 +29,8 @@ fun <E : KoBaseProvider> List<E>.assertNot(function: (E) -> Boolean?): Unit {
  * @param function The predicate function that takes an element of type [E] and returns a [Boolean] value.
  *                If the function returns `true`, the element is considered valid; otherwise, it's considered invalid.
  */
-fun <E : KoBaseProvider> Sequence<E>.assert(function: (E) -> Boolean?): Unit {
-    this.toList().assert(function, true)
+fun <E : KoBaseProvider> Sequence<E>.assert(message: String? = null, function: (E) -> Boolean?): Unit {
+    this.toList().assert(message, function, true)
 }
 
 /**
@@ -39,6 +39,6 @@ fun <E : KoBaseProvider> Sequence<E>.assert(function: (E) -> Boolean?): Unit {
  * @param function The predicate function that takes an element of type [E] and returns a [Boolean] value.
  *                If the function returns `true`, the element is considered invalid; otherwise, it's considered valid.
  */
-fun <E : KoBaseProvider> Sequence<E>.assertNot(function: (E) -> Boolean?): Unit {
-    this.toList().assert(function, false)
+fun <E : KoBaseProvider> Sequence<E>.assertNot(message: String? = null, function: (E) -> Boolean?): Unit {
+    this.toList().assert(message, function, false)
 }

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/api/verify/KoDeclarationAndProviderAssert.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/api/verify/KoDeclarationAndProviderAssert.kt
@@ -6,47 +6,47 @@ import com.lemonappdev.konsist.core.verify.assert
 /**
  * Asserts that all elements in the list match the specified predicate.
  *
- * @param message An optional message to provide additional context when the assertion fails.
+ * @param additionalMessage An optional message to provide additional context when the assertion fails.
  *                This message will be included in the assertion error if the assertion fails.
  * @param function The predicate function that takes an element of type [E] and returns a [Boolean] value.
  *                If the function returns `true`, the element is considered valid; otherwise, it's considered invalid.
  */
-fun <E : KoBaseProvider> List<E>.assert(message: String? = null, function: (E) -> Boolean?): Unit {
-    assert(message, function, positiveCheck = true)
+fun <E : KoBaseProvider> List<E>.assert(additionalMessage: String? = null, function: (E) -> Boolean?): Unit {
+    assert(additionalMessage, function, positiveCheck = true)
 }
 
 /**
  * Asserts that no elements in the list match the specified predicate.
  *
- * @param message An optional message to provide additional context when the assertion fails.
+ * @param additionalMessage An optional message to provide additional context when the assertion fails.
  *                This message will be included in the assertion error if the assertion fails.
  * @param function The predicate function that takes an element of type [E] and returns a [Boolean] value.
  *                If the function returns `true`, the element is considered invalid; otherwise, it's considered valid.
  */
-fun <E : KoBaseProvider> List<E>.assertNot(message: String? = null, function: (E) -> Boolean?): Unit {
-    assert(message, function, positiveCheck = false)
+fun <E : KoBaseProvider> List<E>.assertNot(additionalMessage: String? = null, function: (E) -> Boolean?): Unit {
+    assert(additionalMessage, function, positiveCheck = false)
 }
 
 /**
  * Asserts that all elements in the sequence match the specified predicate.
  *
- * @param message An optional message to provide additional context when the assertion fails.
+ * @param additionalMessage An optional message to provide additional context when the assertion fails.
  *                This message will be included in the assertion error if the assertion fails.
  * @param function The predicate function that takes an element of type [E] and returns a [Boolean] value.
  *                If the function returns `true`, the element is considered valid; otherwise, it's considered invalid.
  */
-fun <E : KoBaseProvider> Sequence<E>.assert(message: String? = null, function: (E) -> Boolean?): Unit {
-    this.toList().assert(message, function, true)
+fun <E : KoBaseProvider> Sequence<E>.assert(additionalMessage: String? = null, function: (E) -> Boolean?): Unit {
+    this.toList().assert(additionalMessage, function, true)
 }
 
 /**
  * Asserts that no elements in the sequence match the specified predicate.
  *
- * @param message An optional message to provide additional context when the assertion fails.
+ * @param additionalMessage An optional message to provide additional context when the assertion fails.
  *                This message will be included in the assertion error if the assertion fails.
  * @param function The predicate function that takes an element of type [E] and returns a [Boolean] value.
  *                If the function returns `true`, the element is considered invalid; otherwise, it's considered valid.
  */
-fun <E : KoBaseProvider> Sequence<E>.assertNot(message: String? = null, function: (E) -> Boolean?): Unit {
-    this.toList().assert(message, function, false)
+fun <E : KoBaseProvider> Sequence<E>.assertNot(additionalMessage: String? = null, function: (E) -> Boolean?): Unit {
+    this.toList().assert(additionalMessage, function, false)
 }

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/api/verify/KoDeclarationAndProviderAssert.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/api/verify/KoDeclarationAndProviderAssert.kt
@@ -6,6 +6,8 @@ import com.lemonappdev.konsist.core.verify.assert
 /**
  * Asserts that all elements in the list match the specified predicate.
  *
+ * @param message An optional message to provide additional context when the assertion fails.
+ *                This message will be included in the assertion error if the assertion fails.
  * @param function The predicate function that takes an element of type [E] and returns a [Boolean] value.
  *                If the function returns `true`, the element is considered valid; otherwise, it's considered invalid.
  */
@@ -16,6 +18,8 @@ fun <E : KoBaseProvider> List<E>.assert(message: String? = null, function: (E) -
 /**
  * Asserts that no elements in the list match the specified predicate.
  *
+ * @param message An optional message to provide additional context when the assertion fails.
+ *                This message will be included in the assertion error if the assertion fails.
  * @param function The predicate function that takes an element of type [E] and returns a [Boolean] value.
  *                If the function returns `true`, the element is considered invalid; otherwise, it's considered valid.
  */
@@ -26,6 +30,8 @@ fun <E : KoBaseProvider> List<E>.assertNot(message: String? = null, function: (E
 /**
  * Asserts that all elements in the sequence match the specified predicate.
  *
+ * @param message An optional message to provide additional context when the assertion fails.
+ *                This message will be included in the assertion error if the assertion fails.
  * @param function The predicate function that takes an element of type [E] and returns a [Boolean] value.
  *                If the function returns `true`, the element is considered valid; otherwise, it's considered invalid.
  */
@@ -36,6 +42,8 @@ fun <E : KoBaseProvider> Sequence<E>.assert(message: String? = null, function: (
 /**
  * Asserts that no elements in the sequence match the specified predicate.
  *
+ * @param message An optional message to provide additional context when the assertion fails.
+ *                This message will be included in the assertion error if the assertion fails.
  * @param function The predicate function that takes an element of type [E] and returns a [Boolean] value.
  *                If the function returns `true`, the element is considered invalid; otherwise, it's considered valid.
  */

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/core/verify/CommonAssert.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/core/verify/CommonAssert.kt
@@ -2,6 +2,7 @@ package com.lemonappdev.konsist.core.verify
 
 private const val INDEX_FOUR = 4
 private const val INDEX_FIVE = 5
+private const val INDEX_SIX = 6
 private const val INDEX_SEVEN = 7
 
 /**
@@ -13,6 +14,11 @@ internal fun getTestMethodNameFromFourthIndex() = getTestMethodName(INDEX_FOUR)
  * In this call stack hierarchy test name is at index 5.
  */
 internal fun getTestMethodNameFromFifthIndex() = getTestMethodName(INDEX_FIVE)
+
+/**
+ * In this call stack hierarchy test name is at index 5.
+ */
+internal fun getTestMethodNameFromSixthIndex() = getTestMethodName(INDEX_SIX)
 
 /**
  * In this call stack hierarchy test name is at index 7.

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/core/verify/KoDeclarationAndProviderAssertCore.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/core/verify/KoDeclarationAndProviderAssertCore.kt
@@ -13,14 +13,14 @@ import com.lemonappdev.konsist.core.exception.KoInternalException
 import com.lemonappdev.konsist.core.exception.KoPreconditionFailedException
 
 internal fun <E : KoBaseProvider> List<E>.assert(
-    message: String? = null,
+    additionalMessage: String? = null,
     function: (E) -> Boolean?,
     positiveCheck: Boolean,
 ) {
     var lastDeclaration: KoBaseProvider? = null
 
     try {
-        val testMethodName = if (message != null) {
+        val testMethodName = if (additionalMessage != null) {
             getTestMethodNameFromFifthIndex()
         } else {
             getTestMethodNameFromSixthIndex()
@@ -39,7 +39,7 @@ internal fun <E : KoBaseProvider> List<E>.assert(
             }
         }
 
-        getResult(notSuppressedDeclarations, result, positiveCheck, testMethodName, message)
+        getResult(notSuppressedDeclarations, result, positiveCheck, testMethodName, additionalMessage)
     } catch (e: KoException) {
         throw e
     } catch (@Suppress("detekt.TooGenericExceptionCaught") e: Exception) {
@@ -118,17 +118,17 @@ private fun getResult(
     result: Map<Boolean?, List<Any>>,
     positiveCheck: Boolean,
     testMethodName: String,
-    message: String?,
+    additionalMessage: String?,
 ) {
     val allChecksPassed = (result[positiveCheck]?.size ?: 0) == items.size
 
     if (!allChecksPassed) {
         val failedItems = result[!positiveCheck] ?: emptyList()
-        throw KoCheckFailedException(getCheckFailedMessage(failedItems, testMethodName, message))
+        throw KoCheckFailedException(getCheckFailedMessage(failedItems, testMethodName, additionalMessage))
     }
 }
 
-private fun getCheckFailedMessage(failedItems: List<*>, testMethodName: String, message: String?): String {
+private fun getCheckFailedMessage(failedItems: List<*>, testMethodName: String, additionalMessage: String?): String {
     var types = ""
     val failedDeclarationsMessage = failedItems.joinToString("\n") {
         val konsistDeclarationClassNamePrefix = "Ko"
@@ -163,6 +163,6 @@ private fun getCheckFailedMessage(failedItems: List<*>, testMethodName: String, 
         }
     }
 
-    val customMessage = if (message != null) "\n${message}\n" else " "
+    val customMessage = if (additionalMessage != null) "\n${additionalMessage}\n" else " "
     return "Assert '$testMethodName' has failed.${customMessage}Invalid $types (${failedItems.size}):\n$failedDeclarationsMessage"
 }

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/core/verify/KoDeclarationAndProviderAssertCore.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/core/verify/KoDeclarationAndProviderAssertCore.kt
@@ -15,15 +15,14 @@ import com.lemonappdev.konsist.core.exception.KoPreconditionFailedException
 internal fun <E : KoBaseProvider> List<E>.assert(
     message: String? = null,
     function: (E) -> Boolean?,
-    positiveCheck: Boolean
+    positiveCheck: Boolean,
 ) {
     var lastDeclaration: KoBaseProvider? = null
 
     try {
         val testMethodName = if (message != null) {
             getTestMethodNameFromFifthIndex()
-        }
-        else {
+        } else {
             getTestMethodNameFromSixthIndex()
         }
 
@@ -52,7 +51,7 @@ private fun checkIfLocalListIsEmpty(localList: List<*>, testMethodName: String) 
     if (localList.isEmpty()) {
         throw KoPreconditionFailedException(
             "Declaration list is empty. Please make sure that list of declarations contain items " +
-                    "before calling the '$testMethodName' method.",
+                "before calling the '$testMethodName' method.",
         )
     }
 }
@@ -64,11 +63,11 @@ private fun <E : KoBaseProvider> checkIfAnnotatedWithSuppress(localList: List<E>
     localList
         .filterNot {
             it is KoAnnotationDeclaration &&
-                    (
-                            it.name == "Suppress" &&
-                                    it.text.contains("\"konsist.$testMethodName\"") ||
-                                    it.text.contains("\"$testMethodName\"")
-                            )
+                (
+                    it.name == "Suppress" &&
+                        it.text.contains("\"konsist.$testMethodName\"") ||
+                        it.text.contains("\"$testMethodName\"")
+                    )
         }
         .forEach { declarations[it] = checkIfDeclarationIsAnnotatedWithSuppress(it, testMethodName) }
 


### PR DESCRIPTION
Now, we may add additional message for `assert/assertNot` methods which will be display when test fails. 

**Before**: 

```kotlin 
@Test
fun `sample test`() {
    Konsist
        .scopeFromProject()
        .classes
        .assert { it.hasPrivateModifier  }
}
```

Error when test fails:
```kotlin
Assert 'sample test' has failed. Invalid files (1):
...
```

**After**:

```kotlin 
@Test
fun `sample test`() {
    Konsist
        .scopeFromProject()
        .classes
        .assert("CUSTOM ASSERT MESSAGE") { it.hasPrivateModifier  }
}
```

Error when test fails:
```kotlin
Assert 'sample test' has failed.
CUSTOM ASSERT MESSAGE
Invalid files (1):
...
```

This message is optional, if you call `assert/assertNot` methods without this, you will get the same error as before the changes.