### PR TITLE
KON-203 Add `hasReturnValue` To KoFunctionDeclaration

### DIFF
--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/kofunction/KoFunctionDeclarationForKoReturnTypeProviderTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/kofunction/KoFunctionDeclarationForKoReturnTypeProviderTest.kt
@@ -98,6 +98,83 @@ class KoFunctionDeclarationForKoReturnTypeProviderTest {
         }
     }
 
+    @Test
+    fun `function-with-block-body-and-declared-type-has-string-return-value`() {
+        // given
+        val sut = getSnippetFile("function-with-block-body-and-declared-type-has-string-return-value")
+            .functions()
+            .first()
+
+        // then
+        sut.hasReturnValue shouldBeEqualTo true
+    }
+
+    @Test
+    fun `function-with-block-body-and-declared-type-has-unit-return-value`() {
+        // given
+        val sut = getSnippetFile("function-with-block-body-and-declared-type-has-unit-return-value")
+            .functions()
+            .first()
+
+        // then
+        sut.hasReturnValue shouldBeEqualTo false
+    }
+
+    @Test
+    fun `function-with-block-body-and-without-declared-type-has-unit-return-value`() {
+        // given
+        val sut = getSnippetFile("function-with-block-body-and-without-declared-type-has-unit-return-value")
+            .functions()
+            .first()
+
+        // then
+        sut.hasReturnValue shouldBeEqualTo false
+    }
+
+    @Test
+    fun `function-with-expression-body-and-declared-type-has-string-return-value`() {
+        // given
+        val sut = getSnippetFile("function-with-expression-body-and-declared-type-has-string-return-value")
+            .functions()
+            .first()
+
+        // then
+        sut.hasReturnValue shouldBeEqualTo true
+    }
+
+    @Test
+    fun `function-with-expression-body-and-declared-type-has-unit-return-value`() {
+        // given
+        val sut = getSnippetFile("function-with-expression-body-and-declared-type-has-unit-return-value")
+            .functions()
+            .first()
+
+        // then
+        sut.hasReturnValue shouldBeEqualTo false
+    }
+
+    @Test
+    fun `function-with-expression-body-and-without-declared-type-has-string-return-value`() {
+        // given
+        val sut = getSnippetFile("function-with-expression-body-and-without-declared-type-has-string-return-value")
+            .functions()
+            .first()
+
+        // then
+        sut.hasReturnValue shouldBeEqualTo true
+    }
+
+    @Test
+    fun `function-with-expression-body-and-without-declared-type-has-unit-return-value`() {
+        // given
+        val sut = getSnippetFile("function-with-expression-body-and-without-declared-type-has-unit-return-value")
+            .functions()
+            .first()
+
+        // then
+        sut.hasReturnValue shouldBeEqualTo true
+    }
+
     private fun getSnippetFile(fileName: String) =
         getSnippetKoScope("core/declaration/kofunction/snippet/forkoreturntypeprovider/", fileName)
 }

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/kofunction/snippet/forkoreturntypeprovider/function-with-block-body-and-declared-type-has-string-return-value.kttxt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/kofunction/snippet/forkoreturntypeprovider/function-with-block-body-and-declared-type-has-string-return-value.kttxt
@@ -1,0 +1,3 @@
+fun sampleFunction(): String {
+    return "some text"
+}

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/kofunction/snippet/forkoreturntypeprovider/function-with-block-body-and-declared-type-has-unit-return-value.kttxt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/kofunction/snippet/forkoreturntypeprovider/function-with-block-body-and-declared-type-has-unit-return-value.kttxt
@@ -1,0 +1,3 @@
+fun sampleFunction(): Unit {
+    println("some text")
+}

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/kofunction/snippet/forkoreturntypeprovider/function-with-block-body-and-without-declared-type-has-unit-return-value.kttxt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/kofunction/snippet/forkoreturntypeprovider/function-with-block-body-and-without-declared-type-has-unit-return-value.kttxt
@@ -1,0 +1,3 @@
+fun sampleFunction() {
+    println("some text")
+}

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/kofunction/snippet/forkoreturntypeprovider/function-with-expression-body-and-declared-type-has-string-return-value.kttxt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/kofunction/snippet/forkoreturntypeprovider/function-with-expression-body-and-declared-type-has-string-return-value.kttxt
@@ -1,0 +1,1 @@
+fun sampleFunction(): String = "some text"

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/kofunction/snippet/forkoreturntypeprovider/function-with-expression-body-and-declared-type-has-unit-return-value.kttxt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/kofunction/snippet/forkoreturntypeprovider/function-with-expression-body-and-declared-type-has-unit-return-value.kttxt
@@ -1,0 +1,1 @@
+fun sampleFunction(): Unit = println("some text")

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/kofunction/snippet/forkoreturntypeprovider/function-with-expression-body-and-without-declared-type-has-string-return-value.kttxt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/kofunction/snippet/forkoreturntypeprovider/function-with-expression-body-and-without-declared-type-has-string-return-value.kttxt
@@ -1,0 +1,1 @@
+fun sampleFunction() = "some text"

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/kofunction/snippet/forkoreturntypeprovider/function-with-expression-body-and-without-declared-type-has-unit-return-value.kttxt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/kofunction/snippet/forkoreturntypeprovider/function-with-expression-body-and-without-declared-type-has-unit-return-value.kttxt
@@ -1,0 +1,1 @@
+fun sampleFunction() = println("some text")

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/api/ext/list/KoReturnTypeProviderListExt.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/api/ext/list/KoReturnTypeProviderListExt.kt
@@ -2,6 +2,7 @@ package com.lemonappdev.konsist.api.ext.list
 
 import com.lemonappdev.konsist.api.declaration.KoTypeDeclaration
 import com.lemonappdev.konsist.api.provider.KoReturnTypeProvider
+import com.lemonappdev.konsist.api.provider.KoTopLevelProvider
 import kotlin.reflect.KClass
 
 /**
@@ -37,6 +38,21 @@ fun <T : KoReturnTypeProvider> List<T>.withoutReturnType(vararg names: String): 
         else -> names.none { type -> it.returnType?.name == type }
     }
 }
+
+/**
+ * List containing declarations with non-Unit return values, which may or may not have explicitly defined return types.
+ *
+ * @return A list containing declarations with the return value other than `Unit`.
+ */
+fun <T : KoReturnTypeProvider> List<T>.withReturnValue(): List<T> = filter { it.hasReturnValue }
+
+/**
+ * List containing declarations with the `Unit` return value, which may or may not have explicitly defined return types.
+ *
+ * @return A list containing declarations with the `Unit` return value.
+ */
+fun <T : KoReturnTypeProvider> List<T>.withoutReturnValue(): List<T> = filterNot { it.hasReturnValue }
+
 
 /**
  * List containing declarations with the specified return type.

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/api/ext/list/KoReturnTypeProviderListExt.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/api/ext/list/KoReturnTypeProviderListExt.kt
@@ -2,7 +2,6 @@ package com.lemonappdev.konsist.api.ext.list
 
 import com.lemonappdev.konsist.api.declaration.KoTypeDeclaration
 import com.lemonappdev.konsist.api.provider.KoReturnTypeProvider
-import com.lemonappdev.konsist.api.provider.KoTopLevelProvider
 import kotlin.reflect.KClass
 
 /**
@@ -52,7 +51,6 @@ fun <T : KoReturnTypeProvider> List<T>.withReturnValue(): List<T> = filter { it.
  * @return A list containing declarations with the `Unit` return value.
  */
 fun <T : KoReturnTypeProvider> List<T>.withoutReturnValue(): List<T> = filterNot { it.hasReturnValue }
-
 
 /**
  * List containing declarations with the specified return type.

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/api/provider/KoReturnTypeProvider.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/api/provider/KoReturnTypeProvider.kt
@@ -22,7 +22,7 @@ interface KoReturnTypeProvider : KoBaseProvider {
      *
      *    Example:
      *    ```kotlin
-     *    fun sampleFunction { "some text" } // Returns false
+     *    fun sampleFunction() { "some text" } // Returns false
      *    ```
      *
      * 2) If the declaration has an expression body, [hasReturnValue] always returns `true`.

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/api/provider/KoReturnTypeProvider.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/api/provider/KoReturnTypeProvider.kt
@@ -15,24 +15,25 @@ interface KoReturnTypeProvider : KoBaseProvider {
     /**
      * Indicates whether a declaration has a non-`Unit` return value.
      *
-     * If a declaration explicitly specifies a return type, [hasReturnValue] returns true only if the declared type is not `Unit`.
+     * - If a declaration explicitly specifies a return type, [hasReturnValue] returns true only if the declared type is not `Unit`.
      *
-     * For declarations without an explicit return type:
-     * 1) If the declaration has a block body, [hasReturnValue] always returns `false`.
+     * - For declarations without an explicit return type:
+     *      1) If the declaration has a block body, [hasReturnValue] always returns `false`.
      *
-     *    Example:
-     *    ```kotlin
-     *    fun sampleFunction() { "some text" } // Returns false
-     *    ```
+     *          Example:
+     *          ```kotlin
+     *          fun sampleFunction() { "some text" } // hasReturnValue == false
+     *          ```
      *
-     * 2) If the declaration has an expression body, [hasReturnValue] always returns `true`.
+     *      2) If the declaration has an expression body, [hasReturnValue] always returns `true`.
      *
-     *    Examples:
-     *    ```kotlin
-     *    fun sampleFunction1() = SampleClass()  // Returns true
+     *          Examples:
+     *          ```kotlin
+     *          fun sampleFunction1() = SampleClass()  // hasReturnValue == true
      *
-     *    fun sampleFunction2() = println("some text") // Returns true, even though it returns an `Unit`
-     *    ```
+     *          fun sampleFunction2() = println("some text") // hasReturnValue == true, because Konsist is not able to
+     *                                                       // determine value of the "println("some text")" expression
+     *       ```
      */
     val hasReturnValue: Boolean
 

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/api/provider/KoReturnTypeProvider.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/api/provider/KoReturnTypeProvider.kt
@@ -13,7 +13,26 @@ interface KoReturnTypeProvider : KoBaseProvider {
     val returnType: KoTypeDeclaration?
 
     /**
-     * Whether declaration has a return value other than `Unit`.
+     * Indicates whether a declaration has a non-`Unit` return value.
+     *
+     * If a declaration explicitly specifies a return type, [hasReturnValue] returns true only if the declared type is not `Unit`.
+     *
+     * For declarations without an explicit return type:
+     * 1) If the declaration has a block body, [hasReturnValue] always returns `false`.
+     *
+     *    Example:
+     *    ```kotlin
+     *    fun sampleFunction { "some text" } // Returns false
+     *    ```
+     *
+     * 2) If the declaration has an expression body, [hasReturnValue] always returns `true`.
+     *
+     *    Examples:
+     *    ```kotlin
+     *    fun sampleFunction1() = SampleClass()  // Returns true
+     *
+     *    fun sampleFunction2() = println("some text") // Returns true, even though it returns an `Unit`
+     *    ```
      */
     val hasReturnValue: Boolean
 

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/api/provider/KoReturnTypeProvider.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/api/provider/KoReturnTypeProvider.kt
@@ -13,6 +13,11 @@ interface KoReturnTypeProvider : KoBaseProvider {
     val returnType: KoTypeDeclaration?
 
     /**
+     * Whether declaration has a return value other than `Unit`.
+     */
+    val hasReturnValue: Boolean
+
+    /**
      * Whether this declaration has a return type.
      */
     @Deprecated("Will be removed in v1.0.0", ReplaceWith("hasReturnType()"))

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/KoReturnTypeProviderCore.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/KoReturnTypeProviderCore.kt
@@ -34,7 +34,7 @@ internal interface KoReturnTypeProviderCore :
             1) fun sampleFunction1() = println("some text") // returns Unit
             2) fun sampleFunction2() = SampleClass() // returns SampleClass,
             so we always return true.
-            */
+             */
             true
         }
 

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/KoReturnTypeProviderCore.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/KoReturnTypeProviderCore.kt
@@ -6,6 +6,7 @@ import com.lemonappdev.konsist.core.util.ReceiverUtil
 import org.jetbrains.kotlin.psi.KtFunction
 import org.jetbrains.kotlin.psi.KtTypeReference
 import org.jetbrains.kotlin.psi.psiUtil.isExtensionDeclaration
+import sun.reflect.generics.tree.ReturnType
 import kotlin.reflect.KClass
 
 internal interface KoReturnTypeProviderCore :
@@ -21,6 +22,16 @@ internal interface KoReturnTypeProviderCore :
 
     override val returnType: KoTypeDeclaration?
         get() = ReceiverUtil.getType(getTypeReferences(), ktFunction.isExtensionDeclaration(), this)
+
+    override val hasReturnValue: Boolean
+        get() {
+            val hasBlockBody = ktFunction.hasBlockBody()
+            return if(!hasBlockBody) {
+                ktFunction.children.filterIsInstance<ReturnType>().isNotEmpty()
+            } else {
+                returnType?.name != "Unit"
+            }
+        }
 
     @Deprecated("Will be removed in v1.0.0", ReplaceWith("hasReturnType()"))
     override val hasReturnType: Boolean

--- a/lib/src/test/kotlin/com/lemonappdev/konsist/api/ext/list/KoReturnTypeProviderListExtTest.kt
+++ b/lib/src/test/kotlin/com/lemonappdev/konsist/api/ext/list/KoReturnTypeProviderListExtTest.kt
@@ -34,6 +34,42 @@ class KoReturnTypeProviderListExtTest {
     }
 
     @Test
+    fun `withReturnValue() returns declaration with return value other than Unit type`() {
+        // given
+        val declaration1: KoReturnTypeProvider = mockk {
+            every { hasReturnValue } returns true
+        }
+        val declaration2: KoReturnTypeProvider = mockk {
+            every { hasReturnValue } returns false
+        }
+        val declarations = listOf(declaration1, declaration2)
+
+        // when
+        val sut = declarations.withReturnValue()
+
+        // then
+        sut shouldBeEqualTo listOf(declaration1)
+    }
+
+    @Test
+    fun `withoutReturnValue() returns declaration with Unit return value`() {
+        // given
+        val declaration1: KoReturnTypeProvider = mockk {
+            every { hasReturnValue } returns true
+        }
+        val declaration2: KoReturnTypeProvider = mockk {
+            every { hasReturnValue } returns false
+        }
+        val declarations = listOf(declaration1, declaration2)
+
+        // when
+        val sut = declarations.withoutReturnValue()
+
+        // then
+        sut shouldBeEqualTo listOf(declaration2)
+    }
+
+    @Test
     fun `withReturnType() returns declaration with any return type`() {
         // given
         val declaration1: KoReturnTypeProvider = mockk {


### PR DESCRIPTION
We may call `hasReturnValue` on function declaration to check if has non-Unit return value (but this function doesn't have to explicitly specifies a return type).

E.g.
- with block body
	-  for `fun sampleFunction() { "some text" }`  - `hasReturnValue` returns `false`
	- 	for `fun sampleFunction(): Unit { "some text" }`  - `hasReturnValue` returns `false`
	-  for `fun sampleFunction(): String { return "some text" }`  - `hasReturnValue` returns `true`
- with expression body
	-  for `fun sampleFunction() = SampleClass()`  - `hasReturnValue` returns `true`
	-  for `fun sampleFunction() = println("some text")`  - `hasReturnValue` returns `true` - **it is an exception!**
	-  for `fun sampleFunction(): SampleClass = SampleClass()`  - `hasReturnValue` returns `true`
	-  for `fun sampleFunction(): Unit = println("some text")`  - `hasReturnValue` returns `false` 
