### PR TITLE
KON-562: Improve snippet CI verification

### DIFF
--- a/.github/workflows/check-kttxt-snippets.yml
+++ b/.github/workflows/check-kttxt-snippets.yml
@@ -47,6 +47,7 @@ jobs:
   check-kttxt-snippets:
     name: Check kttxt Snippets
     runs-on: ubuntu-latest
+    needs: get-github-context
     if: |
       startsWith(needs.get-github-context.outputs.current_branch, 'release/') ||
       needs.get-github-context.outputs.base_ref_branch == 'main' ||
@@ -61,5 +62,27 @@ jobs:
           java-version: 19
           distribution: 'zulu'
 
+      - name: Get Changed Snippets
+        id: changed-snippets-names
+        env:
+          CHANGED_FILES: ${{ needs.get-github-context.outputs.all_changed_files }}
+        run: |
+          read -r -a files_array <<< "${{ env.CHANGED_FILES }}"
+          
+          changed_file_names=""
+          
+          for path in "${files_array[@]}"; do
+            filename="${path##*/}"
+            if [[ "$filename" == *.kttxt ]]; then
+              changed_file_names="$changed_file_names $filename"
+            fi
+          done
+          
+          echo "names=$changed_file_names" >> "$GITHUB_OUTPUT"
+
+
       - name: Check kttxt Snippets
-        run: python3 scripts/check_kttxt_snippets.py
+        env:
+          CHANGED_FILES_NAMES: ${{ steps.changed-snippets-names.outputs.names }}
+        run:
+          python3 scripts/check_kttxt_snippets.py ${{ env.CHANGED_FILES_NAMES }}

--- a/scripts/check_kttxt_snippets.py
+++ b/scripts/check_kttxt_snippets.py
@@ -96,14 +96,18 @@ def compile_kotlin_file(file_path):
     else:
         return (message, success)
 
-def compile_snippets():
+def compile_snippets(snippets_changed):
     global error_occurred
     kotlin_files = []
+
+    snippets_without_ext = [name.split('.kt')[0] for name in snippets_changed]
 
     for root, dirs, files in os.walk(build_dir):
         for file_name in files:
             if file_name.endswith('.kt'):
-                kotlin_files.append(os.path.join(root, file_name))
+                file_name_without_ext = file_name[:-3]
+                if not snippets_changed or file_name_without_ext in snippets_without_ext:
+                    kotlin_files.append(os.path.join(root, file_name))
 
     total_files = len(kotlin_files)
     processed_files = 0
@@ -134,7 +138,8 @@ copy_and_kttxt_files_and_change_extension_to_kt()
 
 num_tests = 0
 if __name__ == '__main__':
-    num_tests = compile_snippets()
+    snippets_changed = sys.argv[1:]
+    num_tests = compile_snippets(snippets_changed)
 
 clean()
 


### PR DESCRIPTION
This commit changes the behavior of CI for snippets, by checking only the list of changed files as part of the snippets that are tested.

If no list has been provided from CI, all snippets would be tested (to support a release process)

---

This PR was tested by disabling the rules that enforce the pipeline to run only after specific conditions and ensuring that it correctly picks up the values.
Moreover, it was tested locally by passing the snippet and checking that only this snippet was picked up.