### PR TITLE
KON-417 Add Provider With `matches` Method

### DIFF
--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koimport/KoImportDeclarationForKoMatchesProviderTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koimport/KoImportDeclarationForKoMatchesProviderTest.kt
@@ -1,0 +1,28 @@
+package com.lemonappdev.konsist.core.declaration.koimport
+
+import com.lemonappdev.konsist.TestSnippetProvider
+import org.amshove.kluent.assertSoftly
+import org.amshove.kluent.shouldBeEqualTo
+import org.junit.jupiter.api.Test
+
+class KoImportDeclarationForKoMatchesProviderTest {
+    @Test
+    fun `import-matches`() {
+        // given
+        val sut = getSnippetFile("import-matches")
+            .imports
+            .first()
+
+        // then
+        assertSoftly (sut) {
+            matches("com..") shouldBeEqualTo true
+            matches("com") shouldBeEqualTo false
+            matches("..testdata..") shouldBeEqualTo true
+            matches("com.lemonappdev..testdata.SampleType") shouldBeEqualTo true
+            matches("com.lemonappdev.konsist.testdata.OtherImport") shouldBeEqualTo false
+        }
+    }
+
+    private fun getSnippetFile(fileName: String) =
+        TestSnippetProvider.getSnippetKoScope("core/declaration/koimport/snippet/forkomatchesprovider/", fileName)
+}

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koimport/KoImportDeclarationForKoMatchesProviderTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koimport/KoImportDeclarationForKoMatchesProviderTest.kt
@@ -14,7 +14,7 @@ class KoImportDeclarationForKoMatchesProviderTest {
             .first()
 
         // then
-        assertSoftly (sut) {
+        assertSoftly(sut) {
             matches("com..") shouldBeEqualTo true
             matches("com") shouldBeEqualTo false
             matches("..testdata..") shouldBeEqualTo true

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koimport/snippet/forkomatchesprovider/import-matches.kttxt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koimport/snippet/forkomatchesprovider/import-matches.kttxt
@@ -1,0 +1,3 @@
+import com.lemonappdev.konsist.testdata.SampleType
+
+class SampleClass(val property: SampleType)

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/api/declaration/KoImportDeclaration.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/api/declaration/KoImportDeclaration.kt
@@ -4,6 +4,7 @@ import com.lemonappdev.konsist.api.provider.KoAliasProvider
 import com.lemonappdev.konsist.api.provider.KoBaseProvider
 import com.lemonappdev.konsist.api.provider.KoContainingFileProvider
 import com.lemonappdev.konsist.api.provider.KoLocationProvider
+import com.lemonappdev.konsist.api.provider.KoMatchesProvider
 import com.lemonappdev.konsist.api.provider.KoNameProvider
 import com.lemonappdev.konsist.api.provider.KoPathProvider
 import com.lemonappdev.konsist.api.provider.KoTextProvider
@@ -18,6 +19,7 @@ interface KoImportDeclaration :
     KoAliasProvider,
     KoContainingFileProvider,
     KoLocationProvider,
+    KoMatchesProvider,
     KoNameProvider,
     KoPathProvider,
     KoTextProvider,

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/api/provider/KoMatchesProvider.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/api/provider/KoMatchesProvider.kt
@@ -1,5 +1,14 @@
 package com.lemonappdev.konsist.api.provider
 
+/**
+ * An interface representing a Kotlin declaration that provides information about whether it matches a specified element.
+ */
 interface KoMatchesProvider: KoBaseProvider {
+    /**
+     *  Whether the given [element] matches to declaration.
+     *
+     * @param element The element to be matched, typically represented as a `String`.
+     * @return `true` if the [element] matches the declaration, `false` otherwise.
+     */
     fun matches(element: String): Boolean
 }

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/api/provider/KoMatchesProvider.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/api/provider/KoMatchesProvider.kt
@@ -3,7 +3,7 @@ package com.lemonappdev.konsist.api.provider
 /**
  * An interface representing a Kotlin declaration that provides information about whether it matches a specified element.
  */
-interface KoMatchesProvider: KoBaseProvider {
+interface KoMatchesProvider : KoBaseProvider {
     /**
      *  Whether the given [element] matches to declaration.
      *

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/api/provider/KoMatchesProvider.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/api/provider/KoMatchesProvider.kt
@@ -1,0 +1,5 @@
+package com.lemonappdev.konsist.api.provider
+
+interface KoMatchesProvider: KoBaseProvider {
+    fun matches(element: String): Boolean
+}

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/core/declaration/KoImportDeclarationCore.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/core/declaration/KoImportDeclarationCore.kt
@@ -8,6 +8,7 @@ import com.lemonappdev.konsist.core.provider.KoAliasProviderCore
 import com.lemonappdev.konsist.core.provider.KoBaseProviderCore
 import com.lemonappdev.konsist.core.provider.KoContainingFileProviderCore
 import com.lemonappdev.konsist.core.provider.KoLocationProviderCore
+import com.lemonappdev.konsist.core.provider.KoMatchesProviderCore
 import com.lemonappdev.konsist.core.provider.KoNameProviderCore
 import com.lemonappdev.konsist.core.provider.KoPathProviderCore
 import com.lemonappdev.konsist.core.provider.KoTextProviderCore
@@ -21,6 +22,7 @@ internal class KoImportDeclarationCore private constructor(override val ktImport
     KoAliasProviderCore,
     KoContainingFileProviderCore,
     KoLocationProviderCore,
+    KoMatchesProviderCore,
     KoNameProviderCore,
     KoPathProviderCore,
     KoTextProviderCore,

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/KoMatchesProviderCore.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/KoMatchesProviderCore.kt
@@ -3,6 +3,6 @@ package com.lemonappdev.konsist.core.provider
 import com.lemonappdev.konsist.api.provider.KoMatchesProvider
 import com.lemonappdev.konsist.core.util.LocationUtil
 
-internal interface KoMatchesProviderCore: KoMatchesProvider, KoNameProviderCore, KoBaseProviderCore {
+internal interface KoMatchesProviderCore : KoMatchesProvider, KoNameProviderCore, KoBaseProviderCore {
     override fun matches(element: String): Boolean = LocationUtil.resideInLocation(element, name)
 }

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/KoMatchesProviderCore.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/KoMatchesProviderCore.kt
@@ -1,0 +1,8 @@
+package com.lemonappdev.konsist.core.provider
+
+import com.lemonappdev.konsist.api.provider.KoMatchesProvider
+import com.lemonappdev.konsist.core.util.LocationUtil
+
+internal interface KoMatchesProviderCore: KoMatchesProvider, KoNameProviderCore, KoBaseProviderCore {
+    override fun matches(element: String): Boolean = LocationUtil.resideInLocation(element, name)
+}


### PR DESCRIPTION
Assume we have this import:
```kotlin
import com.lemonappdev.konsist.testdata.SampleType
```

Now, we may write test:
```kotlin
Konsist
   .scopeFromProject()
   .imports
   .assert { it.matches("..lemonappdev..testdata..") }  // returns `true` for above import
   
Konsist
   .scopeFromProject()
   .imports
   .assert { it.matches("com") }  // returns `false` for above import
```