### PR TITLE
KON-443 Ignore Dot Gradle Directory

### DIFF
--- a/test-projects/konsist-path-tester/.gradle/caches/GradleCachedKotlinClass.kt
+++ b/test-projects/konsist-path-tester/.gradle/caches/GradleCachedKotlinClass.kt
@@ -1,0 +1,1 @@
+class GradleCachedKotlinClass


### PR DESCRIPTION
It looks like Gradle can store Kotlin files inside `/.gradle/caches` directory. These are outside project files and have to be ignored.

See https://github.com/LemonAppDev/konsist/discussions/512