### PR TITLE
KON-563: Run only 1 CI pipeline in parallel for each PR

### DIFF
--- a/.github/workflows/check-kttxt-snippets.yml
+++ b/.github/workflows/check-kttxt-snippets.yml
@@ -4,6 +4,10 @@ on:
   pull_request:
       types: [ opened, synchronize ]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   get-github-context:
     name: Get Branches And Changed Files

--- a/.github/workflows/check-starter-projects.yml
+++ b/.github/workflows/check-starter-projects.yml
@@ -4,6 +4,10 @@ on:
   pull_request:
     types: [ opened, synchronize ]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   get-github-context:
     name: Get Branches And Changed Files


### PR DESCRIPTION
This commit ensures that each PR would run maximum of 1 CI pipeline in parallel, if a new commit was pushed into the PR, the previous pipeline execution would be cancelled in favor of the new one.

The change was applied only PR related as we might want to run multiple PRs on main when it is merged from the develop branch