### PR TITLE
Replace deprecated method innovation of `hasAnnotationsOf()`

### DIFF
--- a/lib/src/snippet/kotlin/com/lemonappdev/konsist/KotlinSerializationSnippets.kt
+++ b/lib/src/snippet/kotlin/com/lemonappdev/konsist/KotlinSerializationSnippets.kt
@@ -17,7 +17,7 @@ class KotlinSerializationSnippets {
             .withAnnotationOf(Serializable::class)
             .properties()
             .assert {
-                it.hasAnnotationsOf(SerialName::class)
+                it.hasAnnotationOf(SerialName::class)
             }
     }
 
@@ -27,6 +27,6 @@ class KotlinSerializationSnippets {
             .withEnumModifier()
             .withAnnotationOf(Serializable::class)
             .enumConstants
-            .assert { it.hasAnnotationsOf(SerialName::class) }
+            .assert { it.hasAnnotationOf(SerialName::class) }
     }
 }


### PR DESCRIPTION
This commit replaces the innovation of the `hasAnnotationsOf()` that would be removed in `V1.0.0` with the appropriate alternatives in the code snippets.

So anybody using the library examples will not use code examples that are going to be replaced in the relatively near future.