### PR TITLE
KON-463 Add `withName{}` And `withoutName{}`

### DIFF
--- a/lib/src/main/kotlin/com/lemonappdev/konsist/api/ext/list/KoNameProviderListExt.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/api/ext/list/KoNameProviderListExt.kt
@@ -1,5 +1,6 @@
 package com.lemonappdev.konsist.api.ext.list
 
+import com.lemonappdev.konsist.api.declaration.KoParentDeclaration
 import com.lemonappdev.konsist.api.provider.KoNameProvider
 
 /**
@@ -27,6 +28,23 @@ fun <T : KoNameProvider> List<T>.withoutName(vararg names: String): List<T> = fi
         else -> names.none { name -> it.name == name }
     }
 }
+
+/**
+ * List containing declarations that have a name matching the provided predicate.
+ *
+ * @param predicate A function that defines the condition to be met by a declaration name.
+ * @return A list containing declarations with the name matching the provided predicate.
+ */
+fun <T : KoNameProvider> List<T>.withName(predicate: (String) -> Boolean): List<T> = filter { predicate(it.name) }
+
+/**
+ * List containing declarations that don't have a name matching the provided predicate.
+ *
+ * @param predicate A function that defines the condition to be met by a declaration name.
+ * @return A list containing declarations without the name matching the provided predicate.
+ */
+fun <T : KoNameProvider> List<T>.withoutName(predicate: (String) -> Boolean): List<T> =
+    filterNot { predicate(it.name) }
 
 /**
  * List containing declarations with name with any of the specified prefix.

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/api/ext/list/KoNameProviderListExt.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/api/ext/list/KoNameProviderListExt.kt
@@ -1,6 +1,5 @@
 package com.lemonappdev.konsist.api.ext.list
 
-import com.lemonappdev.konsist.api.declaration.KoParentDeclaration
 import com.lemonappdev.konsist.api.provider.KoNameProvider
 
 /**

--- a/lib/src/test/kotlin/com/lemonappdev/konsist/api/ext/list/KoNameProviderListExtTest.kt
+++ b/lib/src/test/kotlin/com/lemonappdev/konsist/api/ext/list/KoNameProviderListExtTest.kt
@@ -136,6 +136,52 @@ class KoNameProviderListExtTest {
     }
 
     @Test
+    fun `withName{predicate} returns declaration with name matching to predicate`() {
+        // given
+        val name1 = "sampleName1"
+        val name2 = "sampleName2"
+        val prefix = "sample"
+        val suffix = "1"
+        val predicate: (String) -> Boolean = { it.startsWith(prefix) && it.endsWith(suffix)}
+        val declaration1: KoNameProvider = mockk {
+            every { name } returns name1
+        }
+        val declaration2: KoNameProvider = mockk {
+            every { name } returns name2
+        }
+        val declarations = listOf(declaration1, declaration2)
+
+        // when
+        val sut = declarations.withName(predicate)
+
+        // then
+        sut shouldBeEqualTo listOf(declaration1)
+    }
+
+    @Test
+    fun `withoutName{predicate} returns declaration without name matching to predicate`() {
+        // given
+        val name1 = "sampleName1"
+        val name2 = "sampleName2"
+        val prefix = "sample"
+        val suffix = "1"
+        val predicate: (String) -> Boolean = { it.startsWith(prefix) && it.endsWith(suffix)}
+        val declaration1: KoNameProvider = mockk {
+            every { name } returns name1
+        }
+        val declaration2: KoNameProvider = mockk {
+            every { name } returns name2
+        }
+        val declarations = listOf(declaration1, declaration2)
+
+        // when
+        val sut = declarations.withoutName(predicate)
+
+        // then
+        sut shouldBeEqualTo listOf(declaration2)
+    }
+
+    @Test
     fun `withNameStartingWith() returns declaration which names starts with given prefix`() {
         // given
         val prefix = "prefix"

--- a/lib/src/test/kotlin/com/lemonappdev/konsist/api/ext/list/KoNameProviderListExtTest.kt
+++ b/lib/src/test/kotlin/com/lemonappdev/konsist/api/ext/list/KoNameProviderListExtTest.kt
@@ -142,7 +142,7 @@ class KoNameProviderListExtTest {
         val name2 = "sampleName2"
         val prefix = "sample"
         val suffix = "1"
-        val predicate: (String) -> Boolean = { it.startsWith(prefix) && it.endsWith(suffix)}
+        val predicate: (String) -> Boolean = { it.startsWith(prefix) && it.endsWith(suffix) }
         val declaration1: KoNameProvider = mockk {
             every { name } returns name1
         }
@@ -165,7 +165,7 @@ class KoNameProviderListExtTest {
         val name2 = "sampleName2"
         val prefix = "sample"
         val suffix = "1"
-        val predicate: (String) -> Boolean = { it.startsWith(prefix) && it.endsWith(suffix)}
+        val predicate: (String) -> Boolean = { it.startsWith(prefix) && it.endsWith(suffix) }
         val declaration1: KoNameProvider = mockk {
             every { name } returns name1
         }


### PR DESCRIPTION
**Before**
```kotlin
Konsist
   .scopeFromProject()
   .classes()
   .withNameStarting("Prefix")
   .withNameEnding("Suffix")
   .assert { ... }
``` 
or 
```kotlin
Konsist
   .scopeFromProject()
   .classes()
   .withNameMatching(Regex(....))
   .assert { ... }
``` 

**After**
```kotlin
Konsist
   .scopeFromProject()
   .classes()
   .withName { it.startsWith("Prefix") && it.endsWith("Suffix") } 
   .assert { ... }
``` 