### PR TITLE
KON-257 Add assert architecture on list of files

### DIFF
--- a/lib/src/apiTest/kotlin/com/lemonappdev/konsist/architecture/assertarchitecture/architecture1/Architecture1Test.kt
+++ b/lib/src/apiTest/kotlin/com/lemonappdev/konsist/architecture/assertarchitecture/architecture1/Architecture1Test.kt
@@ -14,9 +14,20 @@ class Architecture1Test {
         Konsist.scopeFromDirectory("lib/src/apiTest/kotlin/com/lemonappdev/konsist/architecture/assertarchitecture/architecture1/project")
 
     @Test
-    fun `passes when dependency is set that layers are independent`() {
+    fun `passes when dependency is set that layers are independent (scope)`() {
         // then
         scope
+            .assertArchitecture {
+                domain.dependsOnNothing()
+                presentation.dependsOnNothing()
+            }
+    }
+
+    @Test
+    fun `passes when dependency is set that layers are independent (files)`() {
+        // then
+        scope
+            .files
             .assertArchitecture {
                 domain.dependsOnNothing()
                 presentation.dependsOnNothing()

--- a/lib/src/apiTest/kotlin/com/lemonappdev/konsist/architecture/assertarchitecture/architecture1/Architecture1Test.kt
+++ b/lib/src/apiTest/kotlin/com/lemonappdev/konsist/architecture/assertarchitecture/architecture1/Architecture1Test.kt
@@ -55,6 +55,8 @@ class Architecture1Test {
         }
 
         // then
-        scope.files.assertArchitecture(koArchitecture)
+        scope
+            .files
+            .assertArchitecture(koArchitecture)
     }
 }

--- a/lib/src/apiTest/kotlin/com/lemonappdev/konsist/architecture/assertarchitecture/architecture1/Architecture1Test.kt
+++ b/lib/src/apiTest/kotlin/com/lemonappdev/konsist/architecture/assertarchitecture/architecture1/Architecture1Test.kt
@@ -35,7 +35,7 @@ class Architecture1Test {
     }
 
     @Test
-    fun `passes when dependency is set that layers are independent when architecture is passed as parameter`() {
+    fun `passes when dependency is set that layers are independent when architecture is passed as parameter (scope)`() {
         // given
         val koArchitecture = architecture {
             domain.dependsOnNothing()
@@ -44,5 +44,17 @@ class Architecture1Test {
 
         // then
         scope.assertArchitecture(koArchitecture)
+    }
+
+    @Test
+    fun `passes when dependency is set that layers are independent when architecture is passed as parameter (files)`() {
+        // given
+        val koArchitecture = architecture {
+            domain.dependsOnNothing()
+            presentation.dependsOnNothing()
+        }
+
+        // then
+        scope.files.assertArchitecture(koArchitecture)
     }
 }

--- a/lib/src/apiTest/kotlin/com/lemonappdev/konsist/architecture/assertarchitecture/architecture2/Architecture2Test.kt
+++ b/lib/src/apiTest/kotlin/com/lemonappdev/konsist/architecture/assertarchitecture/architecture2/Architecture2Test.kt
@@ -23,7 +23,7 @@ class Architecture2Test {
     )
 
     @Test
-    fun `passes when dependency is set that presentation layer is depend on domain layer`() {
+    fun `passes when dependency is set that presentation layer is depend on domain layer (scope)`() {
         // then
         scope
             .assertArchitecture {
@@ -33,7 +33,18 @@ class Architecture2Test {
     }
 
     @Test
-    fun `passes when dependency is set that presentation layer is depend on domain layer and architecture is passed as parameter`() {
+    fun `passes when dependency is set that presentation layer is depend on domain layer (files)`() {
+        // then
+        scope
+            .files
+            .assertArchitecture {
+                domain.dependsOnNothing()
+                presentation.dependsOn(domain)
+            }
+    }
+
+    @Test
+    fun `passes when dependency is set that presentation layer is depend on domain layer and architecture is passed as parameter (scope)`() {
         // given
         val architecture = architecture {
             domain.dependsOnNothing()
@@ -45,7 +56,19 @@ class Architecture2Test {
     }
 
     @Test
-    fun `fails when dependency is set that domain layer is depend on presentation layer`() {
+    fun `passes when dependency is set that presentation layer is depend on domain layer and architecture is passed as parameter (files)`() {
+        // given
+        val architecture = architecture {
+            domain.dependsOnNothing()
+            presentation.dependsOn(domain)
+        }
+
+        // then
+        scope.files.assertArchitecture(architecture)
+    }
+
+    @Test
+    fun `fails when dependency is set that domain layer is depend on presentation layer (scope)`() {
         // then
         try {
             scope.assertArchitecture {
@@ -67,7 +90,29 @@ class Architecture2Test {
     }
 
     @Test
-    fun `fails when dependency is set that domain layer is depend on presentation layer and architecture is passed as parameter`() {
+    fun `fails when dependency is set that domain layer is depend on presentation layer (files)`() {
+        // then
+        try {
+            scope.files.assertArchitecture {
+                presentation.dependsOnNothing()
+                domain.dependsOn(presentation)
+            }
+        } catch (e: KoCheckFailedException) {
+            e.message?.shouldBeEqualTo(
+                "'fails when dependency is set that domain layer is depend on presentation layer' test has failed.\n" +
+                        "Presentation depends on nothing assertion failure:\n" +
+                        "A file $rootPath/lib/src/apiTest/kotlin/com/lemonappdev/konsist/architecture/assertarchitecture" +
+                        "/architecture2/project/presentation/sample/PresentationThirdClass.kt in a Presentation layer " +
+                        "depends on Domain layer, imports:\n" +
+                        "\tcom.lemonappdev.konsist.architecture.assertarchitecture.architecture2.project.domain." +
+                        "DomainFirstClass ($rootPath/lib/src/apiTest/kotlin/com/lemonappdev/konsist/architecture/" +
+                        "assertarchitecture/architecture2/project/presentation/sample/PresentationThirdClass.kt:3:1)",
+            ) ?: throw e
+        }
+    }
+
+    @Test
+    fun `fails when dependency is set that domain layer is depend on presentation layer and architecture is passed as parameter (scope)`() {
         // given
         val architecture = architecture {
             presentation.dependsOnNothing()
@@ -88,6 +133,32 @@ class Architecture2Test {
                     "\tcom.lemonappdev.konsist.architecture.assertarchitecture.architecture2.project.domain." +
                     "DomainFirstClass ($rootPath/lib/src/apiTest/kotlin/com/lemonappdev/konsist/architecture/" +
                     "assertarchitecture/architecture2/project/presentation/sample/PresentationThirdClass.kt:3:1)",
+            ) ?: throw e
+        }
+    }
+
+    @Test
+    fun `fails when dependency is set that domain layer is depend on presentation layer and architecture is passed as parameter (files)`() {
+        // given
+        val architecture = architecture {
+            presentation.dependsOnNothing()
+            domain.dependsOn(presentation)
+        }
+
+        // then
+        try {
+            scope.files.assertArchitecture(architecture)
+        } catch (e: KoCheckFailedException) {
+            e.message?.shouldBeEqualTo(
+                "'fails when dependency is set that domain layer is depend on presentation layer and " +
+                        "architecture is passed as parameter' test has failed.\n" +
+                        "Presentation depends on nothing assertion failure:\n" +
+                        "A file $rootPath/lib/src/apiTest/kotlin/com/lemonappdev/konsist/architecture/assertarchitecture" +
+                        "/architecture2/project/presentation/sample/PresentationThirdClass.kt in a Presentation layer " +
+                        "depends on Domain layer, imports:\n" +
+                        "\tcom.lemonappdev.konsist.architecture.assertarchitecture.architecture2.project.domain." +
+                        "DomainFirstClass ($rootPath/lib/src/apiTest/kotlin/com/lemonappdev/konsist/architecture/" +
+                        "assertarchitecture/architecture2/project/presentation/sample/PresentationThirdClass.kt:3:1)",
             ) ?: throw e
         }
     }

--- a/lib/src/apiTest/kotlin/com/lemonappdev/konsist/architecture/assertarchitecture/architecture2/Architecture2Test.kt
+++ b/lib/src/apiTest/kotlin/com/lemonappdev/konsist/architecture/assertarchitecture/architecture2/Architecture2Test.kt
@@ -44,7 +44,7 @@ class Architecture2Test {
     }
 
     @Test
-    fun `passes when dependency is set that presentation layer is depend on domain layer and architecture is passed as parameter (scope)`() {
+    fun `passes when dependency is set to presentation layer depends on domain layer and arch is passed as parameter (scope)`() {
         // given
         val architecture = architecture {
             domain.dependsOnNothing()
@@ -56,7 +56,7 @@ class Architecture2Test {
     }
 
     @Test
-    fun `passes when dependency is set that presentation layer is depend on domain layer and architecture is passed as parameter (files)`() {
+    fun `passes when dependency is set to presentation layer depends on domain layer and arch is passed as parameter (files)`() {
         // given
         val architecture = architecture {
             domain.dependsOnNothing()
@@ -64,7 +64,9 @@ class Architecture2Test {
         }
 
         // then
-        scope.files.assertArchitecture(architecture)
+        scope
+            .files
+            .assertArchitecture(architecture)
     }
 
     @Test
@@ -77,7 +79,8 @@ class Architecture2Test {
             }
         } catch (e: KoCheckFailedException) {
             e.message?.shouldBeEqualTo(
-                "'fails when dependency is set that domain layer is depend on presentation layer' test has failed.\n" +
+                "'fails when dependency is set that domain layer is depend on presentation layer' " +
+                    "test has failed.\n" +
                     "Presentation depends on nothing assertion failure:\n" +
                     "A file $rootPath/lib/src/apiTest/kotlin/com/lemonappdev/konsist/architecture/assertarchitecture" +
                     "/architecture2/project/presentation/sample/PresentationThirdClass.kt in a Presentation layer " +
@@ -93,24 +96,28 @@ class Architecture2Test {
     fun `fails when dependency is set that domain layer is depend on presentation layer (files)`() {
         // then
         try {
-            scope.files.assertArchitecture {
-                presentation.dependsOnNothing()
-                domain.dependsOn(presentation)
-            }
+            scope
+                .files
+                .assertArchitecture {
+                    presentation.dependsOnNothing()
+                    domain.dependsOn(presentation)
+                }
         } catch (e: KoCheckFailedException) {
             e.message?.shouldBeEqualTo(
-                "'fails when dependency is set that domain layer is depend on presentation layer' test has failed.\n" +
-                        "Presentation depends on nothing assertion failure:\n" +
-                        "A file $rootPath/lib/src/apiTest/kotlin/com/lemonappdev/konsist/architecture/assertarchitecture" +
-                        "/architecture2/project/presentation/sample/PresentationThirdClass.kt in a Presentation layer " +
-                        "depends on Domain layer, imports:\n" +
-                        "\tcom.lemonappdev.konsist.architecture.assertarchitecture.architecture2.project.domain." +
-                        "DomainFirstClass ($rootPath/lib/src/apiTest/kotlin/com/lemonappdev/konsist/architecture/" +
-                        "assertarchitecture/architecture2/project/presentation/sample/PresentationThirdClass.kt:3:1)",
+                "'fails when dependency is set that domain layer is depend on presentation layer' " +
+                    "test has failed.\n" +
+                    "Presentation depends on nothing assertion failure:\n" +
+                    "A file $rootPath/lib/src/apiTest/kotlin/com/lemonappdev/konsist/architecture/assertarchitecture" +
+                    "/architecture2/project/presentation/sample/PresentationThirdClass.kt in a Presentation layer " +
+                    "depends on Domain layer, imports:\n" +
+                    "\tcom.lemonappdev.konsist.architecture.assertarchitecture.architecture2.project.domain." +
+                    "DomainFirstClass ($rootPath/lib/src/apiTest/kotlin/com/lemonappdev/konsist/architecture/" +
+                    "assertarchitecture/architecture2/project/presentation/sample/PresentationThirdClass.kt:3:1)",
             ) ?: throw e
         }
     }
 
+    @Suppress("detekt.MaxLineLength")
     @Test
     fun `fails when dependency is set that domain layer is depend on presentation layer and architecture is passed as parameter (scope)`() {
         // given
@@ -137,6 +144,7 @@ class Architecture2Test {
         }
     }
 
+    @Suppress("detekt.MaxLineLength")
     @Test
     fun `fails when dependency is set that domain layer is depend on presentation layer and architecture is passed as parameter (files)`() {
         // given
@@ -147,18 +155,20 @@ class Architecture2Test {
 
         // then
         try {
-            scope.files.assertArchitecture(architecture)
+            scope
+                .files
+                .assertArchitecture(architecture)
         } catch (e: KoCheckFailedException) {
             e.message?.shouldBeEqualTo(
                 "'fails when dependency is set that domain layer is depend on presentation layer and " +
-                        "architecture is passed as parameter' test has failed.\n" +
-                        "Presentation depends on nothing assertion failure:\n" +
-                        "A file $rootPath/lib/src/apiTest/kotlin/com/lemonappdev/konsist/architecture/assertarchitecture" +
-                        "/architecture2/project/presentation/sample/PresentationThirdClass.kt in a Presentation layer " +
-                        "depends on Domain layer, imports:\n" +
-                        "\tcom.lemonappdev.konsist.architecture.assertarchitecture.architecture2.project.domain." +
-                        "DomainFirstClass ($rootPath/lib/src/apiTest/kotlin/com/lemonappdev/konsist/architecture/" +
-                        "assertarchitecture/architecture2/project/presentation/sample/PresentationThirdClass.kt:3:1)",
+                    "architecture is passed as parameter' test has failed.\n" +
+                    "Presentation depends on nothing assertion failure:\n" +
+                    "A file $rootPath/lib/src/apiTest/kotlin/com/lemonappdev/konsist/architecture/assertarchitecture" +
+                    "/architecture2/project/presentation/sample/PresentationThirdClass.kt in a Presentation layer " +
+                    "depends on Domain layer, imports:\n" +
+                    "\tcom.lemonappdev.konsist.architecture.assertarchitecture.architecture2.project.domain." +
+                    "DomainFirstClass ($rootPath/lib/src/apiTest/kotlin/com/lemonappdev/konsist/architecture/" +
+                    "assertarchitecture/architecture2/project/presentation/sample/PresentationThirdClass.kt:3:1)",
             ) ?: throw e
         }
     }

--- a/lib/src/apiTest/kotlin/com/lemonappdev/konsist/architecture/assertarchitecture/architecture3/Architecture3Test.kt
+++ b/lib/src/apiTest/kotlin/com/lemonappdev/konsist/architecture/assertarchitecture/architecture3/Architecture3Test.kt
@@ -19,7 +19,7 @@ class Architecture3Test {
     )
 
     @Test
-    fun `passes when dependency is set that presentation and domain layers are dependent on each other`() {
+    fun `passes when dependency is set that presentation and domain layers are dependent on each other (scope)`() {
         // then
         scope
             .assertArchitecture {
@@ -29,7 +29,18 @@ class Architecture3Test {
     }
 
     @Test
-    fun `passes when dependency is set that two layers are dependent on each other and architecture is passed as parameter`() {
+    fun `passes when dependency is set that presentation and domain layers are dependent on each other (files)`() {
+        // then
+        scope
+            .files
+            .assertArchitecture {
+                domain.dependsOn(presentation)
+                presentation.dependsOn(domain)
+            }
+    }
+
+    @Test
+    fun `passes when dependency is set that two layers are dependent on each other and architecture is passed as parameter (scope)`() {
         // given
         val architecture = architecture {
             domain.dependsOn(presentation)
@@ -38,5 +49,17 @@ class Architecture3Test {
 
         // then
         scope.assertArchitecture(architecture)
+    }
+
+    @Test
+    fun `passes when dependency is set that two layers are dependent on each other and architecture is passed as parameter (files)`() {
+        // given
+        val architecture = architecture {
+            domain.dependsOn(presentation)
+            presentation.dependsOn(domain)
+        }
+
+        // then
+        scope.files.assertArchitecture(architecture)
     }
 }

--- a/lib/src/apiTest/kotlin/com/lemonappdev/konsist/architecture/assertarchitecture/architecture3/Architecture3Test.kt
+++ b/lib/src/apiTest/kotlin/com/lemonappdev/konsist/architecture/assertarchitecture/architecture3/Architecture3Test.kt
@@ -60,6 +60,8 @@ class Architecture3Test {
         }
 
         // then
-        scope.files.assertArchitecture(architecture)
+        scope
+            .files
+            .assertArchitecture(architecture)
     }
 }

--- a/lib/src/apiTest/kotlin/com/lemonappdev/konsist/architecture/assertarchitecture/architecture4/Architecture4Test.kt
+++ b/lib/src/apiTest/kotlin/com/lemonappdev/konsist/architecture/assertarchitecture/architecture4/Architecture4Test.kt
@@ -24,7 +24,7 @@ class Architecture4Test {
     )
 
     @Test
-    fun `passes when dependency is set that presentation and data layers are depend on domain layer`() {
+    fun `passes when dependency is set that presentation and data layers are depend on domain layer (scope)`() {
         // then
         scope
             .assertArchitecture {
@@ -35,7 +35,19 @@ class Architecture4Test {
     }
 
     @Test
-    fun `passes when dependency is set correctly and architecture is passed as parameter`() {
+    fun `passes when dependency is set that presentation and data layers are depend on domain layer (files)`() {
+        // then
+        scope
+            .files
+            .assertArchitecture {
+                domain.dependsOnNothing()
+                presentation.dependsOn(domain)
+                data.dependsOn(domain)
+            }
+    }
+
+    @Test
+    fun `passes when dependency is set correctly and architecture is passed as parameter (scope)`() {
         // given
         val architecture = architecture {
             domain.dependsOnNothing()
@@ -48,7 +60,22 @@ class Architecture4Test {
     }
 
     @Test
-    fun `fails when bad dependency is set`() {
+    fun `passes when dependency is set correctly and architecture is passed as parameter (files)`() {
+        // given
+        val architecture = architecture {
+            domain.dependsOnNothing()
+            presentation.dependsOn(domain)
+            data.dependsOn(domain)
+        }
+
+        // then
+        scope
+            .files
+            .assertArchitecture(architecture)
+    }
+
+    @Test
+    fun `fails when bad dependency is set (scope)`() {
         // then
         try {
             scope
@@ -59,14 +86,33 @@ class Architecture4Test {
                 }
         } catch (e: KoCheckFailedException) {
             assertSoftly {
-                e.message?.shouldContain("'fails when bad dependency is set' test has failed.\n")
+//                e.message?.shouldContain("'fails when bad dependency is set' test has failed.\n")
                 e.message?.shouldContain("Presentation depends on Data assertion failure:\n")
             }
         }
     }
 
     @Test
-    fun `fails when bad dependency is set and architecture is passed as parameter`() {
+    fun `fails when bad dependency is set (files)`() {
+        // then
+        try {
+            scope
+                .files
+                .assertArchitecture {
+                    data.dependsOnNothing()
+                    presentation.dependsOn(data)
+                    domain.dependsOn(data)
+                }
+        } catch (e: KoCheckFailedException) {
+            assertSoftly {
+//                e.message?.shouldContain("'fails when bad dependency is set' test has failed.\n")
+                e.message?.shouldContain("Presentation depends on Data assertion failure:\n")
+            }
+        }
+    }
+
+    @Test
+    fun `fails when bad dependency is set and architecture is passed as parameter (scope)`() {
         // given
         val architecture = architecture {
             data.dependsOnNothing()
@@ -80,7 +126,29 @@ class Architecture4Test {
                 .assertArchitecture(architecture)
         } catch (e: KoCheckFailedException) {
             assertSoftly {
-                e.message?.shouldContain("'fails when bad dependency is set and architecture is passed as parameter' test has failed.\n")
+//                e.message?.shouldContain("'fails when bad dependency is set and architecture is passed as parameter' test has failed.\n")
+                e.message?.shouldContain("Presentation depends on Data assertion failure:\n")
+            }
+        }
+    }
+
+    @Test
+    fun `fails when bad dependency is set and architecture is passed as parameter (files)`() {
+        // given
+        val architecture = architecture {
+            data.dependsOnNothing()
+            presentation.dependsOn(data)
+            domain.dependsOn(data)
+        }
+
+        // then
+        try {
+            scope
+                .files
+                .assertArchitecture(architecture)
+        } catch (e: KoCheckFailedException) {
+            assertSoftly {
+//                e.message?.shouldContain("'fails when bad dependency is set and architecture is passed as parameter' test has failed.\n")
                 e.message?.shouldContain("Presentation depends on Data assertion failure:\n")
             }
         }

--- a/lib/src/apiTest/kotlin/com/lemonappdev/konsist/architecture/assertarchitecture/architecture4/Architecture4Test.kt
+++ b/lib/src/apiTest/kotlin/com/lemonappdev/konsist/architecture/assertarchitecture/architecture4/Architecture4Test.kt
@@ -86,7 +86,7 @@ class Architecture4Test {
                 }
         } catch (e: KoCheckFailedException) {
             assertSoftly {
-//                e.message?.shouldContain("'fails when bad dependency is set' test has failed.\n")
+                e.message?.shouldContain("'fails when bad dependency is set (scope)' test has failed.\n")
                 e.message?.shouldContain("Presentation depends on Data assertion failure:\n")
             }
         }
@@ -105,7 +105,7 @@ class Architecture4Test {
                 }
         } catch (e: KoCheckFailedException) {
             assertSoftly {
-//                e.message?.shouldContain("'fails when bad dependency is set' test has failed.\n")
+                e.message?.shouldContain("'fails when bad dependency is set (files)' test has failed.\n")
                 e.message?.shouldContain("Presentation depends on Data assertion failure:\n")
             }
         }
@@ -126,7 +126,9 @@ class Architecture4Test {
                 .assertArchitecture(architecture)
         } catch (e: KoCheckFailedException) {
             assertSoftly {
-//                e.message?.shouldContain("'fails when bad dependency is set and architecture is passed as parameter' test has failed.\n")
+                e.message?.shouldContain(
+                    "'fails when bad dependency is set and architecture is passed as parameter (scope)' test has failed.\n"
+                )
                 e.message?.shouldContain("Presentation depends on Data assertion failure:\n")
             }
         }
@@ -148,7 +150,9 @@ class Architecture4Test {
                 .assertArchitecture(architecture)
         } catch (e: KoCheckFailedException) {
             assertSoftly {
-//                e.message?.shouldContain("'fails when bad dependency is set and architecture is passed as parameter' test has failed.\n")
+                e.message?.shouldContain(
+                    "'fails when bad dependency is set and architecture is passed as parameter (files)' test has failed.\n"
+                )
                 e.message?.shouldContain("Presentation depends on Data assertion failure:\n")
             }
         }

--- a/lib/src/apiTest/kotlin/com/lemonappdev/konsist/architecture/assertarchitecture/architecture4/Architecture4Test.kt
+++ b/lib/src/apiTest/kotlin/com/lemonappdev/konsist/architecture/assertarchitecture/architecture4/Architecture4Test.kt
@@ -127,7 +127,7 @@ class Architecture4Test {
         } catch (e: KoCheckFailedException) {
             assertSoftly {
                 e.message?.shouldContain(
-                    "'fails when bad dependency is set and architecture is passed as parameter (scope)' test has failed.\n"
+                    "'fails when bad dependency is set and architecture is passed as parameter (scope)' test has failed.\n",
                 )
                 e.message?.shouldContain("Presentation depends on Data assertion failure:\n")
             }
@@ -151,7 +151,7 @@ class Architecture4Test {
         } catch (e: KoCheckFailedException) {
             assertSoftly {
                 e.message?.shouldContain(
-                    "'fails when bad dependency is set and architecture is passed as parameter (files)' test has failed.\n"
+                    "'fails when bad dependency is set and architecture is passed as parameter (files)' test has failed.\n",
                 )
                 e.message?.shouldContain("Presentation depends on Data assertion failure:\n")
             }

--- a/lib/src/apiTest/kotlin/com/lemonappdev/konsist/architecture/assertarchitecture/architecture5/Architecture5Test.kt
+++ b/lib/src/apiTest/kotlin/com/lemonappdev/konsist/architecture/assertarchitecture/architecture5/Architecture5Test.kt
@@ -21,7 +21,7 @@ class Architecture5Test {
     )
 
     @Test
-    fun `passes when good dependency is set`() {
+    fun `passes when good dependency is set (scope)`() {
         // then
         scope
             .assertArchitecture {
@@ -33,7 +33,20 @@ class Architecture5Test {
     }
 
     @Test
-    fun `passes when good dependency is set and architecture is passed as parameter`() {
+    fun `passes when good dependency is set (files)`() {
+        // then
+        scope
+            .files
+            .assertArchitecture {
+                presentation.dependsOn(application)
+                application.dependsOn(domain, infrastructure)
+                domain.dependsOn(infrastructure)
+                infrastructure.dependsOnNothing()
+            }
+    }
+
+    @Test
+    fun `passes when good dependency is set and architecture is passed as parameter (scope)`() {
         // given
         val architecture = architecture {
             presentation.dependsOn(application)
@@ -48,7 +61,23 @@ class Architecture5Test {
     }
 
     @Test
-    fun `fails when bad dependency is set`() {
+    fun `passes when good dependency is set and architecture is passed as parameter (files)`() {
+        // given
+        val architecture = architecture {
+            presentation.dependsOn(application)
+            application.dependsOn(domain, infrastructure)
+            domain.dependsOn(infrastructure)
+            infrastructure.dependsOnNothing()
+        }
+
+        // then
+        scope
+            .files
+            .assertArchitecture(architecture)
+    }
+
+    @Test
+    fun `fails when bad dependency is set (scope)`() {
         // given
         val sut = {
             scope
@@ -65,7 +94,25 @@ class Architecture5Test {
     }
 
     @Test
-    fun `fails when bad dependency is set and architecture is passed as parameter`() {
+    fun `fails when bad dependency is set (files)`() {
+        // given
+        val sut = {
+            scope
+                .files
+                .assertArchitecture {
+                    presentation.dependsOn(application, infrastructure)
+                    application.dependsOn(infrastructure)
+                    domain.dependsOn(infrastructure)
+                    infrastructure.dependsOnNothing()
+                }
+        }
+
+        // then
+        sut shouldThrow KoCheckFailedException::class
+    }
+
+    @Test
+    fun `fails when bad dependency is set and architecture is passed as parameter (scope)`() {
         // given
         val architecture = architecture {
             presentation.dependsOn(application, infrastructure)
@@ -76,6 +123,24 @@ class Architecture5Test {
 
         val sut = {
             scope.assertArchitecture(architecture)
+        }
+
+        // then
+        sut shouldThrow KoCheckFailedException::class
+    }
+
+    @Test
+    fun `fails when bad dependency is set and architecture is passed as parameter (files)`() {
+        // given
+        val architecture = architecture {
+            presentation.dependsOn(application, infrastructure)
+            application.dependsOn(infrastructure)
+            domain.dependsOn(infrastructure)
+            infrastructure.dependsOnNothing()
+        }
+
+        val sut = {
+            scope.files.assertArchitecture(architecture)
         }
 
         // then

--- a/lib/src/apiTest/kotlin/com/lemonappdev/konsist/architecture/assertarchitecture/architecture5/Architecture5Test.kt
+++ b/lib/src/apiTest/kotlin/com/lemonappdev/konsist/architecture/assertarchitecture/architecture5/Architecture5Test.kt
@@ -140,7 +140,9 @@ class Architecture5Test {
         }
 
         val sut = {
-            scope.files.assertArchitecture(architecture)
+            scope
+                .files
+                .assertArchitecture(architecture)
         }
 
         // then

--- a/lib/src/apiTest/kotlin/com/lemonappdev/konsist/architecture/assertarchitecture/architecture6/Architecture6Test.kt
+++ b/lib/src/apiTest/kotlin/com/lemonappdev/konsist/architecture/assertarchitecture/architecture6/Architecture6Test.kt
@@ -28,7 +28,9 @@ class Architecture6Test {
     fun `throws exception when layer contains no files (files)`() {
         // when
         val func = {
-            scope.files.assertArchitecture { layer.dependsOnNothing() }
+            scope
+                .files
+                .assertArchitecture { layer.dependsOnNothing() }
         }
 
         // then
@@ -50,7 +52,9 @@ class Architecture6Test {
     fun `throws exception when architecture contains no layers (files)`() {
         // when
         val func = {
-            scope.files.assertArchitecture { }
+            scope
+                .files
+                .assertArchitecture { }
         }
 
         // then
@@ -72,7 +76,9 @@ class Architecture6Test {
     fun `throws exception when architecture contains no dependencies (files)`() {
         // when
         val func = {
-            scope.files.assertArchitecture { layer }
+            scope
+                .files
+                .assertArchitecture { layer }
         }
 
         // then

--- a/lib/src/apiTest/kotlin/com/lemonappdev/konsist/architecture/assertarchitecture/architecture6/Architecture6Test.kt
+++ b/lib/src/apiTest/kotlin/com/lemonappdev/konsist/architecture/assertarchitecture/architecture6/Architecture6Test.kt
@@ -14,7 +14,7 @@ class Architecture6Test {
         Konsist.scopeFromPackage("com.lemonappdev.konsist.architecture.assertarchitecture.architecture6.project")
 
     @Test
-    fun `throws exception when layer contains no files`() {
+    fun `throws exception when layer contains no files (scope)`() {
         // when
         val func = {
             scope.assertArchitecture { layer.dependsOnNothing() }
@@ -25,7 +25,18 @@ class Architecture6Test {
     }
 
     @Test
-    fun `throws exception when architecture contains no layers`() {
+    fun `throws exception when layer contains no files (files)`() {
+        // when
+        val func = {
+            scope.files.assertArchitecture { layer.dependsOnNothing() }
+        }
+
+        // then
+        func shouldThrow KoPreconditionFailedException::class withMessage "Layer EmptyLayer doesn't contain any files."
+    }
+
+    @Test
+    fun `throws exception when architecture contains no layers (scope)`() {
         // when
         val func = {
             scope.assertArchitecture { }
@@ -36,10 +47,32 @@ class Architecture6Test {
     }
 
     @Test
-    fun `throws exception when architecture contains no dependencies`() {
+    fun `throws exception when architecture contains no layers (files)`() {
+        // when
+        val func = {
+            scope.files.assertArchitecture { }
+        }
+
+        // then
+        func shouldThrow KoPreconditionFailedException::class withMessage "Architecture doesn't contain layers or dependencies."
+    }
+
+    @Test
+    fun `throws exception when architecture contains no dependencies (scope)`() {
         // when
         val func = {
             scope.assertArchitecture { layer }
+        }
+
+        // then
+        func shouldThrow KoPreconditionFailedException::class withMessage "Architecture doesn't contain layers or dependencies."
+    }
+
+    @Test
+    fun `throws exception when architecture contains no dependencies (files)`() {
+        // when
+        val func = {
+            scope.files.assertArchitecture { layer }
         }
 
         // then

--- a/lib/src/apiTest/kotlin/com/lemonappdev/konsist/architecture/assertarchitecture/architecture7/Architecture7Test.kt
+++ b/lib/src/apiTest/kotlin/com/lemonappdev/konsist/architecture/assertarchitecture/architecture7/Architecture7Test.kt
@@ -11,9 +11,31 @@ class Architecture7Test {
     )
 
     @Test
-    fun `passes when good dependency is set`() {
+    fun `passes when good dependency is set (scope)`() {
         // then
         scope
+            .assertArchitecture {
+                val adapter =
+                    Layer("Adapter", "com.lemonappdev.konsist.architecture.assertarchitecture.architecture7.project.adapter..")
+                val common =
+                    Layer("Common", "com.lemonappdev.konsist.architecture.assertarchitecture.architecture7.project.common..")
+                val domain = Layer("Domain", "com.lemonappdev.konsist.architecture.assertarchitecture.architecture7.project.domain..")
+                val port =
+                    Layer("Port", "com.lemonappdev.konsist.architecture.assertarchitecture.architecture7.project.port..")
+
+                domain.dependsOn(common)
+                adapter.dependsOn(common)
+                port.dependsOn(domain, common)
+                adapter.dependsOn(port)
+                common.dependsOnNothing()
+            }
+    }
+
+    @Test
+    fun `passes when good dependency is set (files)`() {
+        // then
+        scope
+            .files
             .assertArchitecture {
                 val adapter =
                     Layer("Adapter", "com.lemonappdev.konsist.architecture.assertarchitecture.architecture7.project.adapter..")

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/api/architecture/KoArchitectureAssertion.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/api/architecture/KoArchitectureAssertion.kt
@@ -1,6 +1,7 @@
 package com.lemonappdev.konsist.api.architecture
 
 import com.lemonappdev.konsist.api.container.KoScope
+import com.lemonappdev.konsist.api.declaration.KoFileDeclaration
 
 /**
  * An interface for asserting a KoArchitecture with its associated dependencies and configurations.
@@ -20,6 +21,11 @@ interface KoArchitectureAssertion {
      * @param dependencies The [DependencyRules] instance representing the configured dependencies of the architecture.
      */
     fun KoScope.assertArchitecture(dependencies: DependencyRules): Unit
+
+    fun List<KoFileDeclaration>.assertArchitecture(dependencies: DependencyRules.() -> Unit)
+
+    fun List<KoFileDeclaration>.assertArchitecture(dependencies: DependencyRules)
+
 
     /**
      * Creates and returns a [DependencyRules] instance representing the configured dependencies of the architecture,

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/api/architecture/KoArchitectureAssertion.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/api/architecture/KoArchitectureAssertion.kt
@@ -22,10 +22,21 @@ interface KoArchitectureAssertion {
      */
     fun KoScope.assertArchitecture(dependencies: DependencyRules): Unit
 
+    /**
+     * Asserts the architecture (using files declared within the [KoScope]) with the specified [dependencies]
+     * defined as a function literal with receiver [DependencyRules].
+     *
+     * @param dependencies The function literal with receiver [DependencyRules] that allows configuring the dependencies
+     * of the architecture.
+     */
     fun List<KoFileDeclaration>.assertArchitecture(dependencies: DependencyRules.() -> Unit)
 
+    /**
+     * Asserts the architecture (using files declared within the [KoScope]) with the specified [dependencies].
+     *
+     * @param dependencies The [DependencyRules] instance representing the configured dependencies of the architecture.
+     */
     fun List<KoFileDeclaration>.assertArchitecture(dependencies: DependencyRules)
-
 
     /**
      * Creates and returns a [DependencyRules] instance representing the configured dependencies of the architecture,

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/api/architecture/KoArchitectureAssertion.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/api/architecture/KoArchitectureAssertion.kt
@@ -29,14 +29,14 @@ interface KoArchitectureAssertion {
      * @param dependencies The function literal with receiver [DependencyRules] that allows configuring the dependencies
      * of the architecture.
      */
-    fun List<KoFileDeclaration>.assertArchitecture(dependencies: DependencyRules.() -> Unit)
+    fun List<KoFileDeclaration>.assertArchitecture(dependencies: DependencyRules.() -> Unit): Unit
 
     /**
      * Asserts the architecture (using files declared within the [KoScope]) with the specified [dependencies].
      *
      * @param dependencies The [DependencyRules] instance representing the configured dependencies of the architecture.
      */
-    fun List<KoFileDeclaration>.assertArchitecture(dependencies: DependencyRules)
+    fun List<KoFileDeclaration>.assertArchitecture(dependencies: DependencyRules): Unit
 
     /**
      * Creates and returns a [DependencyRules] instance representing the configured dependencies of the architecture,

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/core/architecture/KoArchitectureAssertionCore.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/core/architecture/KoArchitectureAssertionCore.kt
@@ -26,10 +26,12 @@ class KoArchitectureAssertionCore : KoArchitectureAssertion {
         KoArchitectureFiles(dependencies, this).assert()
     }
 
-
     override fun architecture(dependencies: DependencyRules.() -> Unit): DependencyRules =
         instanceDependencyRules(dependencies = dependencies)
 
+    /**
+     * Obtain the dependency rules from dependencies literal function
+     */
     private fun instanceDependencyRules(dependencies: DependencyRules.() -> Unit): DependencyRules {
         val dependencyRules = DependencyRulesCore()
         dependencies(dependencyRules)

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/core/architecture/KoArchitectureAssertionCore.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/core/architecture/KoArchitectureAssertionCore.kt
@@ -3,12 +3,12 @@ package com.lemonappdev.konsist.core.architecture
 import com.lemonappdev.konsist.api.architecture.DependencyRules
 import com.lemonappdev.konsist.api.architecture.KoArchitectureAssertion
 import com.lemonappdev.konsist.api.container.KoScope
+import com.lemonappdev.konsist.api.declaration.KoFileDeclaration
 import com.lemonappdev.konsist.core.verify.assert
 
 class KoArchitectureAssertionCore : KoArchitectureAssertion {
     override fun KoScope.assertArchitecture(dependencies: DependencyRules.() -> Unit) {
-        val dependencyRules = DependencyRulesCore()
-        dependencies(dependencyRules)
+        val dependencyRules = instanceDependencyRules(dependencies = dependencies)
         val architectureScope = KoArchitectureScope(dependencyRules, this)
         architectureScope.assert()
     }
@@ -17,7 +17,20 @@ class KoArchitectureAssertionCore : KoArchitectureAssertion {
         KoArchitectureScope(dependencies, this).assert()
     }
 
-    override fun architecture(dependencies: DependencyRules.() -> Unit): DependencyRules {
+    override fun List<KoFileDeclaration>.assertArchitecture(dependencies: DependencyRules.() -> Unit) {
+        val dependencyRules = instanceDependencyRules(dependencies = dependencies)
+        KoArchitectureFiles(dependencyRules, this).assert()
+    }
+
+    override fun List<KoFileDeclaration>.assertArchitecture(dependencies: DependencyRules) {
+        KoArchitectureFiles(dependencies, this).assert()
+    }
+
+
+    override fun architecture(dependencies: DependencyRules.() -> Unit): DependencyRules =
+        instanceDependencyRules(dependencies = dependencies)
+
+    private fun instanceDependencyRules(dependencies: DependencyRules.() -> Unit): DependencyRules {
         val dependencyRules = DependencyRulesCore()
         dependencies(dependencyRules)
         return dependencyRules

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/core/architecture/KoArchitectureScope.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/core/architecture/KoArchitectureScope.kt
@@ -4,6 +4,17 @@ import com.lemonappdev.konsist.api.architecture.DependencyRules
 import com.lemonappdev.konsist.api.container.KoScope
 import com.lemonappdev.konsist.api.declaration.KoFileDeclaration
 
+/**
+ * Architecture Scope for
+ * @param dependencyRules dependency configuration for a particular Layer
+ * @param koScope Scope of declaration
+ */
 internal data class KoArchitectureScope(val dependencyRules: DependencyRules, val koScope: KoScope)
 
+/**
+ * Architecture files for:
+ *
+ * @param dependencyRules dependency configuration for a particular Layer
+ * @param files Files within the scope
+ */
 internal data class KoArchitectureFiles(val dependencyRules: DependencyRules, val files: List<KoFileDeclaration>)

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/core/architecture/KoArchitectureScope.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/core/architecture/KoArchitectureScope.kt
@@ -2,5 +2,8 @@ package com.lemonappdev.konsist.core.architecture
 
 import com.lemonappdev.konsist.api.architecture.DependencyRules
 import com.lemonappdev.konsist.api.container.KoScope
+import com.lemonappdev.konsist.api.declaration.KoFileDeclaration
 
 internal data class KoArchitectureScope(val dependencyRules: DependencyRules, val koScope: KoScope)
+
+internal data class KoArchitectureFiles(val dependencyRules: DependencyRules, val files: List<KoFileDeclaration>)

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/core/verify/KoArchitectureAssert.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/core/verify/KoArchitectureAssert.kt
@@ -14,17 +14,17 @@ import com.lemonappdev.konsist.core.exception.KoInternalException
 import com.lemonappdev.konsist.core.exception.KoPreconditionFailedException
 import com.lemonappdev.konsist.core.util.LocationUtil
 
-internal fun KoArchitectureFiles.assert() {
+internal fun KoArchitectureFiles.assert(): Unit {
     val dependencyRules = this.dependencyRules as DependencyRulesCore
     validateLayers(this.files, dependencyRules)
 }
 
-internal fun KoArchitectureScope.assert() {
+internal fun KoArchitectureScope.assert(): Unit {
     try {
         val files = this.koScope.files
         val dependencyRules = this.dependencyRules as DependencyRulesCore
         validateLayers(files, dependencyRules)
-     } catch (e: KoException) {
+    } catch (e: KoException) {
         throw e
     } catch (@Suppress("detekt.TooGenericExceptionCaught") e: Exception) {
         throw KoInternalException(e.message.orEmpty(), e)
@@ -39,7 +39,7 @@ internal fun KoArchitectureScope.assert() {
  *
  * @throws KoPreconditionFailedException Layers do not contain files
  */
-private fun validateAllLayersAreValid(files: List<KoFileDeclaration>, dependencyRules: DependencyRulesCore) {
+private fun validateAllLayersAreValid(files: List<KoFileDeclaration>, dependencyRules: DependencyRulesCore): Unit {
     val isAllLayersValid = dependencyRules.allLayers
         .all {
             files
@@ -66,7 +66,7 @@ private fun validateAllLayersAreValid(files: List<KoFileDeclaration>, dependency
  *
  * @throws KoPreconditionFailedException Architecture doesn't contain layers or dependencies
  */
-private fun validateLayersOnDependencyRules(dependencyRules: DependencyRulesCore) {
+private fun validateLayersOnDependencyRules(dependencyRules: DependencyRulesCore): Unit {
     if (dependencyRules.allLayers.isEmpty()) {
         throw KoPreconditionFailedException("Architecture doesn't contain layers or dependencies.")
     }
@@ -80,7 +80,7 @@ private fun validateLayersOnDependencyRules(dependencyRules: DependencyRulesCore
  *
  * @throws KoCheckFailedException contains [FailedFiles]
  */
-private fun validateLayersContainingFailedFiles(files: List<KoFileDeclaration>, dependencyRules: DependencyRulesCore) {
+private fun validateLayersContainingFailedFiles(files: List<KoFileDeclaration>, dependencyRules: DependencyRulesCore): Unit {
     val failedFiles = mutableListOf<FailedFiles>()
 
     dependencyRules
@@ -114,7 +114,7 @@ private fun validateLayersContainingFailedFiles(files: List<KoFileDeclaration>, 
     }
 }
 
-private fun validateLayers(files: List<KoFileDeclaration>, dependencyRules: DependencyRulesCore) {
+private fun validateLayers(files: List<KoFileDeclaration>, dependencyRules: DependencyRulesCore): Unit {
     validateLayersOnDependencyRules(dependencyRules = dependencyRules)
     validateAllLayersAreValid(files = files, dependencyRules = dependencyRules)
     validateLayersContainingFailedFiles(files = files, dependencyRules = dependencyRules)

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/core/verify/KoArchitectureAssert.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/core/verify/KoArchitectureAssert.kt
@@ -41,7 +41,7 @@ internal fun KoArchitectureFiles.assert(): Unit {
 }
 
 @Suppress("detekt.ThrowsCount")
-internal fun KoArchitectureScope.assert(): Unit{
+internal fun KoArchitectureScope.assert(): Unit {
     try {
         val files = this.koScope.files
         val dependencyRules = this.dependencyRules as DependencyRulesCore

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/core/verify/KoDeclarationAndProviderAssertCore.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/core/verify/KoDeclarationAndProviderAssertCore.kt
@@ -212,7 +212,7 @@ private fun getResult(
     positiveCheck: Boolean,
     suppressName: String,
     additionalMessage: String?,
-) {
+): Unit {
     val allChecksPassed = (result[positiveCheck]?.size ?: 0) == items.size
 
     if (!allChecksPassed) {


### PR DESCRIPTION
Add `.assert()` for files within the Scope of an architecture.

- Refactor in order to prevent code duplication
- Add new `internal class` for  `List<KoFileDeclaration>` for `KoArchitectureScope` (KoArchitectureFiles)
- Add new methods to `KoArchitectureAssertion`
- Add tests for files
- Added method for validate some structures of the files. The `assert()` method for `files` and `scope` is fairly similar, but if it's extracted to a new one, the exception is behaving not correcting make it fails.