### PR TITLE
Fix git dir resolver uses the wrong paths

### DIFF
--- a/lib/src/main/kotlin/com/lemonappdev/konsist/core/filesystem/rootprovider/GitProjectRootDirResolver.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/core/filesystem/rootprovider/GitProjectRootDirResolver.kt
@@ -13,8 +13,8 @@ class GitProjectRootDirResolver(
     Description of the '.git' directory https://githowto.com/git_internals_git_directory
      */
     override val paths = setOf(
-        "./git/config".toOsSeparator(),
-        "./git/HEAD".toOsSeparator(),
-        "./git/refs".toOsSeparator(),
+        "./.git/config".toOsSeparator(),
+        "./.git/HEAD".toOsSeparator(),
+        "./.git/refs".toOsSeparator(),
     )
 }

--- a/lib/src/test/kotlin/com/lemonappdev/konsist/core/filesystem/rootprovider/GitProjectRootDirResolverTest.kt
+++ b/lib/src/test/kotlin/com/lemonappdev/konsist/core/filesystem/rootprovider/GitProjectRootDirResolverTest.kt
@@ -1,0 +1,27 @@
+package com.lemonappdev.konsist.core.filesystem.rootprovider
+
+import com.lemonappdev.konsist.core.filesystem.PathVerifier
+import io.mockk.every
+import io.mockk.mockk
+import org.amshove.kluent.shouldBeEqualTo
+import org.junit.jupiter.api.Test
+import java.io.File
+
+class GitProjectRootDirResolverTest {
+    @Test
+    fun `git dir resolver is using the correct git folder paths`() {
+        // given
+        val file = mockk<File>()
+        val pathVerifier = mockk<PathVerifier>()
+        every { pathVerifier.verifyPathIfExists(file, "./.git/config") } returns true
+        every { pathVerifier.verifyPathIfExists(file, "./.git/HEAD") } returns true
+        every { pathVerifier.verifyPathIfExists(file, "./.git/refs") } returns true
+        val sut = GitProjectRootDirResolver(pathVerifier)
+
+        // when
+        val actual = sut.getProjectRootDir(file)
+
+        // then
+        actual shouldBeEqualTo file
+    }
+}


### PR DESCRIPTION
In projects dependent on resolving project directory based on git the following exception would be thrown:
```
com.lemonappdev.konsist.core.exception.KoInternalException: Project directory not found. Searched in /<your-directory-here> and parent directories
```
because the paths defined in `GitProjectRootDirResolver` didn't point to the `.git` directory, but rather a `git` repository missing the `.`.