### PR TITLE
KON-496 - Remove deprecated `.hasmodifiers()`

### DIFF
--- a/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/modifier/KoAbstractModifierProviderCore.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/modifier/KoAbstractModifierProviderCore.kt
@@ -9,5 +9,5 @@ internal interface KoAbstractModifierProviderCore :
     KoBaseProviderCore,
     KoModifierProviderCore {
     override val hasAbstractModifier: Boolean
-        get() = hasModifiers(KoModifier.ABSTRACT)
+        get() = hasModifier(KoModifier.ABSTRACT)
 }

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/modifier/KoActualModifierProviderCore.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/modifier/KoActualModifierProviderCore.kt
@@ -9,5 +9,5 @@ internal interface KoActualModifierProviderCore :
     KoBaseProviderCore,
     KoModifierProviderCore {
     override val hasActualModifier: Boolean
-        get() = hasModifiers(KoModifier.ACTUAL)
+        get() = hasModifier(KoModifier.ACTUAL)
 }

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/modifier/KoAnnotationModifierProviderCore.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/modifier/KoAnnotationModifierProviderCore.kt
@@ -9,5 +9,5 @@ internal interface KoAnnotationModifierProviderCore :
     KoBaseProviderCore,
     KoModifierProviderCore {
     override val hasAnnotationModifier: Boolean
-        get() = hasModifiers(KoModifier.ANNOTATION)
+        get() = hasModifier(KoModifier.ANNOTATION)
 }

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/modifier/KoCompanionModifierProviderCore.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/modifier/KoCompanionModifierProviderCore.kt
@@ -9,5 +9,5 @@ internal interface KoCompanionModifierProviderCore :
     KoBaseProviderCore,
     KoModifierProviderCore {
     override val hasCompanionModifier: Boolean
-        get() = hasModifiers(KoModifier.COMPANION)
+        get() = hasModifier(KoModifier.COMPANION)
 }

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/modifier/KoConstModifierProviderCore.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/modifier/KoConstModifierProviderCore.kt
@@ -9,5 +9,5 @@ internal interface KoConstModifierProviderCore :
     KoBaseProviderCore,
     KoModifierProviderCore {
     override val hasConstModifier: Boolean
-        get() = hasModifiers(KoModifier.CONST)
+        get() = hasModifier(KoModifier.CONST)
 }

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/modifier/KoCrossInlineModifierProviderCore.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/modifier/KoCrossInlineModifierProviderCore.kt
@@ -9,5 +9,5 @@ internal interface KoCrossInlineModifierProviderCore :
     KoBaseProviderCore,
     KoModifierProviderCore {
     override val hasCrossInlineModifier: Boolean
-        get() = hasModifiers(KoModifier.CROSSINLINE)
+        get() = hasModifier(KoModifier.CROSSINLINE)
 }

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/modifier/KoDataModifierProviderCore.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/modifier/KoDataModifierProviderCore.kt
@@ -9,5 +9,5 @@ internal interface KoDataModifierProviderCore :
     KoBaseProviderCore,
     KoModifierProviderCore {
     override val hasDataModifier: Boolean
-        get() = hasModifiers(KoModifier.DATA)
+        get() = hasModifier(KoModifier.DATA)
 }

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/modifier/KoEnumModifierProviderCore.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/modifier/KoEnumModifierProviderCore.kt
@@ -9,5 +9,5 @@ internal interface KoEnumModifierProviderCore :
     KoBaseProviderCore,
     KoModifierProviderCore {
     override val hasEnumModifier: Boolean
-        get() = hasModifiers(KoModifier.ENUM)
+        get() = hasModifier(KoModifier.ENUM)
 }

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/modifier/KoExpectModifierProviderCore.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/modifier/KoExpectModifierProviderCore.kt
@@ -9,5 +9,5 @@ internal interface KoExpectModifierProviderCore :
     KoBaseProviderCore,
     KoModifierProviderCore {
     override val hasExpectModifier: Boolean
-        get() = hasModifiers(KoModifier.EXPECT)
+        get() = hasModifier(KoModifier.EXPECT)
 }

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/modifier/KoExternalModifierProviderCore.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/modifier/KoExternalModifierProviderCore.kt
@@ -9,5 +9,5 @@ internal interface KoExternalModifierProviderCore :
     KoBaseProviderCore,
     KoModifierProviderCore {
     override val hasExternalModifier: Boolean
-        get() = hasModifiers(KoModifier.EXTERNAL)
+        get() = hasModifier(KoModifier.EXTERNAL)
 }

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/modifier/KoFinalModifierProviderCore.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/modifier/KoFinalModifierProviderCore.kt
@@ -9,5 +9,5 @@ internal interface KoFinalModifierProviderCore :
     KoBaseProviderCore,
     KoModifierProviderCore {
     override val hasFinalModifier: Boolean
-        get() = hasModifiers(KoModifier.FINAL)
+        get() = hasModifier(KoModifier.FINAL)
 }

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/modifier/KoFunModifierProviderCore.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/modifier/KoFunModifierProviderCore.kt
@@ -9,5 +9,5 @@ internal interface KoFunModifierProviderCore :
     KoBaseProviderCore,
     KoModifierProviderCore {
     override val hasFunModifier: Boolean
-        get() = hasModifiers(KoModifier.FUN)
+        get() = hasModifier(KoModifier.FUN)
 }

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/modifier/KoInfixModifierProviderCore.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/modifier/KoInfixModifierProviderCore.kt
@@ -9,5 +9,5 @@ internal interface KoInfixModifierProviderCore :
     KoBaseProviderCore,
     KoModifierProviderCore {
     override val hasInfixModifier: Boolean
-        get() = hasModifiers(KoModifier.INFIX)
+        get() = hasModifier(KoModifier.INFIX)
 }

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/modifier/KoInlineModifierProviderCore.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/modifier/KoInlineModifierProviderCore.kt
@@ -9,5 +9,5 @@ internal interface KoInlineModifierProviderCore :
     KoBaseProviderCore,
     KoModifierProviderCore {
     override val hasInlineModifier: Boolean
-        get() = hasModifiers(KoModifier.INLINE)
+        get() = hasModifier(KoModifier.INLINE)
 }

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/modifier/KoInnerModifierProviderCore.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/modifier/KoInnerModifierProviderCore.kt
@@ -9,5 +9,5 @@ internal interface KoInnerModifierProviderCore :
     KoBaseProviderCore,
     KoModifierProviderCore {
     override val hasInnerModifier: Boolean
-        get() = hasModifiers(KoModifier.INNER)
+        get() = hasModifier(KoModifier.INNER)
 }

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/modifier/KoLateinitModifierProviderCore.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/modifier/KoLateinitModifierProviderCore.kt
@@ -9,5 +9,5 @@ internal interface KoLateinitModifierProviderCore :
     KoBaseProviderCore,
     KoModifierProviderCore {
     override val hasLateinitModifier: Boolean
-        get() = hasModifiers(KoModifier.LATEINIT)
+        get() = hasModifier(KoModifier.LATEINIT)
 }

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/modifier/KoNoInlineModifierProviderCore.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/modifier/KoNoInlineModifierProviderCore.kt
@@ -9,5 +9,5 @@ internal interface KoNoInlineModifierProviderCore :
     KoBaseProviderCore,
     KoModifierProviderCore {
     override val hasNoInlineModifier: Boolean
-        get() = hasModifiers(KoModifier.NOINLINE)
+        get() = hasModifier(KoModifier.NOINLINE)
 }

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/modifier/KoOpenModifierProviderCore.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/modifier/KoOpenModifierProviderCore.kt
@@ -9,5 +9,5 @@ internal interface KoOpenModifierProviderCore :
     KoBaseProviderCore,
     KoModifierProviderCore {
     override val hasOpenModifier: Boolean
-        get() = hasModifiers(KoModifier.OPEN)
+        get() = hasModifier(KoModifier.OPEN)
 }

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/modifier/KoOperatorModifierProviderCore.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/modifier/KoOperatorModifierProviderCore.kt
@@ -9,5 +9,5 @@ internal interface KoOperatorModifierProviderCore :
     KoBaseProviderCore,
     KoModifierProviderCore {
     override val hasOperatorModifier: Boolean
-        get() = hasModifiers(KoModifier.OPERATOR)
+        get() = hasModifier(KoModifier.OPERATOR)
 }

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/modifier/KoOverrideModifierProviderCore.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/modifier/KoOverrideModifierProviderCore.kt
@@ -9,5 +9,5 @@ internal interface KoOverrideModifierProviderCore :
     KoBaseProviderCore,
     KoModifierProviderCore {
     override val hasOverrideModifier: Boolean
-        get() = hasModifiers(KoModifier.OVERRIDE)
+        get() = hasModifier(KoModifier.OVERRIDE)
 }

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/modifier/KoSealedModifierProviderCore.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/modifier/KoSealedModifierProviderCore.kt
@@ -9,5 +9,5 @@ internal interface KoSealedModifierProviderCore :
     KoBaseProviderCore,
     KoModifierProviderCore {
     override val hasSealedModifier: Boolean
-        get() = hasModifiers(KoModifier.SEALED)
+        get() = hasModifier(KoModifier.SEALED)
 }

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/modifier/KoSuspendModifierProviderCore.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/modifier/KoSuspendModifierProviderCore.kt
@@ -9,5 +9,5 @@ internal interface KoSuspendModifierProviderCore :
     KoBaseProviderCore,
     KoModifierProviderCore {
     override val hasSuspendModifier: Boolean
-        get() = hasModifiers(KoModifier.SUSPEND)
+        get() = hasModifier(KoModifier.SUSPEND)
 }

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/modifier/KoTailrecModifierProviderCore.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/modifier/KoTailrecModifierProviderCore.kt
@@ -9,5 +9,5 @@ internal interface KoTailrecModifierProviderCore :
     KoBaseProviderCore,
     KoModifierProviderCore {
     override val hasTailrecModifier: Boolean
-        get() = hasModifiers(KoModifier.TAILREC)
+        get() = hasModifier(KoModifier.TAILREC)
 }

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/modifier/KoValueModifierProviderCore.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/modifier/KoValueModifierProviderCore.kt
@@ -9,5 +9,5 @@ internal interface KoValueModifierProviderCore :
     KoBaseProviderCore,
     KoModifierProviderCore {
     override val hasValueModifier: Boolean
-        get() = hasModifiers(KoModifier.VALUE)
+        get() = hasModifier(KoModifier.VALUE)
 }

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/modifier/KoVarArgModifierProviderCore.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/modifier/KoVarArgModifierProviderCore.kt
@@ -9,5 +9,5 @@ internal interface KoVarArgModifierProviderCore :
     KoBaseProviderCore,
     KoModifierProviderCore {
     override val hasVarArgModifier: Boolean
-        get() = hasModifiers(KoModifier.VARARG)
+        get() = hasModifier(KoModifier.VARARG)
 }

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/modifier/KoVisibilityModifierProviderCore.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/modifier/KoVisibilityModifierProviderCore.kt
@@ -10,17 +10,17 @@ internal interface KoVisibilityModifierProviderCore :
     KoBaseProviderCore,
     KoModifierProviderCore {
     override val hasPublicModifier: Boolean
-        get() = hasModifiers(KoModifier.PUBLIC)
+        get() = hasModifier(KoModifier.PUBLIC)
 
     override val hasPublicOrDefaultModifier: Boolean
         get() = ktTypeParameterListOwner.isPublic
 
     override val hasPrivateModifier: Boolean
-        get() = hasModifiers(KoModifier.PRIVATE)
+        get() = hasModifier(KoModifier.PRIVATE)
 
     override val hasProtectedModifier: Boolean
-        get() = hasModifiers(KoModifier.PROTECTED)
+        get() = hasModifier(KoModifier.PROTECTED)
 
     override val hasInternalModifier: Boolean
-        get() = hasModifiers(KoModifier.INTERNAL)
+        get() = hasModifier(KoModifier.INTERNAL)
 }


### PR DESCRIPTION
- Remove deprecated `.hasmodifiers()` from internal providers