### PR TITLE
Replace REGEX to allow using .. as wildcard again

### DIFF
--- a/lib/src/main/kotlin/com/lemonappdev/konsist/core/util/LocationUtil.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/core/util/LocationUtil.kt
@@ -10,10 +10,14 @@ object LocationUtil {
      *    \w  = Matches any word char (alpha & underscore).
      *    +   = Match 1 or more of the preceding token.
      *    |   = OR
+     *  \.{2}?= allow using '..' as wildcard optionally
+     *    \w  = Matches any word char (alpha & underscore).
+     *    +   = Match 1 or more of the preceding token.
+     *    |   = OR
      *  \.{2} = escaped char '.' (dot) appearing 2 times
      *    $   = Matches end of string
      */
-    internal const val REGEX_PACKAGE_NAME_END_TWO_DOTS = "(?:^\\w+|\\w+\\.\\w+)+\\.{2}\$"
+    internal const val REGEX_PACKAGE_NAME_END_TWO_DOTS = "(?:^\\w+|\\w+\\.\\w+\\.{2}?\\w+|\\w+\\.\\w+)+\\.{2}\$"
 
     /**
      * Use '..' as a wildcard for any number of characters.

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/core/util/LocationUtil.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/core/util/LocationUtil.kt
@@ -10,7 +10,7 @@ object LocationUtil {
      *    \w  = Matches any word char (alpha & underscore).
      *    +   = Match 1 or more of the preceding token.
      *    |   = OR
-     *  \.{2}?= allow using '..' as wildcard optionally
+     *  \.{2}?= allow using '..' as wildcard optionally (only one accepted)
      *    \w  = Matches any word char (alpha & underscore).
      *    +   = Match 1 or more of the preceding token.
      *    |   = OR

--- a/lib/src/test/kotlin/com/lemonappdev/konsist/api/architecture/LayerTest.kt
+++ b/lib/src/test/kotlin/com/lemonappdev/konsist/api/architecture/LayerTest.kt
@@ -19,7 +19,7 @@ class LayerTest {
     }
 
     @Test
-    fun `throws an exception when layer is defined by package without two dots at the end and there are another two dots used as wildcard`() {
+    fun `throws an exception when layer is defined by package without two dots at the end with dots as wildcard`() {
         // given
         val sut = { Layer("Domain", "package..feature") }
 
@@ -54,22 +54,11 @@ class LayerTest {
     @Test
     fun `throws an exception when layer is defined by package containing dots with more than two dots at the end`() {
         // given
-        val sut = { Layer("Domain", "first.second.third_p.package....") }
-
-        // then
-        sut shouldThrow KoPreconditionFailedException::class withMessage """
-            Layer Domain must be defined by package ending with '..'. Now: first.second.third_p.package.... .
-        """.trimIndent()
-    }
-
-    @Test
-    fun `throws an exception when layer is defined by package containing dots with more than two dots at the end and there are another two dots used as wildcard`() {
-        // given
         val sut = { Layer("Domain", "first.second..third_p.package....") }
 
         // then
         sut shouldThrow KoPreconditionFailedException::class withMessage """
-            Layer Domain must be defined by package ending with '..'. Now: first.second..third_p.package.... .
+            Layer Domain must be defined by package ending with '..'. Now: first.second.third_p.package.... .
         """.trimIndent()
     }
 

--- a/lib/src/test/kotlin/com/lemonappdev/konsist/api/architecture/LayerTest.kt
+++ b/lib/src/test/kotlin/com/lemonappdev/konsist/api/architecture/LayerTest.kt
@@ -58,7 +58,7 @@ class LayerTest {
 
         // then
         sut shouldThrow KoPreconditionFailedException::class withMessage """
-            Layer Domain must be defined by package ending with '..'. Now: first.second.third_p.package.... .
+            Layer Domain must be defined by package ending with '..'. Now: first.second..third_p.package.... .
         """.trimIndent()
     }
 

--- a/lib/src/test/kotlin/com/lemonappdev/konsist/api/architecture/LayerTest.kt
+++ b/lib/src/test/kotlin/com/lemonappdev/konsist/api/architecture/LayerTest.kt
@@ -19,7 +19,18 @@ class LayerTest {
     }
 
     @Test
-    fun `throws an exception when layer is defined by package without three dots at the end`() {
+    fun `throws an exception when layer is defined by package without two dots at the end and there are another two dots used as wildcard`() {
+        // given
+        val sut = { Layer("Domain", "package..feature") }
+
+        // then
+        sut shouldThrow KoPreconditionFailedException::class withMessage """
+            Layer Domain must be defined by package ending with '..'. Now: package..feature .
+        """.trimIndent()
+    }
+
+    @Test
+    fun `throws an exception when layer is defined by package with three dots at the end`() {
         // given
         val sut = { Layer("Domain", "package...") }
 
@@ -52,6 +63,17 @@ class LayerTest {
     }
 
     @Test
+    fun `throws an exception when layer is defined by package containing dots with more than two dots at the end and there are another two dots used as wildcard`() {
+        // given
+        val sut = { Layer("Domain", "first.second..third_p.package....") }
+
+        // then
+        sut shouldThrow KoPreconditionFailedException::class withMessage """
+            Layer Domain must be defined by package ending with '..'. Now: first.second..third_p.package.... .
+        """.trimIndent()
+    }
+
+    @Test
     fun `do not throw an exception when the package ends with two dots`() {
         // given
         val sut = { Layer("Domain", "first.second.package..") }
@@ -59,6 +81,28 @@ class LayerTest {
         // then
         sut shouldNotThrow KoPreconditionFailedException::class withMessage """
             Layer Domain must be defined by package ending with '..'. Now: first.second.third_p.package.... .
+        """.trimIndent()
+    }
+
+    @Test
+    fun `do not throw an exception when the package ends with two dots and there are another two dots used as wildcard`() {
+        // given
+        val sut = { Layer("Domain", "first.second..package..") }
+
+        // then
+        sut shouldNotThrow KoPreconditionFailedException::class withMessage """
+            Layer Domain must be defined by package ending with '..'. Now: first.second.third_p.package.... .
+        """.trimIndent()
+    }
+
+    @Test
+    fun `throws an exception when the package ends with two dots and there more than two dots used as wildcard`() {
+        // given
+        val sut = { Layer("Domain", "first.second..package..feature1..") }
+
+        // then
+        sut shouldThrow KoPreconditionFailedException::class withMessage """
+            Layer Domain must be defined by package ending with '..'. Now: first.second..package..feature1.. .
         """.trimIndent()
     }
 }


### PR DESCRIPTION
Since this regex was changed, defining a layer implies using the full name and adding two dots at the end. With this, we allow using .. as wildcard.

- com.acme.ui.. :white_check_mark:
- com.acme..feature1.. :white_check_mark:
- com.acme..feature2.. :white_check_mark:
- com.acme..feature3 :x:
