### PR TITLE
KON-553: Allow `null` values in representsType()

### DIFF
--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koannotation/KoAnnotationDeclarationForKoRepresentsTypeProviderTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koannotation/KoAnnotationDeclarationForKoRepresentsTypeProviderTest.kt
@@ -10,7 +10,7 @@ class KoAnnotationDeclarationForKoRepresentsTypeProviderTest {
     @ParameterizedTest
     @MethodSource("provideValues")
     fun `annotation-represents-type`(
-        type: String,
+        type: String?,
         value: Boolean,
     ) {
         // given
@@ -24,6 +24,7 @@ class KoAnnotationDeclarationForKoRepresentsTypeProviderTest {
         sut.representsType(type) shouldBeEqualTo value
     }
 
+    @Suppress("SameParameterValue")
     private fun getSnippetFile(fileName: String) =
         getSnippetKoScope("core/declaration/koannotation/snippet/forkorepresentstypeprovider/", fileName)
 
@@ -35,6 +36,7 @@ class KoAnnotationDeclarationForKoRepresentsTypeProviderTest {
             arguments("OtherAnnotation", false),
             arguments("com.lemonappdev.konsist.testdata.SampleAnnotation", true),
             arguments("com.lemonappdev.konsist.testdata.OtherAnnotation", false),
+            arguments(null, false),
         )
     }
 }

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koclass/KoClassDeclarationForKoRepresentsTypeProviderTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koclass/KoClassDeclarationForKoRepresentsTypeProviderTest.kt
@@ -10,7 +10,7 @@ class KoClassDeclarationForKoRepresentsTypeProviderTest {
     @ParameterizedTest
     @MethodSource("provideValues")
     fun `class-represents-type`(
-        type: String,
+        type: String?,
         value: Boolean,
     ) {
         // given
@@ -22,6 +22,7 @@ class KoClassDeclarationForKoRepresentsTypeProviderTest {
         sut.representsType(type) shouldBeEqualTo value
     }
 
+    @Suppress("SameParameterValue")
     private fun getSnippetFile(fileName: String) =
         getSnippetKoScope("core/declaration/koclass/snippet/forkorepresentstypeprovider/", fileName)
 
@@ -33,6 +34,7 @@ class KoClassDeclarationForKoRepresentsTypeProviderTest {
             arguments("OtherClass", false),
             arguments("com.lemonappdev.konsist.testdata.SampleClass", true),
             arguments("com.lemonappdev.konsist.testdata.OtherClass", false),
+            arguments(null, false),
         )
     }
 }

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/kointerface/KoInterfaceDeclarationForKoRepresentsTypeProviderTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/kointerface/KoInterfaceDeclarationForKoRepresentsTypeProviderTest.kt
@@ -10,7 +10,7 @@ class KoInterfaceDeclarationForKoRepresentsTypeProviderTest {
     @ParameterizedTest
     @MethodSource("provideValues")
     fun `interface-represents-type`(
-        type: String,
+        type: String?,
         value: Boolean,
     ) {
         // given
@@ -22,6 +22,7 @@ class KoInterfaceDeclarationForKoRepresentsTypeProviderTest {
         sut.representsType(type) shouldBeEqualTo value
     }
 
+    @Suppress("SameParameterValue")
     private fun getSnippetFile(fileName: String) =
         getSnippetKoScope("core/declaration/kointerface/snippet/forkorepresentstypeprovider/", fileName)
 
@@ -33,6 +34,7 @@ class KoInterfaceDeclarationForKoRepresentsTypeProviderTest {
             arguments("OtherInterface", false),
             arguments("com.lemonappdev.konsist.testdata.SampleInterface", true),
             arguments("com.lemonappdev.konsist.testdata.OtherInterface", false),
+            arguments(null, false),
         )
     }
 }

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koobject/KoObjectDeclarationForKoRepresentsTypeProviderTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koobject/KoObjectDeclarationForKoRepresentsTypeProviderTest.kt
@@ -10,7 +10,7 @@ class KoObjectDeclarationForKoRepresentsTypeProviderTest {
     @ParameterizedTest
     @MethodSource("provideValues")
     fun `object-represents-type`(
-        type: String,
+        type: String?,
         value: Boolean,
     ) {
         // given
@@ -22,6 +22,7 @@ class KoObjectDeclarationForKoRepresentsTypeProviderTest {
         sut.representsType(type) shouldBeEqualTo value
     }
 
+    @Suppress("SameParameterValue")
     private fun getSnippetFile(fileName: String) =
         getSnippetKoScope("core/declaration/koobject/snippet/forkorepresentstypeprovider/", fileName)
 
@@ -33,6 +34,7 @@ class KoObjectDeclarationForKoRepresentsTypeProviderTest {
             arguments("OtherObject", false),
             arguments("com.lemonappdev.konsist.testdata.SampleObject", true),
             arguments("com.lemonappdev.konsist.testdata.OtherObject", false),
+            arguments(null, false),
         )
     }
 }

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koparameter/KoParameterDeclarationForKoRepresentsTypeProviderTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koparameter/KoParameterDeclarationForKoRepresentsTypeProviderTest.kt
@@ -19,9 +19,11 @@ class KoParameterDeclarationForKoRepresentsTypeProviderTest {
         assertSoftly(sut) {
             representsType("() -> Unit") shouldBeEqualTo true
             representsType("OtherType") shouldBeEqualTo false
+            representsType(null) shouldBeEqualTo false
         }
     }
 
+    @Suppress("SameParameterValue")
     private fun getSnippetFile(fileName: String) =
         getSnippetKoScope("core/declaration/koparameter/snippet/forkorepresentstypeprovider/", fileName)
 }

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/api/ext/list/KoRepresentsTypeProviderListExt.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/api/ext/list/KoRepresentsTypeProviderListExt.kt
@@ -10,7 +10,7 @@ import kotlin.reflect.KClass
  * @param names The type name(s) to include.
  * @return A list containing declarations with the specified types.
  */
-fun <T : KoRepresentsTypeProvider> List<T>.withRepresentedType(name: String, vararg names: String): List<T> = filter {
+fun <T : KoRepresentsTypeProvider> List<T>.withRepresentedType(name: String?, vararg names: String?): List<T> = filter {
     it.representsType(name) || names.any { type -> it.representsType(type) }
 }
 
@@ -21,7 +21,7 @@ fun <T : KoRepresentsTypeProvider> List<T>.withRepresentedType(name: String, var
  * @param names The type name(s) to exclude.
  * @return A list containing declarations without the specified types.
  */
-fun <T : KoRepresentsTypeProvider> List<T>.withoutRepresentedType(name: String, vararg names: String): List<T> =
+fun <T : KoRepresentsTypeProvider> List<T>.withoutRepresentedType(name: String?, vararg names: String?): List<T> =
     filter {
         !it.representsType(name) && names.none { type -> it.representsType(type) }
     }
@@ -33,15 +33,12 @@ fun <T : KoRepresentsTypeProvider> List<T>.withoutRepresentedType(name: String, 
  * @param kClasses The Kotlin classes representing the types to include.
  * @return A list containing declarations with types matching the specified Kotlin classes.
  */
-fun <T : KoRepresentsTypeProvider> List<T>.withRepresentedTypeOf(kClass: KClass<*>, vararg kClasses: KClass<*>): List<T> =
+fun <T : KoRepresentsTypeProvider> List<T>.withRepresentedTypeOf(kClass: KClass<*>?, vararg kClasses: KClass<*>?): List<T> =
     filter {
-        kClass.qualifiedName?.let { type -> it.representsType(type) } ?: false ||
+        it.representsType(kClass?.qualifiedName) ||
             if (kClasses.isNotEmpty()) {
                 kClasses.any { type ->
-                    type
-                        .qualifiedName
-                        ?.let { name -> it.representsType(name) }
-                        ?: false
+                    it.representsType(type?.qualifiedName)
                 }
             } else {
                 false
@@ -55,15 +52,12 @@ fun <T : KoRepresentsTypeProvider> List<T>.withRepresentedTypeOf(kClass: KClass<
  * @param kClasses The Kotlin classes representing the types to exclude.
  * @return A list containing declarations without types matching the specified Kotlin classes.
  */
-fun <T : KoRepresentsTypeProvider> List<T>.withoutRepresentedTypeOf(kClass: KClass<*>, vararg kClasses: KClass<*>): List<T> =
+fun <T : KoRepresentsTypeProvider> List<T>.withoutRepresentedTypeOf(kClass: KClass<*>?, vararg kClasses: KClass<*>?): List<T> =
     filter {
-        kClass.qualifiedName?.let { type -> !it.representsType(type) } ?: true &&
+        kClass?.qualifiedName?.let { type -> !it.representsType(type) } ?: true &&
             if (kClasses.isNotEmpty()) {
                 kClasses.none { type ->
-                    type
-                        .qualifiedName
-                        ?.let { name -> it.representsType(name) }
-                        ?: false
+                    it.representsType(type?.qualifiedName)
                 }
             } else {
                 true

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/api/ext/list/KoRepresentsTypeProviderListExt.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/api/ext/list/KoRepresentsTypeProviderListExt.kt
@@ -54,7 +54,7 @@ fun <T : KoRepresentsTypeProvider> List<T>.withRepresentedTypeOf(kClass: KClass<
  */
 fun <T : KoRepresentsTypeProvider> List<T>.withoutRepresentedTypeOf(kClass: KClass<*>?, vararg kClasses: KClass<*>?): List<T> =
     filter {
-        kClass?.qualifiedName?.let { type -> !it.representsType(type) } ?: true &&
+        !it.representsType(kClass?.qualifiedName) &&
             if (kClasses.isNotEmpty()) {
                 kClasses.none { type ->
                     it.representsType(type?.qualifiedName)

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/api/ext/provider/KoRepresentsTypeProviderExt.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/api/ext/provider/KoRepresentsTypeProviderExt.kt
@@ -13,4 +13,4 @@ import com.lemonappdev.konsist.api.provider.KoRepresentsTypeProvider
  * @return `true` if declaration represents the type of [T], `false` otherwise.
  */
 inline fun <reified T> KoRepresentsTypeProvider.representsTypeOf(): Boolean =
-    T::class.simpleName?.let { representsType(it) } ?: false || T::class.qualifiedName?.let { representsType(it) } ?: false
+    representsType(T::class.simpleName) || representsType(T::class.qualifiedName)

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/api/provider/KoRepresentsTypeProvider.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/api/provider/KoRepresentsTypeProvider.kt
@@ -10,5 +10,5 @@ interface KoRepresentsTypeProvider : KoBaseProvider {
      * @param name the name of type to compare. It can be either a simple name or a fully qualified name.
      * @return `true` if this type represents the specified type, `false` otherwise.
      */
-    fun representsType(name: String): Boolean
+    fun representsType(name: String?): Boolean
 }

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/core/declaration/KoParameterDeclarationCore.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/core/declaration/KoParameterDeclarationCore.kt
@@ -80,7 +80,7 @@ internal class KoParameterDeclarationCore private constructor(
         KoTypeDeclarationCore.getInstance(type, this)
     }
 
-    override fun representsType(name: String): Boolean = type.name == name || type.fullyQualifiedName == name
+    override fun representsType(name: String?): Boolean = type.name == name || type.fullyQualifiedName == name
 
     override val hasValModifier: Boolean by lazy { ktParameter.valOrVarKeyword?.text == "val" }
 

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/KoRepresentsTypeProviderCore.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/KoRepresentsTypeProviderCore.kt
@@ -7,5 +7,5 @@ internal interface KoRepresentsTypeProviderCore :
     KoNameProviderCore,
     KoFullyQualifiedNameProviderCore,
     KoBaseProviderCore {
-    override fun representsType(name: String): Boolean = name == this.name || name == fullyQualifiedName
+    override fun representsType(name: String?): Boolean = name == this.name || name == fullyQualifiedName
 }

--- a/lib/src/test/kotlin/com/lemonappdev/konsist/api/ext/list/KoRepresentsTypeProviderListExtTest.kt
+++ b/lib/src/test/kotlin/com/lemonappdev/konsist/api/ext/list/KoRepresentsTypeProviderListExtTest.kt
@@ -9,6 +9,7 @@ import org.amshove.kluent.shouldBeEqualTo
 import org.junit.jupiter.api.Test
 
 class KoRepresentsTypeProviderListExtTest {
+
     @Test
     fun `withRepresentedType(String) returns declaration with given type`() {
         // given
@@ -52,6 +53,61 @@ class KoRepresentsTypeProviderListExtTest {
 
         // then
         sut shouldBeEqualTo listOf(declaration1, declaration2)
+    }
+
+    @Test
+    fun `withRepresentedType(null) returns empty list`() {
+        // given
+        val type = null
+        val declaration1: KoRepresentsTypeProvider = mockk {
+            every { representsType(type) } returns false
+        }
+
+        val declarations = listOf(declaration1)
+
+        // when
+        val sut = declarations.withRepresentedType(type)
+
+        // then
+        sut shouldBeEqualTo emptyList()
+    }
+
+    @Test
+    fun `withRepresentedType(String, null) returns empty list when both dont match`() {
+        // given
+        val type1 = "type"
+        val type2 = null
+        val declaration1: KoRepresentsTypeProvider = mockk {
+            every { representsType(type1) } returns false
+            every { representsType(type2) } returns false
+        }
+
+        val declarations = listOf(declaration1)
+
+        // when
+        val sut = declarations.withRepresentedType(type1, type2)
+
+        // then
+        sut shouldBeEqualTo emptyList()
+    }
+
+    @Test
+    fun `withRepresentedType(null, String) returns empty list when both dont match`() {
+        // given
+        val type1 = null
+        val type2 = "type"
+        val declaration1: KoRepresentsTypeProvider = mockk {
+            every { representsType(type1) } returns false
+            every { representsType(type2) } returns false
+        }
+
+        val declarations = listOf(declaration1)
+
+        // when
+        val sut = declarations.withRepresentedType(type1, type2)
+
+        // then
+        sut shouldBeEqualTo emptyList()
     }
 
     @Test
@@ -100,6 +156,69 @@ class KoRepresentsTypeProviderListExtTest {
     }
 
     @Test
+    fun `withoutRepresentedType(null) returns all given declarations`() {
+        // given
+        val type1 = null
+        val declaration1: KoRepresentsTypeProvider = mockk {
+            every { representsType(type1) } returns false
+        }
+        val declaration2: KoRepresentsTypeProvider = mockk {
+            every { representsType(type1) } returns false
+        }
+        val declarations = listOf(declaration1, declaration2)
+
+        // when
+        val sut = declarations.withoutRepresentedType(type1)
+
+        // then
+        sut shouldBeEqualTo listOf(declaration1, declaration2)
+    }
+
+    @Test
+    fun `withoutRepresentedType(String, null) returns declaration without any of given types`() {
+        // given
+        val type1 = "type1"
+        val type2 = null
+        val declaration1: KoRepresentsTypeProvider = mockk {
+            every { representsType(type1) } returns true
+            every { representsType(type2) } returns false
+        }
+        val declaration2: KoRepresentsTypeProvider = mockk {
+            every { representsType(type1) } returns false
+            every { representsType(type2) } returns false
+        }
+        val declarations = listOf(declaration1, declaration2)
+
+        // when
+        val sut = declarations.withoutRepresentedType(type1, type2)
+
+        // then
+        sut shouldBeEqualTo listOf(declaration2)
+    }
+
+    @Test
+    fun `withoutRepresentedType(null, String) returns declaration without any of given types`() {
+        // given
+        val type1 = null
+        val type2 = "type1"
+        val declaration1: KoRepresentsTypeProvider = mockk {
+            every { representsType(type1) } returns true
+            every { representsType(type2) } returns false
+        }
+        val declaration2: KoRepresentsTypeProvider = mockk {
+            every { representsType(type1) } returns false
+            every { representsType(type2) } returns false
+        }
+        val declarations = listOf(declaration1, declaration2)
+
+        // when
+        val sut = declarations.withoutRepresentedType(type1, type2)
+
+        // then
+        sut shouldBeEqualTo listOf(declaration2)
+    }
+
+    @Test
     fun `withRepresentedTypeOf(KClass) returns declaration with given type`() {
         // given
         val type = "com.lemonappdev.konsist.testdata.SampleClass1"
@@ -145,6 +264,67 @@ class KoRepresentsTypeProviderListExtTest {
     }
 
     @Test
+    fun `withRepresentedTypeOf(null) returns empty list`() {
+        // given
+        val type = null
+        val declaration: KoRepresentsTypeProvider = mockk {
+            every { representsType(type) } returns false
+        }
+
+        val declarations = listOf(declaration)
+
+        // when
+        val sut = declarations.withRepresentedTypeOf(type)
+
+        // then
+        sut shouldBeEqualTo emptyList()
+    }
+
+    @Test
+    fun `withRepresentedTypeOf(KClass, null) returns declarations with one of given types`() {
+        // given
+        val type1 = "com.lemonappdev.konsist.testdata.SampleClass1"
+        val type2 = null
+        val declaration1: KoRepresentsTypeProvider = mockk {
+            every { representsType(type1) } returns true
+            every { representsType(type2) } returns false
+        }
+        val declaration2: KoRepresentsTypeProvider = mockk {
+            every { representsType(type1) } returns false
+            every { representsType(type2) } returns false
+        }
+        val declarations = listOf(declaration1, declaration2)
+
+        // when
+        val sut = declarations.withRepresentedTypeOf(SampleClass1::class, null)
+
+        // then
+        sut shouldBeEqualTo listOf(declaration1)
+    }
+
+    @Test
+    fun `withRepresentedTypeOf(null, KClass) returns declarations with one of given types`() {
+        // given
+        val type1 = null
+        val type2 = "com.lemonappdev.konsist.testdata.SampleClass1"
+        val declaration1: KoRepresentsTypeProvider = mockk {
+            every { representsType(type1) } returns false
+            every { representsType(type2) } returns true
+        }
+        val declaration2: KoRepresentsTypeProvider = mockk {
+            every { representsType(type1) } returns false
+            every { representsType(type2) } returns false
+        }
+        val declarations = listOf(declaration1, declaration2)
+
+        // when
+        val sut = declarations.withRepresentedTypeOf(null, SampleClass1::class)
+
+        // then
+        sut shouldBeEqualTo listOf(declaration1)
+    }
+
+    @Test
     fun `withoutRepresentedTypeOf(KClass) returns declaration without given type`() {
         // given
         val type = "com.lemonappdev.konsist.testdata.SampleClass1"
@@ -187,5 +367,68 @@ class KoRepresentsTypeProviderListExtTest {
 
         // then
         sut shouldBeEqualTo listOf(declaration3)
+    }
+
+    @Test
+    fun `withoutRepresentedTypeOf(null) returns all declarations`() {
+        // given
+        val type = null
+        val declaration1: KoRepresentsTypeProvider = mockk {
+            every { representsType(type) } returns false
+        }
+        val declaration2: KoRepresentsTypeProvider = mockk {
+            every { representsType(type) } returns false
+        }
+        val declarations = listOf(declaration1, declaration2)
+
+        // when
+        val sut = declarations.withoutRepresentedTypeOf(type)
+
+        // then
+        sut shouldBeEqualTo listOf(declaration1, declaration2)
+    }
+
+    @Test
+    fun `withoutRepresentedTypeOf(KClass, null) returns declaration without any of given types`() {
+        // given
+        val type1 = "com.lemonappdev.konsist.testdata.SampleClass1"
+        val type2 = null
+        val declaration1: KoRepresentsTypeProvider = mockk {
+            every { representsType(type1) } returns true
+            every { representsType(type2) } returns false
+        }
+        val declaration2: KoRepresentsTypeProvider = mockk {
+            every { representsType(type1) } returns false
+            every { representsType(type2) } returns false
+        }
+        val declarations = listOf(declaration1, declaration2)
+
+        // when
+        val sut = declarations.withoutRepresentedTypeOf(SampleClass1::class, null)
+
+        // then
+        sut shouldBeEqualTo listOf(declaration2)
+    }
+
+    @Test
+    fun `withoutRepresentedTypeOf(null, KClass) returns declaration without any of given types`() {
+        // given
+        val type1 = null
+        val type2 = "com.lemonappdev.konsist.testdata.SampleClass1"
+        val declaration1: KoRepresentsTypeProvider = mockk {
+            every { representsType(type1) } returns false
+            every { representsType(type2) } returns true
+        }
+        val declaration2: KoRepresentsTypeProvider = mockk {
+            every { representsType(type1) } returns false
+            every { representsType(type2) } returns false
+        }
+        val declarations = listOf(declaration1, declaration2)
+
+        // when
+        val sut = declarations.withoutRepresentedTypeOf(null, SampleClass1::class)
+
+        // then
+        sut shouldBeEqualTo listOf(declaration2)
     }
 }


### PR DESCRIPTION
This commit allows passing `null` values to the function `representsType()` which will result in a `false` response.

Those changes would allow the consumers of the library to replace the following implementation:

```kotlin
@Test
fun `fields for a particular type are of the interface`() {
    val interfaces = scope.interfaces()

    scope
        .classes()
        .withPackage("..domain..")
        .properties()
        // .with...
        .assertTrue {
            val propertyTypeFQN = it.type?.fullyQualifiedName ?: return@assertTrue false

            interfaces.any { interfacee ->
                interfacee.representsType(propertyTypeFQN)
            }
        }
}
```

With this one:

```kotlin
@Test
fun `fields for a particular type are of the interface`() {
    val interfaces = scope.interfaces()

    scope
        .classes()
        .withPackage("..domain..")
        .properties()
        // .with...
        .assertTrue {
            interfaces.any { interfacee ->
                interfacee.representsType(it.type?.fullyQualifiedName)
            }
        }
}
```

---

Note that while I did try to evaluate other properties that can be `null` I got a bit lost in the codebase and I might have missed some possible properties.