### PR TITLE
KON-578 Annotations `fullyQualifiedName` Is Broken When There Are More Imports In The File Which Contain Its Name

### DIFF
--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koannotation/KoAnnotationDeclarationForKoFullyQualifiedNameProviderTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koannotation/KoAnnotationDeclarationForKoFullyQualifiedNameProviderTest.kt
@@ -85,6 +85,19 @@ class KoAnnotationDeclarationForKoFullyQualifiedNameProviderTest {
         sut.fullyQualifiedName shouldBeEqualTo "SampleAnnotation"
     }
 
+    @Test
+    fun `annotation-fully-qualified-name-when-other-import-contains-its-name`() {
+        // given
+        val sut = getSnippetFile("annotation-fully-qualified-name-when-other-import-contains-its-name")
+            .functions()
+            .first()
+            .annotations
+            .first()
+
+        // then
+        sut.fullyQualifiedName shouldBeEqualTo "com.lemonappdev.konsist.testdata.testpackage.Annotation"
+    }
+
     private fun getSnippetFile(fileName: String) =
         getSnippetKoScope("core/declaration/koannotation/snippet/forkofullyqualifiednameprovider/", fileName)
 }

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koannotation/snippet/forkofullyqualifiednameprovider/annotation-fully-qualified-name-when-other-import-contains-its-name.kttxt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koannotation/snippet/forkofullyqualifiednameprovider/annotation-fully-qualified-name-when-other-import-contains-its-name.kttxt
@@ -1,0 +1,6 @@
+import com.lemonappdev.konsist.testdata.SampleAnnotation
+import com.lemonappdev.konsist.testdata.testpackage.Annotation
+
+@Annotation
+fun sampleFunction() {
+}

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/kotype/KoTypeDeclarationForKoFullyQualifiedNameProviderTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/kotype/KoTypeDeclarationForKoFullyQualifiedNameProviderTest.kt
@@ -3,11 +3,28 @@ package com.lemonappdev.konsist.core.declaration.kotype
 import com.lemonappdev.konsist.TestSnippetProvider
 import com.lemonappdev.konsist.api.ext.list.withPrimaryConstructor
 import org.amshove.kluent.shouldBeEqualTo
+import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.Arguments.arguments
 import org.junit.jupiter.params.provider.MethodSource
 
 class KoTypeDeclarationForKoFullyQualifiedNameProviderTest {
+    @Test
+    fun `type-fully-qualified-name-when-other-import-contains-its-name`() {
+        // given
+        val sut = getSnippetFile("type-fully-qualified-name-when-other-import-contains-its-name")
+            .classes()
+            .withPrimaryConstructor()
+            .first()
+            .primaryConstructor
+            ?.parameters
+            ?.first()
+            ?.type
+
+        // then
+        sut?.fullyQualifiedName shouldBeEqualTo "com.lemonappdev.konsist.testdata.testpackage.Type"
+    }
+
     @ParameterizedTest(name = "fully-qualified-name {0} equals {1}")
     @MethodSource("provideValues")
     fun `fully-qualified-name`(

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/kotype/snippet/forkofullyqualifiednameprovider/type-fully-qualified-name-when-other-import-contains-its-name.kttxt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/kotype/snippet/forkofullyqualifiednameprovider/type-fully-qualified-name-when-other-import-contains-its-name.kttxt
@@ -1,0 +1,4 @@
+import com.lemonappdev.konsist.testdata.SampleType
+import com.lemonappdev.konsist.testdata.testpackage.Type
+
+class SampleClass1(val sampleProperty1: Type)

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/testdata/testpackage/TestNestedData.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/testdata/testpackage/TestNestedData.kt
@@ -1,0 +1,14 @@
+package com.lemonappdev.konsist.testdata.testpackage
+
+@Target(
+    AnnotationTarget.CLASS,
+    AnnotationTarget.PROPERTY,
+    AnnotationTarget.CONSTRUCTOR,
+    AnnotationTarget.FUNCTION,
+    AnnotationTarget.FILE,
+    AnnotationTarget.TYPEALIAS,
+    AnnotationTarget.LOCAL_VARIABLE,
+)
+annotation class Annotation
+
+class Type

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/KoFullyQualifiedNameProviderCore.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/KoFullyQualifiedNameProviderCore.kt
@@ -16,7 +16,7 @@ internal interface KoFullyQualifiedNameProviderCore :
             var fqn = containingFile
                 .imports
                 .map { it.name }
-                .firstOrNull { it.contains(textUsedToFqn) }
+                .firstOrNull { it.endsWith(".$textUsedToFqn") }
 
             if (fqn == null) {
                 fqn = containingFile


### PR DESCRIPTION
Community: https://github.com/LemonAppDev/konsist/discussions/738

**Snippet**:
```kotlin
import com.package.SampleAnnotation
import com.package.complex.Annotation

@Annotation
fun sampleFunction() {
}
```

```kotlin
val annotationFqn = Konsist
    .scopeFromProject()
    .functions()
    .annotations()
    .first { it.name == "sampleFunction" }
    .fullyQualifiedName
```

**Before** 
`annotationFqn` returns `com.package.SampleAnnotation`

**After** 
`annotationFqn` returns `com.package.complex.Annotation`
  