### PR TITLE
KON-532 `hasBlockBody` In KoBodyProvider Returns True When Declaration Has No Body

### DIFF
--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/kofunction/KoFunctionDeclarationForKoBodyProviderTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/kofunction/KoFunctionDeclarationForKoBodyProviderTest.kt
@@ -8,6 +8,20 @@ import org.junit.jupiter.api.Test
 
 class KoFunctionDeclarationForKoBodyProviderTest {
     @Test
+    fun `function-has-no-body`() {
+        // given
+        val sut = getSnippetFile("function-has-no-body")
+            .functions()
+            .first()
+
+        // then
+        assertSoftly(sut) {
+            hasExpressionBody shouldBeEqualTo false
+            hasBlockBody shouldBeEqualTo false
+        }
+    }
+
+    @Test
     fun `function-has-expression-body`() {
         // given
         val sut = getSnippetFile("function-has-expression-body")

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/kofunction/snippet/forkobodyprovider/function-has-no-body.kttxt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/kofunction/snippet/forkobodyprovider/function-has-no-body.kttxt
@@ -1,0 +1,3 @@
+interface SampleInterface {
+    fun sampleFunction()
+}

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/kogetter/KoGetterDeclarationForKoBodyProviderTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/kogetter/KoGetterDeclarationForKoBodyProviderTest.kt
@@ -7,6 +7,21 @@ import org.junit.jupiter.api.Test
 
 class KoGetterDeclarationForKoBodyProviderTest {
     @Test
+    fun `getter-has-no-body`() {
+        // given
+        val sut = getSnippetFile("getter-has-no-body")
+            .properties()
+            .first()
+            .getter
+
+        // then
+        assertSoftly(sut) {
+            it?.hasExpressionBody shouldBeEqualTo false
+            it?.hasBlockBody shouldBeEqualTo false
+        }
+    }
+
+    @Test
     fun `getter-has-expression-body`() {
         // given
         val sut = getSnippetFile("getter-has-expression-body")

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/kogetter/snippet/forkobodyprovider/getter-has-no-body.kttxt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/kogetter/snippet/forkobodyprovider/getter-has-no-body.kttxt
@@ -1,0 +1,2 @@
+val sampleProperty: String = ""
+    get

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/kosetter/KoSetterDeclarationForKoBodyProviderTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/kosetter/KoSetterDeclarationForKoBodyProviderTest.kt
@@ -7,6 +7,21 @@ import org.junit.jupiter.api.Test
 
 class KoSetterDeclarationForKoBodyProviderTest {
     @Test
+    fun `setter-has-no-body`() {
+        // given
+        val sut = getSnippetFile("setter-has-no-body")
+            .properties()
+            .first()
+            .setter
+
+        // then
+        assertSoftly(sut) {
+            it?.hasExpressionBody shouldBeEqualTo false
+            it?.hasBlockBody shouldBeEqualTo false
+        }
+    }
+
+    @Test
     fun `setter-has-expression-body`() {
         // given
         val sut = getSnippetFile("setter-has-expression-body")

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/kosetter/snippet/forkobodyprovider/setter-has-no-body.kttxt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/kosetter/snippet/forkobodyprovider/setter-has-no-body.kttxt
@@ -1,0 +1,2 @@
+var sampleProperty: String = "text"
+    private set

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/KoBodyProviderCore.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/KoBodyProviderCore.kt
@@ -7,8 +7,8 @@ internal interface KoBodyProviderCore : KoBodyProvider, KoBaseProviderCore {
     val ktDeclarationWithBody: KtDeclarationWithBody
 
     override val hasBlockBody: Boolean
-        get() = ktDeclarationWithBody.hasBlockBody()
+        get() = ktDeclarationWithBody.hasBody() && ktDeclarationWithBody.hasBlockBody()
 
     override val hasExpressionBody: Boolean
-        get() = !hasBlockBody
+        get() = ktDeclarationWithBody.hasBody() && !ktDeclarationWithBody.hasBlockBody()
 }


### PR DESCRIPTION
**Snippet:**
```kotlin
interface SampleInterface {
    fun sampleFunction()
}
```

**Behaviour before changes**
`hasBlockBody` returns `true` for `sampleFunction`

**Behaviour after changes**
`hasBlockBody` returns `false` for `sampleFunction`