### PR TITLE
KON-593 `KoPackageMatchingPathProviderCore.hasMatchingPath` fails on windows

### DIFF
--- a/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/KoPackageMatchingPathProviderCore.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/KoPackageMatchingPathProviderCore.kt
@@ -1,6 +1,7 @@
 package com.lemonappdev.konsist.core.provider
 
 import com.lemonappdev.konsist.api.provider.KoPackageMatchingPathProvider
+import com.lemonappdev.konsist.core.util.PathUtil.sep
 
 internal interface KoPackageMatchingPathProviderCore :
     KoPackageMatchingPathProvider,
@@ -11,6 +12,6 @@ internal interface KoPackageMatchingPathProviderCore :
     override val hasMatchingPath: Boolean
         get() =
             path
-                .replace("/", ".")
+                .replace(sep, ".")
                 .endsWith(fullyQualifiedName + "." + containingFile.nameWithExtension)
 }

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/KoPackageMatchingPathProviderCore.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/KoPackageMatchingPathProviderCore.kt
@@ -1,7 +1,7 @@
 package com.lemonappdev.konsist.core.provider
 
 import com.lemonappdev.konsist.api.provider.KoPackageMatchingPathProvider
-import com.lemonappdev.konsist.core.util.PathUtil.sep
+import com.lemonappdev.konsist.core.util.PathUtil.separator
 
 internal interface KoPackageMatchingPathProviderCore :
     KoPackageMatchingPathProvider,
@@ -12,6 +12,6 @@ internal interface KoPackageMatchingPathProviderCore :
     override val hasMatchingPath: Boolean
         get() =
             path
-                .replace(sep, ".")
+                .replace(separator, ".")
                 .endsWith(fullyQualifiedName + "." + containingFile.nameWithExtension)
 }

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/core/util/PathUtil.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/core/util/PathUtil.kt
@@ -3,7 +3,7 @@ package com.lemonappdev.konsist.core.util
 import java.io.File
 
 object PathUtil {
-    val sep: String = File.separator
+    val separator: String = File.separator
 
     fun toOsSeparator(path: String): String = path
         .replace("/", File.separator)

--- a/test-projects/konsist-declaration-tester/app/src/integrationTest/kotlin/com/lemonappdev/konsist/declaration/kopackage/KoPackageDeclarationForKoPackageMatchingPathProviderTest.kt
+++ b/test-projects/konsist-declaration-tester/app/src/integrationTest/kotlin/com/lemonappdev/konsist/declaration/kopackage/KoPackageDeclarationForKoPackageMatchingPathProviderTest.kt
@@ -10,7 +10,7 @@ class KoPackageDeclarationForKoPackageMatchingPathProviderTest {
     @Test
     fun `package-with-matching-file-path`() {
         // given
-        val sut =  Konsist
+        val sut = Konsist
             .scopeFromFile("${PathProvider.appMainSourceSetProjectDirectory}/sample/AppClass.kt".toOsSeparator())
             .packages
             .first()
@@ -22,8 +22,10 @@ class KoPackageDeclarationForKoPackageMatchingPathProviderTest {
     @Test
     fun `package-without-matching-file-path`() {
         // given
-        val sut =  Konsist
-            .scopeFromFile("${PathProvider.appMainSourceSetProjectDirectory}/sample/AppClassWithPackageNotMatchingToPath.kt".toOsSeparator())
+        val sut = Konsist
+            .scopeFromFile(
+                "${PathProvider.appMainSourceSetProjectDirectory}/sample/AppClassWithPackageNotMatchingToPath.kt".toOsSeparator()
+            )
             .packages
             .first()
 

--- a/test-projects/konsist-declaration-tester/app/src/integrationTest/kotlin/com/lemonappdev/konsist/declaration/kopackage/KoPackageDeclarationForKoPackageMatchingPathProviderTest.kt
+++ b/test-projects/konsist-declaration-tester/app/src/integrationTest/kotlin/com/lemonappdev/konsist/declaration/kopackage/KoPackageDeclarationForKoPackageMatchingPathProviderTest.kt
@@ -1,0 +1,33 @@
+package com.lemonappdev.konsist.declaration.kopackage
+
+import com.lemonappdev.konsist.api.Konsist
+import com.lemonappdev.konsist.helper.ext.toOsSeparator
+import com.lemonappdev.konsist.helper.util.PathProvider
+import org.amshove.kluent.shouldBeEqualTo
+import org.junit.jupiter.api.Test
+
+class KoPackageDeclarationForKoPackageMatchingPathProviderTest {
+    @Test
+    fun `package-with-matching-file-path`() {
+        // given
+        val sut =  Konsist
+            .scopeFromFile("${PathProvider.appMainSourceSetProjectDirectory}/sample/AppClass.kt".toOsSeparator())
+            .packages
+            .first()
+
+        // then
+        sut.hasMatchingPath shouldBeEqualTo true
+    }
+
+    @Test
+    fun `package-without-matching-file-path`() {
+        // given
+        val sut =  Konsist
+            .scopeFromFile("${PathProvider.appMainSourceSetProjectDirectory}/sample/AppClassWithPackageNotMatchingPath.kt".toOsSeparator())
+            .packages
+            .first()
+
+        // then
+        sut.hasMatchingPath shouldBeEqualTo false
+    }
+}

--- a/test-projects/konsist-declaration-tester/app/src/integrationTest/kotlin/com/lemonappdev/konsist/declaration/kopackage/KoPackageDeclarationForKoPackageMatchingPathProviderTest.kt
+++ b/test-projects/konsist-declaration-tester/app/src/integrationTest/kotlin/com/lemonappdev/konsist/declaration/kopackage/KoPackageDeclarationForKoPackageMatchingPathProviderTest.kt
@@ -23,7 +23,7 @@ class KoPackageDeclarationForKoPackageMatchingPathProviderTest {
     fun `package-without-matching-file-path`() {
         // given
         val sut =  Konsist
-            .scopeFromFile("${PathProvider.appMainSourceSetProjectDirectory}/sample/AppClassWithPackageNotMatchingPath.kt".toOsSeparator())
+            .scopeFromFile("${PathProvider.appMainSourceSetProjectDirectory}/sample/AppClassWithPackageNotMatchingToPath.kt".toOsSeparator())
             .packages
             .first()
 

--- a/test-projects/konsist-declaration-tester/app/src/main/kotlin/com/lemonappdev/sample/AppClassWithPackageNotMatchingPath.kt
+++ b/test-projects/konsist-declaration-tester/app/src/main/kotlin/com/lemonappdev/sample/AppClassWithPackageNotMatchingPath.kt
@@ -1,0 +1,4 @@
+@file:Suppress(detekt.InvalidPackageDeclaration)
+package com.lemonappdev.sample.src
+
+class AppClassWithPackageNotMatchingPath

--- a/test-projects/konsist-declaration-tester/app/src/main/kotlin/com/lemonappdev/sample/AppClassWithPackageNotMatchingToPath.kt
+++ b/test-projects/konsist-declaration-tester/app/src/main/kotlin/com/lemonappdev/sample/AppClassWithPackageNotMatchingToPath.kt
@@ -1,4 +1,4 @@
 @file:Suppress(detekt.InvalidPackageDeclaration)
 package com.lemonappdev.sample.src
 
-class AppClassWithPackageNotMatchingPath
+class AppClassWithPackageNotMatchingToPath

--- a/test-projects/konsist-declaration-tester/app/src/main/kotlin/com/lemonappdev/sample/AppClassWithPackageNotMatchingToPath.kt
+++ b/test-projects/konsist-declaration-tester/app/src/main/kotlin/com/lemonappdev/sample/AppClassWithPackageNotMatchingToPath.kt
@@ -1,4 +1,4 @@
-@file:Suppress(detekt.InvalidPackageDeclaration)
+@file:Suppress("detekt.InvalidPackageDeclaration")
 package com.lemonappdev.sample.src
 
 class AppClassWithPackageNotMatchingToPath

--- a/test-projects/konsist-path-tester/app/src/integrationTest/kotlin/com/lemonappdev/konsist/helper/ext/PathExt.kt
+++ b/test-projects/konsist-path-tester/app/src/integrationTest/kotlin/com/lemonappdev/konsist/helper/ext/PathExt.kt
@@ -3,7 +3,7 @@ package com.lemonappdev.konsist.helper.ext
 import com.lemonappdev.konsist.core.util.PathUtil
 import java.io.File
 
-internal val fileSeparator: String = PathUtil.sep
+internal val fileSeparator: String = PathUtil.separator
 
 internal fun String.toOsSeparator(): String = PathUtil.toOsSeparator(this)
 


### PR DESCRIPTION
Fixed bug reported at: https://github.com/LemonAppDev/konsist/discussions/864