### PR TITLE
KON-570 Rename `baseSourceType` To `bareSourcetype`

### DIFF
--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/kotype/KoTypeDeclarationForKoSourceAndAliasTypeProviderTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/kotype/KoTypeDeclarationForKoSourceAndAliasTypeProviderTest.kt
@@ -34,7 +34,7 @@ class KoTypeDeclarationForKoSourceAndAliasTypeProviderTest {
         // then
         assertSoftly(sut) {
             it?.sourceType shouldBeEqualTo "SampleType?"
-            it?.bareSourceType shouldBeEqualTo "SampleType?"
+            it?.bareSourceType shouldBeEqualTo "SampleType"
             it?.aliasType shouldBeEqualTo null
             it?.isAlias shouldBeEqualTo false
         }

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/kotype/KoTypeDeclarationForKoSourceAndAliasTypeProviderTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/kotype/KoTypeDeclarationForKoSourceAndAliasTypeProviderTest.kt
@@ -17,7 +17,7 @@ class KoTypeDeclarationForKoSourceAndAliasTypeProviderTest {
         // then
         assertSoftly(sut) {
             it?.sourceType shouldBeEqualTo "SampleType"
-            it?.baseSourceType shouldBeEqualTo "SampleType"
+            it?.bareSourceType shouldBeEqualTo "SampleType"
             it?.aliasType shouldBeEqualTo null
             it?.isAlias shouldBeEqualTo false
         }
@@ -34,7 +34,7 @@ class KoTypeDeclarationForKoSourceAndAliasTypeProviderTest {
         // then
         assertSoftly(sut) {
             it?.sourceType shouldBeEqualTo "SampleType?"
-            it?.baseSourceType shouldBeEqualTo "SampleType?"
+            it?.bareSourceType shouldBeEqualTo "SampleType?"
             it?.aliasType shouldBeEqualTo null
             it?.isAlias shouldBeEqualTo false
         }
@@ -51,7 +51,7 @@ class KoTypeDeclarationForKoSourceAndAliasTypeProviderTest {
         // then
         assertSoftly(sut) {
             it?.sourceType shouldBeEqualTo "List<SampleType>"
-            it?.baseSourceType shouldBeEqualTo "List"
+            it?.bareSourceType shouldBeEqualTo "List"
             it?.aliasType shouldBeEqualTo null
             it?.isAlias shouldBeEqualTo false
         }
@@ -68,7 +68,7 @@ class KoTypeDeclarationForKoSourceAndAliasTypeProviderTest {
         // then
         assertSoftly(sut) {
             it?.sourceType shouldBeEqualTo "List<SampleType?>"
-            it?.baseSourceType shouldBeEqualTo "List"
+            it?.bareSourceType shouldBeEqualTo "List"
             it?.aliasType shouldBeEqualTo null
             it?.isAlias shouldBeEqualTo false
         }
@@ -85,7 +85,7 @@ class KoTypeDeclarationForKoSourceAndAliasTypeProviderTest {
         // then
         assertSoftly(sut) {
             it?.sourceType shouldBeEqualTo "List<SampleType?>?"
-            it?.baseSourceType shouldBeEqualTo "List"
+            it?.bareSourceType shouldBeEqualTo "List"
             it?.aliasType shouldBeEqualTo null
             it?.isAlias shouldBeEqualTo false
         }
@@ -102,7 +102,7 @@ class KoTypeDeclarationForKoSourceAndAliasTypeProviderTest {
         // then
         assertSoftly(sut) {
             it?.sourceType shouldBeEqualTo "List<SampleType>?"
-            it?.baseSourceType shouldBeEqualTo "List"
+            it?.bareSourceType shouldBeEqualTo "List"
             it?.aliasType shouldBeEqualTo null
             it?.isAlias shouldBeEqualTo false
         }
@@ -119,7 +119,7 @@ class KoTypeDeclarationForKoSourceAndAliasTypeProviderTest {
         // then
         assertSoftly(sut) {
             it?.sourceType shouldBeEqualTo "SampleType"
-            it?.baseSourceType shouldBeEqualTo "SampleType"
+            it?.bareSourceType shouldBeEqualTo "SampleType"
             it?.aliasType shouldBeEqualTo "ImportAlias"
             it?.isAlias shouldBeEqualTo true
         }
@@ -136,7 +136,7 @@ class KoTypeDeclarationForKoSourceAndAliasTypeProviderTest {
         // then
         assertSoftly(sut) {
             it?.sourceType shouldBeEqualTo "SampleType"
-            it?.baseSourceType shouldBeEqualTo "SampleType"
+            it?.bareSourceType shouldBeEqualTo "SampleType"
             it?.aliasType shouldBeEqualTo "ImportAlias"
             it?.isAlias shouldBeEqualTo true
         }

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/api/ext/list/KoSourceAndAliasTypeProviderListExt.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/api/ext/list/KoSourceAndAliasTypeProviderListExt.kt
@@ -86,34 +86,40 @@ fun <T : KoSourceAndAliasTypeProvider> List<T>.withAliasTypeOf(kClass: KClass<*>
     }
 
 /**
- * List containing declarations with base source type of.
+ * List containing declarations with bare source type of.
  *
- * @param kClass The Kotlin class representing the base source type to include.
- * @param kClasses The Kotlin classes representing the base source types to include.
- * @return A list containing declarations with the base source type matching any of the specified types.
+ * @param kClass The Kotlin class representing the bare source type to include.
+ * @param kClasses The Kotlin classes representing the bare source types to include.
+ * @return A list containing declarations with the bare source type matching any of the specified types.
  */
-fun <T : KoSourceAndAliasTypeProvider> List<T>.withBaseSourceTypeOf(kClass: KClass<*>, vararg kClasses: KClass<*>): List<T> =
+fun <T : KoSourceAndAliasTypeProvider> List<T>.withBareSourceTypeOf(
+    kClass: KClass<*>,
+    vararg kClasses: KClass<*>,
+): List<T> =
     filter {
-        it.baseSourceType == kClass.simpleName ||
+        it.bareSourceType == kClass.simpleName ||
             if (kClasses.isNotEmpty()) {
-                kClasses.any { kClass -> it.baseSourceType == kClass.simpleName }
+                kClasses.any { kClass -> it.bareSourceType == kClass.simpleName }
             } else {
                 false
             }
     }
 
 /**
- * List containing declarations without base source type of.
+ * List containing declarations without bare source type of.
  *
- * @param kClass The Kotlin class representing the base source type to exclude.
- * @param kClasses The Kotlin classes representing the base source types to exclude.
- * @return A list containing declarations without base source type matching any of the specified types.
+ * @param kClass The Kotlin class representing the bare source type to exclude.
+ * @param kClasses The Kotlin classes representing the bare source types to exclude.
+ * @return A list containing declarations without bare source type matching any of the specified types.
  */
-fun <T : KoSourceAndAliasTypeProvider> List<T>.withoutBaseSourceTypeOf(kClass: KClass<*>, vararg kClasses: KClass<*>): List<T> =
+fun <T : KoSourceAndAliasTypeProvider> List<T>.withoutBareSourceTypeOf(
+    kClass: KClass<*>,
+    vararg kClasses: KClass<*>,
+): List<T> =
     filter {
-        it.baseSourceType != kClass.simpleName &&
+        it.bareSourceType != kClass.simpleName &&
             if (kClasses.isNotEmpty()) {
-                kClasses.none { kClass -> it.baseSourceType == kClass.simpleName }
+                kClasses.none { kClass -> it.bareSourceType == kClass.simpleName }
             } else {
                 true
             }
@@ -122,25 +128,25 @@ fun <T : KoSourceAndAliasTypeProvider> List<T>.withoutBaseSourceTypeOf(kClass: K
 /**
  * List containing declarations with base source type.
  *
- * @param name The base source type name to include.
- * @param names The base source type name(s) to include.
- * @return A list containing declarations with the specified base source types.
+ * @param name The bare source type name to include.
+ * @param names The bare source type name(s) to include.
+ * @return A list containing declarations with the specified bare source types.
  */
-fun <T : KoSourceAndAliasTypeProvider> List<T>.withBaseSourceType(name: String, vararg names: String): List<T> =
+fun <T : KoSourceAndAliasTypeProvider> List<T>.withBareSourceType(name: String, vararg names: String): List<T> =
     filter {
-        it.baseSourceType == name || names.any { type -> it.baseSourceType == type }
+        it.bareSourceType == name || names.any { type -> it.bareSourceType == type }
     }
 
 /**
- * List containing declarations without base source type.
+ * List containing declarations without bare source type.
  *
- * @param name The base source type name to exclude.
- * @param names The base source type name(s) to exclude.
+ * @param name The bare source type name to exclude.
+ * @param names The bare source type name(s) to exclude.
  * @return A list containing declarations without specified base source types.
  */
-fun <T : KoSourceAndAliasTypeProvider> List<T>.withoutBaseSourceType(name: String, vararg names: String): List<T> =
+fun <T : KoSourceAndAliasTypeProvider> List<T>.withoutBareSourceType(name: String, vararg names: String): List<T> =
     filter {
-        it.baseSourceType != name && names.none { type -> it.baseSourceType == type }
+        it.bareSourceType != name && names.none { type -> it.bareSourceType == type }
     }
 
 /**

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/api/provider/KoSourceAndAliasTypeProvider.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/api/provider/KoSourceAndAliasTypeProvider.kt
@@ -24,17 +24,19 @@ interface KoSourceAndAliasTypeProvider : KoBaseProvider {
      * For `val car:MyClass` it will be "MyClass".
      * For `val car:MyClass<String>` it will be "MyClass<String>".
      *
-     * @see baseSourceType
+     *  @see bareSourceType
      */
     val sourceType: String
 
     /**
-     * The source type without generic type argument.
+     * The source type without generic type arguments and nullability ("?").
      *
-     * For `val car:MyClass` baseSourceType will be "MyClass".
-     * For `val car:MyClass<String>` baseSourceType will be "MyClass"
+     * For `val car:MyClass` bareSourceType will be "MyClass".
+     * For `val car:MyClass?` bareSourceType will be "MyClass".
+     * For `val car:MyClass<String>` bareSourceType will be "MyClass"
+     * For `val car:MyClass<String?>?` bareSourceType will be "MyClass"
      *
      * @see sourceType
      */
-    val baseSourceType: String
+    val bareSourceType: String
 }

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/core/declaration/KoTypeDeclarationCore.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/core/declaration/KoTypeDeclarationCore.kt
@@ -48,7 +48,7 @@ internal class KoTypeDeclarationCore private constructor(
         }
     }
 
-    override val textUsedToFqn: String by lazy { bareSourceType.replace("?", "") }
+    override val textUsedToFqn: String by lazy { bareSourceType }
 
     override fun toString(): String = name
 

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/core/declaration/KoTypeDeclarationCore.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/core/declaration/KoTypeDeclarationCore.kt
@@ -48,7 +48,7 @@ internal class KoTypeDeclarationCore private constructor(
         }
     }
 
-    override val textUsedToFqn: String by lazy { baseSourceType.replace("?", "") }
+    override val textUsedToFqn: String by lazy { bareSourceType.replace("?", "") }
 
     override fun toString(): String = name
 

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/KoFullyQualifiedNameProviderCore.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/KoFullyQualifiedNameProviderCore.kt
@@ -32,6 +32,6 @@ internal interface KoFullyQualifiedNameProviderCore :
                     .firstOrNull { it.contains(textUsedToFqn) }
             }
 
-            return fqn ?: textUsedToFqn.replace("?", "")
+            return fqn ?: textUsedToFqn
         }
 }

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/KoKotlinTypeProviderCore.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/KoKotlinTypeProviderCore.kt
@@ -69,7 +69,7 @@ internal interface KoKotlinTypeProviderCore :
         get() = if (isAlias) {
             false
         } else {
-            val rawSourceType = bareSourceType.replace("?", "")
+            val rawSourceType = bareSourceType
             kotlinBasicTypes.any { it == rawSourceType }
         }
 
@@ -77,7 +77,7 @@ internal interface KoKotlinTypeProviderCore :
         get() = if (isAlias) {
             false
         } else {
-            val rawSourceType = bareSourceType.replace("?", "")
+            val rawSourceType = bareSourceType
             kotlinCollectionTypes.any { it == rawSourceType }
         }
 }

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/KoKotlinTypeProviderCore.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/KoKotlinTypeProviderCore.kt
@@ -69,7 +69,7 @@ internal interface KoKotlinTypeProviderCore :
         get() = if (isAlias) {
             false
         } else {
-            val rawSourceType = baseSourceType.replace("?", "")
+            val rawSourceType = bareSourceType.replace("?", "")
             kotlinBasicTypes.any { it == rawSourceType }
         }
 
@@ -77,7 +77,7 @@ internal interface KoKotlinTypeProviderCore :
         get() = if (isAlias) {
             false
         } else {
-            val rawSourceType = baseSourceType.replace("?", "")
+            val rawSourceType = bareSourceType.replace("?", "")
             kotlinCollectionTypes.any { it == rawSourceType }
         }
 }

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/KoSourceAndAliasTypeProviderCore.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/KoSourceAndAliasTypeProviderCore.kt
@@ -33,7 +33,7 @@ internal interface KoSourceAndAliasTypeProviderCore : KoSourceAndAliasTypeProvid
             name
         }
 
-    override val baseSourceType: String
+    override val bareSourceType: String
         get() = sourceType
             .split("<")
             .first()

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/KoSourceAndAliasTypeProviderCore.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/KoSourceAndAliasTypeProviderCore.kt
@@ -35,6 +35,6 @@ internal interface KoSourceAndAliasTypeProviderCore : KoSourceAndAliasTypeProvid
 
     override val bareSourceType: String
         get() = sourceType
-            .split("<")
-            .first()
+            .substringBefore("<")
+            .replace("?", "")
 }

--- a/lib/src/test/kotlin/com/lemonappdev/konsist/api/ext/list/KoSourceAndAliasTypeProviderListExtTest.kt
+++ b/lib/src/test/kotlin/com/lemonappdev/konsist/api/ext/list/KoSourceAndAliasTypeProviderListExtTest.kt
@@ -189,176 +189,176 @@ class KoSourceAndAliasTypeProviderListExtTest {
     }
 
     @Test
-    fun `withBaseSourceTypeOf(KClass) returns declaration with given source declaration`() {
+    fun `withBareSourceTypeOf(KClass) returns declaration with given source declaration`() {
         // given
-        val baseSourceType1 = "SampleClass1"
-        val baseSourceType2 = "SampleClass2"
+        val bareSourceType1 = "SampleClass1"
+        val bareSourceType2 = "SampleClass2"
         val declaration1: KoSourceAndAliasTypeProvider = mockk {
-            every { baseSourceType } returns baseSourceType1
+            every { bareSourceType } returns bareSourceType1
         }
         val declaration2: KoSourceAndAliasTypeProvider = mockk {
-            every { baseSourceType } returns baseSourceType2
+            every { bareSourceType } returns bareSourceType2
         }
         val declarations = listOf(declaration1, declaration2)
 
         // when
-        val sut = declarations.withBaseSourceTypeOf(SampleClass1::class)
+        val sut = declarations.withBareSourceTypeOf(SampleClass1::class)
 
         // then
         sut shouldBeEqualTo listOf(declaration1)
     }
 
     @Test
-    fun `withBaseSourceTypeOf(KClass) returns declarations with one of given source declarations`() {
+    fun `withBareSourceTypeOf(KClass) returns declarations with one of given source declarations`() {
         // given
-        val baseSourceType1 = "SampleClass1"
-        val baseSourceType2 = "SampleClass2"
-        val baseSourceType3 = "SampleClass3"
+        val bareSourceType1 = "SampleClass1"
+        val bareSourceType2 = "SampleClass2"
+        val bareSourceType3 = "SampleClass3"
         val declaration1: KoSourceAndAliasTypeProvider = mockk {
-            every { baseSourceType } returns baseSourceType1
+            every { bareSourceType } returns bareSourceType1
         }
         val declaration2: KoSourceAndAliasTypeProvider = mockk {
-            every { baseSourceType } returns baseSourceType2
+            every { bareSourceType } returns bareSourceType2
         }
         val declaration3: KoSourceAndAliasTypeProvider = mockk {
-            every { baseSourceType } returns baseSourceType3
+            every { bareSourceType } returns bareSourceType3
         }
         val declarations = listOf(declaration1, declaration2, declaration3)
 
         // when
-        val sut = declarations.withBaseSourceTypeOf(SampleClass1::class, SampleClass2::class)
+        val sut = declarations.withBareSourceTypeOf(SampleClass1::class, SampleClass2::class)
 
         // then
         sut shouldBeEqualTo listOf(declaration1, declaration2)
     }
 
     @Test
-    fun `withoutBaseSourceTypeOf(KClass) returns declaration without given source declaration`() {
+    fun `withoutBareSourceTypeOf(KClass) returns declaration without given source declaration`() {
         // given
-        val baseSourceType1 = "SampleClass1"
-        val baseSourceType2 = "SampleClass2"
+        val bareSourceType1 = "SampleClass1"
+        val bareSourceType2 = "SampleClass2"
         val declaration1: KoSourceAndAliasTypeProvider = mockk {
-            every { baseSourceType } returns baseSourceType1
+            every { bareSourceType } returns bareSourceType1
         }
         val declaration2: KoSourceAndAliasTypeProvider = mockk {
-            every { baseSourceType } returns baseSourceType2
+            every { bareSourceType } returns bareSourceType2
         }
         val declarations = listOf(declaration1, declaration2)
 
         // when
-        val sut = declarations.withoutBaseSourceTypeOf(SampleClass1::class)
+        val sut = declarations.withoutBareSourceTypeOf(SampleClass1::class)
 
         // then
         sut shouldBeEqualTo listOf(declaration2)
     }
 
     @Test
-    fun `withoutBaseSourceTypeOf(KClass) returns declaration without any of given source declarations`() {
+    fun `withoutBareSourceTypeOf(KClass) returns declaration without any of given source declarations`() {
         // given
-        val baseSourceType1 = "SampleClass1"
-        val baseSourceType2 = "SampleClass2"
-        val baseSourceType3 = "SampleClass3"
+        val bareSourceType1 = "SampleClass1"
+        val bareSourceType2 = "SampleClass2"
+        val bareSourceType3 = "SampleClass3"
         val declaration1: KoSourceAndAliasTypeProvider = mockk {
-            every { baseSourceType } returns baseSourceType1
+            every { bareSourceType } returns bareSourceType1
         }
         val declaration2: KoSourceAndAliasTypeProvider = mockk {
-            every { baseSourceType } returns baseSourceType2
+            every { bareSourceType } returns bareSourceType2
         }
         val declaration3: KoSourceAndAliasTypeProvider = mockk {
-            every { baseSourceType } returns baseSourceType3
+            every { bareSourceType } returns bareSourceType3
         }
         val declarations = listOf(declaration1, declaration2, declaration3)
 
         // when
-        val sut = declarations.withoutBaseSourceTypeOf(SampleClass1::class, SampleClass2::class)
+        val sut = declarations.withoutBareSourceTypeOf(SampleClass1::class, SampleClass2::class)
 
         // then
         sut shouldBeEqualTo listOf(declaration3)
     }
 
     @Test
-    fun `withBaseSourceType(type) returns declaration with given source type`() {
+    fun `withBareSourceType(type) returns declaration with given source type`() {
         // given
-        val baseSourceType1 = "SampleClass1"
-        val baseSourceType2 = "SampleClass2"
+        val bareSourceType1 = "SampleClass1"
+        val bareSourceType2 = "SampleClass2"
         val declaration1: KoSourceAndAliasTypeProvider = mockk {
-            every { baseSourceType } returns baseSourceType1
+            every { bareSourceType } returns bareSourceType1
         }
         val declaration2: KoSourceAndAliasTypeProvider = mockk {
-            every { baseSourceType } returns baseSourceType2
+            every { bareSourceType } returns bareSourceType2
         }
         val declarations = listOf(declaration1, declaration2)
 
         // when
-        val sut = declarations.withBaseSourceType(baseSourceType1)
+        val sut = declarations.withBareSourceType(bareSourceType1)
 
         // then
         sut shouldBeEqualTo listOf(declaration1)
     }
 
     @Test
-    fun `withBaseSourceType(type) returns declarations with one of given source declarations`() {
+    fun `withBareSourceType(type) returns declarations with one of given source declarations`() {
         // given
-        val baseSourceType1 = "SampleClass1"
-        val baseSourceType2 = "SampleClass2"
-        val baseSourceType3 = "SampleClass3"
+        val bareSourceType1 = "SampleClass1"
+        val bareSourceType2 = "SampleClass2"
+        val bareSourceType3 = "SampleClass3"
         val declaration1: KoSourceAndAliasTypeProvider = mockk {
-            every { baseSourceType } returns baseSourceType1
+            every { bareSourceType } returns bareSourceType1
         }
         val declaration2: KoSourceAndAliasTypeProvider = mockk {
-            every { baseSourceType } returns baseSourceType2
+            every { bareSourceType } returns bareSourceType2
         }
         val declaration3: KoSourceAndAliasTypeProvider = mockk {
-            every { baseSourceType } returns baseSourceType3
+            every { bareSourceType } returns bareSourceType3
         }
         val declarations = listOf(declaration1, declaration2, declaration3)
 
         // when
-        val sut = declarations.withBaseSourceType(baseSourceType1, baseSourceType2)
+        val sut = declarations.withBareSourceType(bareSourceType1, bareSourceType2)
 
         // then
         sut shouldBeEqualTo listOf(declaration1, declaration2)
     }
 
     @Test
-    fun `withoutBaseSourceType(type) returns declaration without given source type`() {
+    fun `withoutBareSourceType(type) returns declaration without given source type`() {
         // given
-        val baseSourceType1 = "SampleClass1"
-        val baseSourceType2 = "SampleClass2"
+        val bareSourceType1 = "SampleClass1"
+        val bareSourceType2 = "SampleClass2"
         val declaration1: KoSourceAndAliasTypeProvider = mockk {
-            every { baseSourceType } returns baseSourceType1
+            every { bareSourceType } returns bareSourceType1
         }
         val declaration2: KoSourceAndAliasTypeProvider = mockk {
-            every { baseSourceType } returns baseSourceType2
+            every { bareSourceType } returns bareSourceType2
         }
         val declarations = listOf(declaration1, declaration2)
 
         // when
-        val sut = declarations.withoutBaseSourceType(baseSourceType1)
+        val sut = declarations.withoutBareSourceType(bareSourceType1)
 
         // then
         sut shouldBeEqualTo listOf(declaration2)
     }
 
     @Test
-    fun `withoutBaseSourceType(type) returns declaration without any of given source type`() {
+    fun `withoutBareSourceType(type) returns declaration without any of given source type`() {
         // given
-        val baseSourceType1 = "SampleClass1"
-        val baseSourceType2 = "SampleClass2"
-        val baseSourceType3 = "SampleClass3"
+        val bareSourceType1 = "SampleClass1"
+        val bareSourceType2 = "SampleClass2"
+        val bareSourceType3 = "SampleClass3"
         val declaration1: KoSourceAndAliasTypeProvider = mockk {
-            every { baseSourceType } returns baseSourceType1
+            every { bareSourceType } returns bareSourceType1
         }
         val declaration2: KoSourceAndAliasTypeProvider = mockk {
-            every { baseSourceType } returns baseSourceType2
+            every { bareSourceType } returns bareSourceType2
         }
         val declaration3: KoSourceAndAliasTypeProvider = mockk {
-            every { baseSourceType } returns baseSourceType3
+            every { bareSourceType } returns bareSourceType3
         }
         val declarations = listOf(declaration1, declaration2, declaration3)
 
         // when
-        val sut = declarations.withoutBaseSourceType(baseSourceType1, baseSourceType2)
+        val sut = declarations.withoutBareSourceType(bareSourceType1, bareSourceType2)
 
         // then
         sut shouldBeEqualTo listOf(declaration3)


### PR DESCRIPTION
- rename `baseSourceType` To `bareSourcetype`
- type does not have nullability information