### PR TITLE
KON-414 Add Extensions To Expose `tags`

### DIFF
--- a/lib/src/main/kotlin/com/lemonappdev/konsist/api/ext/list/KoKDocTagsProviderListExt.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/api/ext/list/KoKDocTagsProviderListExt.kt
@@ -1,0 +1,53 @@
+package com.lemonappdev.konsist.api.ext.list
+
+import com.lemonappdev.konsist.api.declaration.KoKDocTagDeclaration
+import com.lemonappdev.konsist.api.declaration.KoValuedKDocTagDeclaration
+import com.lemonappdev.konsist.api.provider.KoKDocTagsProvider
+
+/**
+ * List containing tags.
+ */
+val <T : KoKDocTagsProvider> List<T>.tags: List<KoKDocTagDeclaration>
+    get() = flatMap { it.tags }
+
+/**
+ * List containing param tags.
+ */
+val <T : KoKDocTagsProvider> List<T>.paramTags: List<KoValuedKDocTagDeclaration>
+    get() = flatMap { it.paramTags }
+
+/**
+ * List containing property tags.
+ */
+val <T : KoKDocTagsProvider> List<T>.propertyTags: List<KoValuedKDocTagDeclaration>
+    get() = flatMap { it.propertyTags }
+
+/**
+ * List containing throws tags.
+ */
+val <T : KoKDocTagsProvider> List<T>.throwsTags: List<KoValuedKDocTagDeclaration>
+    get() = flatMap { it.throwsTags }
+
+/**
+ * List containing exception tags.
+ */
+val <T : KoKDocTagsProvider> List<T>.exceptionTags: List<KoValuedKDocTagDeclaration>
+    get() = flatMap { it.exceptionTags }
+
+/**
+ * List containing sample tags.
+ */
+val <T : KoKDocTagsProvider> List<T>.sampleTags: List<KoValuedKDocTagDeclaration>
+    get() = flatMap { it.sampleTags }
+
+/**
+ * List containing see tags.
+ */
+val <T : KoKDocTagsProvider> List<T>.seeTags: List<KoValuedKDocTagDeclaration>
+    get() = flatMap { it.seeTags }
+
+/**
+ * List containing author tags.
+ */
+val <T : KoKDocTagsProvider> List<T>.authorTags: List<KoKDocTagDeclaration>
+    get() = flatMap { it.authorTags }

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/api/provider/KoKDocTagsProvider.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/api/provider/KoKDocTagsProvider.kt
@@ -24,17 +24,17 @@ interface KoKDocTagsProvider : KoBaseProvider {
     val paramTags: List<KoValuedKDocTagDeclaration>
 
     /**
-     * List of `@return` tags.
+     * The `@return` tag.
      */
     val returnTag: KoKDocTagDeclaration?
 
     /**
-     * List of `@constructor` tags.
+     * The `@constructor` tag.
      */
     val constructorTag: KoKDocTagDeclaration?
 
     /**
-     * List of `@receiver` tags.
+     * The `@receiver` tag.
      */
     val receiverTag: KoKDocTagDeclaration?
 
@@ -69,27 +69,27 @@ interface KoKDocTagsProvider : KoBaseProvider {
     val authorTags: List<KoKDocTagDeclaration>
 
     /**
-     * List of `@since` tags.
+     * The `@since` tag.
      */
     val sinceTag: KoKDocTagDeclaration?
 
     /**
-     * List of `@suppress` tags.
+     * The `@suppress` tag.
      */
     val suppressTag: KoKDocTagDeclaration?
 
     /**
-     * List of `@version` tags.
+     * The `@version` tag.
      */
     val versionTag: KoKDocTagDeclaration?
 
     /**
-     * List of `@propertySetter` tags.
+     * The `@propertySetter` tag.
      */
     val propertySetterTag: KoKDocTagDeclaration?
 
     /**
-     * List of `@propertyGetter` tags.
+     * The `@propertyGetter` tag.
      */
     val propertyGetterTag: KoKDocTagDeclaration?
 

--- a/lib/src/test/kotlin/com/lemonappdev/konsist/api/ext/list/KoKDocTagsProviderListExtTest.kt
+++ b/lib/src/test/kotlin/com/lemonappdev/konsist/api/ext/list/KoKDocTagsProviderListExtTest.kt
@@ -1,0 +1,203 @@
+package com.lemonappdev.konsist.api.ext.list
+
+import com.lemonappdev.konsist.api.declaration.KoKDocTagDeclaration
+import com.lemonappdev.konsist.api.declaration.KoValuedKDocTagDeclaration
+import com.lemonappdev.konsist.api.provider.KoKDocTagsProvider
+import io.mockk.every
+import io.mockk.mockk
+import org.amshove.kluent.shouldBeEqualTo
+import org.junit.jupiter.api.Test
+
+class KoKDocTagsProviderListExtTest {
+    @Test
+    fun `tags returns tags from all declarations`() {
+        // given
+        val tag1: KoKDocTagDeclaration = mockk()
+        val tag2: KoKDocTagDeclaration = mockk()
+        val tag3: KoKDocTagDeclaration = mockk()
+        val declaration1: KoKDocTagsProvider = mockk {
+            every { tags } returns listOf(tag1, tag2)
+        }
+        val declaration2: KoKDocTagsProvider = mockk {
+            every { tags } returns listOf(tag3)
+        }
+        val declaration3: KoKDocTagsProvider = mockk {
+            every { tags } returns emptyList()
+        }
+        val declarations = listOf(declaration1, declaration2, declaration3)
+
+        // when
+        val sut = declarations.tags
+
+        // then
+        sut shouldBeEqualTo listOf(tag1, tag2, tag3)
+    }
+
+    @Test
+    fun `paramTags returns param tags from all declarations`() {
+        // given
+        val tag1: KoValuedKDocTagDeclaration = mockk()
+        val tag2: KoValuedKDocTagDeclaration = mockk()
+        val tag3: KoValuedKDocTagDeclaration = mockk()
+        val declaration1: KoKDocTagsProvider = mockk {
+            every { paramTags } returns listOf(tag1, tag2)
+        }
+        val declaration2: KoKDocTagsProvider = mockk {
+            every { paramTags } returns listOf(tag3)
+        }
+        val declaration3: KoKDocTagsProvider = mockk {
+            every { paramTags } returns emptyList()
+        }
+        val declarations = listOf(declaration1, declaration2, declaration3)
+
+        // when
+        val sut = declarations.paramTags
+
+        // then
+        sut shouldBeEqualTo listOf(tag1, tag2, tag3)
+    }
+
+    @Test
+    fun `propertyTags returns property tags from all declarations`() {
+        // given
+        val tag1: KoValuedKDocTagDeclaration = mockk()
+        val tag2: KoValuedKDocTagDeclaration = mockk()
+        val tag3: KoValuedKDocTagDeclaration = mockk()
+        val declaration1: KoKDocTagsProvider = mockk {
+            every { propertyTags } returns listOf(tag1, tag2)
+        }
+        val declaration2: KoKDocTagsProvider = mockk {
+            every { propertyTags } returns listOf(tag3)
+        }
+        val declaration3: KoKDocTagsProvider = mockk {
+            every { propertyTags } returns emptyList()
+        }
+        val declarations = listOf(declaration1, declaration2, declaration3)
+
+        // when
+        val sut = declarations.propertyTags
+
+        // then
+        sut shouldBeEqualTo listOf(tag1, tag2, tag3)
+    }
+
+    @Test
+    fun `throwsTags returns throws tags from all declarations`() {
+        // given
+        val tag1: KoValuedKDocTagDeclaration = mockk()
+        val tag2: KoValuedKDocTagDeclaration = mockk()
+        val tag3: KoValuedKDocTagDeclaration = mockk()
+        val declaration1: KoKDocTagsProvider = mockk {
+            every { throwsTags } returns listOf(tag1, tag2)
+        }
+        val declaration2: KoKDocTagsProvider = mockk {
+            every { throwsTags } returns listOf(tag3)
+        }
+        val declaration3: KoKDocTagsProvider = mockk {
+            every { throwsTags } returns emptyList()
+        }
+        val declarations = listOf(declaration1, declaration2, declaration3)
+
+        // when
+        val sut = declarations.throwsTags
+
+        // then
+        sut shouldBeEqualTo listOf(tag1, tag2, tag3)
+    }
+
+    @Test
+    fun `exceptionTags returns exception tags from all declarations`() {
+        // given
+        val tag1: KoValuedKDocTagDeclaration = mockk()
+        val tag2: KoValuedKDocTagDeclaration = mockk()
+        val tag3: KoValuedKDocTagDeclaration = mockk()
+        val declaration1: KoKDocTagsProvider = mockk {
+            every { exceptionTags } returns listOf(tag1, tag2)
+        }
+        val declaration2: KoKDocTagsProvider = mockk {
+            every { exceptionTags } returns listOf(tag3)
+        }
+        val declaration3: KoKDocTagsProvider = mockk {
+            every { exceptionTags } returns emptyList()
+        }
+        val declarations = listOf(declaration1, declaration2, declaration3)
+
+        // when
+        val sut = declarations.exceptionTags
+
+        // then
+        sut shouldBeEqualTo listOf(tag1, tag2, tag3)
+    }
+
+    @Test
+    fun `sampleTags returns sample tags from all declarations`() {
+        // given
+        val tag1: KoValuedKDocTagDeclaration = mockk()
+        val tag2: KoValuedKDocTagDeclaration = mockk()
+        val tag3: KoValuedKDocTagDeclaration = mockk()
+        val declaration1: KoKDocTagsProvider = mockk {
+            every { sampleTags } returns listOf(tag1, tag2)
+        }
+        val declaration2: KoKDocTagsProvider = mockk {
+            every { sampleTags } returns listOf(tag3)
+        }
+        val declaration3: KoKDocTagsProvider = mockk {
+            every { sampleTags } returns emptyList()
+        }
+        val declarations = listOf(declaration1, declaration2, declaration3)
+
+        // when
+        val sut = declarations.sampleTags
+
+        // then
+        sut shouldBeEqualTo listOf(tag1, tag2, tag3)
+    }
+
+    @Test
+    fun `seeTags returns see tags from all declarations`() {
+        // given
+        val tag1: KoValuedKDocTagDeclaration = mockk()
+        val tag2: KoValuedKDocTagDeclaration = mockk()
+        val tag3: KoValuedKDocTagDeclaration = mockk()
+        val declaration1: KoKDocTagsProvider = mockk {
+            every { seeTags } returns listOf(tag1, tag2)
+        }
+        val declaration2: KoKDocTagsProvider = mockk {
+            every { seeTags } returns listOf(tag3)
+        }
+        val declaration3: KoKDocTagsProvider = mockk {
+            every { seeTags } returns emptyList()
+        }
+        val declarations = listOf(declaration1, declaration2, declaration3)
+
+        // when
+        val sut = declarations.seeTags
+
+        // then
+        sut shouldBeEqualTo listOf(tag1, tag2, tag3)
+    }
+
+    @Test
+    fun `authorTags returns author tags from all declarations`() {
+        // given
+        val tag1: KoKDocTagDeclaration = mockk()
+        val tag2: KoKDocTagDeclaration = mockk()
+        val tag3: KoKDocTagDeclaration = mockk()
+        val declaration1: KoKDocTagsProvider = mockk {
+            every { authorTags } returns listOf(tag1, tag2)
+        }
+        val declaration2: KoKDocTagsProvider = mockk {
+            every { authorTags } returns listOf(tag3)
+        }
+        val declaration3: KoKDocTagsProvider = mockk {
+            every { authorTags } returns emptyList()
+        }
+        val declarations = listOf(declaration1, declaration2, declaration3)
+
+        // when
+        val sut = declarations.authorTags
+
+        // then
+        sut shouldBeEqualTo listOf(tag1, tag2, tag3)
+    }
+}


### PR DESCRIPTION
**Before changes:**
```kotlin
Konsist
   .scopeFromProject()
   .declarationsOf<KoKDocTagsProvider>()
   .flatMap { it.tags }
   .assert { // test }
```

**After changes:**
```kotlin
Konsist
   .scopeFromProject()
   .declarationsOf<KoKDocTagsProvider>()
   .tags
   .assert { // test }
```

The same with `paramTags`, `propertyTags`, `throwsTags`, `exceptionTags`, `sampleTags`, `seeTags`, `authorTags`.