### PR TITLE
draft using stack walker plus jvmChain

### DIFF
--- a/lib/build.gradle.kts
+++ b/lib/build.gradle.kts
@@ -13,6 +13,10 @@ dependencies {
     testImplementation(libs.kluent)
 }
 
+kotlin {
+    jvmToolchain(19)
+}
+
 @Suppress("UnstableApiUsage")
 testing {
     suites {

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/core/verify/CommonAssert.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/core/verify/CommonAssert.kt
@@ -8,21 +8,35 @@ private const val INDEX_SEVEN = 7
 /**
  * In this call stack hierarchy test name is at index 4.
  */
-internal fun getTestMethodNameFromFourthIndex() = getTestMethodName(INDEX_FOUR)
+internal fun getTestMethodNameFromFourthIndex() = getTestMethodNameWithStackWalker(INDEX_FOUR)
 
 /**
  * In this call stack hierarchy test name is at index 5.
  */
-internal fun getTestMethodNameFromFifthIndex() = getTestMethodName(INDEX_FIVE)
+internal fun getTestMethodNameFromFifthIndex() = getTestMethodNameWithStackWalker(INDEX_FIVE)
 
 /**
  * In this call stack hierarchy test name is at index 5.
  */
-internal fun getTestMethodNameFromSixthIndex() = getTestMethodName(INDEX_SIX)
+internal fun getTestMethodNameFromSixthIndex() = getTestMethodNameWithStackWalker(INDEX_SIX)
 
 /**
  * In this call stack hierarchy test name is at index 7.
  */
-internal fun getTestMethodNameFromSeventhIndex() = getTestMethodName(INDEX_SEVEN)
+internal fun getTestMethodNameFromSeventhIndex() = getTestMethodNameWithStackWalker(INDEX_SEVEN)
 
+/**
+ * Use StalkWalker to get the testMethodName
+ */
+private fun getTestMethodNameWithStackWalker(index: Int): String =
+    StackWalker.getInstance()
+        .walk {
+            it.skip(index.toLong() - 1).findFirst().get()
+        }
+        .methodName
+
+@Deprecated(message = "Using StackWalker",
+    replaceWith = ReplaceWith("getTestMethodNameWithStackWalker")
+)
+@Suppress("UnusedPrivateMember")
 private fun getTestMethodName(index: Int): String = Thread.currentThread().stackTrace[index].methodName


### PR DESCRIPTION
Proposal based on some findings.

Based on the JVM api, there is a better and safer way to retrieve the testName rather than getting it from the CurrentThread.
This can be achieved with StackWalker API (https://openjdk.org/jeps/259). Based on docs, it is thread-safe, allows multiple threads to share a single StackWalker instance for accessing their respective stacks.

Because of that, i needed to update the `build.gradle.kts` with 
```
kotlin {
    jvmToolchain(19)
}
```

Because it's running after JDK 9 + and I was having some conflicts when compiling.