### PR TITLE
Update Assert Error Message

### DIFF
--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/verify/kodeclarationassert/KoDeclarationAssertForDeclarationListTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/verify/kodeclarationassert/KoDeclarationAssertForDeclarationListTest.kt
@@ -24,7 +24,7 @@ class KoDeclarationAssertForDeclarationListTest {
         try {
             sut.assert { false }
         } catch (e: Exception) {
-            e.message?.shouldContain("Assert 'declaration-assert-test-method-name' has failed. Invalid declarations (1)")
+            e.message?.shouldContain("Assert 'declaration-assert-test-method-name' was violated (1 times)")
                 ?: throw e
         }
     }
@@ -39,7 +39,7 @@ class KoDeclarationAssertForDeclarationListTest {
         try {
             sut.assert { false }
         } catch (e: Exception) {
-            e.message?.shouldContain("Assert 'file-declaration-assert-test-method-name' has failed. Invalid files (1)")
+            e.message?.shouldContain("Assert 'file-declaration-assert-test-method-name' was violated (1 times)")
                 ?: throw e
         }
     }
@@ -56,8 +56,8 @@ class KoDeclarationAssertForDeclarationListTest {
             sut.assert(message) { false }
         } catch (e: Exception) {
             e.message?.shouldContain(
-                "Assert 'declaration-assert-error-with-custom-message' has failed." +
-                    "\n$message\nInvalid declarations (1)",
+                "Assert 'declaration-assert-error-with-custom-message' was violated (1 times)." +
+                    "\n$message\nInvalid declarations",
             )
                 ?: throw e
         }
@@ -75,8 +75,8 @@ class KoDeclarationAssertForDeclarationListTest {
             sut.assert(message) { false }
         } catch (e: Exception) {
             e.message?.shouldContain(
-                "Assert 'file-declaration-assert-error-with-custom-message' has failed." +
-                    "\n$message\nInvalid files (1)",
+                "Assert 'file-declaration-assert-error-with-custom-message' was violated (1 times)." +
+                    "\n$message\nInvalid files:",
             )
                 ?: throw e
         }

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/verify/kodeclarationassert/KoDeclarationAssertForDeclarationSequenceTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/verify/kodeclarationassert/KoDeclarationAssertForDeclarationSequenceTest.kt
@@ -24,7 +24,7 @@ class KoDeclarationAssertForDeclarationSequenceTest {
         try {
             sut.assert { false }
         } catch (e: Exception) {
-            e.message?.shouldContain("Assert 'declaration-assert-test-method-name' has failed. Invalid declarations (1)") ?: throw e
+            e.message?.shouldContain("Assert 'declaration-assert-test-method-name' was violated (1 times)") ?: throw e
         }
     }
 
@@ -39,7 +39,7 @@ class KoDeclarationAssertForDeclarationSequenceTest {
         try {
             sut.assert { false }
         } catch (e: Exception) {
-            e.message?.shouldContain("Assert 'file-declaration-assert-test-method-name' has failed. Invalid files (1)") ?: throw e
+            e.message?.shouldContain("Assert 'file-declaration-assert-test-method-name' was violated (1 times)") ?: throw e
         }
     }
 
@@ -56,8 +56,8 @@ class KoDeclarationAssertForDeclarationSequenceTest {
             sut.assert(message) { false }
         } catch (e: Exception) {
             e.message?.shouldContain(
-                "Assert 'declaration-assert-error-with-custom-message' has failed." +
-                    "\n$message\nInvalid declarations (1)",
+                "Assert 'declaration-assert-error-with-custom-message' was violated (1 times)." +
+                    "\n$message\nInvalid declarations:",
             )
                 ?: throw e
         }
@@ -76,8 +76,8 @@ class KoDeclarationAssertForDeclarationSequenceTest {
             sut.assert(message) { false }
         } catch (e: Exception) {
             e.message?.shouldContain(
-                "Assert 'file-declaration-assert-error-with-custom-message' has failed." +
-                    "\n$message\nInvalid files (1)",
+                "Assert 'file-declaration-assert-error-with-custom-message' was violated (1 times)." +
+                    "\n$message\nInvalid files:",
             )
                 ?: throw e
         }

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/verify/koproviderassert/KoDeclarationAssertForProviderListTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/verify/koproviderassert/KoDeclarationAssertForProviderListTest.kt
@@ -28,7 +28,7 @@ class KoDeclarationAssertForProviderListTest {
         try {
             sut.assert { false }
         } catch (e: Exception) {
-            e.message?.shouldContain("Assert 'provider-assert-test-method-name' has failed. Invalid declarations (2)")
+            e.message?.shouldContain("Assert 'provider-assert-test-method-name' was violated (2 times)")
                 ?: throw e
         }
     }
@@ -46,8 +46,8 @@ class KoDeclarationAssertForProviderListTest {
             sut.assert(message) { false }
         } catch (e: Exception) {
             e.message?.shouldContain(
-                "Assert 'provider-assert-error-with-custom-message' has failed." +
-                    "\n$message\nInvalid declarations (2)",
+                "Assert 'provider-assert-error-with-custom-message' was violated (2 times)." +
+                    "\n$message\nInvalid declarations:",
             )
                 ?: throw e
         }

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/verify/koproviderassert/KoDeclarationAssertForProviderSequenceTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/verify/koproviderassert/KoDeclarationAssertForProviderSequenceTest.kt
@@ -29,7 +29,7 @@ class KoDeclarationAssertForProviderSequenceTest {
         try {
             sut.assert { false }
         } catch (e: Exception) {
-            e.message?.shouldContain("Assert 'provider-assert-test-method-name' has failed. Invalid declarations (2)")
+            e.message?.shouldContain("Assert 'provider-assert-test-method-name' was violated (2 times)")
                 ?: throw e
         }
     }
@@ -48,8 +48,8 @@ class KoDeclarationAssertForProviderSequenceTest {
             sut.assert(message) { false }
         } catch (e: Exception) {
             e.message?.shouldContain(
-                "Assert 'provider-assert-error-with-custom-message' has failed." +
-                    "\n$message\nInvalid declarations (2)",
+                "Assert 'provider-assert-error-with-custom-message' was violated (2 times)." +
+                    "\n$message\nInvalid declarations:",
             )
                 ?: throw e
         }

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/core/verify/KoDeclarationAndProviderAssertCore.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/core/verify/KoDeclarationAndProviderAssertCore.kt
@@ -164,5 +164,5 @@ private fun getCheckFailedMessage(failedItems: List<*>, testMethodName: String, 
     }
 
     val customMessage = if (additionalMessage != null) "\n${additionalMessage}\n" else " "
-    return "Assert '$testMethodName' has failed.${customMessage}Invalid $types (${failedItems.size}):\n$failedDeclarationsMessage"
+    return "Assert '$testMethodName' was violated (${failedItems.size} times).${customMessage}Invalid $types:\n$failedDeclarationsMessage"
 }


### PR DESCRIPTION
Before
```
com.lemonappdev.konsist.core.exception.KoCheckFailedException: Assert 'Konsist - adapter package should not access domain package' has failed. Invalid files (1):
```

After
```
com.lemonappdev.konsist.core.exception.KoCheckFailedException: Assert 'Konsist - adapter package should not access domain package' was violated (1 times). Invalid files:
```