### PR TITLE
Fix wrong detection of Git root project dir

### DIFF
--- a/lib/src/main/kotlin/com/lemonappdev/konsist/core/filesystem/rootprovider/GitProjectRootDirResolver.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/core/filesystem/rootprovider/GitProjectRootDirResolver.kt
@@ -13,8 +13,8 @@ class GitProjectRootDirResolver(
     Description of the '.git' directory https://githowto.com/git_internals_git_directory
      */
     override val paths = setOf(
-        "./git/config".toOsSeparator(),
-        "./git/HEAD".toOsSeparator(),
-        "./git/refs".toOsSeparator(),
+        ".git/config".toOsSeparator(),
+        ".git/HEAD".toOsSeparator(),
+        ".git/refs".toOsSeparator(),
     )
 }


### PR DESCRIPTION
Detection never worked before because Git creates directory called '.git', while code was checking 'git'.

For example, it wasn't possible to use Konsist in projects using Maven, but not using Maven Wrapper. `MavenProjectRootDirResolver.kt` assumes `mvnw` is present in a Maven project (which is not true for many Maven projects). Konsist was falling back to GitProjectRootDirResolver, which was broken and never worked. As result, exception happened:

```
com.lemonappdev.konsist.core.exception.KoInternalException: Project directory not found. Searched in /my-project and parent directories

	at com.lemonappdev.konsist.core.filesystem.PathProvider$rootProjectPath$2.invoke(PathProvider.kt:17)
	at com.lemonappdev.konsist.core.filesystem.PathProvider$rootProjectPath$2.invoke(PathProvider.kt:10)
	at kotlin.SynchronizedLazyImpl.getValue(LazyJVM.kt:74)
	at com.lemonappdev.konsist.core.filesystem.PathProvider.getRootProjectPath(PathProvider.kt:10)
	at com.lemonappdev.konsist.core.container.KoScopeCreatorCore$projectKotlinFiles$2.invoke(KoScopeCreatorCore.kt:18)
	at com.lemonappdev.konsist.core.container.KoScopeCreatorCore$projectKotlinFiles$2.invoke(KoScopeCreatorCore.kt:18)
```

After my PR, Konsist will work for Maven projects, because the detection will work by falling back to Git detection of the root project.