### PR TITLE
Update Assert Error Message

### DIFF
--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/verify/kodeclarationassert/KoDeclarationAssertForDeclarationListTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/verify/kodeclarationassert/KoDeclarationAssertForDeclarationListTest.kt
@@ -24,7 +24,7 @@ class KoDeclarationAssertForDeclarationListTest {
         try {
             sut.assert { false }
         } catch (e: Exception) {
-            e.message?.shouldContain("Assert 'declaration-assert-test-method-name' was violated (1 times)")
+            e.message?.shouldContain("Assert 'declaration-assert-test-method-name' was violated (1 time)")
                 ?: throw e
         }
     }
@@ -39,7 +39,7 @@ class KoDeclarationAssertForDeclarationListTest {
         try {
             sut.assert { false }
         } catch (e: Exception) {
-            e.message?.shouldContain("Assert 'file-declaration-assert-test-method-name' was violated (1 times)")
+            e.message?.shouldContain("Assert 'file-declaration-assert-test-method-name' was violated (1 time)")
                 ?: throw e
         }
     }
@@ -56,7 +56,7 @@ class KoDeclarationAssertForDeclarationListTest {
             sut.assert(message) { false }
         } catch (e: Exception) {
             e.message?.shouldContain(
-                "Assert 'declaration-assert-error-with-custom-message' was violated (1 times)." +
+                "Assert 'declaration-assert-error-with-custom-message' was violated (1 time)." +
                     "\n$message\nInvalid declarations",
             )
                 ?: throw e
@@ -75,7 +75,7 @@ class KoDeclarationAssertForDeclarationListTest {
             sut.assert(message) { false }
         } catch (e: Exception) {
             e.message?.shouldContain(
-                "Assert 'file-declaration-assert-error-with-custom-message' was violated (1 times)." +
+                "Assert 'file-declaration-assert-error-with-custom-message' was violated (1 time)." +
                     "\n$message\nInvalid files:",
             )
                 ?: throw e

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/verify/kodeclarationassert/KoDeclarationAssertForDeclarationSequenceTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/verify/kodeclarationassert/KoDeclarationAssertForDeclarationSequenceTest.kt
@@ -24,7 +24,7 @@ class KoDeclarationAssertForDeclarationSequenceTest {
         try {
             sut.assert { false }
         } catch (e: Exception) {
-            e.message?.shouldContain("Assert 'declaration-assert-test-method-name' was violated (1 times)") ?: throw e
+            e.message?.shouldContain("Assert 'declaration-assert-test-method-name' was violated (1 time)") ?: throw e
         }
     }
 
@@ -39,7 +39,7 @@ class KoDeclarationAssertForDeclarationSequenceTest {
         try {
             sut.assert { false }
         } catch (e: Exception) {
-            e.message?.shouldContain("Assert 'file-declaration-assert-test-method-name' was violated (1 times)") ?: throw e
+            e.message?.shouldContain("Assert 'file-declaration-assert-test-method-name' was violated (1 time)") ?: throw e
         }
     }
 
@@ -56,7 +56,7 @@ class KoDeclarationAssertForDeclarationSequenceTest {
             sut.assert(message) { false }
         } catch (e: Exception) {
             e.message?.shouldContain(
-                "Assert 'declaration-assert-error-with-custom-message' was violated (1 times)." +
+                "Assert 'declaration-assert-error-with-custom-message' was violated (1 time)." +
                     "\n$message\nInvalid declarations:",
             )
                 ?: throw e
@@ -76,7 +76,7 @@ class KoDeclarationAssertForDeclarationSequenceTest {
             sut.assert(message) { false }
         } catch (e: Exception) {
             e.message?.shouldContain(
-                "Assert 'file-declaration-assert-error-with-custom-message' was violated (1 times)." +
+                "Assert 'file-declaration-assert-error-with-custom-message' was violated (1 time)." +
                     "\n$message\nInvalid files:",
             )
                 ?: throw e

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/core/verify/KoDeclarationAndProviderAssertCore.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/core/verify/KoDeclarationAndProviderAssertCore.kt
@@ -164,5 +164,6 @@ private fun getCheckFailedMessage(failedItems: List<*>, testMethodName: String, 
     }
 
     val customMessage = if (additionalMessage != null) "\n${additionalMessage}\n" else " "
-    return "Assert '$testMethodName' was violated (${failedItems.size} times).${customMessage}Invalid $types:\n$failedDeclarationsMessage"
+    val times = if (failedItems.size == 1) "time" else "times"
+    return "Assert '$testMethodName' was violated (${failedItems.size} $times).${customMessage}Invalid $types:\n$failedDeclarationsMessage"
 }

--- a/lib/src/snippet/kotlin/com/lemonappdev/konsist/ArchitectureSnippets.kt
+++ b/lib/src/snippet/kotlin/com/lemonappdev/konsist/ArchitectureSnippets.kt
@@ -11,10 +11,16 @@ class ArchitectureSnippets {
             .scopeFromProject()
             .assertArchitecture {
                 val presentation = Layer("Presentation", "com.myapp.presentation..")
-                val data = Layer("Data", "com.myapp.data..")
+                val business = Layer("Business", "com.myapp.business..")
+                val persistence = Layer("Persistence", "com.myapp.persistence..")
+                val database = Layer("Database", "com.myapp.database..")
 
-                presentation.dependsOn(data)
-                data.dependsOnNothing()
+                presentation.dependsOn(business)
+                business.dependsOn(presentation)
+                business.dependsOn(persistence)
+                persistence.dependsOn(business)
+                business.dependsOn(database)
+                database.dependsOn(business)
             }
     }
 


### PR DESCRIPTION
Change wording for a single declaration failure = `1 times` -> `1 time`

Before
```
...KoCheckFailedException: Assert 'test name' was violated (1 times). Invalid files:
```

After
```
...KoCheckFailedException: Assert 'test name' was violated (1 time). Invalid files:
```