### PR TITLE
KON-507 Add `hasExpressionBody` And `hasBlockBody` To KoFunctionDeclaration

### DIFF
--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/kofunction/KoFunctionDeclarationForKoBodyProviderTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/kofunction/KoFunctionDeclarationForKoBodyProviderTest.kt
@@ -1,0 +1,40 @@
+package com.lemonappdev.konsist.core.declaration.kofunction
+
+import com.lemonappdev.konsist.TestSnippetProvider.getSnippetKoScope
+import com.lemonappdev.konsist.api.ext.list.functions
+import org.amshove.kluent.assertSoftly
+import org.amshove.kluent.shouldBeEqualTo
+import org.junit.jupiter.api.Test
+
+class KoFunctionDeclarationForKoBodyProviderTest {
+    @Test
+    fun `function-has-expression-body`() {
+        // given
+        val sut = getSnippetFile("function-has-expression-body")
+            .functions()
+            .first()
+
+        // then
+        assertSoftly(sut) {
+            hasExpressionBody shouldBeEqualTo true
+            hasBlockBody shouldBeEqualTo false
+        }
+    }
+
+    @Test
+    fun `function-has-block-body`() {
+        // given
+        val sut = getSnippetFile("function-has-block-body")
+            .functions()
+            .first()
+
+        // then
+        assertSoftly(sut) {
+            hasExpressionBody shouldBeEqualTo false
+            hasBlockBody shouldBeEqualTo true
+        }
+    }
+
+    private fun getSnippetFile(fileName: String) =
+        getSnippetKoScope("core/declaration/kofunction/snippet/forkobodyprovider/", fileName)
+}

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/kofunction/snippet/forkobodyprovider/function-has-block-body.kttxt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/kofunction/snippet/forkobodyprovider/function-has-block-body.kttxt
@@ -1,0 +1,3 @@
+fun sampleFunction(): Int {
+    return 0
+}

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/kofunction/snippet/forkobodyprovider/function-has-expression-body.kttxt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/kofunction/snippet/forkobodyprovider/function-has-expression-body.kttxt
@@ -1,0 +1,1 @@
+fun sampleFunction() = 0

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/api/declaration/KoFunctionDeclaration.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/api/declaration/KoFunctionDeclaration.kt
@@ -2,6 +2,7 @@ package com.lemonappdev.konsist.api.declaration
 
 import com.lemonappdev.konsist.api.provider.KoAnnotationProvider
 import com.lemonappdev.konsist.api.provider.KoBaseProvider
+import com.lemonappdev.konsist.api.provider.KoBodyProvider
 import com.lemonappdev.konsist.api.provider.KoContainingDeclarationProvider
 import com.lemonappdev.konsist.api.provider.KoContainingFileProvider
 import com.lemonappdev.konsist.api.provider.KoFullyQualifiedNameProvider
@@ -44,6 +45,7 @@ interface KoFunctionDeclaration :
     KoBaseDeclaration,
     KoBaseProvider,
     KoAnnotationProvider,
+    KoBodyProvider,
     KoContainingFileProvider,
     KoReturnTypeProvider,
     KoFullyQualifiedNameProvider,

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/api/ext/list/KoBodyProviderListExt.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/api/ext/list/KoBodyProviderListExt.kt
@@ -1,0 +1,31 @@
+package com.lemonappdev.konsist.api.ext.list
+
+import com.lemonappdev.konsist.api.provider.KoBodyProvider
+
+/**
+ * List containing declarations with expression body.
+ *
+ * @return A list containing the declarations with expression body.
+ */
+fun <T : KoBodyProvider> List<T>.withExpressionBody(): List<T> = filter { it.hasExpressionBody }
+
+/**
+ * List containing declarations without expression body.
+ *
+ * @return A list containing the declarations without expression body.
+ */
+fun <T : KoBodyProvider> List<T>.withoutExpressionBody(): List<T> = filterNot { it.hasExpressionBody }
+
+/**
+ * List containing declarations with block body.
+ *
+ * @return A list containing the declarations with block body.
+ */
+fun <T : KoBodyProvider> List<T>.withBlockBody(): List<T> = filter { it.hasBlockBody }
+
+/**
+ * List containing declarations without block body.
+ *
+ * @return A list containing the declarations without block body.
+ */
+fun <T : KoBodyProvider> List<T>.withoutBlockBody(): List<T> = filterNot { it.hasBlockBody }

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/api/provider/KoBodyProvider.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/api/provider/KoBodyProvider.kt
@@ -1,7 +1,7 @@
 package com.lemonappdev.konsist.api.provider
 
 /**
- * An interface representing a Kotlin declaration that provides an information whether it has expression or block body.
+ * An interface representing a Kotlin declaration that provides an information whether it body.
  */
 interface KoBodyProvider : KoBaseProvider {
     /**

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/api/provider/KoBodyProvider.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/api/provider/KoBodyProvider.kt
@@ -1,7 +1,7 @@
 package com.lemonappdev.konsist.api.provider
 
 /**
- * An interface representing a Kotlin declaration that provides an information whether it body.
+ * An interface representing a Kotlin declaration that provides an information about the body.
  */
 interface KoBodyProvider : KoBaseProvider {
     /**

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/api/provider/KoBodyProvider.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/api/provider/KoBodyProvider.kt
@@ -1,0 +1,16 @@
+package com.lemonappdev.konsist.api.provider
+
+/**
+ * An interface representing a Kotlin declaration that provides an information whether it has expression or block body.
+ */
+interface KoBodyProvider : KoBaseProvider {
+    /**
+     * Whatever declaration has expression body.
+     */
+    val hasExpressionBody: Boolean
+
+    /**
+     * Whatever declaration has block body.
+     */
+    val hasBlockBody: Boolean
+}

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/core/declaration/KoFunctionDeclarationCore.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/core/declaration/KoFunctionDeclarationCore.kt
@@ -7,6 +7,7 @@ import com.lemonappdev.konsist.api.provider.KoContainingDeclarationProvider
 import com.lemonappdev.konsist.core.cache.KoDeclarationCache
 import com.lemonappdev.konsist.core.provider.KoAnnotationProviderCore
 import com.lemonappdev.konsist.core.provider.KoBaseProviderCore
+import com.lemonappdev.konsist.core.provider.KoBodyProviderCore
 import com.lemonappdev.konsist.core.provider.KoContainingDeclarationProviderCore
 import com.lemonappdev.konsist.core.provider.KoContainingFileProviderCore
 import com.lemonappdev.konsist.core.provider.KoDeclarationFullyQualifiedNameProviderCore
@@ -44,6 +45,7 @@ import com.lemonappdev.konsist.core.provider.packagee.KoPackageDeclarationProvid
 import com.lemonappdev.konsist.core.provider.util.KoLocalDeclarationProviderCoreUtil
 import org.jetbrains.kotlin.psi.KtAnnotated
 import org.jetbrains.kotlin.psi.KtCallableDeclaration
+import org.jetbrains.kotlin.psi.KtDeclarationWithBody
 import org.jetbrains.kotlin.psi.KtElement
 import org.jetbrains.kotlin.psi.KtFunction
 import org.jetbrains.kotlin.psi.KtTypeParameterListOwner
@@ -55,6 +57,7 @@ internal class KoFunctionDeclarationCore private constructor(
     KoFunctionDeclaration,
     KoBaseProviderCore,
     KoAnnotationProviderCore,
+    KoBodyProviderCore,
     KoContainingFileProviderCore,
     KoDeclarationFullyQualifiedNameProviderCore,
     KoReturnTypeProviderCore,
@@ -98,6 +101,8 @@ internal class KoFunctionDeclarationCore private constructor(
     override val psiElement: PsiElement by lazy { ktFunction }
 
     override val ktElement: KtElement by lazy { ktFunction }
+
+    override val ktDeclarationWithBody: KtDeclarationWithBody by lazy { ktFunction }
 
     override val hasImplementation: Boolean = ktFunction.hasBody()
 

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/KoBodyProviderCore.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/KoBodyProviderCore.kt
@@ -1,0 +1,14 @@
+package com.lemonappdev.konsist.core.provider
+
+import com.lemonappdev.konsist.api.provider.KoBodyProvider
+import org.jetbrains.kotlin.psi.KtDeclarationWithBody
+
+internal interface KoBodyProviderCore : KoBodyProvider, KoBaseProviderCore {
+    val ktDeclarationWithBody: KtDeclarationWithBody
+
+    override val hasBlockBody: Boolean
+        get() =  ktDeclarationWithBody.hasBlockBody()
+
+    override val hasExpressionBody: Boolean
+        get() = !hasBlockBody
+}

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/KoBodyProviderCore.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/KoBodyProviderCore.kt
@@ -7,7 +7,7 @@ internal interface KoBodyProviderCore : KoBodyProvider, KoBaseProviderCore {
     val ktDeclarationWithBody: KtDeclarationWithBody
 
     override val hasBlockBody: Boolean
-        get() =  ktDeclarationWithBody.hasBlockBody()
+        get() = ktDeclarationWithBody.hasBlockBody()
 
     override val hasExpressionBody: Boolean
         get() = !hasBlockBody

--- a/lib/src/test/kotlin/com/lemonappdev/konsist/api/ext/list/KoBodyProviderListExtTest.kt
+++ b/lib/src/test/kotlin/com/lemonappdev/konsist/api/ext/list/KoBodyProviderListExtTest.kt
@@ -1,0 +1,81 @@
+package com.lemonappdev.konsist.api.ext.list
+
+import com.lemonappdev.konsist.api.provider.KoBodyProvider
+import io.mockk.every
+import io.mockk.mockk
+import org.amshove.kluent.shouldBeEqualTo
+import org.junit.jupiter.api.Test
+
+class KoBodyProviderListExtTest {
+    @Test
+    fun `withExpressionBody() returns declaration with expression body`() {
+        // given
+        val declaration1: KoBodyProvider = mockk {
+            every { hasExpressionBody } returns true
+        }
+        val declaration2: KoBodyProvider = mockk {
+            every { hasExpressionBody } returns false
+        }
+        val declarations = listOf(declaration1, declaration2)
+
+        // when
+        val sut = declarations.withExpressionBody()
+
+        // then
+        sut shouldBeEqualTo listOf(declaration1)
+    }
+
+    @Test
+    fun `withoutExpressionBody() returns declaration without expression body`() {
+        // given
+        val declaration1: KoBodyProvider = mockk {
+            every { hasExpressionBody } returns true
+        }
+        val declaration2: KoBodyProvider = mockk {
+            every { hasExpressionBody } returns false
+        }
+        val declarations = listOf(declaration1, declaration2)
+
+        // when
+        val sut = declarations.withoutExpressionBody()
+
+        // then
+        sut shouldBeEqualTo listOf(declaration2)
+    }
+
+    @Test
+    fun `withBlockBody() returns declaration with block body`() {
+        // given
+        val declaration1: KoBodyProvider = mockk {
+            every { hasBlockBody } returns true
+        }
+        val declaration2: KoBodyProvider = mockk {
+            every { hasBlockBody } returns false
+        }
+        val declarations = listOf(declaration1, declaration2)
+
+        // when
+        val sut = declarations.withBlockBody()
+
+        // then
+        sut shouldBeEqualTo listOf(declaration1)
+    }
+
+    @Test
+    fun `withoutBlockBody() returns declaration without block body`() {
+        // given
+        val declaration1: KoBodyProvider = mockk {
+            every { hasBlockBody } returns true
+        }
+        val declaration2: KoBodyProvider = mockk {
+            every { hasBlockBody } returns false
+        }
+        val declarations = listOf(declaration1, declaration2)
+
+        // when
+        val sut = declarations.withoutBlockBody()
+
+        // then
+        sut shouldBeEqualTo listOf(declaration2)
+    }
+}


### PR DESCRIPTION
We now have access to information whether the function has an expression or block body:

```kotlin
Konsist
   .scopeFromProduction()
   .functions()
   .assertTrue { it.hasBlockBody } 
```

We may also filtering the declarations by whether they have expression or block body:

```kotlin
Konsist
   .scopeFromProduction()
   .functions()
   .withBlockBody()
   .assertTrue { it.hasReturnType() } 
```