### PR TITLE
KON-457 KoConstructorProviderListExt Change `withConstructor` To `withConstructors` And `withoutConstructor` To `withoutConstructors`

### DIFF
--- a/lib/src/konsistTest/kotlin/com/lemonappdev/konsist/core/DeclarationKonsistTest.kt
+++ b/lib/src/konsistTest/kotlin/com/lemonappdev/konsist/core/DeclarationKonsistTest.kt
@@ -9,6 +9,9 @@ import com.lemonappdev.konsist.api.verify.assertNot
 import org.junit.jupiter.api.Test
 
 class DeclarationKonsistTest {
+    private val declarationPackageScope =
+        Konsist.scopeFromPackage("com.lemonappdev.konsist.core.declaration..", sourceSetName = "main")
+
     @Test
     fun `every function has explicit return type declaration`() {
         declarationPackageScope
@@ -61,10 +64,5 @@ class DeclarationKonsistTest {
             .assert {
                 it.containsFunction { function -> function.name == "toString" }
             }
-    }
-
-    companion object {
-        val declarationPackageScope =
-            Konsist.scopeFromPackage("com.lemonappdev.konsist.core.declaration..", sourceSetName = "main")
     }
 }

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/api/ext/list/KoConstructorProviderListExt.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/api/ext/list/KoConstructorProviderListExt.kt
@@ -1,5 +1,3 @@
-@file:Suppress("konsist.every provider containing property with list of declarations type has correct extensions")
-
 package com.lemonappdev.konsist.api.ext.list
 
 import com.lemonappdev.konsist.api.declaration.KoConstructorDeclaration

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/api/ext/list/KoConstructorProviderListExt.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/api/ext/list/KoConstructorProviderListExt.kt
@@ -14,6 +14,7 @@ val <T : KoConstructorProvider> List<T>.constructors: List<KoConstructorDeclarat
  *
  * @return A list containing declarations with the constructor.
  */
+@Deprecated("Will be removed in v1.0.0", ReplaceWith("withConstructors()"))
 fun <T : KoConstructorProvider> List<T>.withConstructor(): List<T> = filter { it.hasConstructors() }
 
 /**
@@ -21,7 +22,22 @@ fun <T : KoConstructorProvider> List<T>.withConstructor(): List<T> = filter { it
  *
  * @return A list containing declarations without the constructor.
  */
+@Deprecated("Will be removed in v1.0.0", ReplaceWith("withoutConstructors()"))
 fun <T : KoConstructorProvider> List<T>.withoutConstructor(): List<T> = filterNot { it.hasConstructors() }
+
+/**
+ * List containing declarations with constructor.
+ *
+ * @return A list containing declarations with the constructor.
+ */
+fun <T : KoConstructorProvider> List<T>.withConstructors(): List<T> = filter { it.hasConstructors() }
+
+/**
+ * List containing declarations without constructor.
+ *
+ * @return A list containing declarations without the constructor.
+ */
+fun <T : KoConstructorProvider> List<T>.withoutConstructors(): List<T> = filterNot { it.hasConstructors() }
 
 /**
  * List containing declarations whose at least one constructor matches the given predicate.

--- a/lib/src/test/kotlin/com/lemonappdev/konsist/api/ext/list/KoConstructorProviderListExtTest.kt
+++ b/lib/src/test/kotlin/com/lemonappdev/konsist/api/ext/list/KoConstructorProviderListExtTest.kt
@@ -33,6 +33,42 @@ class KoConstructorProviderListExtTest {
     }
 
     @Test
+    fun `withConstructors() returns declaration with constructor`() {
+        // given
+        val declaration1: KoConstructorProvider = mockk {
+            every { hasConstructors() } returns true
+        }
+        val declaration2: KoConstructorProvider = mockk {
+            every { hasConstructors() } returns false
+        }
+        val declarations = listOf(declaration1, declaration2)
+
+        // when
+        val sut = declarations.withConstructors()
+
+        // then
+        sut shouldBeEqualTo listOf(declaration1)
+    }
+
+    @Test
+    fun `withoutConstructors() returns declaration without constructor`() {
+        // given
+        val declaration1: KoConstructorProvider = mockk {
+            every { hasConstructors() } returns true
+        }
+        val declaration2: KoConstructorProvider = mockk {
+            every { hasConstructors() } returns false
+        }
+        val declarations = listOf(declaration1, declaration2)
+
+        // when
+        val sut = declarations.withoutConstructors()
+
+        // then
+        sut shouldBeEqualTo listOf(declaration2)
+    }
+
+    @Test
     fun `withConstructor() returns declaration with constructor`() {
         // given
         val declaration1: KoConstructorProvider = mockk {


### PR DESCRIPTION
Assume we have filter all classes with any constructor. The previous version didn't match to our naming conventions. 

Before:
```kotlin 
Konsist
   .scopeFromProject()
   .classes()
   .withConstructor()
```

After:
```kotlin 
Konsist
   .scopeFromProject()
   .classes()
   .withConstructors()
```

The same with `withoutConstructors()`.