### PR TITLE
Stop running `kttxt` validation on every PR to `main`

### DIFF
--- a/.github/workflows/check-kttxt-snippets.yml
+++ b/.github/workflows/check-kttxt-snippets.yml
@@ -32,12 +32,10 @@ jobs:
       - name: Echo Run Condition (any true to run)
         run: |
           echo Current branch starts with "release/": ${{ startsWith(steps.branch-name.outputs.current_branch, 'release/') }}
-          echo Base ref branch is "main": ${{ steps.branch-name.outputs.base_ref_branch == 'main' }}
           echo Changed .kttxt files: ${{  contains(steps.changed-files.outputs.all_changed_files, '.kttxt') }}
 
     outputs:
       current_branch: ${{ steps.branch-name.outputs.current_branch }}
-      base_ref_branch: ${{ steps.branch-name.outputs.base_ref_branch }}
       all_changed_files: ${{ steps.changed-files.outputs.all_changed_files }}
 
   check-kttxt-snippets:
@@ -46,7 +44,6 @@ jobs:
     needs: get-github-context
     if: |
       startsWith(needs.get-github-context.outputs.current_branch, 'release/') ||
-      needs.get-github-context.outputs.base_ref_branch == 'main' ||
       contains(needs.get-github-context.outputs.all_changed_files, '.kttxt')
     steps:
       - name: Checkout


### PR DESCRIPTION
This commit stops running the code snippet validation on any PR to the `main` branch, as the step is very slow (in most of the cases I have faced over 1h).

Instead, the snippets would be executed ONLY when they're changed, and by that, the organization can save expensive runner calculation minutes that are currently used for no good.

Moreover, any PR that does not touch the snippets could be merged to the `main` branch much faster as no validation of the snippets would be required.

![image](https://github.com/LemonAppDev/konsist/assets/14914865/0b540001-3e9f-4e6c-a151-e14eb8e39af0)

