### PR TITLE
KON-577 Layer doesn't allow string that uses a package wildcard twice

### DIFF
--- a/lib/src/main/kotlin/com/lemonappdev/konsist/core/util/LocationUtil.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/core/util/LocationUtil.kt
@@ -5,13 +5,17 @@ object LocationUtil {
     /**
      *  Regex to match packages names ending with 2 (two) dots '.' at the end.
      *
-     *   (?:)   = non-capturing group.
-     *  \.{0,2} = Matches zero, one, or two dots optionally.
-     *    \w+   = Matches one or more word characters (alphanumeric characters or underscore).
-     *   \.{2}  = escaped char '.' (dot) appearing 2 times
-     *     $    = Matches end of string
+     *   (?:)    = non-capturing group.
+     *    \w+    = Matches one or more word characters (alphanumeric characters or underscore).
+     *     |     = OR
+     * \.{2}\w+  = Matches two dots followed by one or more word characters.
+     *  \.{0,2}  = Matches zero, one, or two dots optionally.
+     *    \w+    = Matches one or more word characters (alphanumeric characters or underscore).
+     *     +     = Match 1 or more of the preceding token.
+     *   \.{2}   = escaped char '.' (dot) appearing 2 times
+     *     $     = Matches end of string
      */
-    internal const val REGEX_PACKAGE_NAME_END_TWO_DOTS = "(?:\\.{0,2}\\w+)+\\.{2}\$"
+    internal const val REGEX_PACKAGE_NAME_END_TWO_DOTS = "(?:\\w+|\\.{2}\\w+)(?:\\.{0,2}\\w+)+\\.{2}\$"
 
     /**
      * Use '..' as a wildcard for any number of characters.

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/core/util/LocationUtil.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/core/util/LocationUtil.kt
@@ -2,21 +2,14 @@ package com.lemonappdev.konsist.core.util
 
 object LocationUtil {
 
-    // Todo: update comment
     /**
      *  Regex to match packages names ending with 2 (two) dots '.' at the end.
      *
-     *   (?:) = non-capturing group.
-     *    ^   = Matches the beginning of the string.
-     *    \w  = Matches any word char (alpha & underscore).
-     *    +   = Match 1 or more of the preceding token.
-     *    |   = OR
-     *  \.{2}?= allow using '..' as wildcard optionally (only one accepted)
-     *    \w  = Matches any word char (alpha & underscore).
-     *    +   = Match 1 or more of the preceding token.
-     *    |   = OR
-     *  \.{2} = escaped char '.' (dot) appearing 2 times
-     *    $   = Matches end of string
+     *   (?:)   = non-capturing group.
+     *  \.{0,2} = Matches zero, one, or two dots optionally.
+     *    \w+   = Matches one or more word characters (alphanumeric characters or underscore).
+     *   \.{2}  = escaped char '.' (dot) appearing 2 times
+     *     $    = Matches end of string
      */
     internal const val REGEX_PACKAGE_NAME_END_TWO_DOTS = "(?:\\.{0,2}\\w+)+\\.{2}\$"
 

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/core/util/LocationUtil.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/core/util/LocationUtil.kt
@@ -2,6 +2,7 @@ package com.lemonappdev.konsist.core.util
 
 object LocationUtil {
 
+    // Todo: update comment
     /**
      *  Regex to match packages names ending with 2 (two) dots '.' at the end.
      *

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/core/util/LocationUtil.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/core/util/LocationUtil.kt
@@ -17,7 +17,7 @@ object LocationUtil {
      *  \.{2} = escaped char '.' (dot) appearing 2 times
      *    $   = Matches end of string
      */
-    internal const val REGEX_PACKAGE_NAME_END_TWO_DOTS = "(?:^\\w+|\\w+\\.\\w+\\.{2}?\\w+|\\w+\\.\\w+)+\\.{2}\$"
+    internal const val REGEX_PACKAGE_NAME_END_TWO_DOTS = "(?:\\.{0,2}\\w+)+\\.{2}\$"
 
     /**
      * Use '..' as a wildcard for any number of characters.

--- a/lib/src/test/kotlin/com/lemonappdev/konsist/api/architecture/LayerTest.kt
+++ b/lib/src/test/kotlin/com/lemonappdev/konsist/api/architecture/LayerTest.kt
@@ -111,7 +111,7 @@ class LayerTest {
         sut shouldNotThrow KoPreconditionFailedException::class
     }
 
-    //Todo: which test is correct? This above or below?
+    // Todo: which test is correct? This above or below?
     /*
     @Test
     fun `throws an exception when the package ends with two dots and there more than two dots used as wildcard`() {

--- a/lib/src/test/kotlin/com/lemonappdev/konsist/api/architecture/LayerTest.kt
+++ b/lib/src/test/kotlin/com/lemonappdev/konsist/api/architecture/LayerTest.kt
@@ -96,7 +96,7 @@ class LayerTest {
     @Test
     fun `do not throw an exception when the package contains at the center and at the end two dots`() {
         // given
-        val sut = { Layer("Domain", "package..feature..") }
+        val sut = { Layer("Domain", "first.second..package..feature1..") }
 
         // then
         sut shouldNotThrow KoPreconditionFailedException::class
@@ -110,19 +110,4 @@ class LayerTest {
         // then
         sut shouldNotThrow KoPreconditionFailedException::class
     }
-
-    // Todo: which test is correct? This above or below?
-
-    /*
-    @Test
-    fun `throws an exception when the package ends with two dots and there more than two dots used as wildcard`() {
-        // given
-        val sut = { Layer("Domain", "first.second..package..feature1..") }
-
-        // then
-        sut shouldThrow KoPreconditionFailedException::class withMessage """
-            Layer Domain must be defined by package ending with '..'. Now: first.second..package..feature1.. .
-        """.trimIndent()
-    }
-     */
 }

--- a/lib/src/test/kotlin/com/lemonappdev/konsist/api/architecture/LayerTest.kt
+++ b/lib/src/test/kotlin/com/lemonappdev/konsist/api/architecture/LayerTest.kt
@@ -111,6 +111,8 @@ class LayerTest {
         sut shouldNotThrow KoPreconditionFailedException::class
     }
 
+    //Todo: which test is correct? This above or below?
+    /*
     @Test
     fun `throws an exception when the package ends with two dots and there more than two dots used as wildcard`() {
         // given
@@ -121,4 +123,5 @@ class LayerTest {
             Layer Domain must be defined by package ending with '..'. Now: first.second..package..feature1.. .
         """.trimIndent()
     }
+     */
 }

--- a/lib/src/test/kotlin/com/lemonappdev/konsist/api/architecture/LayerTest.kt
+++ b/lib/src/test/kotlin/com/lemonappdev/konsist/api/architecture/LayerTest.kt
@@ -112,11 +112,12 @@ class LayerTest {
     }
 
     // Todo: which test is correct? This above or below?
+
     /*
     @Test
     fun `throws an exception when the package ends with two dots and there more than two dots used as wildcard`() {
         // given
-        val sut = { Layer("Domain", "first..second.package..feature1..") }
+        val sut = { Layer("Domain", "first.second..package..feature1..") }
 
         // then
         sut shouldThrow KoPreconditionFailedException::class withMessage """

--- a/lib/src/test/kotlin/com/lemonappdev/konsist/api/architecture/LayerTest.kt
+++ b/lib/src/test/kotlin/com/lemonappdev/konsist/api/architecture/LayerTest.kt
@@ -85,9 +85,36 @@ class LayerTest {
     }
 
     @Test
+    fun `do not throw an exception when the package starts and ends with two dots`() {
+        // given
+        val sut = { Layer("Domain", "..package..") }
+
+        // then
+        sut shouldNotThrow KoPreconditionFailedException::class
+    }
+
+    @Test
+    fun `do not throw an exception when the package contains at the center and at the end two dots`() {
+        // given
+        val sut = { Layer("Domain", "package..feature..") }
+
+        // then
+        sut shouldNotThrow KoPreconditionFailedException::class
+    }
+
+    @Test
+    fun `do not throw an exception when the package contains at the center, at the start and at the end two dots`() {
+        // given
+        val sut = { Layer("Domain", "..package..feature..") }
+
+        // then
+        sut shouldNotThrow KoPreconditionFailedException::class
+    }
+
+    @Test
     fun `throws an exception when the package ends with two dots and there more than two dots used as wildcard`() {
         // given
-        val sut = { Layer("Domain", "first.second..package..feature1..") }
+        val sut = { Layer("Domain", "first..second.package..feature1..") }
 
         // then
         sut shouldThrow KoPreconditionFailedException::class withMessage """


### PR DESCRIPTION
Fixed bug reported at: https://github.com/LemonAppDev/konsist/discussions/765.