### PR TITLE
KON-428 KoParentProvider Add `hasParent` Methods

### DIFF
--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koclass/KoClassDeclarationForKoParentProviderTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koclass/KoClassDeclarationForKoParentProviderTest.kt
@@ -19,7 +19,11 @@ class KoClassDeclarationForKoParentProviderTest {
             numParents shouldBeEqualTo 0
             countParents { it.name == "SampleParentClass" } shouldBeEqualTo 0
             hasParents() shouldBeEqualTo false
-            hasParents("SampleClass") shouldBeEqualTo false
+            hasParentWithName("SampleParentClass") shouldBeEqualTo false
+            hasParentsWithAllNames("SampleParentClass", "SampleParentInterface") shouldBeEqualTo false
+            hasParent { it.name == "SampleParentClass" } shouldBeEqualTo false
+            hasAllParents { it.hasNameStartingWith("Sample") } shouldBeEqualTo true
+            hasParents("SampleParentClass") shouldBeEqualTo false
         }
     }
 
@@ -41,6 +45,18 @@ class KoClassDeclarationForKoParentProviderTest {
             countParents { it.name == "SampleParentClass" } shouldBeEqualTo 1
             countParents { it.hasNameStartingWith("SampleParentInterface") } shouldBeEqualTo 2
             hasParents() shouldBeEqualTo true
+            hasParentWithName("SampleParentClass") shouldBeEqualTo true
+            hasParentWithName("OtherInterface") shouldBeEqualTo false
+            hasParentWithName("SampleParentClass", "OtherInterface") shouldBeEqualTo true
+            hasParentsWithAllNames("SampleParentClass") shouldBeEqualTo true
+            hasParentsWithAllNames("OtherInterface") shouldBeEqualTo false
+            hasParentsWithAllNames("SampleParentClass", "SampleParentInterface1") shouldBeEqualTo true
+            hasParentsWithAllNames("SampleParentClass", "OtherInterface") shouldBeEqualTo false
+            hasParent { it.name == "SampleParentClass" } shouldBeEqualTo true
+            hasParent { it.name == "OtherClass" } shouldBeEqualTo false
+            hasAllParents { it.name == "SampleParentClass" } shouldBeEqualTo false
+            hasAllParents { it.hasNameStartingWith("Sample") } shouldBeEqualTo true
+            hasAllParents { it.hasNameStartingWith("Other") } shouldBeEqualTo false
             hasParents("SampleParentClass") shouldBeEqualTo true
             hasParents("OtherInterface") shouldBeEqualTo false
             hasParents("SampleParentClass", "SampleParentInterface1") shouldBeEqualTo true

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/kointerface/KoInterfaceDeclarationForKoParentProviderTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/kointerface/KoInterfaceDeclarationForKoParentProviderTest.kt
@@ -17,9 +17,13 @@ class KoInterfaceDeclarationForKoParentProviderTest {
         assertSoftly(sut) {
             parents shouldBeEqualTo emptyList()
             numParents shouldBeEqualTo 0
-            countParents { it.name == "SampleParentClass" } shouldBeEqualTo 0
+            countParents { it.name == "SampleParentInterface" } shouldBeEqualTo 0
             hasParents() shouldBeEqualTo false
-            hasParents("SampleInterface") shouldBeEqualTo false
+            hasParentWithName("SampleParentInterface") shouldBeEqualTo false
+            hasParentsWithAllNames("SampleParentInterface1", "SampleParentInterface2") shouldBeEqualTo false
+            hasParent { it.name == "SampleParentInterface" } shouldBeEqualTo false
+            hasAllParents { it.hasNameStartingWith("Sample") } shouldBeEqualTo true
+            hasParents("SampleParentInterface") shouldBeEqualTo false
         }
     }
 
@@ -37,6 +41,18 @@ class KoInterfaceDeclarationForKoParentProviderTest {
             countParents { it.name == "SampleParentInterface1" } shouldBeEqualTo 1
             countParents { it.hasNameStartingWith("SampleParentInterface") } shouldBeEqualTo 2
             hasParents() shouldBeEqualTo true
+            hasParentWithName("SampleParentInterface1") shouldBeEqualTo true
+            hasParentWithName("OtherInterface") shouldBeEqualTo false
+            hasParentWithName("SampleParentInterface1", "OtherInterface") shouldBeEqualTo true
+            hasParentsWithAllNames("SampleParentInterface1") shouldBeEqualTo true
+            hasParentsWithAllNames("OtherInterface") shouldBeEqualTo false
+            hasParentsWithAllNames("SampleParentInterface1", "SampleParentInterface2") shouldBeEqualTo true
+            hasParentsWithAllNames("SampleParentInterface1", "OtherInterface") shouldBeEqualTo false
+            hasParent { it.name == "SampleParentInterface1" } shouldBeEqualTo true
+            hasParent { it.name == "OtherInterface" } shouldBeEqualTo false
+            hasAllParents { it.name == "SampleParentInterface1" } shouldBeEqualTo false
+            hasAllParents { it.hasNameStartingWith("Sample") } shouldBeEqualTo true
+            hasAllParents { it.hasNameStartingWith("Other") } shouldBeEqualTo false
             hasParents("SampleParentInterface1") shouldBeEqualTo true
             hasParents("OtherInterface") shouldBeEqualTo false
             hasParents("SampleParentInterface1", "SampleParentInterface2") shouldBeEqualTo true

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koobject/KoObjectDeclarationForKoParentProviderTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koobject/KoObjectDeclarationForKoParentProviderTest.kt
@@ -19,7 +19,11 @@ class KoObjectDeclarationForKoParentProviderTest {
             numParents shouldBeEqualTo 0
             countParents { it.name == "SampleParentClass" } shouldBeEqualTo 0
             hasParents() shouldBeEqualTo false
-            hasParents("SampleClass") shouldBeEqualTo false
+            hasParentWithName("SampleParentClass") shouldBeEqualTo false
+            hasParentsWithAllNames("SampleParentClass", "SampleParentInterface") shouldBeEqualTo false
+            hasParent { it.name == "SampleParentClass" } shouldBeEqualTo false
+            hasAllParents { it.hasNameStartingWith("Sample") } shouldBeEqualTo true
+            hasParents("SampleParentClass") shouldBeEqualTo false
         }
     }
 
@@ -41,6 +45,18 @@ class KoObjectDeclarationForKoParentProviderTest {
             countParents { it.name == "SampleParentClass" } shouldBeEqualTo 1
             countParents { it.hasNameStartingWith("SampleParentInterface") } shouldBeEqualTo 2
             hasParents() shouldBeEqualTo true
+            hasParentWithName("SampleParentClass") shouldBeEqualTo true
+            hasParentWithName("OtherInterface") shouldBeEqualTo false
+            hasParentWithName("SampleParentClass", "OtherInterface") shouldBeEqualTo true
+            hasParentsWithAllNames("SampleParentClass") shouldBeEqualTo true
+            hasParentsWithAllNames("OtherInterface") shouldBeEqualTo false
+            hasParentsWithAllNames("SampleParentClass", "SampleParentInterface1") shouldBeEqualTo true
+            hasParentsWithAllNames("SampleParentClass", "OtherInterface") shouldBeEqualTo false
+            hasParent { it.name == "SampleParentClass" } shouldBeEqualTo true
+            hasParent { it.name == "OtherClass" } shouldBeEqualTo false
+            hasAllParents { it.name == "SampleParentClass" } shouldBeEqualTo false
+            hasAllParents { it.hasNameStartingWith("Sample") } shouldBeEqualTo true
+            hasAllParents { it.hasNameStartingWith("Other") } shouldBeEqualTo false
             hasParents("SampleParentClass") shouldBeEqualTo true
             hasParents("OtherInterface") shouldBeEqualTo false
             hasParents("SampleParentClass", "SampleParentInterface1") shouldBeEqualTo true

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/api/ext/list/KoParentProviderListExt.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/api/ext/list/KoParentProviderListExt.kt
@@ -207,7 +207,13 @@ fun <T : KoParentProvider> List<T>.withoutSomeParentsOf(kClass: KClass<*>, varar
  * @param names The name(s) of the parent(s) to include.
  * @return A list containing declarations with all specified parent(s).
  */
-@Deprecated("Will be removed in v1.0.0.", ReplaceWith("withAllParentsNamed(*names)"))
+@Deprecated(
+    """
+            Will be removed in v1.0.0. 
+            If you passed one argument - replace with `withParentNamed`, otherwise with `withAllParentsNamed`.
+            """,
+    ReplaceWith("withParentNamed/withAllParentsNamed")
+)
 fun <T : KoParentProvider> List<T>.withAllParents(name: String, vararg names: String): List<T> = filter {
     it.hasParents(name, *names)
 }
@@ -231,7 +237,13 @@ fun <T : KoParentProvider> List<T>.withSomeParents(name: String, vararg names: S
  * @param names The name(s) of the parent(s) to exclude.
  * @return A list containing declarations without all specified parent(s).
  */
-@Deprecated("Will be removed in v1.0.0.", ReplaceWith("withoutAllParentsNamed(*names"))
+@Deprecated(
+    """
+            Will be removed in v1.0.0. 
+            If you passed one argument - replace with `withoutParentNamed`, otherwise with `withoutAllParentsNamed`.
+            """,
+    ReplaceWith("withoutParentNamed/withoutAllParentsNamed")
+)
 fun <T : KoParentProvider> List<T>.withoutAllParents(name: String, vararg names: String): List<T> = filter {
     !it.hasParents(name, *names)
 }

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/api/ext/list/KoParentProviderListExt.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/api/ext/list/KoParentProviderListExt.kt
@@ -18,12 +18,65 @@ val <T : KoParentProvider> List<T>.parents: List<KoParentDeclaration>
 fun <T : KoParentProvider> List<T>.withParents(): List<T> = filter { it.hasParents() }
 
 /**
+ * List containing declarations with no parent - class does not extend any class and does not implement any interface.
+ *
+ * @return A list containing declarations with no parent - class does not extend any class and does not implement any
+ * interface.
+ */
+fun <T : KoParentProvider> List<T>.withoutParents(): List<T> = filterNot { it.hasParents() }
+
+/**
+ * List containing declarations that have at least one parent with the specified name(s).
+ *
+ * @param name The name of the parent to include.
+ * @param names The names of additional parents to include.
+ * @return A list containing declarations with at least one of the specified parent(s).
+ */
+fun <T : KoParentProvider> List<T>.withParentNamed(name: String, vararg names: String): List<T> = filter {
+    it.hasParentWithName(name, *names)
+}
+
+/**
+ * List containing declarations without any of specified parents.
+ *
+ * @param name The name of the parent to exclude.
+ * @param names The names of additional parents to exclude.
+ * @return A list containing declarations without any of specified parents.
+ */
+fun <T : KoParentProvider> List<T>.withoutParentNamed(name: String, vararg names: String): List<T> = filterNot {
+    it.hasParentWithName(name, *names)
+}
+
+/**
+ * List containing declarations that have all specified parents.
+ *
+ * @param name The name of the parent to include.
+ * @param names The name(s) of the parent(s) to include.
+ * @return A list containing declarations with all specified parent(s).
+ */
+fun <T : KoParentProvider> List<T>.withAllParentsNamed(name: String, vararg names: String): List<T> = filter {
+    it.hasParentsWithAllNames(name, *names)
+}
+
+/**
+ * List containing declarations without all specified parents.
+ *
+ * @param name The name of the parent to exclude.
+ * @param names The name(s) of the parent(s) to exclude.
+ * @return A list containing declarations without all specified parent(s).
+ */
+fun <T : KoParentProvider> List<T>.withoutAllParentsNamed(name: String, vararg names: String): List<T> = filterNot {
+    it.hasParentsWithAllNames(name, *names)
+}
+
+/**
  * List containing declarations with all specified parents.
  *
  * @param name The name of the parent to include.
  * @param names The name(s) of the parent(s) to include.
  * @return A list containing declarations with all specified parent(s).
  */
+@Deprecated("Will be removed in v1.0.0.", ReplaceWith("withAllParentsNamed(*names"))
 fun <T : KoParentProvider> List<T>.withAllParents(name: String, vararg names: String): List<T> = filter {
     it.hasParents(name, *names)
 }
@@ -35,17 +88,10 @@ fun <T : KoParentProvider> List<T>.withAllParents(name: String, vararg names: St
  * @param names The names of the parents to include.
  * @return A list containing declarations with at least one of the specified parent(s).
  */
+@Deprecated("Will be removed in v1.0.0.", ReplaceWith("withParentNamed(*names"))
 fun <T : KoParentProvider> List<T>.withSomeParents(name: String, vararg names: String): List<T> = filter {
     it.hasParents(name) || names.any { name -> it.hasParents(name) }
 }
-
-/**
- * List containing declarations with no parent - class does not extend any class and does not implement any interface.
- *
- * @return A list containing declarations with no parent - class does not extend any class and does not implement any
- * interface.
- */
-fun <T : KoParentProvider> List<T>.withoutParents(): List<T> = filterNot { it.hasParents() }
 
 /**
  * List containing declarations without all specified parents.
@@ -54,6 +100,7 @@ fun <T : KoParentProvider> List<T>.withoutParents(): List<T> = filterNot { it.ha
  * @param names The name(s) of the parent(s) to exclude.
  * @return A list containing declarations without all specified parent(s).
  */
+@Deprecated("Will be removed in v1.0.0.", ReplaceWith("withoutAllParentsNamed(*names"))
 fun <T : KoParentProvider> List<T>.withoutAllParents(name: String, vararg names: String): List<T> = filter {
     !it.hasParents(name, *names)
 }
@@ -65,6 +112,7 @@ fun <T : KoParentProvider> List<T>.withoutAllParents(name: String, vararg names:
  * @param names The names of the parents to exclude.
  * @return A list containing declarations without at least one of the specified parent(s).
  */
+@Deprecated("Will be removed in v1.0.0.", ReplaceWith("withoutParentNamed(*names"))
 fun <T : KoParentProvider> List<T>.withoutSomeParents(name: String, vararg names: String): List<T> = filter {
     !it.hasParents(name) && if (names.isNotEmpty()) {
         names.any { name -> !it.hasParents(name) }

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/api/ext/list/KoParentProviderListExt.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/api/ext/list/KoParentProviderListExt.kt
@@ -1,3 +1,5 @@
+@file:Suppress("detekt.TooManyFunctions")
+
 package com.lemonappdev.konsist.api.ext.list
 
 import com.lemonappdev.konsist.api.declaration.KoParentDeclaration
@@ -138,11 +140,11 @@ fun <T : KoParentProvider> List<T>.withoutParents(predicate: (List<KoParentDecla
 fun <T : KoParentProvider> List<T>.withAllParentsOf(kClass: KClass<*>, vararg kClasses: KClass<*>): List<T> =
     filter {
         it.parents.any { parent -> parent.name == kClass.simpleName } &&
-                kClasses.all { kClass ->
-                    it
-                        .parents
-                        .any { parent -> parent.name == kClass.simpleName }
-                }
+            kClasses.all { kClass ->
+                it
+                    .parents
+                    .any { parent -> parent.name == kClass.simpleName }
+            }
     }
 
 /**
@@ -155,11 +157,11 @@ fun <T : KoParentProvider> List<T>.withAllParentsOf(kClass: KClass<*>, vararg kC
 fun <T : KoParentProvider> List<T>.withSomeParentsOf(kClass: KClass<*>, vararg kClasses: KClass<*>): List<T> =
     filter {
         it.parents.any { parent -> parent.name == kClass.simpleName } ||
-                kClasses.any { kClass ->
-                    it
-                        .parents
-                        .any { parent -> parent.name == kClass.simpleName }
-                }
+            kClasses.any { kClass ->
+                it
+                    .parents
+                    .any { parent -> parent.name == kClass.simpleName }
+            }
     }
 
 /**
@@ -172,11 +174,11 @@ fun <T : KoParentProvider> List<T>.withSomeParentsOf(kClass: KClass<*>, vararg k
 fun <T : KoParentProvider> List<T>.withoutAllParentsOf(kClass: KClass<*>, vararg kClasses: KClass<*>): List<T> =
     filter {
         it.parents.none { parent -> parent.name == kClass.simpleName } &&
-                kClasses.none { kClass ->
-                    it
-                        .parents
-                        .any { parent -> parent.name == kClass.simpleName }
-                }
+            kClasses.none { kClass ->
+                it
+                    .parents
+                    .any { parent -> parent.name == kClass.simpleName }
+            }
     }
 
 /**
@@ -189,15 +191,15 @@ fun <T : KoParentProvider> List<T>.withoutAllParentsOf(kClass: KClass<*>, vararg
 fun <T : KoParentProvider> List<T>.withoutSomeParentsOf(kClass: KClass<*>, vararg kClasses: KClass<*>): List<T> =
     filter {
         it.parents.none { parent -> parent.name == kClass.simpleName } &&
-                if (kClasses.isNotEmpty()) {
-                    kClasses.any { kClass ->
-                        it
-                            .parents
-                            .none { parent -> parent.name == kClass.simpleName }
-                    }
-                } else {
-                    true
+            if (kClasses.isNotEmpty()) {
+                kClasses.any { kClass ->
+                    it
+                        .parents
+                        .none { parent -> parent.name == kClass.simpleName }
                 }
+            } else {
+                true
+            }
     }
 
 /**
@@ -212,7 +214,7 @@ fun <T : KoParentProvider> List<T>.withoutSomeParentsOf(kClass: KClass<*>, varar
             Will be removed in v1.0.0. 
             If you passed one argument - replace with `withParentNamed`, otherwise with `withAllParentsNamed`.
             """,
-    ReplaceWith("withParentNamed/withAllParentsNamed")
+    ReplaceWith("withParentNamed/withAllParentsNamed"),
 )
 fun <T : KoParentProvider> List<T>.withAllParents(name: String, vararg names: String): List<T> = filter {
     it.hasParents(name, *names)
@@ -242,7 +244,7 @@ fun <T : KoParentProvider> List<T>.withSomeParents(name: String, vararg names: S
             Will be removed in v1.0.0. 
             If you passed one argument - replace with `withoutParentNamed`, otherwise with `withoutAllParentsNamed`.
             """,
-    ReplaceWith("withoutParentNamed/withoutAllParentsNamed")
+    ReplaceWith("withoutParentNamed/withoutAllParentsNamed"),
 )
 fun <T : KoParentProvider> List<T>.withoutAllParents(name: String, vararg names: String): List<T> = filter {
     !it.hasParents(name, *names)

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/api/provider/KoParentProvider.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/api/provider/KoParentProvider.kt
@@ -36,7 +36,7 @@ interface KoParentProvider : KoBaseProvider {
         """
             Will be removed in v1.0.0. 
             If you passed one argument - replace with `hasParentWithName`, otherwise with `hasParentsWithAllNames`.
-            """
+            """,
     )
     fun hasParents(vararg names: String): Boolean
 

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/api/provider/KoParentProvider.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/api/provider/KoParentProvider.kt
@@ -32,7 +32,12 @@ interface KoParentProvider : KoBaseProvider {
      * @param names the names of the parents to check.
      * @return `true` if the declaration has parents with the specified names (or any parent if [names] is empty), `false` otherwise.
      */
-    @Deprecated("Will be removed in v1.0.0.", ReplaceWith("hasParentsWithAllNames(*names)"))
+    @Deprecated(
+        """
+            Will be removed in v1.0.0. 
+            If you passed one argument - replace with `hasParentWithName`, otherwise with `hasParentsWithAllNames`.
+            """
+    )
     fun hasParents(vararg names: String): Boolean
 
     /**

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/api/provider/KoParentProvider.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/api/provider/KoParentProvider.kt
@@ -32,5 +32,16 @@ interface KoParentProvider : KoBaseProvider {
      * @param names the names of the parents to check.
      * @return `true` if the class has parents with the specified names (or any parent if [names] is empty), `false` otherwise.
      */
+    @Deprecated("Will be removed in v1.0.0.", ReplaceWith("hasParentsWithAllNames(*names)"))
     fun hasParents(vararg names: String): Boolean
+
+    fun hasParents(): Boolean
+
+    fun hasParentWithName(vararg names: String): Boolean
+
+    fun hasParentsWithAllNames(vararg names: String): Boolean
+
+    fun hasParent(predicate: (KoParentDeclaration) -> Boolean): Boolean
+
+    fun hasAllParents(predicate: (KoParentDeclaration) -> Boolean): Boolean
 }

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/api/provider/KoParentProvider.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/api/provider/KoParentProvider.kt
@@ -26,22 +26,60 @@ interface KoParentProvider : KoBaseProvider {
     fun countParents(predicate: (KoParentDeclaration) -> Boolean): Int
 
     /**
-     * Whatever class has parents (parent class and parent interfaces) defined directly in the Kotlin file.
+     * Whatever declaration has parents (parent class and parent interfaces) defined directly in the Kotlin file.
      * Does not include parents defined in other files such as parent of the parent.
      *
      * @param names the names of the parents to check.
-     * @return `true` if the class has parents with the specified names (or any parent if [names] is empty), `false` otherwise.
+     * @return `true` if the declaration has parents with the specified names (or any parent if [names] is empty), `false` otherwise.
      */
     @Deprecated("Will be removed in v1.0.0.", ReplaceWith("hasParentsWithAllNames(*names)"))
     fun hasParents(vararg names: String): Boolean
 
+    /**
+     * Whatever declaration has any parent (parent class and parent interfaces) defined directly in the Kotlin file.
+     * Does not include parents defined in other files such as parent of the parent.
+     *
+     * @return `true` if the declaration has any parent, `false` otherwise.
+     */
     fun hasParents(): Boolean
 
+    /**
+     * Determines whether the declaration has at least one parent (parent class and parent interfaces) defined directly
+     * in the Kotlin file whose name matches any of the specified names.
+     * This method does not include parents defined in other files, such as parents of the parent.
+     *
+     * @param names the names of the parents to check.
+     * @return `true` if there is a matching declaration, `false` otherwise.
+     */
     fun hasParentWithName(vararg names: String): Boolean
 
+    /**
+     * Determines whether the declaration has parents (parent classes and parent interfaces) defined directly in the Kotlin
+     * file with all the specified names.
+     * This method does not include parents defined in other files, such as parents of the parent.
+     *
+     * @param names The names of the parents to check.
+     * @return `true` if there are declarations with all the specified names, `false` otherwise.
+     */
     fun hasParentsWithAllNames(vararg names: String): Boolean
 
+    /**
+     * Determines whether the declaration has at least one parent (parent class or parent interface) defined directly
+     * in the Kotlin file that satisfies the provided predicate.
+     * This method does not include parents defined in other files, such as parents of the parent.
+     *
+     * @param predicate A function that defines the condition to be met by a parent declaration.
+     * @return `true` if there is a matching declaration, `false` otherwise.
+     */
     fun hasParent(predicate: (KoParentDeclaration) -> Boolean): Boolean
 
+    /**
+     * Determines whether the declaration has all parents (parent classes and parent interfaces) defined directly
+     * in the Kotlin file that satisfy the provided predicate.
+     * This method does not include parents defined in other files, such as parents of the parent.
+     *
+     * @param predicate A function that defines the condition to be met by parent declarations.
+     * @return `true` if all parent declarations satisfy the predicate, `false` otherwise.
+     */
     fun hasAllParents(predicate: (KoParentDeclaration) -> Boolean): Boolean
 }

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/KoParentProviderCore.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/KoParentProviderCore.kt
@@ -26,10 +26,25 @@ internal interface KoParentProviderCore :
     override fun countParents(predicate: (KoParentDeclaration) -> Boolean): Int =
         parents.count { predicate(it) }
 
+    @Deprecated("Will be removed in v1.0.0")
     override fun hasParents(vararg names: String): Boolean = when {
         names.isEmpty() -> parents.isNotEmpty()
         else -> names.all {
             parents.any { parent -> it == parent.name }
         }
     }
+
+    override fun hasParents(): Boolean = parents.isNotEmpty()
+
+    override fun hasParentWithName(vararg names: String): Boolean = names.any {
+        parents.any { parent -> it == parent.name }
+    }
+
+    override fun hasParentsWithAllNames(vararg names: String): Boolean = names.all {
+        parents.any { parent -> it == parent.name }
+    }
+
+    override fun hasParent(predicate: (KoParentDeclaration) -> Boolean): Boolean = parents.any(predicate)
+
+    override fun hasAllParents(predicate: (KoParentDeclaration) -> Boolean): Boolean = parents.all(predicate)
 }

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/KoParentProviderCore.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/KoParentProviderCore.kt
@@ -26,7 +26,7 @@ internal interface KoParentProviderCore :
     override fun countParents(predicate: (KoParentDeclaration) -> Boolean): Int =
         parents.count { predicate(it) }
 
-    @Deprecated("Will be removed in v1.0.0")
+    @Deprecated("Will be removed in v1.0.0.", ReplaceWith("hasParentsWithAllNames(*names)"))
     override fun hasParents(vararg names: String): Boolean = when {
         names.isEmpty() -> parents.isNotEmpty()
         else -> names.all {

--- a/lib/src/snippet/kotlin/com/lemonappdev/konsist/CleanArchitectureSnippets.kt
+++ b/lib/src/snippet/kotlin/com/lemonappdev/konsist/CleanArchitectureSnippets.kt
@@ -4,9 +4,7 @@ import com.lemonappdev.konsist.api.Konsist
 import com.lemonappdev.konsist.api.architecture.KoArchitectureCreator.assertArchitecture
 import com.lemonappdev.konsist.api.architecture.Layer
 import com.lemonappdev.konsist.api.ext.list.withAllAnnotationsOf
-import com.lemonappdev.konsist.api.ext.list.withAllParents
 import com.lemonappdev.konsist.api.ext.list.withNameEndingWith
-import com.lemonappdev.konsist.api.ext.list.withParent
 import com.lemonappdev.konsist.api.ext.list.withParentNamed
 import com.lemonappdev.konsist.api.verify.assert
 import org.springframework.stereotype.Repository
@@ -62,7 +60,7 @@ class CleanArchitectureSnippets {
         Konsist
             .scopeFromProduction()
             .classes()
-            .withParentNamed ("UseCase")
+            .withParentNamed("UseCase")
             .assert { it.hasTestClass() }
     }
 }

--- a/lib/src/snippet/kotlin/com/lemonappdev/konsist/CleanArchitectureSnippets.kt
+++ b/lib/src/snippet/kotlin/com/lemonappdev/konsist/CleanArchitectureSnippets.kt
@@ -6,6 +6,8 @@ import com.lemonappdev.konsist.api.architecture.Layer
 import com.lemonappdev.konsist.api.ext.list.withAllAnnotationsOf
 import com.lemonappdev.konsist.api.ext.list.withAllParents
 import com.lemonappdev.konsist.api.ext.list.withNameEndingWith
+import com.lemonappdev.konsist.api.ext.list.withParent
+import com.lemonappdev.konsist.api.ext.list.withParentNamed
 import com.lemonappdev.konsist.api.verify.assert
 import org.springframework.stereotype.Repository
 
@@ -60,7 +62,7 @@ class CleanArchitectureSnippets {
         Konsist
             .scopeFromProduction()
             .classes()
-            .withAllParents("UseCase")
+            .withParentNamed ("UseCase")
             .assert { it.hasTestClass() }
     }
 }

--- a/lib/src/test/kotlin/com/lemonappdev/konsist/api/ext/list/KoParentProviderListExtTest.kt
+++ b/lib/src/test/kotlin/com/lemonappdev/konsist/api/ext/list/KoParentProviderListExtTest.kt
@@ -1,8 +1,6 @@
 package com.lemonappdev.konsist.api.ext.list
 
-import com.lemonappdev.konsist.api.declaration.KoImportDeclaration
 import com.lemonappdev.konsist.api.declaration.KoParentDeclaration
-import com.lemonappdev.konsist.api.provider.KoImportProvider
 import com.lemonappdev.konsist.api.provider.KoParentProvider
 import com.lemonappdev.konsist.testdata.SampleClass
 import com.lemonappdev.konsist.testdata.SampleInterface

--- a/lib/src/test/kotlin/com/lemonappdev/konsist/api/ext/list/KoParentProviderListExtTest.kt
+++ b/lib/src/test/kotlin/com/lemonappdev/konsist/api/ext/list/KoParentProviderListExtTest.kt
@@ -1,6 +1,8 @@
 package com.lemonappdev.konsist.api.ext.list
 
+import com.lemonappdev.konsist.api.declaration.KoImportDeclaration
 import com.lemonappdev.konsist.api.declaration.KoParentDeclaration
+import com.lemonappdev.konsist.api.provider.KoImportProvider
 import com.lemonappdev.konsist.api.provider.KoParentProvider
 import com.lemonappdev.konsist.testdata.SampleClass
 import com.lemonappdev.konsist.testdata.SampleInterface
@@ -66,6 +68,302 @@ class KoParentProviderListExtTest {
 
         // when
         val sut = declarations.withoutParents()
+
+        // then
+        sut shouldBeEqualTo listOf(declaration2)
+    }
+
+    @Test
+    fun `withParentNamed(name) returns declaration with given parent`() {
+        // given
+        val name = "SampleName"
+        val declaration1: KoParentProvider = mockk {
+            every { hasParentWithName(name) } returns true
+        }
+        val declaration2: KoParentProvider = mockk {
+            every { hasParentWithName(name) } returns false
+        }
+        val declarations = listOf(declaration1, declaration2)
+
+        // when
+        val sut = declarations.withParentNamed(name)
+
+        // then
+        sut shouldBeEqualTo listOf(declaration1)
+    }
+
+    @Test
+    fun `withParentNamed(String) returns declaration with any of given parents`() {
+        // given
+        val name1 = "SampleName1"
+        val name2 = "SampleName2"
+        val declaration1: KoParentProvider = mockk {
+            every { hasParentWithName(name1, name2) } returns true
+        }
+        val declaration2: KoParentProvider = mockk {
+            every { hasParentWithName(name1, name2) } returns false
+        }
+        val declarations = listOf(declaration1, declaration2)
+
+        // when
+        val sut = declarations.withParentNamed(name1, name2)
+
+        // then
+        sut shouldBeEqualTo listOf(declaration1)
+    }
+
+    @Test
+    fun `withoutParentNamed(name) returns declaration without given parent`() {
+        // given
+        val name = "SampleName"
+        val declaration1: KoParentProvider = mockk {
+            every { hasParentWithName(name) } returns true
+        }
+        val declaration2: KoParentProvider = mockk {
+            every { hasParentWithName(name) } returns false
+        }
+        val declarations = listOf(declaration1, declaration2)
+
+        // when
+        val sut = declarations.withoutParentNamed(name)
+
+        // then
+        sut shouldBeEqualTo listOf(declaration2)
+    }
+
+    @Test
+    fun `withoutParentNamed(String) returns declaration without any of given parents`() {
+        // given
+        val name1 = "SampleName1"
+        val name2 = "SampleName2"
+        val declaration1: KoParentProvider = mockk {
+            every { hasParentWithName(name1, name2) } returns true
+        }
+        val declaration2: KoParentProvider = mockk {
+            every { hasParentWithName(name1, name2) } returns false
+        }
+        val declarations = listOf(declaration1, declaration2)
+
+        // when
+        val sut = declarations.withoutParentNamed(name1, name2)
+
+        // then
+        sut shouldBeEqualTo listOf(declaration2)
+    }
+
+    @Test
+    fun `withAllParentsNamed(name) returns declaration with given parent`() {
+        // given
+        val name = "SampleName"
+        val declaration1: KoParentProvider = mockk {
+            every { hasParentsWithAllNames(name) } returns true
+        }
+        val declaration2: KoParentProvider = mockk {
+            every { hasParentsWithAllNames(name) } returns false
+        }
+        val declarations = listOf(declaration1, declaration2)
+
+        // when
+        val sut = declarations.withAllParentsNamed(name)
+
+        // then
+        sut shouldBeEqualTo listOf(declaration1)
+    }
+
+    @Test
+    fun `withAllParentsNamed(String) returns declaration with all given parents`() {
+        // given
+        val name1 = "SampleName1"
+        val name2 = "SampleName2"
+        val declaration1: KoParentProvider = mockk {
+            every { hasParentsWithAllNames(name1, name2) } returns true
+        }
+        val declaration2: KoParentProvider = mockk {
+            every { hasParentsWithAllNames(name1, name2) } returns false
+        }
+        val declarations = listOf(declaration1, declaration2)
+
+        // when
+        val sut = declarations.withAllParentsNamed(name1, name2)
+
+        // then
+        sut shouldBeEqualTo listOf(declaration1)
+    }
+
+    @Test
+    fun `withoutAllParentsNamed(name) returns declaration without given parent`() {
+        // given
+        val name = "SampleName"
+        val declaration1: KoParentProvider = mockk {
+            every { hasParentsWithAllNames(name) } returns true
+        }
+        val declaration2: KoParentProvider = mockk {
+            every { hasParentsWithAllNames(name) } returns false
+        }
+        val declarations = listOf(declaration1, declaration2)
+
+        // when
+        val sut = declarations.withoutAllParentsNamed(name)
+
+        // then
+        sut shouldBeEqualTo listOf(declaration2)
+    }
+
+    @Test
+    fun `withoutAllParentsNamed(String) returns declaration without all of given parents`() {
+        // given
+        val name1 = "SampleName1"
+        val name2 = "SampleName2"
+        val declaration1: KoParentProvider = mockk {
+            every { hasParentsWithAllNames(name1, name2) } returns true
+        }
+        val declaration2: KoParentProvider = mockk {
+            every { hasParentsWithAllNames(name1, name2) } returns false
+        }
+        val declarations = listOf(declaration1, declaration2)
+
+        // when
+        val sut = declarations.withoutAllParentsNamed(name1, name2)
+
+        // then
+        sut shouldBeEqualTo listOf(declaration2)
+    }
+
+    @Test
+    fun `withParent{} returns declaration with parent which satisfy predicate`() {
+        // given
+        val suffix = "Name"
+        val predicate: (KoParentDeclaration) -> Boolean = { it.hasNameEndingWith(suffix) }
+        val declaration1: KoParentProvider = mockk {
+            every { hasParent(predicate) } returns true
+        }
+        val declaration2: KoParentProvider = mockk {
+            every { hasParent(predicate) } returns false
+        }
+        val declarations = listOf(declaration1, declaration2)
+
+        // when
+        val sut = declarations.withParent(predicate)
+
+        // then
+        sut shouldBeEqualTo listOf(declaration1)
+    }
+
+    @Test
+    fun `withoutParent{} returns declaration without parent which satisfy predicate`() {
+        // given
+        val suffix = "Name"
+        val predicate: (KoParentDeclaration) -> Boolean = { it.hasNameEndingWith(suffix) }
+        val declaration1: KoParentProvider = mockk {
+            every { hasParent(predicate) } returns true
+        }
+        val declaration2: KoParentProvider = mockk {
+            every { hasParent(predicate) } returns false
+        }
+        val declarations = listOf(declaration1, declaration2)
+
+        // when
+        val sut = declarations.withoutParent(predicate)
+
+        // then
+        sut shouldBeEqualTo listOf(declaration2)
+    }
+
+    @Test
+    fun `withAllParents{} returns declaration with all parents satisfy predicate`() {
+        // given
+        val suffix = "Name"
+        val predicate: (KoParentDeclaration) -> Boolean = { it.hasNameEndingWith(suffix) }
+        val declaration1: KoParentProvider = mockk {
+            every { hasAllParents(predicate) } returns true
+        }
+        val declaration2: KoParentProvider = mockk {
+            every { hasAllParents(predicate) } returns false
+        }
+        val declarations = listOf(declaration1, declaration2)
+
+        // when
+        val sut = declarations.withAllParents(predicate)
+
+        // then
+        sut shouldBeEqualTo listOf(declaration1)
+    }
+
+    @Test
+    fun `withoutAllParents{} returns declaration with all parents which not satisfy predicate`() {
+        // given
+        val suffix = "Name"
+        val predicate: (KoParentDeclaration) -> Boolean = { it.hasNameEndingWith(suffix) }
+        val declaration1: KoParentProvider = mockk {
+            every { hasAllParents(predicate) } returns true
+        }
+        val declaration2: KoParentProvider = mockk {
+            every { hasAllParents(predicate) } returns false
+        }
+        val declarations = listOf(declaration1, declaration2)
+
+        // when
+        val sut = declarations.withoutAllParents(predicate)
+
+        // then
+        sut shouldBeEqualTo listOf(declaration2)
+    }
+
+    @Test
+    fun `withParents{} returns declaration with parents which satisfy predicate`() {
+        // given
+        val suffix = "Name"
+        val predicate: (List<KoParentDeclaration>) -> Boolean =
+            { it.all { parent -> parent.hasNameEndingWith(suffix) } }
+        val parent1: KoParentDeclaration = mockk {
+            every { hasNameEndingWith(suffix) } returns true
+        }
+        val parent2: KoParentDeclaration = mockk {
+            every { hasNameEndingWith(suffix) } returns false
+        }
+        val declaration1: KoParentProvider = mockk {
+            every { parents } returns listOf(parent1)
+        }
+        val declaration2: KoParentProvider = mockk {
+            every { parents } returns listOf(parent2)
+        }
+        val declaration3: KoParentProvider = mockk {
+            every { parents } returns emptyList()
+        }
+        val declarations = listOf(declaration1, declaration2, declaration3)
+
+        // when
+        val sut = declarations.withParents(predicate)
+
+        // then
+        sut shouldBeEqualTo listOf(declaration1, declaration3)
+    }
+
+    @Test
+    fun `withoutParents{} returns declaration without parents which satisfy predicate`() {
+        // given
+        val suffix = "Name"
+        val predicate: (List<KoParentDeclaration>) -> Boolean =
+            { it.all { parent -> parent.hasNameEndingWith(suffix) } }
+        val parent1: KoParentDeclaration = mockk {
+            every { hasNameEndingWith(suffix) } returns true
+        }
+        val parent2: KoParentDeclaration = mockk {
+            every { hasNameEndingWith(suffix) } returns false
+        }
+        val declaration1: KoParentProvider = mockk {
+            every { parents } returns listOf(parent1)
+        }
+        val declaration2: KoParentProvider = mockk {
+            every { parents } returns listOf(parent2)
+        }
+        val declaration3: KoParentProvider = mockk {
+            every { parents } returns emptyList()
+        }
+        val declarations = listOf(declaration1, declaration2, declaration3)
+
+        // when
+        val sut = declarations.withoutParents(predicate)
 
         // then
         sut shouldBeEqualTo listOf(declaration2)


### PR DESCRIPTION
**Example 1**
Assume that we have this class: `class SampleClass : SampleParentClass(), SampleParentInterface` in the `scope`. For this class we have:
```kotlin
scope
   .classes()
   .assert { 
      it.hasParents()  // returns true
      it.hasParentWithName("SampleParentClass", "OtherParentClass") // returns true, because SampleClass has at least one parent with given name
      it.hasParentsWithAllNames("SampleParentClass", "OtherParentClass") // returns false, because SampleClass has no OtherParentClass parent
      it.hasParentsWithAllNames("SampleParentClass", "SampleParentInterface") // returns true, because SampleClass has parents with all given names
      it.hasParent { parent -> parent.hasNameEndingWith("Class") } // returns true, because SampleClass has at least one parent which specify predicate
      it.hasAllParents { parent -> parent.hasNameEndingWith("Class") } // returns false, because SampleParentInterface not specify predicate
      it.hasAllParents { parent -> parent.hasNameStartingWith("Sample") } // returns true, because all SampleClass parents specify predicate
   }
```

**Example 2**
Assume we have such classes in the `scope`:
```kotlin
class SampleClass1 : SampleParentClass(), SampleParentInterface
class SampleClass2 : SampleParentClass()
class SampleClass3 : SampleParentInterface
class SampleClass4 : OtherInterface
class SampleClass5
```

- `withParents/withoutParents`
```kotlin
scope.withParents() // returns list of SampleClass1, SampleClass2, SampleClass3, SampleClass4
```

```kotlin
scope.withoutParents() // returns list of SampleClass5
```

- `withParentNamed/withoutParentNamed`
```kotlin
scope.withParentNamed("SampleParentClass", "SampleParentInterface") // returns list of `SampleClass1, SampleClass2, SampleClass3
```

```kotlin
scope.withoutParentNamed("SampleParentClass") // returns list of SampleClass3, SampleClass4, SampleClass5
```

```kotlin
scope.withoutParentNamed("SampleParentClass", "SampleParentInterface") // returns list of SampleClass4, SampleClass5
```

- `withAllParentsNamed/withoutAllParentsNamed`
```kotlin
scope.withAllParentsNamed("SampleParentClass") // returns list of SampleClass1, SampleClass2
```

```kotlin
scope.withAllParentsNamed("SampleParentClass", "SampleParentInterface") // returns list of SampleClass1
```

```kotlin
scope.withoutAllParentsNamed("SampleParentClass") // returns list of SampleClass3, SampleClass4, SampleClass5
```

```kotlin
scope.withoutAllParentsNamed("SampleParentClass", "SampleParentInterface") // returns list of SampleClass2, SampleClass3, SampleClass4, SampleClass5
```

- `withParent {} / withoutParent {} `
```kotlin
scope.withParent { it.hasNameEndingWith("Class") } // returns list of SampleClass1, SampleClass2
```

```kotlin
scope.withoutParent { it.hasNameEndingWith("Class") } // returns list of SampleClass3, SampleClass4, SampleClass5
```

- `withAllParents {} / withoutAllParents {} `
```kotlin
scope.withAllParents { it.hasNameEndingWith("Class") } // returns list of SampleClass2, SampleClass5
```

```kotlin
scope.withoutAllParents { it.hasNameEndingWith("Class")  // returns list of SampleClass1, SampleClass3, SampleClass4
```