### PR TITLE
Add regex pattern to deal with ending (only) 2 dots at the end of package name

### DIFF
--- a/lib/src/apiTest/kotlin/com/lemonappdev/konsist/architecture/assertarchitecture/architecture5/Architecture5Test.kt
+++ b/lib/src/apiTest/kotlin/com/lemonappdev/konsist/architecture/assertarchitecture/architecture5/Architecture5Test.kt
@@ -9,10 +9,10 @@ import org.amshove.kluent.withMessage
 import org.junit.jupiter.api.Test
 
 class Architecture5Test {
-    private val layer = Layer("EmptyLayer", "com/lemonappdev/konsist/assertarchitecture/architecture5/project/emptylayer..")
+    private val layer = Layer("EmptyLayer", "com.lemonappdev.konsist.assertarchitecture.architecture5.project.emptylayer..")
     private val scope =
         Konsist.scopeFromPackage("com.lemonappdev.konsist.architecture.assertarchitecture.architecture5.project")
-
+    
     @Test
     fun `throws exception when layer contains no files`() {
         // when

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/api/architecture/Layer.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/api/architecture/Layer.kt
@@ -13,7 +13,8 @@ import com.lemonappdev.konsist.core.util.LocationUtil
  */
 data class Layer(internal val name: String, internal val definedBy: String) {
     init {
-        if (!definedBy.endsWith(LocationUtil.WILD_CARD_SYNTAX)) {
+        val pattern = Regex(pattern = LocationUtil.REGEX_PACKAGE_NAME_END_TWO_DOTS)
+        if (!definedBy.matches(pattern)) {
             throw KoPreconditionFailedException("Layer $name must be defined by package ending with '..'. Now: $definedBy .")
         }
     }

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/api/architecture/Layer.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/api/architecture/Layer.kt
@@ -14,6 +14,7 @@ import com.lemonappdev.konsist.core.util.LocationUtil
 data class Layer(internal val name: String, internal val definedBy: String) {
     init {
         val pattern = Regex(pattern = LocationUtil.REGEX_PACKAGE_NAME_END_TWO_DOTS)
+
         if (!definedBy.matches(pattern)) {
             throw KoPreconditionFailedException("Layer $name must be defined by package ending with '..'. Now: $definedBy .")
         }

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/core/util/LocationUtil.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/core/util/LocationUtil.kt
@@ -1,7 +1,19 @@
 package com.lemonappdev.konsist.core.util
 
 object LocationUtil {
-    internal const val WILD_CARD_SYNTAX = ".."
+
+    /**
+     *  Regex to match packages names ending with (2) dots '.' at the end.
+     *
+     *   (?:) = non-capturing group.
+     *    ^   = Matches the beginning of the string.
+     *    \w  = Matches any word char (alpha & underscore).
+     *    +   = Match 1 or more of the preceding token.
+     *    |   = OR
+     *  \.{2} = escaped char '.' (dot) appearing 2 times
+     *    $   = Matches end of string
+     */
+    internal const val REGEX_PACKAGE_NAME_END_TWO_DOTS = "(?:^\\w+|\\w+\\.\\w+)+\\.{2}\$"
 
     /**
      * Use '..' as a wildcard for any number of characters.

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/core/util/LocationUtil.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/core/util/LocationUtil.kt
@@ -3,7 +3,7 @@ package com.lemonappdev.konsist.core.util
 object LocationUtil {
 
     /**
-     *  Regex to match packages names ending with (2) dots '.' at the end.
+     *  Regex to match packages names ending with 2 (two) dots '.' at the end.
      *
      *   (?:) = non-capturing group.
      *    ^   = Matches the beginning of the string.

--- a/lib/src/test/kotlin/com/lemonappdev/konsist/api/architecture/LayerTest.kt
+++ b/lib/src/test/kotlin/com/lemonappdev/konsist/api/architecture/LayerTest.kt
@@ -1,6 +1,7 @@
 package com.lemonappdev.konsist.api.architecture
 
 import com.lemonappdev.konsist.core.exception.KoPreconditionFailedException
+import org.amshove.kluent.shouldNotThrow
 import org.amshove.kluent.shouldThrow
 import org.amshove.kluent.withMessage
 import org.junit.jupiter.api.Test
@@ -14,6 +15,50 @@ class LayerTest {
         // then
         sut shouldThrow KoPreconditionFailedException::class withMessage """
             Layer Layer must be defined by package ending with '..'. Now: package .
+        """.trimIndent()
+    }
+
+    @Test
+    fun `throws an exception when layer is defined by package without three dots at the end`() {
+        // given
+        val sut = { Layer("Layer", "package...") }
+
+        // then
+        sut shouldThrow KoPreconditionFailedException::class withMessage """
+            Layer Layer must be defined by package ending with '..'. Now: package... .
+        """.trimIndent()
+    }
+
+    @Test
+    fun `throws an exception when layer is defined by package with dots without two dots at the end`() {
+        // given
+        val sut = { Layer("Layer", "first.package") }
+
+        // then
+        sut shouldThrow KoPreconditionFailedException::class withMessage """
+            Layer Layer must be defined by package ending with '..'. Now: first.package .
+        """.trimIndent()
+    }
+
+    @Test
+    fun `throws an exception when layer is defined by package containing dots with more than two dots at the end`() {
+        // given
+        val sut = { Layer("Layer", "first.second.third_p.package....") }
+
+        // then
+        sut shouldThrow KoPreconditionFailedException::class withMessage """
+            Layer Layer must be defined by package ending with '..'. Now: first.second.third_p.package.... .
+        """.trimIndent()
+    }
+
+    @Test
+    fun `do not throw an exception when the package ends with two dots`() {
+        // given
+        val sut = { Layer("Layer", "first.second.package..") }
+
+        // then
+        sut shouldNotThrow KoPreconditionFailedException::class withMessage """
+            Layer Layer must be defined by package ending with '..'. Now: first.second.third_p.package.... .
         """.trimIndent()
     }
 }

--- a/lib/src/test/kotlin/com/lemonappdev/konsist/api/architecture/LayerTest.kt
+++ b/lib/src/test/kotlin/com/lemonappdev/konsist/api/architecture/LayerTest.kt
@@ -10,55 +10,55 @@ class LayerTest {
     @Test
     fun `throws an exception when layer is defined by package without two dots at the end`() {
         // given
-        val sut = { Layer("Layer", "package") }
+        val sut = { Layer("Domain", "package") }
 
         // then
         sut shouldThrow KoPreconditionFailedException::class withMessage """
-            Layer Layer must be defined by package ending with '..'. Now: package .
+            Layer Domain must be defined by package ending with '..'. Now: package .
         """.trimIndent()
     }
 
     @Test
     fun `throws an exception when layer is defined by package without three dots at the end`() {
         // given
-        val sut = { Layer("Layer", "package...") }
+        val sut = { Layer("Domain", "package...") }
 
         // then
         sut shouldThrow KoPreconditionFailedException::class withMessage """
-            Layer Layer must be defined by package ending with '..'. Now: package... .
+            Layer Domain must be defined by package ending with '..'. Now: package... .
         """.trimIndent()
     }
 
     @Test
     fun `throws an exception when layer is defined by package with dots without two dots at the end`() {
         // given
-        val sut = { Layer("Layer", "first.package") }
+        val sut = { Layer("Domain", "first.package") }
 
         // then
         sut shouldThrow KoPreconditionFailedException::class withMessage """
-            Layer Layer must be defined by package ending with '..'. Now: first.package .
+            Layer Domain must be defined by package ending with '..'. Now: first.package .
         """.trimIndent()
     }
 
     @Test
     fun `throws an exception when layer is defined by package containing dots with more than two dots at the end`() {
         // given
-        val sut = { Layer("Layer", "first.second.third_p.package....") }
+        val sut = { Layer("Domain", "first.second.third_p.package....") }
 
         // then
         sut shouldThrow KoPreconditionFailedException::class withMessage """
-            Layer Layer must be defined by package ending with '..'. Now: first.second.third_p.package.... .
+            Layer Domain must be defined by package ending with '..'. Now: first.second.third_p.package.... .
         """.trimIndent()
     }
 
     @Test
     fun `do not throw an exception when the package ends with two dots`() {
         // given
-        val sut = { Layer("Layer", "first.second.package..") }
+        val sut = { Layer("Domain", "first.second.package..") }
 
         // then
         sut shouldNotThrow KoPreconditionFailedException::class withMessage """
-            Layer Layer must be defined by package ending with '..'. Now: first.second.third_p.package.... .
+            Layer Domain must be defined by package ending with '..'. Now: first.second.third_p.package.... .
         """.trimIndent()
     }
 }


### PR DESCRIPTION
- I replaced the `WILD_CARD_SYNTAX` with `REGEX_PACKAGE_NAME_END_TWO_DOTS` in `LocationUtil`.
- Added test on `LayerTest` with different endings (and packages names)

I believe that it's a better way to make use of this regex. However, I didn't want to change a lot of things being this my first PR and also my lack of knowledge of the domain.