### PR TITLE
add suppress name for assert with KoTest context

### DIFF
--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/verify/kodeclarationassert/KoDeclarationAssertOnListTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/verify/kodeclarationassert/KoDeclarationAssertOnListTest.kt
@@ -661,6 +661,19 @@ class KoDeclarationAssertOnListTest {
         sut.assertTrue { it.name.endsWith("suppress") }
     }
 
+    @Test
+    fun `assert-suppress-with-suppress-name-parameter`() {
+        // given
+        val sut =
+            getSnippetFile("assert-suppress-with-suppress-name-parameter")
+                .functions(includeNested = true)
+
+        // then
+        sut.assert(suppressName = "konsist.assert-suppress-with-suppress-name-parameter") {
+            it.name.endsWith("Kotest")
+        }
+    }
+
     private fun getSnippetFile(fileName: String) =
         TestSnippetProvider.getSnippetKoScope("core/verify/kodeclarationassert/snippet/", fileName)
 }

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/verify/kodeclarationassert/KoDeclarationAssertOnListTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/verify/kodeclarationassert/KoDeclarationAssertOnListTest.kt
@@ -669,7 +669,7 @@ class KoDeclarationAssertOnListTest {
                 .functions(includeNested = true)
 
         // then
-        sut.assert(suppressName = "konsist.assert-suppress-with-suppress-name-parameter") {
+        sut.assertTrue(suppressName = "konsist.assert-suppress-with-suppress-name-parameter") {
             it.name.endsWith("Kotest")
         }
     }

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/verify/kodeclarationassert/KoDeclarationAssertOnSequenceTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/verify/kodeclarationassert/KoDeclarationAssertOnSequenceTest.kt
@@ -718,7 +718,7 @@ class KoDeclarationAssertOnSequenceTest {
                 .asSequence()
 
         // then
-        sut.assert(suppressName = "konsist.assert-suppress-with-suppress-name-parameter") {
+        sut.assertTrue(suppressName = "konsist.assert-suppress-with-suppress-name-parameter") {
             it.name.endsWith("Kotest")
         }
     }

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/verify/kodeclarationassert/KoDeclarationAssertOnSequenceTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/verify/kodeclarationassert/KoDeclarationAssertOnSequenceTest.kt
@@ -709,6 +709,20 @@ class KoDeclarationAssertOnSequenceTest {
         sut.assertTrue { it.name.endsWith("suppress") }
     }
 
+    @Test
+    fun `assert-suppress-with-suppress-name-parameter`() {
+        // given
+        val sut =
+            getSnippetFile("assert-suppress-with-suppress-name-parameter")
+                .functions(includeNested = true)
+                .asSequence()
+
+        // then
+        sut.assert(suppressName = "konsist.assert-suppress-with-suppress-name-parameter") {
+            it.name.endsWith("Kotest")
+        }
+    }
+
     private fun getSnippetFile(fileName: String) =
         TestSnippetProvider.getSnippetKoScope("core/verify/kodeclarationassert/snippet/", fileName)
 }

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/verify/kodeclarationassert/KoDeclarationAssertOnSingleElementTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/verify/kodeclarationassert/KoDeclarationAssertOnSingleElementTest.kt
@@ -557,6 +557,20 @@ class KoDeclarationAssertOnSingleElementTest {
         sut.assertTrue { it.name.endsWith("Text") }
     }
 
+    @Test
+    fun `assert-suppress-with-suppress-name-parameter`() {
+        // given
+        val sut =
+            getSnippetFile("assert-suppress-with-suppress-name-parameter")
+                .functions(includeNested = true)
+                .first()
+
+        // then
+        sut.assert(suppressName = "konsist.assert-suppress-with-suppress-name-parameter") {
+            it.name.endsWith("Kotest")
+        }
+    }
+
     private fun getSnippetFile(fileName: String) =
         TestSnippetProvider.getSnippetKoScope("core/verify/kodeclarationassert/snippet/", fileName)
 }

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/verify/kodeclarationassert/KoDeclarationAssertOnSingleElementTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/verify/kodeclarationassert/KoDeclarationAssertOnSingleElementTest.kt
@@ -566,7 +566,7 @@ class KoDeclarationAssertOnSingleElementTest {
                 .first()
 
         // then
-        sut.assert(suppressName = "konsist.assert-suppress-with-suppress-name-parameter") {
+        sut.assertTrue(suppressName = "konsist.assert-suppress-with-suppress-name-parameter") {
             it.name.endsWith("Kotest")
         }
     }

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/verify/kodeclarationassert/snippet/assert-suppress-with-suppress-name-parameter.kttxt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/verify/kodeclarationassert/snippet/assert-suppress-with-suppress-name-parameter.kttxt
@@ -1,0 +1,5 @@
+class SampleClassKotest {
+    @Suppress("konsist.assert-suppress-with-suppress-name-parameter")
+    fun sampleFunctionFromKotest() {
+    }
+}

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/api/verify/KoDeclarationAndProviderAssert.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/api/verify/KoDeclarationAndProviderAssert.kt
@@ -13,9 +13,9 @@ import com.lemonappdev.konsist.core.verify.assert
  *               By default, false.
  * @param additionalMessage An optional message to provide additional context when the assertion fails.
  *                This message will be included in the assertion error if the assertion fails.
+ * @param suppressName An optional test method name coming obtained from different context
  * @param function The predicate function that takes an element of type [E] and returns a [Boolean] value.
  *                If the function returns `true`, the element is considered valid; otherwise, it's considered invalid.
- * @param suppressName An optional test method name coming obtained from different context
  */
 fun <E : KoBaseProvider> E?.assertTrue(
     strict: Boolean = false,
@@ -36,6 +36,7 @@ fun <E : KoBaseProvider> E?.assertTrue(
  *               By default, false.
  * @param additionalMessage An optional message to provide additional context when the assertion fails.
  *                This message will be included in the assertion error if the assertion fails.
+ * @param suppressName An optional test method name coming obtained from different context
  * @param function The predicate function that takes an element of type [E] and returns a [Boolean] value.
  *                If the function returns `true`, the element is considered invalid; otherwise, it's considered valid.
  */
@@ -58,6 +59,7 @@ fun <E : KoBaseProvider> E?.assertFalse(
  *               By default, false.
  * @param additionalMessage An optional message to provide additional context when the assertion fails.
  *                This message will be included in the assertion error if the assertion fails.
+ * @param suppressName An optional test method name coming obtained from different context
  * @param function The predicate function that takes an element of type [E] and returns a [Boolean] value.
  *                If the function returns `true`, the element is considered valid; otherwise, it's considered invalid.
  */
@@ -80,6 +82,7 @@ fun <E : KoBaseProvider> List<E?>.assertTrue(
  *               By default, false.
  * @param additionalMessage An optional message to provide additional context when the assertion fails.
  *                This message will be included in the assertion error if the assertion fails.
+ * @param suppressName An optional test method name coming obtained from different context
  * @param function The predicate function that takes an element of type [E] and returns a [Boolean] value.
  *                If the function returns `true`, the element is considered invalid; otherwise, it's considered valid.
  */
@@ -102,6 +105,7 @@ fun <E : KoBaseProvider> List<E?>.assertFalse(
  *               By default, false.
  * @param additionalMessage An optional message to provide additional context when the assertion fails.
  *                This message will be included in the assertion error if the assertion fails.
+ * @param suppressName An optional test method name coming obtained from different context
  * @param function The predicate function that takes an element of type [E] and returns a [Boolean] value.
  *                If the function returns `true`, the element is considered valid; otherwise, it's considered invalid.
  */
@@ -124,6 +128,7 @@ fun <E : KoBaseProvider> Sequence<E?>.assertTrue(
  *               By default, false.
  * @param additionalMessage An optional message to provide additional context when the assertion fails.
  *                This message will be included in the assertion error if the assertion fails.
+ * @param suppressName An optional test method name coming obtained from different context
  * @param function The predicate function that takes an element of type [E] and returns a [Boolean] value.
  *                If the function returns `true`, the element is considered invalid; otherwise, it's considered valid.
  */
@@ -156,7 +161,6 @@ fun <E : KoBaseProvider> E.assert(additionalMessage: String? = null, function: (
  *                This message will be included in the assertion error if the assertion fails.
  * @param function The predicate function that takes an element of type [E] and returns a [Boolean] value.
  *                If the function returns `true`, the element is considered invalid; otherwise, it's considered valid.
- * @param suppressName An optional test method name coming obtained from different context
  */
 @Deprecated("Will be removed in v1.0.0", ReplaceWith("assertFalse"))
 fun <E : KoBaseProvider> E.assertNot(additionalMessage: String? = null, function: (E) -> Boolean?): Unit {
@@ -170,7 +174,6 @@ fun <E : KoBaseProvider> E.assertNot(additionalMessage: String? = null, function
  *                This message will be included in the assertion error if the assertion fails.
  * @param function The predicate function that takes an element of type [E] and returns a [Boolean] value.
  *                If the function returns `true`, the element is considered valid; otherwise, it's considered invalid.
- * @param suppressName An optional test method name coming obtained from different context
  */
 @Deprecated("Will be removed in v1.0.0", ReplaceWith("assertTrue"))
 fun <E : KoBaseProvider> List<E>.assert(additionalMessage: String? = null, function: (E) -> Boolean?): Unit {
@@ -184,7 +187,6 @@ fun <E : KoBaseProvider> List<E>.assert(additionalMessage: String? = null, funct
  *                This message will be included in the assertion error if the assertion fails.
  * @param function The predicate function that takes an element of type [E] and returns a [Boolean] value.
  *                If the function returns `true`, the element is considered invalid; otherwise, it's considered valid.
- * @param suppressName An optional test method name coming obtained from different context
  */
 @Deprecated("Will be removed in v1.0.0", ReplaceWith("assertFalse"))
 fun <E : KoBaseProvider> List<E>.assertNot(additionalMessage: String? = null, function: (E) -> Boolean?): Unit {
@@ -198,7 +200,6 @@ fun <E : KoBaseProvider> List<E>.assertNot(additionalMessage: String? = null, fu
  *                This message will be included in the assertion error if the assertion fails.
  * @param function The predicate function that takes an element of type [E] and returns a [Boolean] value.
  *                If the function returns `true`, the element is considered valid; otherwise, it's considered invalid.
- * @param suppressName An optional test method name coming obtained from different context
  */
 @Deprecated("Will be removed in v1.0.0", ReplaceWith("assertTrue"))
 fun <E : KoBaseProvider> Sequence<E>.assert(additionalMessage: String? = null, function: (E) -> Boolean?): Unit {
@@ -212,7 +213,6 @@ fun <E : KoBaseProvider> Sequence<E>.assert(additionalMessage: String? = null, f
  *                This message will be included in the assertion error if the assertion fails.
  * @param function The predicate function that takes an element of type [E] and returns a [Boolean] value.
  *                If the function returns `true`, the element is considered invalid; otherwise, it's considered valid.
- * @param suppressName An optional test method name coming obtained from different context
  */
 @Deprecated("Will be removed in v1.0.0", ReplaceWith("assertFalse"))
 fun <E : KoBaseProvider> Sequence<E>.assertNot(additionalMessage: String? = null, function: (E) -> Boolean?): Unit {

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/api/verify/KoDeclarationAndProviderAssert.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/api/verify/KoDeclarationAndProviderAssert.kt
@@ -15,6 +15,7 @@ import com.lemonappdev.konsist.core.verify.assert
  *                This message will be included in the assertion error if the assertion fails.
  * @param function The predicate function that takes an element of type [E] and returns a [Boolean] value.
  *                If the function returns `true`, the element is considered valid; otherwise, it's considered invalid.
+ * @param suppressName An optional test method name coming obtained from different context
  */
 fun <E : KoBaseProvider> E?.assertTrue(
     strict: Boolean = false,
@@ -149,6 +150,7 @@ fun <E : KoBaseProvider> E.assert(additionalMessage: String? = null, function: (
  *                This message will be included in the assertion error if the assertion fails.
  * @param function The predicate function that takes an element of type [E] and returns a [Boolean] value.
  *                If the function returns `true`, the element is considered invalid; otherwise, it's considered valid.
+ * @param suppressName An optional test method name coming obtained from different context
  */
 @Deprecated("Will be removed in v1.0.0", ReplaceWith("assertFalse"))
 fun <E : KoBaseProvider> E.assertNot(additionalMessage: String? = null, function: (E) -> Boolean?): Unit {
@@ -162,6 +164,7 @@ fun <E : KoBaseProvider> E.assertNot(additionalMessage: String? = null, function
  *                This message will be included in the assertion error if the assertion fails.
  * @param function The predicate function that takes an element of type [E] and returns a [Boolean] value.
  *                If the function returns `true`, the element is considered valid; otherwise, it's considered invalid.
+ * @param suppressName An optional test method name coming obtained from different context
  */
 @Deprecated("Will be removed in v1.0.0", ReplaceWith("assertTrue"))
 fun <E : KoBaseProvider> List<E>.assert(additionalMessage: String? = null, function: (E) -> Boolean?): Unit {
@@ -175,6 +178,7 @@ fun <E : KoBaseProvider> List<E>.assert(additionalMessage: String? = null, funct
  *                This message will be included in the assertion error if the assertion fails.
  * @param function The predicate function that takes an element of type [E] and returns a [Boolean] value.
  *                If the function returns `true`, the element is considered invalid; otherwise, it's considered valid.
+ * @param suppressName An optional test method name coming obtained from different context
  */
 @Deprecated("Will be removed in v1.0.0", ReplaceWith("assertFalse"))
 fun <E : KoBaseProvider> List<E>.assertNot(additionalMessage: String? = null, function: (E) -> Boolean?): Unit {
@@ -188,6 +192,7 @@ fun <E : KoBaseProvider> List<E>.assertNot(additionalMessage: String? = null, fu
  *                This message will be included in the assertion error if the assertion fails.
  * @param function The predicate function that takes an element of type [E] and returns a [Boolean] value.
  *                If the function returns `true`, the element is considered valid; otherwise, it's considered invalid.
+ * @param suppressName An optional test method name coming obtained from different context
  */
 @Deprecated("Will be removed in v1.0.0", ReplaceWith("assertTrue"))
 fun <E : KoBaseProvider> Sequence<E>.assert(additionalMessage: String? = null, function: (E) -> Boolean?): Unit {
@@ -201,6 +206,7 @@ fun <E : KoBaseProvider> Sequence<E>.assert(additionalMessage: String? = null, f
  *                This message will be included in the assertion error if the assertion fails.
  * @param function The predicate function that takes an element of type [E] and returns a [Boolean] value.
  *                If the function returns `true`, the element is considered invalid; otherwise, it's considered valid.
+ * @param suppressName An optional test method name coming obtained from different context
  */
 @Deprecated("Will be removed in v1.0.0", ReplaceWith("assertFalse"))
 fun <E : KoBaseProvider> Sequence<E>.assertNot(additionalMessage: String? = null, function: (E) -> Boolean?): Unit {

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/api/verify/KoDeclarationAndProviderAssert.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/api/verify/KoDeclarationAndProviderAssert.kt
@@ -20,9 +20,10 @@ import com.lemonappdev.konsist.core.verify.assert
 fun <E : KoBaseProvider> E?.assertTrue(
     strict: Boolean = false,
     additionalMessage: String? = null,
+    suppressName: String? = null,
     function: (E) -> Boolean?,
 ): Unit {
-    listOf(this).assert(strict, additionalMessage, function, positiveCheck = true)
+    listOf(this).assert(strict, additionalMessage, suppressName, function, positiveCheck = true)
 }
 
 /**
@@ -41,9 +42,10 @@ fun <E : KoBaseProvider> E?.assertTrue(
 fun <E : KoBaseProvider> E?.assertFalse(
     strict: Boolean = false,
     additionalMessage: String? = null,
+    suppressName: String? = null,
     function: (E) -> Boolean?,
 ): Unit {
-    listOf(this).assert(strict, additionalMessage, function, positiveCheck = false)
+    listOf(this).assert(strict, additionalMessage, suppressName, function, positiveCheck = false)
 }
 
 /**
@@ -62,9 +64,10 @@ fun <E : KoBaseProvider> E?.assertFalse(
 fun <E : KoBaseProvider> List<E?>.assertTrue(
     strict: Boolean = false,
     additionalMessage: String? = null,
+    suppressName: String? = null,
     function: (E) -> Boolean?,
 ): Unit {
-    assert(strict, additionalMessage, function, positiveCheck = true)
+    assert(strict, additionalMessage, suppressName, function, positiveCheck = true)
 }
 
 /**
@@ -83,9 +86,10 @@ fun <E : KoBaseProvider> List<E?>.assertTrue(
 fun <E : KoBaseProvider> List<E?>.assertFalse(
     strict: Boolean = false,
     additionalMessage: String? = null,
+    suppressName: String? = null,
     function: (E) -> Boolean?,
 ): Unit {
-    assert(strict, additionalMessage, function, positiveCheck = false)
+    assert(strict, additionalMessage, suppressName, function, positiveCheck = false)
 }
 
 /**
@@ -104,9 +108,10 @@ fun <E : KoBaseProvider> List<E?>.assertFalse(
 fun <E : KoBaseProvider> Sequence<E?>.assertTrue(
     strict: Boolean = false,
     additionalMessage: String? = null,
+    suppressName: String? = null,
     function: (E) -> Boolean?,
 ): Unit {
-    this.toList().assert(strict, additionalMessage, function, true)
+    this.toList().assert(strict, additionalMessage, suppressName, function, true)
 }
 
 /**
@@ -125,9 +130,10 @@ fun <E : KoBaseProvider> Sequence<E?>.assertTrue(
 fun <E : KoBaseProvider> Sequence<E?>.assertFalse(
     strict: Boolean = false,
     additionalMessage: String? = null,
+    suppressName: String? = null,
     function: (E) -> Boolean?,
 ): Unit {
-    this.toList().assert(strict, additionalMessage, function, false)
+    this.toList().assert(strict, additionalMessage, suppressName, function, false)
 }
 
 /**

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/core/verify/KoDeclarationAndProviderAssertCore.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/core/verify/KoDeclarationAndProviderAssertCore.kt
@@ -37,16 +37,16 @@ internal fun <E : KoBaseProvider> List<E?>.assert(
             checkIfLocalListHasOnlyNullElements(this, assertMethodName)
         }
 
-        val methodNameOrSuppressName = suppressName ?: testMethodName
+        val methodOrSuppressName = suppressName ?: testMethodName
 
-        val notSuppressedDeclarations = checkIfAnnotatedWithSuppress(this.filterNotNull(), methodNameOrSuppressName)
+        val notSuppressedDeclarations = checkIfAnnotatedWithSuppress(this.filterNotNull(), methodOrSuppressName)
 
         val result = notSuppressedDeclarations.groupBy {
             lastDeclaration = it
             function(it) ?: positiveCheck
         }
 
-        getResult(notSuppressedDeclarations, result, positiveCheck, testMethodName, additionalMessage)
+        getResult(notSuppressedDeclarations, result, positiveCheck, methodOrSuppressName, additionalMessage)
     } catch (e: KoException) {
         throw e
     } catch (@Suppress("detekt.TooGenericExceptionCaught") e: Exception) {

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/core/verify/KoDeclarationAndProviderAssertCore.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/core/verify/KoDeclarationAndProviderAssertCore.kt
@@ -56,15 +56,13 @@ internal fun <E : KoBaseProvider> List<E>.assert(
     additionalMessage: String? = null,
     function: (E) -> Boolean?,
     positiveCheck: Boolean,
+    suppressName: String? = null
 ) {
     var lastDeclaration: KoBaseProvider? = null
 
     try {
-        val testMethodName = if (additionalMessage != null) {
-            getTestMethodNameFromFifthIndex()
-        } else {
-            getTestMethodNameFromSixthIndex()
-        }
+        val testMethodName: String =
+            getTestMethodName(additionalMessage = additionalMessage, suppressName = suppressName)
 
         checkIfLocalListIsEmpty(this, getTestMethodNameFromFourthIndex())
 

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/core/verify/KoDeclarationAndProviderAssertCore.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/core/verify/KoDeclarationAndProviderAssertCore.kt
@@ -39,7 +39,7 @@ internal fun <E : KoBaseProvider> List<E?>.assert(
 
         val methodNameOrSuppressName = suppressName ?: testMethodName
 
-        val notSuppressedDeclarations = checkIfAnnotatedWithSuppress(this.filterNotNull(), testMethodName)
+        val notSuppressedDeclarations = checkIfAnnotatedWithSuppress(this.filterNotNull(), methodNameOrSuppressName)
 
         val result = notSuppressedDeclarations.groupBy {
             lastDeclaration = it

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/core/verify/KoDeclarationAndProviderAssertCore.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/core/verify/KoDeclarationAndProviderAssertCore.kt
@@ -39,7 +39,7 @@ internal fun <E : KoBaseProvider> List<E?>.assert(
 
         val methodNameOrSuppressName = suppressName ?: testMethodName
 
-        val notSuppressedDeclarations = checkIfAnnotatedWithSuppress(this.filterNotNull(), methodNameOrSuppressName)
+        val notSuppressedDeclarations = checkIfAnnotatedWithSuppress(this.filterNotNull(), testMethodName)
 
         val result = notSuppressedDeclarations.groupBy {
             lastDeclaration = it
@@ -59,12 +59,15 @@ internal fun <E : KoBaseProvider> List<E>.assert(
     additionalMessage: String? = null,
     function: (E) -> Boolean?,
     positiveCheck: Boolean,
-    suppressName: String? = null,
 ) {
     var lastDeclaration: KoBaseProvider? = null
 
     try {
-        val testMethodName: String = suppressName ?: getTestMethodNameFromSixthIndex()
+        val testMethodName = if (additionalMessage != null) {
+            getTestMethodNameFromFifthIndex()
+        } else {
+            getTestMethodNameFromSixthIndex()
+        }
 
         checkIfLocalListIsEmpty(this, getTestMethodNameFromFourthIndex())
 

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/core/verify/KoDeclarationAndProviderAssertCore.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/core/verify/KoDeclarationAndProviderAssertCore.kt
@@ -15,6 +15,7 @@ import com.lemonappdev.konsist.core.exception.KoPreconditionFailedException
 internal fun <E : KoBaseProvider> List<E?>.assert(
     strict: Boolean,
     additionalMessage: String?,
+    suppressName: String?,
     function: (E) -> Boolean?,
     positiveCheck: Boolean,
 ) {
@@ -36,7 +37,9 @@ internal fun <E : KoBaseProvider> List<E?>.assert(
             checkIfLocalListHasOnlyNullElements(this, assertMethodName)
         }
 
-        val notSuppressedDeclarations = checkIfAnnotatedWithSuppress(this.filterNotNull(), testMethodName)
+        val methodNameOrSuppressName = suppressName ?: testMethodName
+
+        val notSuppressedDeclarations = checkIfAnnotatedWithSuppress(this.filterNotNull(), methodNameOrSuppressName)
 
         val result = notSuppressedDeclarations.groupBy {
             lastDeclaration = it
@@ -56,13 +59,12 @@ internal fun <E : KoBaseProvider> List<E>.assert(
     additionalMessage: String? = null,
     function: (E) -> Boolean?,
     positiveCheck: Boolean,
-    suppressName: String? = null
+    suppressName: String? = null,
 ) {
     var lastDeclaration: KoBaseProvider? = null
 
     try {
-        val testMethodName: String =
-            getTestMethodName(additionalMessage = additionalMessage, suppressName = suppressName)
+        val testMethodName: String = suppressName ?: getTestMethodNameFromSixthIndex()
 
         checkIfLocalListIsEmpty(this, getTestMethodNameFromFourthIndex())
 


### PR DESCRIPTION
Issue is that when using Kotest in combination with Konsist, the testName is not been captured due to that the execution of Kotest provides a CustomDSL and it works on a different context from which the name cannot be caught in the current way with konsist.

- Add `suppressName` to test for KoTest context.


Usage:

- Class with Suppress annotation:

```
@Suppress("endWithResource")
class TestResource {
...
}
```

- Test

```
...
import io.kotest.core.spec.style.FreeSpec // using kotest. Others imports not shown for simplicity
...
class ArchitectureTest: FreeSpec({
   
   "endWithResource" {
        Konsist
            .scopeFromProject()
            .classes()
            .withNameEndingWith("Resource")
             // adding suppressName grabbing from context (this) the testCase name
            .assert(suppressName = this.testCase.name.testName) { it.resideInPackage("..resource..") } 
    }
})
```


I will make another round to test it. I struggled a bit with the naming of the test because of adding the suppress name.
Simplified the call to get method name
`val testMethodName: String = suppressName ?: getTestMethodNameFromSixthIndex()`