### PR TITLE
Revert Stack Walker

### DIFF
--- a/buildSrc/src/main/kotlin/local.base.gradle.kts
+++ b/buildSrc/src/main/kotlin/local.base.gradle.kts
@@ -9,3 +9,7 @@ plugins {
 repositories {
     mavenCentral()
 }
+
+kotlin {
+    jvmToolchain(19)
+}

--- a/buildSrc/src/main/kotlin/local.javalibrary.gradle.kts
+++ b/buildSrc/src/main/kotlin/local.javalibrary.gradle.kts
@@ -6,7 +6,7 @@ java {
     // Make consist compatible with  Java 1.8
     toolchain {
         // Java 8 == bytecode version 52.0
-        languageVersion.set(JavaLanguageVersion.of(9))
+        languageVersion.set(JavaLanguageVersion.of(8))
     }
 
     // Generated sources.jar for the library jar

--- a/lib/build.gradle.kts
+++ b/lib/build.gradle.kts
@@ -13,10 +13,6 @@ dependencies {
     testImplementation(libs.kluent)
 }
 
-kotlin {
-    jvmToolchain(19)
-}
-
 @Suppress("UnstableApiUsage")
 testing {
     suites {

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/core/verify/CommonAssert.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/core/verify/CommonAssert.kt
@@ -5,24 +5,24 @@ private const val INDEX_FIVE = 5
 private const val INDEX_SIX = 6
 private const val INDEX_SEVEN = 7
 
-internal fun getTestMethodNameFromFourthIndex() = getTestMethodNameWithStackWalker(INDEX_FOUR)
+/**
+ * In this call stack hierarchy test name is at index 4.
+ */
+internal fun getTestMethodNameFromFourthIndex() = getTestMethodName(INDEX_FOUR)
 
-internal fun getTestMethodNameFromFifthIndex() = getTestMethodNameWithStackWalker(INDEX_FIVE)
+/**
+ * In this call stack hierarchy test name is at index 5.
+ */
+internal fun getTestMethodNameFromFifthIndex() = getTestMethodName(INDEX_FIVE)
 
-internal fun getTestMethodNameFromSixthIndex() = getTestMethodNameWithStackWalker(INDEX_SIX)
+/**
+ * In this call stack hierarchy test name is at index 5.
+ */
+internal fun getTestMethodNameFromSixthIndex() = getTestMethodName(INDEX_SIX)
 
-internal fun getTestMethodNameFromSeventhIndex() = getTestMethodNameWithStackWalker(INDEX_SEVEN)
+/**
+ * In this call stack hierarchy test name is at index 7.
+ */
+internal fun getTestMethodNameFromSeventhIndex() = getTestMethodName(INDEX_SEVEN)
 
-private fun getTestMethodNameWithStackWalker(index: Int): String =
-    StackWalker.getInstance()
-        .walk {
-            it.skip(index.toLong() - 1).findFirst().get()
-        }
-        .methodName
-
-@Deprecated(
-    message = "Using StackWalker",
-    replaceWith = ReplaceWith("getTestMethodNameWithStackWalker"),
-)
-@Suppress("UnusedPrivateMember")
 private fun getTestMethodName(index: Int): String = Thread.currentThread().stackTrace[index].methodName


### PR DESCRIPTION
Revert the Java version to `8`.

Reasons:
- `Java 9` and `Java 10` were non-LTS(Long time support) releases, meaning `Java 8` has a longer maintenance cycle
- `Java 9` is not officially supported on MacOs anymore.
- `Java 9` was introduced in `Android 9`, so some Android apps will most likely target this Android version to allow this version. We could have an Androdi module targeting `Java 8` and a dedicated Konsist module with `Java 9` versions, however, multiple Java versions lead to Gradle build issues.
- Stack Walker API does not provide any benefit, besides a bit clearer API

**Android Java Info**
- Android 13 has access to Java 8, 9, 11, and 17
- Android 11 and 12 have access to Java 8, 9, and 11
- Android Pie (9) and 10 has access to Java 8 and 9
- Android Oreo (8) has access to Java 8
- Android Nougat (7) has access to Java 8
