### PR TITLE
KON-578 Fix fully qualified name

### DIFF
--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/kotype/snippet/forkofullyqualifiednameprovider/import-alias.kttxt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/kotype/snippet/forkofullyqualifiednameprovider/import-alias.kttxt
@@ -1,3 +1,4 @@
+import com.lemonappdev.konsist.testdata.AnotherSampleType as AnotherImportAlias
 import com.lemonappdev.konsist.testdata.SampleType as ImportAlias
 
 class SampleClass1(val sampleProperty1: ImportAlias)

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/kotype/snippet/forkofullyqualifiednameprovider/list-type.kttxt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/kotype/snippet/forkofullyqualifiednameprovider/list-type.kttxt
@@ -1,3 +1,4 @@
+import com.lemonappdev.konsist.testdata.AnotherList
 import com.lemonappdev.konsist.testdata.SampleType
 
 class SampleClass1(val sampleProperty1: List<SampleType?>)

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/kotype/snippet/forkofullyqualifiednameprovider/non-nullable-type-without-import-and-package.kttxt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/kotype/snippet/forkofullyqualifiednameprovider/non-nullable-type-without-import-and-package.kttxt
@@ -1,3 +1,4 @@
 class SampleClass1(val sampleProperty1: SampleTypeClass)
 
+class AnotherSampleTypeClass
 class SampleTypeClass

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/kotype/snippet/forkofullyqualifiednameprovider/non-nullable-type-without-import-and-with-package.kttxt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/kotype/snippet/forkofullyqualifiednameprovider/non-nullable-type-without-import-and-with-package.kttxt
@@ -2,4 +2,5 @@ package com.samplepackage
 
 class SampleClass1(val sampleProperty1: SampleTypeClass)
 
+class AnotherSampleTypeClass
 class SampleTypeClass

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/kotype/snippet/forkofullyqualifiednameprovider/nullable-import-alias.kttxt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/kotype/snippet/forkofullyqualifiednameprovider/nullable-import-alias.kttxt
@@ -1,3 +1,5 @@
+import com.lemonappdev.konsist.testdata.AnotherSampleType
+import com.lemonappdev.konsist.testdata.AnotherSampleType as AnotherSampleType
 import com.lemonappdev.konsist.testdata.SampleType as ImportAlias
 
 class SampleClass1(val sampleProperty1: ImportAlias?)

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/kotype/snippet/forkofullyqualifiednameprovider/nullable-list-type.kttxt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/kotype/snippet/forkofullyqualifiednameprovider/nullable-list-type.kttxt
@@ -1,3 +1,4 @@
+import com.lemonappdev.konsist.testdata.AnotherList
 import com.lemonappdev.konsist.testdata.SampleType
 
 class SampleClass1(val sampleProperty1: List<SampleType?>?)

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/kotype/snippet/forkofullyqualifiednameprovider/nullable-type-without-import-and-package.kttxt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/kotype/snippet/forkofullyqualifiednameprovider/nullable-type-without-import-and-package.kttxt
@@ -1,3 +1,4 @@
 class SampleClass1(val sampleProperty1: SampleTypeClass?)
 
+class AnotherSampleTypeClass
 class SampleTypeClass

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/kotype/snippet/forkofullyqualifiednameprovider/nullable-type-without-import-and-with-package.kttxt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/kotype/snippet/forkofullyqualifiednameprovider/nullable-type-without-import-and-with-package.kttxt
@@ -2,4 +2,6 @@ package com.samplepackage
 
 class SampleClass1(val sampleProperty1: SampleTypeClass?)
 
+class AnotherSampleTypeClass
+
 class SampleTypeClass

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/kotype/snippet/forkofullyqualifiednameprovider/nullable-type.kttxt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/kotype/snippet/forkofullyqualifiednameprovider/nullable-type.kttxt
@@ -1,3 +1,4 @@
+import com.lemonappdev.konsist.testdata.AnotherSampleType
 import com.lemonappdev.konsist.testdata.SampleType
 
 class SampleClass1(val sampleProperty1: SampleType?)

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/kotype/snippet/forkofullyqualifiednameprovider/type.kttxt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/kotype/snippet/forkofullyqualifiednameprovider/type.kttxt
@@ -1,3 +1,4 @@
+import com.lemonappdev.konsist.testdata.AnotherSampleType
 import com.lemonappdev.konsist.testdata.SampleType
 
 class SampleClass1(val sampleProperty1: SampleType)

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/KoFullyQualifiedNameProviderCore.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/KoFullyQualifiedNameProviderCore.kt
@@ -16,7 +16,7 @@ internal interface KoFullyQualifiedNameProviderCore :
             var fqn = containingFile
                 .imports
                 .map { it.name }
-                .firstOrNull { it.contains(textUsedToFqn) }
+                .firstOrNull { it.isFullyQualifiedName() }
 
             if (fqn == null) {
                 fqn = containingFile
@@ -29,9 +29,11 @@ internal interface KoFullyQualifiedNameProviderCore :
                         }
                     }
                     .mapNotNull { (it as? KoFullyQualifiedNameProvider)?.fullyQualifiedName }
-                    .firstOrNull { it.contains(textUsedToFqn) }
+                    .firstOrNull { it.isFullyQualifiedName() }
             }
 
             return fqn ?: textUsedToFqn
         }
+
+    fun String.isFullyQualifiedName() = split(".").last() == textUsedToFqn
 }


### PR DESCRIPTION
`fullyQualifiedName` was broken, because it tries to match first import which CONTAINS the expected type name. Ex: `org.AnotherPerson` contains `Person`, but should matches this predicate, but it not the fully qualified name or `Perso`.

I chose to update existing snippets used in `KoTypeDeclarationForKoFullyQualifiedNameProviderTest`, instead of trying to build all possible combinations :
* current list of use cases
* with or without another import… which name start, contains or ends with expected `fullyQualifiedName` … or not

I think it's preferable.