### PR TITLE
Hotfix KON-494 KoInternalException When Data Class Contains An Annotation Before The Comment Block

### DIFF
--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koclass/forkomodifier/KoClassDeclarationForKoModifierProviderTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koclass/forkomodifier/KoClassDeclarationForKoModifierProviderTest.kt
@@ -91,6 +91,12 @@ class KoClassDeclarationForKoModifierProviderTest {
             arguments("class-has-modifiers-annotation-and-comment", listOf(PRIVATE, OPEN)),
             arguments("class-has-modifiers-and-annotations", listOf(PRIVATE, OPEN)),
             arguments("class-has-modifiers-and-annotation-with-angle-brackets", listOf(PRIVATE, OPEN)),
+
+            arguments("class-has-modifiers-and-kdoc", listOf(PRIVATE, OPEN)),
+            arguments("class-has-modifiers-kdoc-and-annotation-before-them", listOf(PRIVATE, OPEN)),
+            arguments("class-has-modifiers-multiline-comment-and-annotation-before-them", listOf(PRIVATE, OPEN)),
+            arguments("class-has-modifiers-and-comment-before-them", listOf(PRIVATE, OPEN)),
+            arguments("class-has-modifiers-and-comment-after-them", listOf(PRIVATE, OPEN)),
         )
     }
 }

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koclass/forkomodifier/KoClassDeclarationForKoModifierProviderTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koclass/forkomodifier/KoClassDeclarationForKoModifierProviderTest.kt
@@ -91,7 +91,6 @@ class KoClassDeclarationForKoModifierProviderTest {
             arguments("class-has-modifiers-annotation-and-comment", listOf(PRIVATE, OPEN)),
             arguments("class-has-modifiers-and-annotations", listOf(PRIVATE, OPEN)),
             arguments("class-has-modifiers-and-annotation-with-angle-brackets", listOf(PRIVATE, OPEN)),
-
             arguments("class-has-modifiers-and-kdoc", listOf(PRIVATE, OPEN)),
             arguments("class-has-modifiers-kdoc-and-annotation-before-them", listOf(PRIVATE, OPEN)),
             arguments("class-has-modifiers-multiline-comment-and-annotation-before-them", listOf(PRIVATE, OPEN)),

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koclass/forkomodifier/snippet/forkomodifierprovider/class-has-modifiers-and-comment-after-them.kttxt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koclass/forkomodifier/snippet/forkomodifierprovider/class-has-modifiers-and-comment-after-them.kttxt
@@ -1,0 +1,3 @@
+private open // Some comment
+class SampleClass {
+}

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koclass/forkomodifier/snippet/forkomodifierprovider/class-has-modifiers-and-comment-before-them.kttxt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koclass/forkomodifier/snippet/forkomodifierprovider/class-has-modifiers-and-comment-before-them.kttxt
@@ -1,0 +1,3 @@
+// Some comment
+private open class SampleClass {
+}

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koclass/forkomodifier/snippet/forkomodifierprovider/class-has-modifiers-and-kdoc.kttxt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koclass/forkomodifier/snippet/forkomodifierprovider/class-has-modifiers-and-kdoc.kttxt
@@ -1,0 +1,5 @@
+/**
+ * Some comment
+ */
+private open class SampleClass {
+}

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koclass/forkomodifier/snippet/forkomodifierprovider/class-has-modifiers-kdoc-and-annotation-before-them.kttxt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koclass/forkomodifier/snippet/forkomodifierprovider/class-has-modifiers-kdoc-and-annotation-before-them.kttxt
@@ -1,0 +1,8 @@
+import com.lemonappdev.konsist.testdata.SampleAnnotation
+
+@SampleAnnotation
+/**
+ * Some comment
+ */
+private open class SampleClass {
+}

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koclass/forkomodifier/snippet/forkomodifierprovider/class-has-modifiers-multiline-comment-and-annotation-before-them.kttxt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koclass/forkomodifier/snippet/forkomodifierprovider/class-has-modifiers-multiline-comment-and-annotation-before-them.kttxt
@@ -1,0 +1,8 @@
+import com.lemonappdev.konsist.testdata.SampleAnnotation
+
+@SampleAnnotation
+/*
+ Some comment
+ */
+private open class SampleClass {
+}

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/kofunction/forkomodifier/KoFunctionDeclarationForKoModifierProviderTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/kofunction/forkomodifier/KoFunctionDeclarationForKoModifierProviderTest.kt
@@ -92,6 +92,11 @@ class KoFunctionDeclarationForKoModifierProviderTest {
             arguments("function-has-modifiers-annotation-and-comment", listOf(PROTECTED, OPEN)),
             arguments("function-has-modifiers-and-annotations", listOf(PROTECTED, OPEN)),
             arguments("function-has-modifiers-and-annotation-with-angle-brackets", listOf(PROTECTED, OPEN)),
+            arguments("function-has-modifiers-and-kdoc", listOf(PROTECTED, OPEN)),
+            arguments("function-has-modifiers-kdoc-and-annotation-before-them", listOf(PROTECTED, OPEN)),
+            arguments("function-has-modifiers-multiline-comment-and-annotation-before-them", listOf(PROTECTED, OPEN)),
+            arguments("function-has-modifiers-and-comment-before-them", listOf(PROTECTED, OPEN)),
+            arguments("function-has-modifiers-and-comment-after-them", listOf(PROTECTED, OPEN)),
         )
     }
 }

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/kofunction/forkomodifier/snippet/forkomodifierprovider/function-has-modifiers-and-comment-after-them.kttxt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/kofunction/forkomodifier/snippet/forkomodifierprovider/function-has-modifiers-and-comment-after-them.kttxt
@@ -1,0 +1,5 @@
+class SampleClass {
+    protected open // Some comment
+    fun invoke() {
+    }
+}

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/kofunction/forkomodifier/snippet/forkomodifierprovider/function-has-modifiers-and-comment-before-them.kttxt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/kofunction/forkomodifier/snippet/forkomodifierprovider/function-has-modifiers-and-comment-before-them.kttxt
@@ -1,0 +1,5 @@
+class SampleClass {
+    // Some comment
+    protected open fun invoke() {
+    }
+}

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/kofunction/forkomodifier/snippet/forkomodifierprovider/function-has-modifiers-and-kdoc.kttxt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/kofunction/forkomodifier/snippet/forkomodifierprovider/function-has-modifiers-and-kdoc.kttxt
@@ -1,0 +1,7 @@
+class SampleClass {
+    /**
+     * Some comment
+     */
+    protected open fun invoke() {
+    }
+}

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/kofunction/forkomodifier/snippet/forkomodifierprovider/function-has-modifiers-kdoc-and-annotation-before-them.kttxt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/kofunction/forkomodifier/snippet/forkomodifierprovider/function-has-modifiers-kdoc-and-annotation-before-them.kttxt
@@ -2,6 +2,9 @@ import com.lemonappdev.konsist.testdata.SampleAnnotation
 
 class SampleClass {
     @SampleAnnotation
+    /**
+     * Some comment
+     */
     protected open fun invoke() {
     }
 }

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/kofunction/forkomodifier/snippet/forkomodifierprovider/function-has-modifiers-multiline-comment-and-annotation-before-them.kttxt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/kofunction/forkomodifier/snippet/forkomodifierprovider/function-has-modifiers-multiline-comment-and-annotation-before-them.kttxt
@@ -2,6 +2,9 @@ import com.lemonappdev.konsist.testdata.SampleAnnotation
 
 class SampleClass {
     @SampleAnnotation
+    /*
+  Some comment
+  */
     protected open fun invoke() {
     }
 }

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/kointerface/forkomodifier/KoInterfaceDeclarationForKoModifierProviderTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/kointerface/forkomodifier/KoInterfaceDeclarationForKoModifierProviderTest.kt
@@ -94,6 +94,11 @@ class KoInterfaceDeclarationForKoModifierProviderTest {
             arguments("interface-has-modifiers-annotation-and-comment", listOf(PUBLIC, ABSTRACT)),
             arguments("interface-has-modifiers-and-annotations", listOf(PUBLIC, ABSTRACT)),
             arguments("interface-has-modifiers-and-annotation-with-angle-brackets", listOf(PUBLIC, ABSTRACT)),
+            arguments("interface-has-modifiers-and-kdoc", listOf(PUBLIC, ABSTRACT)),
+            arguments("interface-has-modifiers-kdoc-and-annotation-before-them", listOf(PUBLIC, ABSTRACT)),
+            arguments("interface-has-modifiers-multiline-comment-and-annotation-before-them", listOf(PUBLIC, ABSTRACT)),
+            arguments("interface-has-modifiers-and-comment-before-them", listOf(PUBLIC, ABSTRACT)),
+            arguments("interface-has-modifiers-and-comment-after-them", listOf(PUBLIC, ABSTRACT)),
         )
     }
 }

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/kointerface/forkomodifier/snippet/forkomodifierprovider/interface-has-modifiers-and-comment-after-them.kttxt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/kointerface/forkomodifier/snippet/forkomodifierprovider/interface-has-modifiers-and-comment-after-them.kttxt
@@ -1,0 +1,3 @@
+public abstract // Some comment
+interface SampleInterface {
+}

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/kointerface/forkomodifier/snippet/forkomodifierprovider/interface-has-modifiers-and-comment-before-them.kttxt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/kointerface/forkomodifier/snippet/forkomodifierprovider/interface-has-modifiers-and-comment-before-them.kttxt
@@ -1,0 +1,3 @@
+// Some comment
+public abstract interface SampleInterface {
+}

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/kointerface/forkomodifier/snippet/forkomodifierprovider/interface-has-modifiers-and-kdoc.kttxt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/kointerface/forkomodifier/snippet/forkomodifierprovider/interface-has-modifiers-and-kdoc.kttxt
@@ -1,0 +1,6 @@
+/**
+ * Some comment
+ */
+public abstract interface SampleInterface {
+}
+

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/kointerface/forkomodifier/snippet/forkomodifierprovider/interface-has-modifiers-kdoc-and-annotation-before-them.kttxt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/kointerface/forkomodifier/snippet/forkomodifierprovider/interface-has-modifiers-kdoc-and-annotation-before-them.kttxt
@@ -1,0 +1,8 @@
+import com.lemonappdev.konsist.testdata.SampleAnnotation
+
+@SampleAnnotation
+/**
+ * Some comment
+ */
+public abstract interface SampleInterface {
+}

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/kointerface/forkomodifier/snippet/forkomodifierprovider/interface-has-modifiers-multiline-comment-and-annotation-before-them.kttxt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/kointerface/forkomodifier/snippet/forkomodifierprovider/interface-has-modifiers-multiline-comment-and-annotation-before-them.kttxt
@@ -1,0 +1,9 @@
+import com.lemonappdev.konsist.testdata.SampleAnnotation
+
+@SampleAnnotation
+/*
+ Some comment
+ */
+public abstract interface SampleInterface {
+}
+

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koobject/forkomodifier/KoObjectDeclarationForKoModifierProviderTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koobject/forkomodifier/KoObjectDeclarationForKoModifierProviderTest.kt
@@ -92,6 +92,11 @@ class KoObjectDeclarationForKoModifierProviderTest {
             arguments("object-has-modifiers-annotation-and-comment", listOf(PRIVATE, DATA)),
             arguments("object-has-modifiers-and-annotations", listOf(PRIVATE, DATA)),
             arguments("object-has-modifiers-and-annotation-with-angle-brackets", listOf(PRIVATE, DATA)),
+            arguments("object-has-modifiers-and-kdoc", listOf(PRIVATE, DATA)),
+            arguments("object-has-modifiers-kdoc-and-annotation-before-them", listOf(PRIVATE, DATA)),
+            arguments("object-has-modifiers-multiline-comment-and-annotation-before-them", listOf(PRIVATE, DATA)),
+            arguments("object-has-modifiers-and-comment-before-them", listOf(PRIVATE, DATA)),
+            arguments("object-has-modifiers-and-comment-after-them", listOf(PRIVATE, DATA)),
         )
     }
 }

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koobject/forkomodifier/snippet/forkomodifierprovider/object-has-modifiers-and-comment-after-them.kttxt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koobject/forkomodifier/snippet/forkomodifierprovider/object-has-modifiers-and-comment-after-them.kttxt
@@ -1,0 +1,3 @@
+private data // Some comment
+object SampleObject {
+}

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koobject/forkomodifier/snippet/forkomodifierprovider/object-has-modifiers-and-comment-before-them.kttxt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koobject/forkomodifier/snippet/forkomodifierprovider/object-has-modifiers-and-comment-before-them.kttxt
@@ -1,0 +1,3 @@
+// Some comment
+private data object SampleObject {
+}

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koobject/forkomodifier/snippet/forkomodifierprovider/object-has-modifiers-and-kdoc.kttxt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koobject/forkomodifier/snippet/forkomodifierprovider/object-has-modifiers-and-kdoc.kttxt
@@ -1,0 +1,6 @@
+/**
+ * Some comment
+ */
+private data object SampleObject {
+}
+

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koobject/forkomodifier/snippet/forkomodifierprovider/object-has-modifiers-kdoc-and-annotation-before-them.kttxt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koobject/forkomodifier/snippet/forkomodifierprovider/object-has-modifiers-kdoc-and-annotation-before-them.kttxt
@@ -1,0 +1,9 @@
+import com.lemonappdev.konsist.testdata.SampleAnnotation
+
+@SampleAnnotation
+/**
+ * Some comment
+ */
+private data object SampleObject {
+}
+

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koobject/forkomodifier/snippet/forkomodifierprovider/object-has-modifiers-multiline-comment-and-annotation-before-them.kttxt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koobject/forkomodifier/snippet/forkomodifierprovider/object-has-modifiers-multiline-comment-and-annotation-before-them.kttxt
@@ -1,0 +1,9 @@
+import com.lemonappdev.konsist.testdata.SampleAnnotation
+
+@SampleAnnotation
+/*
+ Some comment
+ */
+private data object SampleObject {
+}
+

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koproperty/forkomodifier/KoPropertyDeclarationForKoModifierProviderTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koproperty/forkomodifier/KoPropertyDeclarationForKoModifierProviderTest.kt
@@ -93,6 +93,11 @@ class KoPropertyDeclarationForKoModifierProviderTest {
             arguments("property-has-modifiers-annotation-and-comment", listOf(PROTECTED, OPEN)),
             arguments("property-has-modifiers-and-annotations", listOf(PROTECTED, OPEN)),
             arguments("property-has-modifiers-and-annotation-with-angle-brackets", listOf(PROTECTED, OPEN)),
+            arguments("property-has-modifiers-and-kdoc", listOf(PROTECTED, OPEN)),
+            arguments("property-has-modifiers-kdoc-and-annotation-before-them", listOf(PROTECTED, OPEN)),
+            arguments("property-has-modifiers-multiline-comment-and-annotation-before-them", listOf(PROTECTED, OPEN)),
+            arguments("property-has-modifiers-and-comment-before-them", listOf(PROTECTED, OPEN)),
+            arguments("property-has-modifiers-and-comment-after-them", listOf(PROTECTED, OPEN)),
         )
     }
 }

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koproperty/forkomodifier/snippet/forkomodifierprovider/property-has-modifiers-and-comment-after-them.kttxt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koproperty/forkomodifier/snippet/forkomodifierprovider/property-has-modifiers-and-comment-after-them.kttxt
@@ -1,0 +1,4 @@
+open class SampleClass {
+    protected open // Some comment
+    val sampleProperty: Boolean = true
+}

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koproperty/forkomodifier/snippet/forkomodifierprovider/property-has-modifiers-and-comment-before-them.kttxt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koproperty/forkomodifier/snippet/forkomodifierprovider/property-has-modifiers-and-comment-before-them.kttxt
@@ -1,0 +1,4 @@
+open class SampleClass {
+    // Some comment
+    protected open val sampleProperty: Boolean = true
+}

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koproperty/forkomodifier/snippet/forkomodifierprovider/property-has-modifiers-and-kdoc.kttxt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koproperty/forkomodifier/snippet/forkomodifierprovider/property-has-modifiers-and-kdoc.kttxt
@@ -1,0 +1,6 @@
+open class SampleClass {
+    /**
+     * Some comment
+     */
+    protected open val sampleProperty: Boolean = true
+}

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koproperty/forkomodifier/snippet/forkomodifierprovider/property-has-modifiers-kdoc-and-annotation-before-them.kttxt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koproperty/forkomodifier/snippet/forkomodifierprovider/property-has-modifiers-kdoc-and-annotation-before-them.kttxt
@@ -1,0 +1,9 @@
+import com.lemonappdev.konsist.testdata.SampleAnnotation
+
+open class SampleClass {
+    @SampleAnnotation
+    /**
+     * Some comment
+     */
+    protected open val sampleProperty: Boolean = true
+}

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koproperty/forkomodifier/snippet/forkomodifierprovider/property-has-modifiers-multiline-comment-and-annotation-before-them.kttxt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koproperty/forkomodifier/snippet/forkomodifierprovider/property-has-modifiers-multiline-comment-and-annotation-before-them.kttxt
@@ -1,0 +1,9 @@
+import com.lemonappdev.konsist.testdata.SampleAnnotation
+
+open class SampleClass {
+    @SampleAnnotation
+    /*
+     Some comment
+     */
+    protected open val sampleProperty: Boolean = true
+}

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/kotypealias/forkomodifier/KoTypeAliasDeclarationForKoModifierProviderTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/kotypealias/forkomodifier/KoTypeAliasDeclarationForKoModifierProviderTest.kt
@@ -72,6 +72,11 @@ class KoTypeAliasDeclarationForKoModifierProviderTest {
             arguments("typealias-has-modifiers-annotation-and-comment"),
             arguments("typealias-has-modifiers-and-annotations"),
             arguments("typealias-has-modifiers-and-annotation-with-angle-brackets"),
+            arguments("typealias-has-modifiers-and-kdoc"),
+            arguments("typealias-has-modifiers-kdoc-and-annotation-before-them"),
+            arguments("typealias-has-modifiers-multiline-comment-and-annotation-before-them"),
+            arguments("typealias-has-modifiers-and-comment-before-them"),
+            arguments("typealias-has-modifiers-and-comment-after-them"),
         )
     }
 }

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/kotypealias/forkomodifier/snippet/forkomodifierprovider/typealias-has-modifiers-and-comment-after-them.kttxt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/kotypealias/forkomodifier/snippet/forkomodifierprovider/typealias-has-modifiers-and-comment-after-them.kttxt
@@ -1,0 +1,4 @@
+private // Some comment
+typealias SampleTypeAlias = (Boolean) -> Int
+
+class SampleClass(val sampleProperty: SampleTypeAlias)

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/kotypealias/forkomodifier/snippet/forkomodifierprovider/typealias-has-modifiers-and-comment-before-them.kttxt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/kotypealias/forkomodifier/snippet/forkomodifierprovider/typealias-has-modifiers-and-comment-before-them.kttxt
@@ -1,0 +1,4 @@
+// Some comment
+private typealias SampleTypeAlias = (Boolean) -> Int
+
+class SampleClass(val sampleProperty: SampleTypeAlias)

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/kotypealias/forkomodifier/snippet/forkomodifierprovider/typealias-has-modifiers-and-kdoc.kttxt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/kotypealias/forkomodifier/snippet/forkomodifierprovider/typealias-has-modifiers-and-kdoc.kttxt
@@ -1,0 +1,6 @@
+/**
+ * Some comment
+ */
+private typealias SampleTypeAlias = (Boolean) -> Int
+
+class SampleClass(val sampleProperty: SampleTypeAlias)

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/kotypealias/forkomodifier/snippet/forkomodifierprovider/typealias-has-modifiers-kdoc-and-annotation-before-them.kttxt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/kotypealias/forkomodifier/snippet/forkomodifierprovider/typealias-has-modifiers-kdoc-and-annotation-before-them.kttxt
@@ -1,0 +1,9 @@
+import com.lemonappdev.konsist.testdata.SampleAnnotation
+
+@SampleAnnotation
+/**
+ * Some comment
+ */
+private typealias SampleTypeAlias = (Boolean) -> Int
+
+class SampleClass(val sampleProperty: SampleTypeAlias)

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/kotypealias/forkomodifier/snippet/forkomodifierprovider/typealias-has-modifiers-multiline-comment-and-annotation-before-them.kttxt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/kotypealias/forkomodifier/snippet/forkomodifierprovider/typealias-has-modifiers-multiline-comment-and-annotation-before-them.kttxt
@@ -1,0 +1,9 @@
+import com.lemonappdev.konsist.testdata.SampleAnnotation
+
+@SampleAnnotation
+/*
+ Some comment
+ */
+private typealias SampleTypeAlias = (Boolean) -> Int
+
+class SampleClass(val sampleProperty: SampleTypeAlias)

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/modifier/KoModifierProviderCore.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/modifier/KoModifierProviderCore.kt
@@ -14,21 +14,14 @@ internal interface KoModifierProviderCore : KoModifierProvider, KoBaseProviderCo
         get() = ktTypeParameterListOwner
             .modifierList
             ?.text
+            ?.removeMultilineComments()
             ?.split(EndOfLine.UNIX.value)
-            ?.map { it.substringBefore("//") }
-            ?.flatMap { it.split(" ") }
-            ?.takeLastWhile {
-                // We filter this way because this list contains modifiers and annotations,
-                // and we need to exclude all annotations especially with blank spaces
-                // e.g. @SampleAnnotation(parameter = "sample parameter")
-                // and with angle brackets
-                // e.g. @SampleAnnotation<String, Int>
-                !it.contains('<') &&
-                    !it.contains('>') &&
-                    !it.contains(')') &&
-                    !it.contains('@') &&
-                    it.isNotBlank()
-            }
+            ?.map { it.ignoreCommentsOnTheSameLineAsModifiers() }
+            ?.filterNot { it.isBlank() }
+            ?.filterNot { it.isCommentLine() }
+            ?.filterNot { it.isKDocLine() }
+            ?.splitTextToSeparateDeclarations()
+            ?.takeOnlyModifiers()
             ?.map {
                 KoModifier
                     .entries
@@ -61,4 +54,37 @@ internal interface KoModifierProviderCore : KoModifierProvider, KoBaseProviderCo
 
     override fun hasAllModifiers(modifier: KoModifier, vararg modifiers: KoModifier): Boolean =
         this.modifiers.containsAll(modifiers.toList() + modifier)
+
+    private fun String.isKDocLine(): Boolean {
+        val trimmed = trim()
+        return trimmed.startsWith("/*") || trimmed.startsWith("*/") || trimmed.startsWith("*")
+    }
+
+    private fun String.isCommentLine(): Boolean = trim().startsWith("//")
+
+    private fun List<String>.splitTextToSeparateDeclarations(): List<String> = flatMap { it.split(" ") }
+
+    private fun List<String>.takeOnlyModifiers(): List<String> = takeLastWhile {
+        // We filter this way because this list contains modifiers and annotations,
+        // and we need to exclude all annotations especially with blank spaces
+        // e.g. @SampleAnnotation(parameter = "sample parameter")
+        // and with angle brackets
+        // e.g. @SampleAnnotation<String, Int>
+        !it.contains('<') &&
+                !it.contains('>') &&
+                !it.contains(')') &&
+                !it.contains('@') &&
+                it.isNotBlank()
+    }
+
+    private fun String.removeMultilineComments(): String = substringAfter("*/")
+
+    /* 
+    This method avoid situations when comment is in the same line as modifiers:
+    ```
+    private open // sample comment
+    class SampleClass
+    ```
+    */
+    private fun String.ignoreCommentsOnTheSameLineAsModifiers(): String = substringBefore("//")
 }

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/modifier/KoModifierProviderCore.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/modifier/KoModifierProviderCore.kt
@@ -62,14 +62,17 @@ internal interface KoModifierProviderCore : KoModifierProvider, KoBaseProviderCo
 
     private fun String.isCommentLine(): Boolean = trim().startsWith("//")
 
+    // E.g. "private open" splits to listOf("private", "open")
     private fun List<String>.splitTextToSeparateDeclarations(): List<String> = flatMap { it.split(" ") }
 
     private fun List<String>.takeOnlyModifiers(): List<String> = takeLastWhile {
-        // We filter this way because this list contains modifiers and annotations,
-        // and we need to exclude all annotations especially with blank spaces
-        // e.g. @SampleAnnotation(parameter = "sample parameter")
-        // and with angle brackets
-        // e.g. @SampleAnnotation<String, Int>
+        /*
+        We filter this way because this list contains modifiers and annotations,
+        and we need to exclude all annotations especially with blank spaces
+        e.g. @SampleAnnotation(parameter = "sample parameter")
+        and with angle brackets
+        e.g. @SampleAnnotation<String, Int>
+         */
         !it.contains('<') &&
             !it.contains('>') &&
             !it.contains(')') &&

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/modifier/KoModifierProviderCore.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/modifier/KoModifierProviderCore.kt
@@ -71,20 +71,20 @@ internal interface KoModifierProviderCore : KoModifierProvider, KoBaseProviderCo
         // and with angle brackets
         // e.g. @SampleAnnotation<String, Int>
         !it.contains('<') &&
-                !it.contains('>') &&
-                !it.contains(')') &&
-                !it.contains('@') &&
-                it.isNotBlank()
+            !it.contains('>') &&
+            !it.contains(')') &&
+            !it.contains('@') &&
+            it.isNotBlank()
     }
 
     private fun String.removeMultilineComments(): String = substringAfter("*/")
 
-    /* 
+    /*
     This method avoid situations when comment is in the same line as modifiers:
     ```
     private open // sample comment
     class SampleClass
     ```
-    */
+     */
     private fun String.ignoreCommentsOnTheSameLineAsModifiers(): String = substringBefore("//")
 }


### PR DESCRIPTION
Fix the bug from community: [More information about bug](https://github.com/LemonAppDev/konsist/discussions/593)