### PR TITLE
KON-596 Add extensions to retrieve properties of the source type

### DIFF
--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/type/kotype/KoTypeDeclarationForKoSourceDeclarationProviderTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/type/kotype/KoTypeDeclarationForKoSourceDeclarationProviderTest.kt
@@ -1,0 +1,72 @@
+package com.lemonappdev.konsist.core.declaration.type.kotype
+
+import com.lemonappdev.konsist.TestSnippetProvider
+import com.lemonappdev.konsist.api.declaration.KoClassDeclaration
+import com.lemonappdev.konsist.api.declaration.KoExternalDeclaration
+import com.lemonappdev.konsist.api.declaration.KoImportAliasDeclaration
+import com.lemonappdev.konsist.api.declaration.KoInterfaceDeclaration
+import com.lemonappdev.konsist.api.declaration.KoObjectDeclaration
+import com.lemonappdev.konsist.api.declaration.KoTypeAliasDeclaration
+import com.lemonappdev.konsist.api.declaration.type.KoFunctionTypeDeclaration
+import com.lemonappdev.konsist.api.declaration.type.KoKotlinTypeDeclaration
+import org.amshove.kluent.assertSoftly
+import org.amshove.kluent.shouldBeEqualTo
+import org.amshove.kluent.shouldBeInstanceOf
+import org.amshove.kluent.shouldNotBeInstanceOf
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.Arguments.arguments
+import org.junit.jupiter.params.provider.MethodSource
+import kotlin.reflect.KClass
+
+class KoTypeDeclarationForKoSourceDeclarationProviderTest {
+    @ParameterizedTest
+    @MethodSource("provideValues")
+    fun `source declaration`(
+        fileName: String,
+        instanceOf: KClass<*>,
+        notInstanceOf: KClass<*>,
+    ) {
+        // given
+        val sut = getSnippetFile(fileName)
+            .classes()
+            .first()
+            .primaryConstructor
+            ?.parameters
+            ?.first()
+            ?.type
+
+        // then
+        assertSoftly(sut) {
+            it?.sourceDeclaration shouldBeInstanceOf instanceOf
+            it?.sourceDeclaration shouldNotBeInstanceOf notInstanceOf
+        }
+    }
+
+    private fun getSnippetFile(fileName: String) =
+        TestSnippetProvider.getSnippetKoScope("core/declaration/type/kotype/snippet/forkosourcedeclarationprovider/", fileName)
+
+    companion object {
+        @Suppress("unused")
+        @JvmStatic
+        fun provideValues() = listOf(
+            arguments("nullable-kotlin-basic-type", KoKotlinTypeDeclaration::class, KoClassDeclaration::class),
+            arguments("not-nullable-kotlin-basic-type", KoKotlinTypeDeclaration::class, KoClassDeclaration::class),
+            arguments("nullable-kotlin-collection-type", KoKotlinTypeDeclaration::class, KoClassDeclaration::class),
+            arguments("not-nullable-kotlin-collection-type", KoKotlinTypeDeclaration::class, KoClassDeclaration::class),
+            arguments("nullable-class-type", KoClassDeclaration::class, KoKotlinTypeDeclaration::class),
+            arguments("not-nullable-class-type", KoClassDeclaration::class, KoKotlinTypeDeclaration::class),
+            arguments("nullable-interface-type", KoInterfaceDeclaration::class, KoKotlinTypeDeclaration::class),
+            arguments("not-nullable-interface-type", KoInterfaceDeclaration::class, KoKotlinTypeDeclaration::class),
+            arguments("nullable-object-type", KoObjectDeclaration::class, KoKotlinTypeDeclaration::class),
+            arguments("not-nullable-object-type", KoObjectDeclaration::class, KoKotlinTypeDeclaration::class),
+            arguments("nullable-function-type", KoFunctionTypeDeclaration::class, KoKotlinTypeDeclaration::class),
+            arguments("not-nullable-function-type", KoFunctionTypeDeclaration::class, KoKotlinTypeDeclaration::class),
+            arguments("nullable-import-alias-type", KoImportAliasDeclaration::class, KoKotlinTypeDeclaration::class),
+            arguments("not-nullable-import-alias-type", KoImportAliasDeclaration::class, KoKotlinTypeDeclaration::class),
+            arguments("nullable-typealias-type", KoTypeAliasDeclaration::class, KoKotlinTypeDeclaration::class),
+            arguments("not-nullable-typealias-type", KoTypeAliasDeclaration::class, KoKotlinTypeDeclaration::class),
+            arguments("nullable-external-type", KoExternalDeclaration::class, KoKotlinTypeDeclaration::class),
+            arguments("not-nullable-external-type", KoExternalDeclaration::class, KoKotlinTypeDeclaration::class),
+        )
+    }
+}

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/type/kotype/KoTypeDeclarationForKoSourceDeclarationProviderTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/type/kotype/KoTypeDeclarationForKoSourceDeclarationProviderTest.kt
@@ -13,6 +13,7 @@ import org.amshove.kluent.assertSoftly
 import org.amshove.kluent.shouldBeEqualTo
 import org.amshove.kluent.shouldBeInstanceOf
 import org.amshove.kluent.shouldNotBeInstanceOf
+import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.Arguments.arguments
 import org.junit.jupiter.params.provider.MethodSource
@@ -42,8 +43,461 @@ class KoTypeDeclarationForKoSourceDeclarationProviderTest {
         }
     }
 
+    @Test
+    fun `nullable-kotlin-basic-type`() {
+        // given
+        val sut = getSnippetFile("nullable-kotlin-basic-type")
+            .classes()
+            .first()
+            .primaryConstructor
+            ?.parameters
+            ?.first()
+            ?.type
+
+        // then
+        assertSoftly(sut) {
+            it?.sourceKotlinType shouldBeInstanceOf KoKotlinTypeDeclaration::class
+            it?.sourceKotlinType?.name shouldBeEqualTo "String"
+            it?.sourceClass shouldBeEqualTo null
+            it?.sourceObject shouldBeEqualTo null
+            it?.sourceInterface shouldBeEqualTo null
+            it?.sourceTypeAlias shouldBeEqualTo null
+            it?.sourceImportAlias shouldBeEqualTo null
+            it?.sourceFunctionType shouldBeEqualTo null
+            it?.sourceExternalType shouldBeEqualTo null
+        }
+    }
+
+    @Test
+    fun `not-nullable-kotlin-basic-type`() {
+        // given
+        val sut = getSnippetFile("not-nullable-kotlin-basic-type")
+            .classes()
+            .first()
+            .primaryConstructor
+            ?.parameters
+            ?.first()
+            ?.type
+
+        // then
+        assertSoftly(sut) {
+            it?.sourceKotlinType shouldBeInstanceOf KoKotlinTypeDeclaration::class
+            it?.sourceKotlinType?.name shouldBeEqualTo "String"
+            it?.sourceClass shouldBeEqualTo null
+            it?.sourceObject shouldBeEqualTo null
+            it?.sourceInterface shouldBeEqualTo null
+            it?.sourceTypeAlias shouldBeEqualTo null
+            it?.sourceImportAlias shouldBeEqualTo null
+            it?.sourceFunctionType shouldBeEqualTo null
+            it?.sourceExternalType shouldBeEqualTo null
+        }
+    }
+
+    @Test
+    fun `nullable-kotlin-collection-type`() {
+        // given
+        val sut = getSnippetFile("nullable-kotlin-collection-type")
+            .classes()
+            .first()
+            .primaryConstructor
+            ?.parameters
+            ?.first()
+            ?.type
+
+        // then
+        assertSoftly(sut) {
+            it?.sourceKotlinType shouldBeInstanceOf KoKotlinTypeDeclaration::class
+            it?.sourceKotlinType?.name shouldBeEqualTo "List<String>"
+            it?.sourceClass shouldBeEqualTo null
+            it?.sourceObject shouldBeEqualTo null
+            it?.sourceInterface shouldBeEqualTo null
+            it?.sourceTypeAlias shouldBeEqualTo null
+            it?.sourceImportAlias shouldBeEqualTo null
+            it?.sourceFunctionType shouldBeEqualTo null
+            it?.sourceExternalType shouldBeEqualTo null
+        }
+    }
+
+    @Test
+    fun `not-nullable-kotlin-collection-type`() {
+        // given
+        val sut = getSnippetFile("not-nullable-kotlin-collection-type")
+            .classes()
+            .first()
+            .primaryConstructor
+            ?.parameters
+            ?.first()
+            ?.type
+
+        // then
+        assertSoftly(sut) {
+            it?.sourceKotlinType shouldBeInstanceOf KoKotlinTypeDeclaration::class
+            it?.sourceKotlinType?.name shouldBeEqualTo "List<String>"
+            it?.sourceClass shouldBeEqualTo null
+            it?.sourceObject shouldBeEqualTo null
+            it?.sourceInterface shouldBeEqualTo null
+            it?.sourceTypeAlias shouldBeEqualTo null
+            it?.sourceImportAlias shouldBeEqualTo null
+            it?.sourceFunctionType shouldBeEqualTo null
+            it?.sourceExternalType shouldBeEqualTo null
+        }
+    }
+
+    @Test
+    fun `nullable-class-type`() {
+        // given
+        val sut = getSnippetFile("nullable-class-type")
+            .classes()
+            .first()
+            .primaryConstructor
+            ?.parameters
+            ?.first()
+            ?.type
+
+        // then
+        assertSoftly(sut) {
+            it?.sourceClass shouldBeInstanceOf KoClassDeclaration::class
+            it?.sourceClass?.name shouldBeEqualTo "SampleType"
+            it?.sourceObject shouldBeEqualTo null
+            it?.sourceInterface shouldBeEqualTo null
+            it?.sourceTypeAlias shouldBeEqualTo null
+            it?.sourceImportAlias shouldBeEqualTo null
+            it?.sourceKotlinType shouldBeEqualTo null
+            it?.sourceFunctionType shouldBeEqualTo null
+            it?.sourceExternalType shouldBeEqualTo null
+        }
+    }
+
+    @Test
+    fun `not-nullable-class-type`() {
+        // given
+        val sut = getSnippetFile("not-nullable-class-type")
+            .classes()
+            .first()
+            .primaryConstructor
+            ?.parameters
+            ?.first()
+            ?.type
+
+        // then
+        assertSoftly(sut) {
+            it?.sourceClass shouldBeInstanceOf KoClassDeclaration::class
+            it?.sourceClass?.name shouldBeEqualTo "SampleType"
+            it?.sourceObject shouldBeEqualTo null
+            it?.sourceInterface shouldBeEqualTo null
+            it?.sourceTypeAlias shouldBeEqualTo null
+            it?.sourceImportAlias shouldBeEqualTo null
+            it?.sourceKotlinType shouldBeEqualTo null
+            it?.sourceFunctionType shouldBeEqualTo null
+            it?.sourceExternalType shouldBeEqualTo null
+        }
+    }
+
+    @Test
+    fun `nullable-interface-type`() {
+        // given
+        val sut = getSnippetFile("nullable-interface-type")
+            .classes()
+            .first()
+            .primaryConstructor
+            ?.parameters
+            ?.first()
+            ?.type
+
+        // then
+        assertSoftly(sut) {
+            it?.sourceInterface shouldBeInstanceOf KoInterfaceDeclaration::class
+            it?.sourceInterface?.name shouldBeEqualTo "SampleInterface"
+            it?.sourceClass shouldBeEqualTo null
+            it?.sourceObject shouldBeEqualTo null
+            it?.sourceTypeAlias shouldBeEqualTo null
+            it?.sourceImportAlias shouldBeEqualTo null
+            it?.sourceKotlinType shouldBeEqualTo null
+            it?.sourceFunctionType shouldBeEqualTo null
+            it?.sourceExternalType shouldBeEqualTo null
+        }
+    }
+
+    @Test
+    fun `not-nullable-interface-type`() {
+        // given
+        val sut = getSnippetFile("not-nullable-interface-type")
+            .classes()
+            .first()
+            .primaryConstructor
+            ?.parameters
+            ?.first()
+            ?.type
+
+        // then
+        assertSoftly(sut) {
+            it?.sourceInterface shouldBeInstanceOf KoInterfaceDeclaration::class
+            it?.sourceInterface?.name shouldBeEqualTo "SampleInterface"
+            it?.sourceClass shouldBeEqualTo null
+            it?.sourceObject shouldBeEqualTo null
+            it?.sourceTypeAlias shouldBeEqualTo null
+            it?.sourceImportAlias shouldBeEqualTo null
+            it?.sourceKotlinType shouldBeEqualTo null
+            it?.sourceFunctionType shouldBeEqualTo null
+            it?.sourceExternalType shouldBeEqualTo null
+        }
+    }
+
+    @Test
+    fun `nullable-object-type`() {
+        // given
+        val sut = getSnippetFile("nullable-object-type")
+            .classes()
+            .first()
+            .primaryConstructor
+            ?.parameters
+            ?.first()
+            ?.type
+
+        // then
+        assertSoftly(sut) {
+            it?.sourceObject shouldBeInstanceOf KoObjectDeclaration::class
+            it?.sourceObject?.name shouldBeEqualTo "SampleObject"
+            it?.sourceClass shouldBeEqualTo null
+            it?.sourceInterface shouldBeEqualTo null
+            it?.sourceTypeAlias shouldBeEqualTo null
+            it?.sourceImportAlias shouldBeEqualTo null
+            it?.sourceKotlinType shouldBeEqualTo null
+            it?.sourceFunctionType shouldBeEqualTo null
+            it?.sourceExternalType shouldBeEqualTo null
+        }
+    }
+
+    @Test
+    fun `not-nullable-object-type`() {
+        // given
+        val sut = getSnippetFile("not-nullable-object-type")
+            .classes()
+            .first()
+            .primaryConstructor
+            ?.parameters
+            ?.first()
+            ?.type
+
+        // then
+        assertSoftly(sut) {
+            it?.sourceObject shouldBeInstanceOf KoObjectDeclaration::class
+            it?.sourceObject?.name shouldBeEqualTo "SampleObject"
+            it?.sourceClass shouldBeEqualTo null
+            it?.sourceInterface shouldBeEqualTo null
+            it?.sourceTypeAlias shouldBeEqualTo null
+            it?.sourceImportAlias shouldBeEqualTo null
+            it?.sourceKotlinType shouldBeEqualTo null
+            it?.sourceFunctionType shouldBeEqualTo null
+            it?.sourceExternalType shouldBeEqualTo null
+        }
+    }
+
+    @Test
+    fun `nullable-function-type`() {
+        // given
+        val sut = getSnippetFile("nullable-function-type")
+            .classes()
+            .first()
+            .primaryConstructor
+            ?.parameters
+            ?.first()
+            ?.type
+
+        // then
+        assertSoftly(sut) {
+            it?.sourceFunctionType shouldBeInstanceOf KoFunctionTypeDeclaration::class
+            it?.sourceFunctionType?.name shouldBeEqualTo "(SampleObject) -> Unit"
+            it?.sourceClass shouldBeEqualTo null
+            it?.sourceObject shouldBeEqualTo null
+            it?.sourceInterface shouldBeEqualTo null
+            it?.sourceTypeAlias shouldBeEqualTo null
+            it?.sourceImportAlias shouldBeEqualTo null
+            it?.sourceKotlinType shouldBeEqualTo null
+            it?.sourceExternalType shouldBeEqualTo null
+        }
+    }
+
+    @Test
+    fun `not-nullable-function-type`() {
+        // given
+        val sut = getSnippetFile("not-nullable-function-type")
+            .classes()
+            .first()
+            .primaryConstructor
+            ?.parameters
+            ?.first()
+            ?.type
+
+        // then
+        assertSoftly(sut) {
+            it?.sourceFunctionType shouldBeInstanceOf KoFunctionTypeDeclaration::class
+            it?.sourceFunctionType?.name shouldBeEqualTo "(SampleObject) -> Unit"
+            it?.sourceClass shouldBeEqualTo null
+            it?.sourceObject shouldBeEqualTo null
+            it?.sourceInterface shouldBeEqualTo null
+            it?.sourceTypeAlias shouldBeEqualTo null
+            it?.sourceImportAlias shouldBeEqualTo null
+            it?.sourceKotlinType shouldBeEqualTo null
+            it?.sourceExternalType shouldBeEqualTo null
+        }
+    }
+
+    @Test
+    fun `nullable-import-alias-type`() {
+        // given
+        val sut = getSnippetFile("nullable-import-alias-type")
+            .classes()
+            .first()
+            .primaryConstructor
+            ?.parameters
+            ?.first()
+            ?.type
+
+        // then
+        assertSoftly(sut) {
+            it?.sourceImportAlias shouldBeInstanceOf KoImportAliasDeclaration::class
+            it?.sourceImportAlias?.name shouldBeEqualTo "ImportAlias"
+            it?.sourceClass shouldBeEqualTo null
+            it?.sourceObject shouldBeEqualTo null
+            it?.sourceInterface shouldBeEqualTo null
+            it?.sourceTypeAlias shouldBeEqualTo null
+            it?.sourceKotlinType shouldBeEqualTo null
+            it?.sourceFunctionType shouldBeEqualTo null
+            it?.sourceExternalType shouldBeEqualTo null
+        }
+    }
+
+    @Test
+    fun `not-nullable-import-alias-type`() {
+        // given
+        val sut = getSnippetFile("not-nullable-import-alias-type")
+            .classes()
+            .first()
+            .primaryConstructor
+            ?.parameters
+            ?.first()
+            ?.type
+
+        // then
+        assertSoftly(sut) {
+            it?.sourceImportAlias shouldBeInstanceOf KoImportAliasDeclaration::class
+            it?.sourceImportAlias?.name shouldBeEqualTo "ImportAlias"
+            it?.sourceClass shouldBeEqualTo null
+            it?.sourceObject shouldBeEqualTo null
+            it?.sourceInterface shouldBeEqualTo null
+            it?.sourceTypeAlias shouldBeEqualTo null
+            it?.sourceKotlinType shouldBeEqualTo null
+            it?.sourceFunctionType shouldBeEqualTo null
+            it?.sourceExternalType shouldBeEqualTo null
+        }
+    }
+
+    @Test
+    fun `nullable-typealias-type`() {
+        // given
+        val sut = getSnippetFile("nullable-typealias-type")
+            .classes()
+            .first()
+            .primaryConstructor
+            ?.parameters
+            ?.first()
+            ?.type
+
+        // then
+        assertSoftly(sut) {
+            it?.sourceTypeAlias shouldBeInstanceOf KoTypeAliasDeclaration::class
+            it?.sourceTypeAlias?.name shouldBeEqualTo "SampleTypeAlias"
+            it?.sourceClass shouldBeEqualTo null
+            it?.sourceObject shouldBeEqualTo null
+            it?.sourceInterface shouldBeEqualTo null
+            it?.sourceImportAlias shouldBeEqualTo null
+            it?.sourceKotlinType shouldBeEqualTo null
+            it?.sourceFunctionType shouldBeEqualTo null
+            it?.sourceExternalType shouldBeEqualTo null
+        }
+    }
+
+    @Test
+    fun `not-nullable-typealias-type`() {
+        // given
+        val sut = getSnippetFile("not-nullable-typealias-type")
+            .classes()
+            .first()
+            .primaryConstructor
+            ?.parameters
+            ?.first()
+            ?.type
+
+        // then
+        assertSoftly(sut) {
+            it?.sourceTypeAlias shouldBeInstanceOf KoTypeAliasDeclaration::class
+            it?.sourceTypeAlias?.name shouldBeEqualTo "SampleTypeAlias"
+            it?.sourceClass shouldBeEqualTo null
+            it?.sourceObject shouldBeEqualTo null
+            it?.sourceInterface shouldBeEqualTo null
+            it?.sourceImportAlias shouldBeEqualTo null
+            it?.sourceKotlinType shouldBeEqualTo null
+            it?.sourceFunctionType shouldBeEqualTo null
+            it?.sourceExternalType shouldBeEqualTo null
+        }
+    }
+
+    @Test
+    fun `nullable-external-type`() {
+        // given
+        val sut = getSnippetFile("nullable-external-type")
+            .classes()
+            .first()
+            .primaryConstructor
+            ?.parameters
+            ?.first()
+            ?.type
+
+        // then
+        assertSoftly(sut) {
+            it?.sourceExternalType shouldBeInstanceOf KoExternalDeclaration::class
+            it?.sourceExternalType?.name shouldBeEqualTo "SampleExternalClass"
+            it?.sourceClass shouldBeEqualTo null
+            it?.sourceObject shouldBeEqualTo null
+            it?.sourceInterface shouldBeEqualTo null
+            it?.sourceTypeAlias shouldBeEqualTo null
+            it?.sourceImportAlias shouldBeEqualTo null
+            it?.sourceKotlinType shouldBeEqualTo null
+            it?.sourceFunctionType shouldBeEqualTo null
+        }
+    }
+
+    @Test
+    fun `not-nullable-external-type`() {
+        // given
+        val sut = getSnippetFile("not-nullable-external-type")
+            .classes()
+            .first()
+            .primaryConstructor
+            ?.parameters
+            ?.first()
+            ?.type
+
+        // then
+        assertSoftly(sut) {
+            it?.sourceExternalType shouldBeInstanceOf KoExternalDeclaration::class
+            it?.sourceExternalType?.name shouldBeEqualTo "SampleExternalClass"
+            it?.sourceClass shouldBeEqualTo null
+            it?.sourceObject shouldBeEqualTo null
+            it?.sourceInterface shouldBeEqualTo null
+            it?.sourceTypeAlias shouldBeEqualTo null
+            it?.sourceImportAlias shouldBeEqualTo null
+            it?.sourceKotlinType shouldBeEqualTo null
+            it?.sourceFunctionType shouldBeEqualTo null
+        }
+    }
+
     private fun getSnippetFile(fileName: String) =
-        TestSnippetProvider.getSnippetKoScope("core/declaration/type/kotype/snippet/forkosourcedeclarationprovider/", fileName)
+        TestSnippetProvider.getSnippetKoScope(
+            "core/declaration/type/kotype/snippet/forkosourcedeclarationprovider/",
+            fileName
+        )
 
     companion object {
         @Suppress("unused")

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/type/kotype/KoTypeDeclarationForKoSourceDeclarationProviderTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/type/kotype/KoTypeDeclarationForKoSourceDeclarationProviderTest.kt
@@ -496,7 +496,7 @@ class KoTypeDeclarationForKoSourceDeclarationProviderTest {
     private fun getSnippetFile(fileName: String) =
         TestSnippetProvider.getSnippetKoScope(
             "core/declaration/type/kotype/snippet/forkosourcedeclarationprovider/",
-            fileName
+            fileName,
         )
 
     companion object {

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/type/kotype/KoTypeDeclarationForKoSourceDeclarationProviderTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/type/kotype/KoTypeDeclarationForKoSourceDeclarationProviderTest.kt
@@ -24,6 +24,7 @@ import org.junit.jupiter.params.provider.Arguments.arguments
 import org.junit.jupiter.params.provider.MethodSource
 import kotlin.reflect.KClass
 
+@Suppress("detekt.LargeClass")
 class KoTypeDeclarationForKoSourceDeclarationProviderTest {
     @ParameterizedTest
     @MethodSource("provideValues")

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/type/kotype/KoTypeDeclarationForKoSourceDeclarationProviderTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/type/kotype/KoTypeDeclarationForKoSourceDeclarationProviderTest.kt
@@ -9,6 +9,11 @@ import com.lemonappdev.konsist.api.declaration.KoObjectDeclaration
 import com.lemonappdev.konsist.api.declaration.KoTypeAliasDeclaration
 import com.lemonappdev.konsist.api.declaration.type.KoFunctionTypeDeclaration
 import com.lemonappdev.konsist.api.declaration.type.KoKotlinTypeDeclaration
+import com.lemonappdev.konsist.externalsample.SampleExternalClass
+import com.lemonappdev.konsist.testdata.SampleClass
+import com.lemonappdev.konsist.testdata.SampleInterface
+import com.lemonappdev.konsist.testdata.SampleObject
+import com.lemonappdev.konsist.testdata.SampleType
 import org.amshove.kluent.assertSoftly
 import org.amshove.kluent.shouldBeEqualTo
 import org.amshove.kluent.shouldBeInstanceOf
@@ -58,13 +63,29 @@ class KoTypeDeclarationForKoSourceDeclarationProviderTest {
         assertSoftly(sut) {
             it?.sourceKotlinType shouldBeInstanceOf KoKotlinTypeDeclaration::class
             it?.sourceKotlinType?.name shouldBeEqualTo "String"
+            it?.hasSourceKotlinType() shouldBeEqualTo true
+            it?.hasSourceKotlinType { declaration -> declaration.name == "String" } shouldBeEqualTo true
+            it?.hasSourceKotlinType { declaration -> declaration.name == "List<String>" } shouldBeEqualTo false
+            it?.hasSourceKotlinTypeOf(String::class) shouldBeEqualTo true
+            it?.hasSourceKotlinTypeOf(Int::class) shouldBeEqualTo false
             it?.sourceClass shouldBeEqualTo null
+            it?.hasSourceClass() shouldBeEqualTo false
+            it?.hasSourceClassOf(String::class) shouldBeEqualTo false
             it?.sourceObject shouldBeEqualTo null
+            it?.hasSourceObject() shouldBeEqualTo false
+            it?.hasSourceObjectOf(String::class) shouldBeEqualTo false
             it?.sourceInterface shouldBeEqualTo null
+            it?.hasSourceInterface() shouldBeEqualTo false
+            it?.hasSourceInterfaceOf(String::class) shouldBeEqualTo false
             it?.sourceTypeAlias shouldBeEqualTo null
+            it?.hasSourceTypeAlias() shouldBeEqualTo false
             it?.sourceImportAlias shouldBeEqualTo null
+            it?.hasSourceImportAlias() shouldBeEqualTo false
             it?.sourceFunctionType shouldBeEqualTo null
+            it?.hasSourceFunctionType() shouldBeEqualTo false
             it?.sourceExternalType shouldBeEqualTo null
+            it?.hasSourceExternalType() shouldBeEqualTo false
+            it?.hasSourceExternalTypeOf(String::class) shouldBeEqualTo false
         }
     }
 
@@ -83,13 +104,29 @@ class KoTypeDeclarationForKoSourceDeclarationProviderTest {
         assertSoftly(sut) {
             it?.sourceKotlinType shouldBeInstanceOf KoKotlinTypeDeclaration::class
             it?.sourceKotlinType?.name shouldBeEqualTo "String"
+            it?.hasSourceKotlinType() shouldBeEqualTo true
+            it?.hasSourceKotlinType { declaration -> declaration.name == "String" } shouldBeEqualTo true
+            it?.hasSourceKotlinType { declaration -> declaration.name == "List<String>" } shouldBeEqualTo false
+            it?.hasSourceKotlinTypeOf(String::class) shouldBeEqualTo true
+            it?.hasSourceKotlinTypeOf(Int::class) shouldBeEqualTo false
             it?.sourceClass shouldBeEqualTo null
+            it?.hasSourceClass() shouldBeEqualTo false
+            it?.hasSourceClassOf(String::class) shouldBeEqualTo false
             it?.sourceObject shouldBeEqualTo null
+            it?.hasSourceObject() shouldBeEqualTo false
+            it?.hasSourceObjectOf(String::class) shouldBeEqualTo false
             it?.sourceInterface shouldBeEqualTo null
+            it?.hasSourceInterface() shouldBeEqualTo false
+            it?.hasSourceInterfaceOf(String::class) shouldBeEqualTo false
             it?.sourceTypeAlias shouldBeEqualTo null
+            it?.hasSourceTypeAlias() shouldBeEqualTo false
             it?.sourceImportAlias shouldBeEqualTo null
+            it?.hasSourceImportAlias() shouldBeEqualTo false
             it?.sourceFunctionType shouldBeEqualTo null
+            it?.hasSourceFunctionType() shouldBeEqualTo false
             it?.sourceExternalType shouldBeEqualTo null
+            it?.hasSourceExternalType() shouldBeEqualTo false
+            it?.hasSourceExternalTypeOf(String::class) shouldBeEqualTo false
         }
     }
 
@@ -108,13 +145,29 @@ class KoTypeDeclarationForKoSourceDeclarationProviderTest {
         assertSoftly(sut) {
             it?.sourceKotlinType shouldBeInstanceOf KoKotlinTypeDeclaration::class
             it?.sourceKotlinType?.name shouldBeEqualTo "List<String>"
+            it?.hasSourceKotlinType() shouldBeEqualTo true
+            it?.hasSourceKotlinType { declaration -> declaration.name == "List<String>" } shouldBeEqualTo true
+            it?.hasSourceKotlinType { declaration -> declaration.name == "String" } shouldBeEqualTo false
+            it?.hasSourceKotlinTypeOf(List::class) shouldBeEqualTo true
+            it?.hasSourceKotlinTypeOf(String::class) shouldBeEqualTo false
             it?.sourceClass shouldBeEqualTo null
+            it?.hasSourceClass() shouldBeEqualTo false
+            it?.hasSourceClassOf(List::class) shouldBeEqualTo false
             it?.sourceObject shouldBeEqualTo null
+            it?.hasSourceObject() shouldBeEqualTo false
+            it?.hasSourceObjectOf(List::class) shouldBeEqualTo false
             it?.sourceInterface shouldBeEqualTo null
+            it?.hasSourceInterface() shouldBeEqualTo false
+            it?.hasSourceInterfaceOf(List::class) shouldBeEqualTo false
             it?.sourceTypeAlias shouldBeEqualTo null
+            it?.hasSourceTypeAlias() shouldBeEqualTo false
             it?.sourceImportAlias shouldBeEqualTo null
+            it?.hasSourceImportAlias() shouldBeEqualTo false
             it?.sourceFunctionType shouldBeEqualTo null
+            it?.hasSourceFunctionType() shouldBeEqualTo false
             it?.sourceExternalType shouldBeEqualTo null
+            it?.hasSourceExternalType() shouldBeEqualTo false
+            it?.hasSourceExternalTypeOf(List::class) shouldBeEqualTo false
         }
     }
 
@@ -133,13 +186,29 @@ class KoTypeDeclarationForKoSourceDeclarationProviderTest {
         assertSoftly(sut) {
             it?.sourceKotlinType shouldBeInstanceOf KoKotlinTypeDeclaration::class
             it?.sourceKotlinType?.name shouldBeEqualTo "List<String>"
+            it?.hasSourceKotlinType() shouldBeEqualTo true
+            it?.hasSourceKotlinType { declaration -> declaration.name == "List<String>" } shouldBeEqualTo true
+            it?.hasSourceKotlinType { declaration -> declaration.name == "String" } shouldBeEqualTo false
+            it?.hasSourceKotlinTypeOf(List::class) shouldBeEqualTo true
+            it?.hasSourceKotlinTypeOf(String::class) shouldBeEqualTo false
             it?.sourceClass shouldBeEqualTo null
+            it?.hasSourceClass() shouldBeEqualTo false
+            it?.hasSourceClassOf(List::class) shouldBeEqualTo false
             it?.sourceObject shouldBeEqualTo null
+            it?.hasSourceObject() shouldBeEqualTo false
+            it?.hasSourceObjectOf(List::class) shouldBeEqualTo false
             it?.sourceInterface shouldBeEqualTo null
+            it?.hasSourceInterface() shouldBeEqualTo false
+            it?.hasSourceInterfaceOf(List::class) shouldBeEqualTo false
             it?.sourceTypeAlias shouldBeEqualTo null
+            it?.hasSourceTypeAlias() shouldBeEqualTo false
             it?.sourceImportAlias shouldBeEqualTo null
+            it?.hasSourceImportAlias() shouldBeEqualTo false
             it?.sourceFunctionType shouldBeEqualTo null
+            it?.hasSourceFunctionType() shouldBeEqualTo false
             it?.sourceExternalType shouldBeEqualTo null
+            it?.hasSourceExternalType() shouldBeEqualTo false
+            it?.hasSourceExternalTypeOf(List::class) shouldBeEqualTo false
         }
     }
 
@@ -158,13 +227,28 @@ class KoTypeDeclarationForKoSourceDeclarationProviderTest {
         assertSoftly(sut) {
             it?.sourceClass shouldBeInstanceOf KoClassDeclaration::class
             it?.sourceClass?.name shouldBeEqualTo "SampleType"
+            it?.hasSourceClass() shouldBeEqualTo true
+            it?.hasSourceClass { declaration -> declaration.name == "SampleType" } shouldBeEqualTo true
+            it?.hasSourceClass { declaration -> declaration.name == "OtherName" } shouldBeEqualTo false
+            it?.hasSourceClassOf(SampleType::class) shouldBeEqualTo true
+            it?.hasSourceClassOf(SampleClass::class) shouldBeEqualTo false
             it?.sourceObject shouldBeEqualTo null
+            it?.hasSourceObject() shouldBeEqualTo false
+            it?.hasSourceObjectOf(SampleType::class) shouldBeEqualTo false
             it?.sourceInterface shouldBeEqualTo null
+            it?.hasSourceInterface() shouldBeEqualTo false
+            it?.hasSourceInterfaceOf(SampleType::class) shouldBeEqualTo false
             it?.sourceTypeAlias shouldBeEqualTo null
+            it?.hasSourceTypeAlias() shouldBeEqualTo false
             it?.sourceImportAlias shouldBeEqualTo null
+            it?.hasSourceImportAlias() shouldBeEqualTo false
             it?.sourceKotlinType shouldBeEqualTo null
+            it?.hasSourceKotlinType() shouldBeEqualTo false
+            it?.hasSourceKotlinTypeOf(SampleType::class) shouldBeEqualTo false
             it?.sourceFunctionType shouldBeEqualTo null
+            it?.hasSourceFunctionType() shouldBeEqualTo false
             it?.sourceExternalType shouldBeEqualTo null
+            it?.hasSourceExternalType() shouldBeEqualTo false
         }
     }
 
@@ -183,13 +267,28 @@ class KoTypeDeclarationForKoSourceDeclarationProviderTest {
         assertSoftly(sut) {
             it?.sourceClass shouldBeInstanceOf KoClassDeclaration::class
             it?.sourceClass?.name shouldBeEqualTo "SampleType"
+            it?.hasSourceClass() shouldBeEqualTo true
+            it?.hasSourceClass { declaration -> declaration.name == "SampleType" } shouldBeEqualTo true
+            it?.hasSourceClass { declaration -> declaration.name == "OtherName" } shouldBeEqualTo false
+            it?.hasSourceClassOf(SampleType::class) shouldBeEqualTo true
+            it?.hasSourceClassOf(SampleClass::class) shouldBeEqualTo false
             it?.sourceObject shouldBeEqualTo null
+            it?.hasSourceObject() shouldBeEqualTo false
+            it?.hasSourceObjectOf(SampleType::class) shouldBeEqualTo false
             it?.sourceInterface shouldBeEqualTo null
+            it?.hasSourceInterface() shouldBeEqualTo false
+            it?.hasSourceInterfaceOf(SampleType::class) shouldBeEqualTo false
             it?.sourceTypeAlias shouldBeEqualTo null
+            it?.hasSourceTypeAlias() shouldBeEqualTo false
             it?.sourceImportAlias shouldBeEqualTo null
+            it?.hasSourceImportAlias() shouldBeEqualTo false
             it?.sourceKotlinType shouldBeEqualTo null
+            it?.hasSourceKotlinType() shouldBeEqualTo false
+            it?.hasSourceKotlinTypeOf(SampleType::class) shouldBeEqualTo false
             it?.sourceFunctionType shouldBeEqualTo null
+            it?.hasSourceFunctionType() shouldBeEqualTo false
             it?.sourceExternalType shouldBeEqualTo null
+            it?.hasSourceExternalType() shouldBeEqualTo false
         }
     }
 
@@ -208,13 +307,28 @@ class KoTypeDeclarationForKoSourceDeclarationProviderTest {
         assertSoftly(sut) {
             it?.sourceInterface shouldBeInstanceOf KoInterfaceDeclaration::class
             it?.sourceInterface?.name shouldBeEqualTo "SampleInterface"
+            it?.hasSourceInterface() shouldBeEqualTo true
+            it?.hasSourceInterface { declaration -> declaration.name == "SampleInterface" } shouldBeEqualTo true
+            it?.hasSourceInterface { declaration -> declaration.name == "OtherName" } shouldBeEqualTo false
+            it?.hasSourceInterfaceOf(SampleInterface::class) shouldBeEqualTo true
+            it?.hasSourceInterfaceOf(SampleClass::class) shouldBeEqualTo false
             it?.sourceClass shouldBeEqualTo null
+            it?.hasSourceClass() shouldBeEqualTo false
+            it?.hasSourceClassOf(SampleInterface::class) shouldBeEqualTo false
             it?.sourceObject shouldBeEqualTo null
+            it?.hasSourceObject() shouldBeEqualTo false
+            it?.hasSourceObjectOf(SampleInterface::class) shouldBeEqualTo false
             it?.sourceTypeAlias shouldBeEqualTo null
+            it?.hasSourceTypeAlias() shouldBeEqualTo false
             it?.sourceImportAlias shouldBeEqualTo null
+            it?.hasSourceImportAlias() shouldBeEqualTo false
             it?.sourceKotlinType shouldBeEqualTo null
+            it?.hasSourceKotlinType() shouldBeEqualTo false
+            it?.hasSourceKotlinTypeOf(SampleInterface::class) shouldBeEqualTo false
             it?.sourceFunctionType shouldBeEqualTo null
+            it?.hasSourceFunctionType() shouldBeEqualTo false
             it?.sourceExternalType shouldBeEqualTo null
+            it?.hasSourceExternalType() shouldBeEqualTo false
         }
     }
 
@@ -233,13 +347,28 @@ class KoTypeDeclarationForKoSourceDeclarationProviderTest {
         assertSoftly(sut) {
             it?.sourceInterface shouldBeInstanceOf KoInterfaceDeclaration::class
             it?.sourceInterface?.name shouldBeEqualTo "SampleInterface"
+            it?.hasSourceInterface() shouldBeEqualTo true
+            it?.hasSourceInterface { declaration -> declaration.name == "SampleInterface" } shouldBeEqualTo true
+            it?.hasSourceInterface { declaration -> declaration.name == "OtherName" } shouldBeEqualTo false
+            it?.hasSourceInterfaceOf(SampleInterface::class) shouldBeEqualTo true
+            it?.hasSourceInterfaceOf(SampleClass::class) shouldBeEqualTo false
             it?.sourceClass shouldBeEqualTo null
+            it?.hasSourceClass() shouldBeEqualTo false
+            it?.hasSourceClassOf(SampleInterface::class) shouldBeEqualTo false
             it?.sourceObject shouldBeEqualTo null
+            it?.hasSourceObject() shouldBeEqualTo false
+            it?.hasSourceObjectOf(SampleInterface::class) shouldBeEqualTo false
             it?.sourceTypeAlias shouldBeEqualTo null
+            it?.hasSourceTypeAlias() shouldBeEqualTo false
             it?.sourceImportAlias shouldBeEqualTo null
+            it?.hasSourceImportAlias() shouldBeEqualTo false
             it?.sourceKotlinType shouldBeEqualTo null
+            it?.hasSourceKotlinType() shouldBeEqualTo false
+            it?.hasSourceKotlinTypeOf(SampleInterface::class) shouldBeEqualTo false
             it?.sourceFunctionType shouldBeEqualTo null
+            it?.hasSourceFunctionType() shouldBeEqualTo false
             it?.sourceExternalType shouldBeEqualTo null
+            it?.hasSourceExternalType() shouldBeEqualTo false
         }
     }
 
@@ -258,13 +387,28 @@ class KoTypeDeclarationForKoSourceDeclarationProviderTest {
         assertSoftly(sut) {
             it?.sourceObject shouldBeInstanceOf KoObjectDeclaration::class
             it?.sourceObject?.name shouldBeEqualTo "SampleObject"
+            it?.hasSourceObject() shouldBeEqualTo true
+            it?.hasSourceObject { declaration -> declaration.name == "SampleObject" } shouldBeEqualTo true
+            it?.hasSourceObject { declaration -> declaration.name == "OtherName" } shouldBeEqualTo false
+            it?.hasSourceObjectOf(SampleObject::class) shouldBeEqualTo true
+            it?.hasSourceObjectOf(SampleClass::class) shouldBeEqualTo false
             it?.sourceClass shouldBeEqualTo null
+            it?.hasSourceClass() shouldBeEqualTo false
+            it?.hasSourceClassOf(SampleObject::class) shouldBeEqualTo false
             it?.sourceInterface shouldBeEqualTo null
+            it?.hasSourceInterface() shouldBeEqualTo false
+            it?.hasSourceInterfaceOf(SampleObject::class) shouldBeEqualTo false
             it?.sourceTypeAlias shouldBeEqualTo null
+            it?.hasSourceTypeAlias() shouldBeEqualTo false
             it?.sourceImportAlias shouldBeEqualTo null
+            it?.hasSourceImportAlias() shouldBeEqualTo false
             it?.sourceKotlinType shouldBeEqualTo null
+            it?.hasSourceKotlinType() shouldBeEqualTo false
+            it?.hasSourceKotlinTypeOf(SampleObject::class) shouldBeEqualTo false
             it?.sourceFunctionType shouldBeEqualTo null
+            it?.hasSourceFunctionType() shouldBeEqualTo false
             it?.sourceExternalType shouldBeEqualTo null
+            it?.hasSourceExternalType() shouldBeEqualTo false
         }
     }
 
@@ -283,13 +427,28 @@ class KoTypeDeclarationForKoSourceDeclarationProviderTest {
         assertSoftly(sut) {
             it?.sourceObject shouldBeInstanceOf KoObjectDeclaration::class
             it?.sourceObject?.name shouldBeEqualTo "SampleObject"
+            it?.hasSourceObject() shouldBeEqualTo true
+            it?.hasSourceObject { declaration -> declaration.name == "SampleObject" } shouldBeEqualTo true
+            it?.hasSourceObject { declaration -> declaration.name == "OtherName" } shouldBeEqualTo false
+            it?.hasSourceObjectOf(SampleObject::class) shouldBeEqualTo true
+            it?.hasSourceObjectOf(SampleClass::class) shouldBeEqualTo false
             it?.sourceClass shouldBeEqualTo null
+            it?.hasSourceClass() shouldBeEqualTo false
+            it?.hasSourceClassOf(SampleObject::class) shouldBeEqualTo false
             it?.sourceInterface shouldBeEqualTo null
+            it?.hasSourceInterface() shouldBeEqualTo false
+            it?.hasSourceInterfaceOf(SampleObject::class) shouldBeEqualTo false
             it?.sourceTypeAlias shouldBeEqualTo null
+            it?.hasSourceTypeAlias() shouldBeEqualTo false
             it?.sourceImportAlias shouldBeEqualTo null
+            it?.hasSourceImportAlias() shouldBeEqualTo false
             it?.sourceKotlinType shouldBeEqualTo null
+            it?.hasSourceKotlinType() shouldBeEqualTo false
+            it?.hasSourceKotlinTypeOf(SampleObject::class) shouldBeEqualTo false
             it?.sourceFunctionType shouldBeEqualTo null
+            it?.hasSourceFunctionType() shouldBeEqualTo false
             it?.sourceExternalType shouldBeEqualTo null
+            it?.hasSourceExternalType() shouldBeEqualTo false
         }
     }
 
@@ -308,13 +467,23 @@ class KoTypeDeclarationForKoSourceDeclarationProviderTest {
         assertSoftly(sut) {
             it?.sourceFunctionType shouldBeInstanceOf KoFunctionTypeDeclaration::class
             it?.sourceFunctionType?.name shouldBeEqualTo "(SampleObject) -> Unit"
+            it?.hasSourceFunctionType() shouldBeEqualTo true
+            it?.hasSourceFunctionType { declaration -> declaration.name == "(SampleObject) -> Unit" } shouldBeEqualTo true
+            it?.hasSourceFunctionType { declaration -> declaration.name == "SampleObject" } shouldBeEqualTo false
             it?.sourceClass shouldBeEqualTo null
+            it?.hasSourceClass() shouldBeEqualTo false
             it?.sourceObject shouldBeEqualTo null
+            it?.hasSourceObject() shouldBeEqualTo false
             it?.sourceInterface shouldBeEqualTo null
+            it?.hasSourceInterface() shouldBeEqualTo false
             it?.sourceTypeAlias shouldBeEqualTo null
+            it?.hasSourceTypeAlias() shouldBeEqualTo false
             it?.sourceImportAlias shouldBeEqualTo null
+            it?.hasSourceImportAlias() shouldBeEqualTo false
             it?.sourceKotlinType shouldBeEqualTo null
+            it?.hasSourceKotlinType() shouldBeEqualTo false
             it?.sourceExternalType shouldBeEqualTo null
+            it?.hasSourceExternalType() shouldBeEqualTo false
         }
     }
 
@@ -333,13 +502,23 @@ class KoTypeDeclarationForKoSourceDeclarationProviderTest {
         assertSoftly(sut) {
             it?.sourceFunctionType shouldBeInstanceOf KoFunctionTypeDeclaration::class
             it?.sourceFunctionType?.name shouldBeEqualTo "(SampleObject) -> Unit"
+            it?.hasSourceFunctionType() shouldBeEqualTo true
+            it?.hasSourceFunctionType { declaration -> declaration.name == "(SampleObject) -> Unit" } shouldBeEqualTo true
+            it?.hasSourceFunctionType { declaration -> declaration.name == "SampleObject" } shouldBeEqualTo false
             it?.sourceClass shouldBeEqualTo null
+            it?.hasSourceClass() shouldBeEqualTo false
             it?.sourceObject shouldBeEqualTo null
+            it?.hasSourceObject() shouldBeEqualTo false
             it?.sourceInterface shouldBeEqualTo null
+            it?.hasSourceInterface() shouldBeEqualTo false
             it?.sourceTypeAlias shouldBeEqualTo null
+            it?.hasSourceTypeAlias() shouldBeEqualTo false
             it?.sourceImportAlias shouldBeEqualTo null
+            it?.hasSourceImportAlias() shouldBeEqualTo false
             it?.sourceKotlinType shouldBeEqualTo null
+            it?.hasSourceKotlinType() shouldBeEqualTo false
             it?.sourceExternalType shouldBeEqualTo null
+            it?.hasSourceExternalType() shouldBeEqualTo false
         }
     }
 
@@ -358,13 +537,23 @@ class KoTypeDeclarationForKoSourceDeclarationProviderTest {
         assertSoftly(sut) {
             it?.sourceImportAlias shouldBeInstanceOf KoImportAliasDeclaration::class
             it?.sourceImportAlias?.name shouldBeEqualTo "ImportAlias"
+            it?.hasSourceImportAlias() shouldBeEqualTo true
+            it?.hasSourceImportAlias { declaration -> declaration.name == "ImportAlias" } shouldBeEqualTo true
+            it?.hasSourceImportAlias { declaration -> declaration.name == "OtherName" } shouldBeEqualTo false
             it?.sourceClass shouldBeEqualTo null
+            it?.hasSourceClass() shouldBeEqualTo false
             it?.sourceObject shouldBeEqualTo null
+            it?.hasSourceObject() shouldBeEqualTo false
             it?.sourceInterface shouldBeEqualTo null
+            it?.hasSourceInterface() shouldBeEqualTo false
             it?.sourceTypeAlias shouldBeEqualTo null
+            it?.hasSourceTypeAlias() shouldBeEqualTo false
             it?.sourceKotlinType shouldBeEqualTo null
+            it?.hasSourceKotlinType() shouldBeEqualTo false
             it?.sourceFunctionType shouldBeEqualTo null
+            it?.hasSourceFunctionType() shouldBeEqualTo false
             it?.sourceExternalType shouldBeEqualTo null
+            it?.hasSourceExternalType() shouldBeEqualTo false
         }
     }
 
@@ -383,13 +572,23 @@ class KoTypeDeclarationForKoSourceDeclarationProviderTest {
         assertSoftly(sut) {
             it?.sourceImportAlias shouldBeInstanceOf KoImportAliasDeclaration::class
             it?.sourceImportAlias?.name shouldBeEqualTo "ImportAlias"
+            it?.hasSourceImportAlias() shouldBeEqualTo true
+            it?.hasSourceImportAlias { declaration -> declaration.name == "ImportAlias" } shouldBeEqualTo true
+            it?.hasSourceImportAlias { declaration -> declaration.name == "OtherName" } shouldBeEqualTo false
             it?.sourceClass shouldBeEqualTo null
+            it?.hasSourceClass() shouldBeEqualTo false
             it?.sourceObject shouldBeEqualTo null
+            it?.hasSourceObject() shouldBeEqualTo false
             it?.sourceInterface shouldBeEqualTo null
+            it?.hasSourceInterface() shouldBeEqualTo false
             it?.sourceTypeAlias shouldBeEqualTo null
+            it?.hasSourceTypeAlias() shouldBeEqualTo false
             it?.sourceKotlinType shouldBeEqualTo null
+            it?.hasSourceKotlinType() shouldBeEqualTo false
             it?.sourceFunctionType shouldBeEqualTo null
+            it?.hasSourceFunctionType() shouldBeEqualTo false
             it?.sourceExternalType shouldBeEqualTo null
+            it?.hasSourceExternalType() shouldBeEqualTo false
         }
     }
 
@@ -408,13 +607,23 @@ class KoTypeDeclarationForKoSourceDeclarationProviderTest {
         assertSoftly(sut) {
             it?.sourceTypeAlias shouldBeInstanceOf KoTypeAliasDeclaration::class
             it?.sourceTypeAlias?.name shouldBeEqualTo "SampleTypeAlias"
+            it?.hasSourceTypeAlias() shouldBeEqualTo true
+            it?.hasSourceTypeAlias { declaration -> declaration.name == "SampleTypeAlias" } shouldBeEqualTo true
+            it?.hasSourceTypeAlias { declaration -> declaration.name == "OtherName" } shouldBeEqualTo false
             it?.sourceClass shouldBeEqualTo null
+            it?.hasSourceClass() shouldBeEqualTo false
             it?.sourceObject shouldBeEqualTo null
+            it?.hasSourceObject() shouldBeEqualTo false
             it?.sourceInterface shouldBeEqualTo null
+            it?.hasSourceInterface() shouldBeEqualTo false
             it?.sourceImportAlias shouldBeEqualTo null
+            it?.hasSourceImportAlias() shouldBeEqualTo false
             it?.sourceKotlinType shouldBeEqualTo null
+            it?.hasSourceKotlinType() shouldBeEqualTo false
             it?.sourceFunctionType shouldBeEqualTo null
+            it?.hasSourceFunctionType() shouldBeEqualTo false
             it?.sourceExternalType shouldBeEqualTo null
+            it?.hasSourceExternalType() shouldBeEqualTo false
         }
     }
 
@@ -433,13 +642,23 @@ class KoTypeDeclarationForKoSourceDeclarationProviderTest {
         assertSoftly(sut) {
             it?.sourceTypeAlias shouldBeInstanceOf KoTypeAliasDeclaration::class
             it?.sourceTypeAlias?.name shouldBeEqualTo "SampleTypeAlias"
+            it?.hasSourceTypeAlias() shouldBeEqualTo true
+            it?.hasSourceTypeAlias { declaration -> declaration.name == "SampleTypeAlias" } shouldBeEqualTo true
+            it?.hasSourceTypeAlias { declaration -> declaration.name == "OtherName" } shouldBeEqualTo false
             it?.sourceClass shouldBeEqualTo null
+            it?.hasSourceClass() shouldBeEqualTo false
             it?.sourceObject shouldBeEqualTo null
+            it?.hasSourceObject() shouldBeEqualTo false
             it?.sourceInterface shouldBeEqualTo null
+            it?.hasSourceInterface() shouldBeEqualTo false
             it?.sourceImportAlias shouldBeEqualTo null
+            it?.hasSourceImportAlias() shouldBeEqualTo false
             it?.sourceKotlinType shouldBeEqualTo null
+            it?.hasSourceKotlinType() shouldBeEqualTo false
             it?.sourceFunctionType shouldBeEqualTo null
+            it?.hasSourceFunctionType() shouldBeEqualTo false
             it?.sourceExternalType shouldBeEqualTo null
+            it?.hasSourceExternalType() shouldBeEqualTo false
         }
     }
 
@@ -458,13 +677,29 @@ class KoTypeDeclarationForKoSourceDeclarationProviderTest {
         assertSoftly(sut) {
             it?.sourceExternalType shouldBeInstanceOf KoExternalDeclaration::class
             it?.sourceExternalType?.name shouldBeEqualTo "SampleExternalClass"
+            it?.hasSourceExternalType() shouldBeEqualTo true
+            it?.hasSourceExternalType { declaration -> declaration.name == "SampleExternalClass" } shouldBeEqualTo true
+            it?.hasSourceExternalType { declaration -> declaration.name == "OtherName" } shouldBeEqualTo false
+            it?.hasSourceExternalTypeOf(SampleExternalClass::class) shouldBeEqualTo true
+            it?.hasSourceExternalTypeOf(SampleClass::class) shouldBeEqualTo false
             it?.sourceClass shouldBeEqualTo null
+            it?.hasSourceClass() shouldBeEqualTo false
+            it?.hasSourceClassOf(SampleExternalClass::class) shouldBeEqualTo false
             it?.sourceObject shouldBeEqualTo null
+            it?.hasSourceObject() shouldBeEqualTo false
+            it?.hasSourceObjectOf(SampleExternalClass::class) shouldBeEqualTo false
             it?.sourceInterface shouldBeEqualTo null
+            it?.hasSourceInterface() shouldBeEqualTo false
+            it?.hasSourceInterfaceOf(SampleExternalClass::class) shouldBeEqualTo false
             it?.sourceTypeAlias shouldBeEqualTo null
+            it?.hasSourceTypeAlias() shouldBeEqualTo false
             it?.sourceImportAlias shouldBeEqualTo null
+            it?.hasSourceImportAlias() shouldBeEqualTo false
             it?.sourceKotlinType shouldBeEqualTo null
+            it?.hasSourceKotlinType() shouldBeEqualTo false
+            it?.hasSourceKotlinTypeOf(SampleExternalClass::class) shouldBeEqualTo false
             it?.sourceFunctionType shouldBeEqualTo null
+            it?.hasSourceFunctionType() shouldBeEqualTo false
         }
     }
 
@@ -483,13 +718,29 @@ class KoTypeDeclarationForKoSourceDeclarationProviderTest {
         assertSoftly(sut) {
             it?.sourceExternalType shouldBeInstanceOf KoExternalDeclaration::class
             it?.sourceExternalType?.name shouldBeEqualTo "SampleExternalClass"
+            it?.hasSourceExternalType() shouldBeEqualTo true
+            it?.hasSourceExternalType { declaration -> declaration.name == "SampleExternalClass" } shouldBeEqualTo true
+            it?.hasSourceExternalType { declaration -> declaration.name == "OtherName" } shouldBeEqualTo false
+            it?.hasSourceExternalTypeOf(SampleExternalClass::class) shouldBeEqualTo true
+            it?.hasSourceExternalTypeOf(SampleClass::class) shouldBeEqualTo false
             it?.sourceClass shouldBeEqualTo null
+            it?.hasSourceClass() shouldBeEqualTo false
+            it?.hasSourceClassOf(SampleExternalClass::class) shouldBeEqualTo false
             it?.sourceObject shouldBeEqualTo null
+            it?.hasSourceObject() shouldBeEqualTo false
+            it?.hasSourceObjectOf(SampleExternalClass::class) shouldBeEqualTo false
             it?.sourceInterface shouldBeEqualTo null
+            it?.hasSourceInterface() shouldBeEqualTo false
+            it?.hasSourceInterfaceOf(SampleExternalClass::class) shouldBeEqualTo false
             it?.sourceTypeAlias shouldBeEqualTo null
+            it?.hasSourceTypeAlias() shouldBeEqualTo false
             it?.sourceImportAlias shouldBeEqualTo null
+            it?.hasSourceImportAlias() shouldBeEqualTo false
             it?.sourceKotlinType shouldBeEqualTo null
+            it?.hasSourceKotlinType() shouldBeEqualTo false
+            it?.hasSourceKotlinTypeOf(SampleExternalClass::class) shouldBeEqualTo false
             it?.sourceFunctionType shouldBeEqualTo null
+            it?.hasSourceFunctionType() shouldBeEqualTo false
         }
     }
 

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/type/kotype/KoTypeDeclarationForKoSourceDeclarationProviderTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/type/kotype/KoTypeDeclarationForKoSourceDeclarationProviderTest.kt
@@ -61,6 +61,10 @@ class KoTypeDeclarationForKoSourceDeclarationProviderTest {
 
         // then
         assertSoftly(sut) {
+            it?.hasSourceDeclaration { declaration -> declaration.name == "String" } shouldBeEqualTo true
+            it?.hasSourceDeclaration { declaration -> declaration.name == "List<String>" } shouldBeEqualTo false
+            it?.hasSourceDeclarationOf(String::class) shouldBeEqualTo true
+            it?.hasSourceDeclarationOf(List::class) shouldBeEqualTo false
             it?.sourceKotlinType shouldBeInstanceOf KoKotlinTypeDeclaration::class
             it?.sourceKotlinType?.name shouldBeEqualTo "String"
             it?.hasSourceKotlinType() shouldBeEqualTo true
@@ -102,6 +106,10 @@ class KoTypeDeclarationForKoSourceDeclarationProviderTest {
 
         // then
         assertSoftly(sut) {
+            it?.hasSourceDeclaration { declaration -> declaration.name == "String" } shouldBeEqualTo true
+            it?.hasSourceDeclaration { declaration -> declaration.name == "List<String>" } shouldBeEqualTo false
+            it?.hasSourceDeclarationOf(String::class) shouldBeEqualTo true
+            it?.hasSourceDeclarationOf(List::class) shouldBeEqualTo false
             it?.sourceKotlinType shouldBeInstanceOf KoKotlinTypeDeclaration::class
             it?.sourceKotlinType?.name shouldBeEqualTo "String"
             it?.hasSourceKotlinType() shouldBeEqualTo true
@@ -143,6 +151,10 @@ class KoTypeDeclarationForKoSourceDeclarationProviderTest {
 
         // then
         assertSoftly(sut) {
+            it?.hasSourceDeclaration { declaration -> declaration.name == "List<String>" } shouldBeEqualTo true
+            it?.hasSourceDeclaration { declaration -> declaration.name == "String" } shouldBeEqualTo false
+            it?.hasSourceDeclarationOf(List::class) shouldBeEqualTo true
+            it?.hasSourceDeclarationOf(String::class) shouldBeEqualTo false
             it?.sourceKotlinType shouldBeInstanceOf KoKotlinTypeDeclaration::class
             it?.sourceKotlinType?.name shouldBeEqualTo "List<String>"
             it?.hasSourceKotlinType() shouldBeEqualTo true
@@ -184,6 +196,10 @@ class KoTypeDeclarationForKoSourceDeclarationProviderTest {
 
         // then
         assertSoftly(sut) {
+            it?.hasSourceDeclaration { declaration -> declaration.name == "List<String>" } shouldBeEqualTo true
+            it?.hasSourceDeclaration { declaration -> declaration.name == "String" } shouldBeEqualTo false
+            it?.hasSourceDeclarationOf(List::class) shouldBeEqualTo true
+            it?.hasSourceDeclarationOf(String::class) shouldBeEqualTo false
             it?.sourceKotlinType shouldBeInstanceOf KoKotlinTypeDeclaration::class
             it?.sourceKotlinType?.name shouldBeEqualTo "List<String>"
             it?.hasSourceKotlinType() shouldBeEqualTo true
@@ -225,6 +241,10 @@ class KoTypeDeclarationForKoSourceDeclarationProviderTest {
 
         // then
         assertSoftly(sut) {
+            it?.hasSourceDeclaration { declaration -> declaration.name == "SampleType" } shouldBeEqualTo true
+            it?.hasSourceDeclaration { declaration -> declaration.name == "OtherName" } shouldBeEqualTo false
+            it?.hasSourceDeclarationOf(SampleType::class) shouldBeEqualTo true
+            it?.hasSourceDeclarationOf(SampleClass::class) shouldBeEqualTo false
             it?.sourceClass shouldBeInstanceOf KoClassDeclaration::class
             it?.sourceClass?.name shouldBeEqualTo "SampleType"
             it?.hasSourceClass() shouldBeEqualTo true
@@ -265,6 +285,10 @@ class KoTypeDeclarationForKoSourceDeclarationProviderTest {
 
         // then
         assertSoftly(sut) {
+            it?.hasSourceDeclaration { declaration -> declaration.name == "SampleType" } shouldBeEqualTo true
+            it?.hasSourceDeclaration { declaration -> declaration.name == "OtherName" } shouldBeEqualTo false
+            it?.hasSourceDeclarationOf(SampleType::class) shouldBeEqualTo true
+            it?.hasSourceDeclarationOf(SampleClass::class) shouldBeEqualTo false
             it?.sourceClass shouldBeInstanceOf KoClassDeclaration::class
             it?.sourceClass?.name shouldBeEqualTo "SampleType"
             it?.hasSourceClass() shouldBeEqualTo true
@@ -305,6 +329,10 @@ class KoTypeDeclarationForKoSourceDeclarationProviderTest {
 
         // then
         assertSoftly(sut) {
+            it?.hasSourceDeclaration { declaration -> declaration.name == "SampleInterface" } shouldBeEqualTo true
+            it?.hasSourceDeclaration { declaration -> declaration.name == "OtherName" } shouldBeEqualTo false
+            it?.hasSourceDeclarationOf(SampleInterface::class) shouldBeEqualTo true
+            it?.hasSourceDeclarationOf(SampleClass::class) shouldBeEqualTo false
             it?.sourceInterface shouldBeInstanceOf KoInterfaceDeclaration::class
             it?.sourceInterface?.name shouldBeEqualTo "SampleInterface"
             it?.hasSourceInterface() shouldBeEqualTo true
@@ -345,6 +373,10 @@ class KoTypeDeclarationForKoSourceDeclarationProviderTest {
 
         // then
         assertSoftly(sut) {
+            it?.hasSourceDeclaration { declaration -> declaration.name == "SampleInterface" } shouldBeEqualTo true
+            it?.hasSourceDeclaration { declaration -> declaration.name == "OtherName" } shouldBeEqualTo false
+            it?.hasSourceDeclarationOf(SampleInterface::class) shouldBeEqualTo true
+            it?.hasSourceDeclarationOf(SampleClass::class) shouldBeEqualTo false
             it?.sourceInterface shouldBeInstanceOf KoInterfaceDeclaration::class
             it?.sourceInterface?.name shouldBeEqualTo "SampleInterface"
             it?.hasSourceInterface() shouldBeEqualTo true
@@ -385,6 +417,10 @@ class KoTypeDeclarationForKoSourceDeclarationProviderTest {
 
         // then
         assertSoftly(sut) {
+            it?.hasSourceDeclaration { declaration -> declaration.name == "SampleObject" } shouldBeEqualTo true
+            it?.hasSourceDeclaration { declaration -> declaration.name == "OtherName" } shouldBeEqualTo false
+            it?.hasSourceDeclarationOf(SampleObject::class) shouldBeEqualTo true
+            it?.hasSourceDeclarationOf(SampleClass::class) shouldBeEqualTo false
             it?.sourceObject shouldBeInstanceOf KoObjectDeclaration::class
             it?.sourceObject?.name shouldBeEqualTo "SampleObject"
             it?.hasSourceObject() shouldBeEqualTo true
@@ -425,6 +461,10 @@ class KoTypeDeclarationForKoSourceDeclarationProviderTest {
 
         // then
         assertSoftly(sut) {
+            it?.hasSourceDeclaration { declaration -> declaration.name == "SampleObject" } shouldBeEqualTo true
+            it?.hasSourceDeclaration { declaration -> declaration.name == "OtherName" } shouldBeEqualTo false
+            it?.hasSourceDeclarationOf(SampleObject::class) shouldBeEqualTo true
+            it?.hasSourceDeclarationOf(SampleClass::class) shouldBeEqualTo false
             it?.sourceObject shouldBeInstanceOf KoObjectDeclaration::class
             it?.sourceObject?.name shouldBeEqualTo "SampleObject"
             it?.hasSourceObject() shouldBeEqualTo true
@@ -465,6 +505,9 @@ class KoTypeDeclarationForKoSourceDeclarationProviderTest {
 
         // then
         assertSoftly(sut) {
+            it?.hasSourceDeclaration { declaration -> declaration.name == "(SampleObject) -> Unit" } shouldBeEqualTo true
+            it?.hasSourceDeclaration { declaration -> declaration.name == "OtherName" } shouldBeEqualTo false
+            it?.hasSourceDeclarationOf(SampleObject::class) shouldBeEqualTo false
             it?.sourceFunctionType shouldBeInstanceOf KoFunctionTypeDeclaration::class
             it?.sourceFunctionType?.name shouldBeEqualTo "(SampleObject) -> Unit"
             it?.hasSourceFunctionType() shouldBeEqualTo true
@@ -500,6 +543,9 @@ class KoTypeDeclarationForKoSourceDeclarationProviderTest {
 
         // then
         assertSoftly(sut) {
+            it?.hasSourceDeclaration { declaration -> declaration.name == "(SampleObject) -> Unit" } shouldBeEqualTo true
+            it?.hasSourceDeclaration { declaration -> declaration.name == "OtherName" } shouldBeEqualTo false
+            it?.hasSourceDeclarationOf(SampleObject::class) shouldBeEqualTo false
             it?.sourceFunctionType shouldBeInstanceOf KoFunctionTypeDeclaration::class
             it?.sourceFunctionType?.name shouldBeEqualTo "(SampleObject) -> Unit"
             it?.hasSourceFunctionType() shouldBeEqualTo true
@@ -535,6 +581,9 @@ class KoTypeDeclarationForKoSourceDeclarationProviderTest {
 
         // then
         assertSoftly(sut) {
+            it?.hasSourceDeclaration { declaration -> declaration.name == "ImportAlias" } shouldBeEqualTo true
+            it?.hasSourceDeclaration { declaration -> declaration.name == "OtherName" } shouldBeEqualTo false
+            it?.hasSourceDeclarationOf(SampleObject::class) shouldBeEqualTo false
             it?.sourceImportAlias shouldBeInstanceOf KoImportAliasDeclaration::class
             it?.sourceImportAlias?.name shouldBeEqualTo "ImportAlias"
             it?.hasSourceImportAlias() shouldBeEqualTo true
@@ -570,6 +619,9 @@ class KoTypeDeclarationForKoSourceDeclarationProviderTest {
 
         // then
         assertSoftly(sut) {
+            it?.hasSourceDeclaration { declaration -> declaration.name == "ImportAlias" } shouldBeEqualTo true
+            it?.hasSourceDeclaration { declaration -> declaration.name == "OtherName" } shouldBeEqualTo false
+            it?.hasSourceDeclarationOf(SampleObject::class) shouldBeEqualTo false
             it?.sourceImportAlias shouldBeInstanceOf KoImportAliasDeclaration::class
             it?.sourceImportAlias?.name shouldBeEqualTo "ImportAlias"
             it?.hasSourceImportAlias() shouldBeEqualTo true
@@ -605,6 +657,9 @@ class KoTypeDeclarationForKoSourceDeclarationProviderTest {
 
         // then
         assertSoftly(sut) {
+            it?.hasSourceDeclaration { declaration -> declaration.name == "SampleTypeAlias" } shouldBeEqualTo true
+            it?.hasSourceDeclaration { declaration -> declaration.name == "OtherName" } shouldBeEqualTo false
+            it?.hasSourceDeclarationOf(SampleObject::class) shouldBeEqualTo false
             it?.sourceTypeAlias shouldBeInstanceOf KoTypeAliasDeclaration::class
             it?.sourceTypeAlias?.name shouldBeEqualTo "SampleTypeAlias"
             it?.hasSourceTypeAlias() shouldBeEqualTo true
@@ -640,6 +695,9 @@ class KoTypeDeclarationForKoSourceDeclarationProviderTest {
 
         // then
         assertSoftly(sut) {
+            it?.hasSourceDeclaration { declaration -> declaration.name == "SampleTypeAlias" } shouldBeEqualTo true
+            it?.hasSourceDeclaration { declaration -> declaration.name == "OtherName" } shouldBeEqualTo false
+            it?.hasSourceDeclarationOf(SampleObject::class) shouldBeEqualTo false
             it?.sourceTypeAlias shouldBeInstanceOf KoTypeAliasDeclaration::class
             it?.sourceTypeAlias?.name shouldBeEqualTo "SampleTypeAlias"
             it?.hasSourceTypeAlias() shouldBeEqualTo true
@@ -675,6 +733,10 @@ class KoTypeDeclarationForKoSourceDeclarationProviderTest {
 
         // then
         assertSoftly(sut) {
+            it?.hasSourceDeclaration { declaration -> declaration.name == "SampleExternalClass" } shouldBeEqualTo true
+            it?.hasSourceDeclaration { declaration -> declaration.name == "OtherName" } shouldBeEqualTo false
+            it?.hasSourceDeclarationOf(SampleExternalClass::class) shouldBeEqualTo true
+            it?.hasSourceDeclarationOf(SampleClass::class) shouldBeEqualTo false
             it?.sourceExternalType shouldBeInstanceOf KoExternalDeclaration::class
             it?.sourceExternalType?.name shouldBeEqualTo "SampleExternalClass"
             it?.hasSourceExternalType() shouldBeEqualTo true
@@ -716,6 +778,10 @@ class KoTypeDeclarationForKoSourceDeclarationProviderTest {
 
         // then
         assertSoftly(sut) {
+            it?.hasSourceDeclaration { declaration -> declaration.name == "SampleExternalClass" } shouldBeEqualTo true
+            it?.hasSourceDeclaration { declaration -> declaration.name == "OtherName" } shouldBeEqualTo false
+            it?.hasSourceDeclarationOf(SampleExternalClass::class) shouldBeEqualTo true
+            it?.hasSourceDeclarationOf(SampleClass::class) shouldBeEqualTo false
             it?.sourceExternalType shouldBeInstanceOf KoExternalDeclaration::class
             it?.sourceExternalType?.name shouldBeEqualTo "SampleExternalClass"
             it?.hasSourceExternalType() shouldBeEqualTo true

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/type/kotype/KoTypeDeclarationTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/type/kotype/KoTypeDeclarationTest.kt
@@ -21,7 +21,7 @@ import kotlin.reflect.KClass
 class KoTypeDeclarationTest {
 
     @ParameterizedTest
-    @MethodSource("provideValuesForToString")
+    @MethodSource("provideValues")
     fun `to-string`(
         fileName: String,
         value: String,
@@ -38,36 +38,13 @@ class KoTypeDeclarationTest {
         sut?.toString() shouldBeEqualTo value
     }
 
-    @ParameterizedTest
-    @MethodSource("provideValuesForDeclaration")
-    fun `declaration`(
-        fileName: String,
-        instanceOf: KClass<*>,
-        notInstanceOf: KClass<*>,
-    ) {
-        // given
-        val sut = getSnippetFile(fileName)
-            .classes()
-            .first()
-            .primaryConstructor
-            ?.parameters
-            ?.first()
-            ?.type
-
-        // then
-        assertSoftly(sut) {
-            it?.sourceDeclaration shouldBeInstanceOf instanceOf
-            it?.sourceDeclaration shouldNotBeInstanceOf notInstanceOf
-        }
-    }
-
     private fun getSnippetFile(fileName: String) =
         TestSnippetProvider.getSnippetKoScope("core/declaration/type/kotype/snippet/forgeneral/", fileName)
 
     companion object {
         @Suppress("unused")
         @JvmStatic
-        fun provideValuesForToString() = listOf(
+        fun provideValues() = listOf(
             arguments("nullable-kotlin-basic-type", "String?"),
             arguments("not-nullable-kotlin-basic-type", "String"),
             arguments("nullable-kotlin-collection-type", "List<String>?"),
@@ -86,29 +63,6 @@ class KoTypeDeclarationTest {
             arguments("not-nullable-typealias-type", "SampleTypeAlias"),
             arguments("nullable-external-type", "SampleExternalClass?"),
             arguments("not-nullable-external-type", "SampleExternalClass"),
-        )
-
-        @Suppress("unused")
-        @JvmStatic
-        fun provideValuesForDeclaration() = listOf(
-            arguments("nullable-kotlin-basic-type", KoKotlinTypeDeclaration::class, KoClassDeclaration::class),
-            arguments("not-nullable-kotlin-basic-type", KoKotlinTypeDeclaration::class, KoClassDeclaration::class),
-            arguments("nullable-kotlin-collection-type", KoKotlinTypeDeclaration::class, KoClassDeclaration::class),
-            arguments("not-nullable-kotlin-collection-type", KoKotlinTypeDeclaration::class, KoClassDeclaration::class),
-            arguments("nullable-class-type", KoClassDeclaration::class, KoKotlinTypeDeclaration::class),
-            arguments("not-nullable-class-type", KoClassDeclaration::class, KoKotlinTypeDeclaration::class),
-            arguments("nullable-interface-type", KoInterfaceDeclaration::class, KoKotlinTypeDeclaration::class),
-            arguments("not-nullable-interface-type", KoInterfaceDeclaration::class, KoKotlinTypeDeclaration::class),
-            arguments("nullable-object-type", KoObjectDeclaration::class, KoKotlinTypeDeclaration::class),
-            arguments("not-nullable-object-type", KoObjectDeclaration::class, KoKotlinTypeDeclaration::class),
-            arguments("nullable-function-type", KoFunctionTypeDeclaration::class, KoKotlinTypeDeclaration::class),
-            arguments("not-nullable-function-type", KoFunctionTypeDeclaration::class, KoKotlinTypeDeclaration::class),
-            arguments("nullable-import-alias-type", KoImportAliasDeclaration::class, KoKotlinTypeDeclaration::class),
-            arguments("not-nullable-import-alias-type", KoImportAliasDeclaration::class, KoKotlinTypeDeclaration::class),
-            arguments("nullable-typealias-type", KoTypeAliasDeclaration::class, KoKotlinTypeDeclaration::class),
-            arguments("not-nullable-typealias-type", KoTypeAliasDeclaration::class, KoKotlinTypeDeclaration::class),
-            arguments("nullable-external-type", KoExternalDeclaration::class, KoKotlinTypeDeclaration::class),
-            arguments("not-nullable-external-type", KoExternalDeclaration::class, KoKotlinTypeDeclaration::class),
         )
     }
 }

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/type/kotype/KoTypeDeclarationTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/type/kotype/KoTypeDeclarationTest.kt
@@ -1,22 +1,10 @@
 package com.lemonappdev.konsist.core.declaration.type.kotype
 
 import com.lemonappdev.konsist.TestSnippetProvider
-import com.lemonappdev.konsist.api.declaration.KoClassDeclaration
-import com.lemonappdev.konsist.api.declaration.KoExternalDeclaration
-import com.lemonappdev.konsist.api.declaration.KoImportAliasDeclaration
-import com.lemonappdev.konsist.api.declaration.KoInterfaceDeclaration
-import com.lemonappdev.konsist.api.declaration.KoObjectDeclaration
-import com.lemonappdev.konsist.api.declaration.KoTypeAliasDeclaration
-import com.lemonappdev.konsist.api.declaration.type.KoFunctionTypeDeclaration
-import com.lemonappdev.konsist.api.declaration.type.KoKotlinTypeDeclaration
-import org.amshove.kluent.assertSoftly
 import org.amshove.kluent.shouldBeEqualTo
-import org.amshove.kluent.shouldBeInstanceOf
-import org.amshove.kluent.shouldNotBeInstanceOf
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.Arguments.arguments
 import org.junit.jupiter.params.provider.MethodSource
-import kotlin.reflect.KClass
 
 class KoTypeDeclarationTest {
 

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/type/kotype/snippet/forkosourcedeclarationprovider/not-nullable-class-type.kttxt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/type/kotype/snippet/forkosourcedeclarationprovider/not-nullable-class-type.kttxt
@@ -1,0 +1,3 @@
+import com.lemonappdev.konsist.testdata.SampleType
+
+class SampleClass1(val sampleProperty1: SampleType)

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/type/kotype/snippet/forkosourcedeclarationprovider/not-nullable-external-type.kttxt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/type/kotype/snippet/forkosourcedeclarationprovider/not-nullable-external-type.kttxt
@@ -1,0 +1,3 @@
+import com.lemonappdev.konsist.externalsample.SampleExternalClass
+
+class SampleClass1(val sampleProperty1: SampleExternalClass)

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/type/kotype/snippet/forkosourcedeclarationprovider/not-nullable-function-type.kttxt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/type/kotype/snippet/forkosourcedeclarationprovider/not-nullable-function-type.kttxt
@@ -1,0 +1,3 @@
+import com.lemonappdev.konsist.testdata.SampleObject
+
+class SampleClass1(val sampleProperty1: (SampleObject) -> Unit)

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/type/kotype/snippet/forkosourcedeclarationprovider/not-nullable-import-alias-type.kttxt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/type/kotype/snippet/forkosourcedeclarationprovider/not-nullable-import-alias-type.kttxt
@@ -1,0 +1,3 @@
+import com.lemonappdev.konsist.testdata.SampleObject as ImportAlias
+
+class SampleClass1(val sampleProperty1: ImportAlias)

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/type/kotype/snippet/forkosourcedeclarationprovider/not-nullable-interface-type.kttxt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/type/kotype/snippet/forkosourcedeclarationprovider/not-nullable-interface-type.kttxt
@@ -1,0 +1,3 @@
+import com.lemonappdev.konsist.testdata.SampleInterface
+
+class SampleClass1(val sampleProperty1: SampleInterface)

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/type/kotype/snippet/forkosourcedeclarationprovider/not-nullable-kotlin-basic-type.kttxt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/type/kotype/snippet/forkosourcedeclarationprovider/not-nullable-kotlin-basic-type.kttxt
@@ -1,0 +1,1 @@
+class SampleClass1(val sampleProperty1: String)

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/type/kotype/snippet/forkosourcedeclarationprovider/not-nullable-kotlin-collection-type.kttxt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/type/kotype/snippet/forkosourcedeclarationprovider/not-nullable-kotlin-collection-type.kttxt
@@ -1,0 +1,1 @@
+class SampleClass1(val sampleProperty1: List<String>)

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/type/kotype/snippet/forkosourcedeclarationprovider/not-nullable-object-type.kttxt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/type/kotype/snippet/forkosourcedeclarationprovider/not-nullable-object-type.kttxt
@@ -1,0 +1,3 @@
+import com.lemonappdev.konsist.testdata.SampleObject
+
+class SampleClass1(val sampleProperty1: SampleObject)

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/type/kotype/snippet/forkosourcedeclarationprovider/not-nullable-typealias-type.kttxt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/type/kotype/snippet/forkosourcedeclarationprovider/not-nullable-typealias-type.kttxt
@@ -1,0 +1,5 @@
+import com.lemonappdev.konsist.testdata.SampleObject
+
+class SampleClass1(val sampleProperty1: SampleTypeAlias)
+
+typealias SampleTypeAlias = (SampleObject) -> Unit

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/type/kotype/snippet/forkosourcedeclarationprovider/nullable-class-type.kttxt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/type/kotype/snippet/forkosourcedeclarationprovider/nullable-class-type.kttxt
@@ -1,0 +1,3 @@
+import com.lemonappdev.konsist.testdata.SampleType
+
+class SampleClass1(val sampleProperty1: SampleType?)

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/type/kotype/snippet/forkosourcedeclarationprovider/nullable-external-type.kttxt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/type/kotype/snippet/forkosourcedeclarationprovider/nullable-external-type.kttxt
@@ -1,0 +1,3 @@
+import com.lemonappdev.konsist.externalsample.SampleExternalClass
+
+class SampleClass1(val sampleProperty1: SampleExternalClass?)

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/type/kotype/snippet/forkosourcedeclarationprovider/nullable-function-type.kttxt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/type/kotype/snippet/forkosourcedeclarationprovider/nullable-function-type.kttxt
@@ -1,0 +1,3 @@
+import com.lemonappdev.konsist.testdata.SampleObject
+
+class SampleClass1(val sampleProperty1: ((SampleObject) -> Unit)?)

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/type/kotype/snippet/forkosourcedeclarationprovider/nullable-import-alias-type.kttxt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/type/kotype/snippet/forkosourcedeclarationprovider/nullable-import-alias-type.kttxt
@@ -1,0 +1,3 @@
+import com.lemonappdev.konsist.testdata.SampleObject as ImportAlias
+
+class SampleClass1(val sampleProperty1: ImportAlias?)

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/type/kotype/snippet/forkosourcedeclarationprovider/nullable-interface-type.kttxt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/type/kotype/snippet/forkosourcedeclarationprovider/nullable-interface-type.kttxt
@@ -1,0 +1,3 @@
+import com.lemonappdev.konsist.testdata.SampleInterface
+
+class SampleClass1(val sampleProperty1: SampleInterface?)

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/type/kotype/snippet/forkosourcedeclarationprovider/nullable-kotlin-basic-type.kttxt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/type/kotype/snippet/forkosourcedeclarationprovider/nullable-kotlin-basic-type.kttxt
@@ -1,0 +1,1 @@
+class SampleClass1(val sampleProperty1: String?)

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/type/kotype/snippet/forkosourcedeclarationprovider/nullable-kotlin-collection-type.kttxt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/type/kotype/snippet/forkosourcedeclarationprovider/nullable-kotlin-collection-type.kttxt
@@ -1,0 +1,1 @@
+class SampleClass1(val sampleProperty1: List<String>?)

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/type/kotype/snippet/forkosourcedeclarationprovider/nullable-object-type.kttxt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/type/kotype/snippet/forkosourcedeclarationprovider/nullable-object-type.kttxt
@@ -1,0 +1,3 @@
+import com.lemonappdev.konsist.testdata.SampleObject
+
+class SampleClass1(val sampleProperty1: SampleObject?)

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/type/kotype/snippet/forkosourcedeclarationprovider/nullable-typealias-type.kttxt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/type/kotype/snippet/forkosourcedeclarationprovider/nullable-typealias-type.kttxt
@@ -1,0 +1,5 @@
+import com.lemonappdev.konsist.testdata.SampleObject
+
+class SampleClass1(val sampleProperty1: SampleTypeAlias?)
+
+typealias SampleTypeAlias = (SampleObject) -> Unit

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/type/kotype/snippet/forkosourcedeclarationprovider/nullable-typealias-type.kttxt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/type/kotype/snippet/forkosourcedeclarationprovider/nullable-typealias-type.kttxt
@@ -1,5 +1,3 @@
-import com.lemonappdev.konsist.testdata.SampleObject
+import com.lemonappdev.konsist.testdata.SampleTypeAlias
 
 class SampleClass1(val sampleProperty1: SampleTypeAlias?)
-
-typealias SampleTypeAlias = (SampleObject) -> Unit

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/testdata/TestData.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/testdata/TestData.kt
@@ -68,6 +68,8 @@ interface SampleGenericSuperInterface<T>
 
 object SampleObject
 
+typealias SampleTypeAlias = (SampleClass) -> Unit
+
 annotation class NonExistingAnnotation
 
 @Target(

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/api/declaration/type/KoTypeDeclaration.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/api/declaration/type/KoTypeDeclaration.kt
@@ -14,6 +14,7 @@ import com.lemonappdev.konsist.api.provider.KoPackageProvider
 import com.lemonappdev.konsist.api.provider.KoPathProvider
 import com.lemonappdev.konsist.api.provider.KoResideInPackageProvider
 import com.lemonappdev.konsist.api.provider.KoSourceAndAliasTypeProvider
+import com.lemonappdev.konsist.api.provider.KoSourceDeclarationProvider
 import com.lemonappdev.konsist.api.provider.KoSourceSetProvider
 import com.lemonappdev.konsist.api.provider.KoTextProvider
 
@@ -36,15 +37,5 @@ interface KoTypeDeclaration :
     KoGenericTypeProvider,
     KoSourceAndAliasTypeProvider,
     KoPackageProvider,
-    KoResideInPackageProvider {
-    /**
-     * Represents the source declaration associated with this type.
-     *
-     * The `sourceDeclaration` property provides access to the declaration of the type within the Kotlin codebase.
-     * It points to an instance of [KoBaseTypeDeclaration], which serves as the base interface for various types of
-     * declarations in Kotlin.
-     * This allows retrieving additional information about the declaration, such as its properties, functions,
-     * annotations, and other relevant metadata.
-     */
-    val sourceDeclaration: KoBaseTypeDeclaration
-}
+    KoResideInPackageProvider,
+    KoSourceDeclarationProvider

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/api/ext/list/KoSourceDeclarationProviderListExt.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/api/ext/list/KoSourceDeclarationProviderListExt.kt
@@ -13,6 +13,7 @@ import com.lemonappdev.konsist.api.declaration.type.KoTypeDeclaration
 import com.lemonappdev.konsist.api.provider.KoNonNullableTypeProvider
 import com.lemonappdev.konsist.api.provider.KoNullableTypeProvider
 import com.lemonappdev.konsist.api.provider.KoSourceDeclarationProvider
+import kotlin.reflect.KClass
 
 /**
  * List containing source declarations associated with types.
@@ -87,6 +88,41 @@ fun <T : KoSourceDeclarationProvider> List<T>.withoutSourceDeclaration(predicate
     filterNot { predicate(it.sourceDeclaration) }
 
 /**
+ * List containing declarations with source declaration of.
+ *
+ * @param kClass The Kotlin class representing the source declaration to include.
+ * @param kClasses The Kotlin class(es) representing the source declaration(s) to include.
+ * @return A list containing declarations with the source declaration of the specified Kotlin class(es).
+ */
+fun <T : KoSourceDeclarationProvider> List<T>.withSourceDeclarationOf(kClass: KClass<*>, vararg kClasses: KClass<*>): List<T> =
+    filter {
+        it.hasSourceDeclarationOf(kClass) ||
+                if (kClasses.isNotEmpty()) {
+                    kClasses.any { kClass -> it.hasSourceDeclarationOf(kClass) }
+                } else {
+                    false
+                }
+    }
+
+/**
+ * List containing declarations without source declaration of.
+ *
+ * @param kClass The Kotlin class representing the source declaration to exclude.
+ * @param kClasses The Kotlin class(es) representing the source declaration(s) to exclude.
+ * @return A list containing declarations without source declaration of the specified Kotlin class(es).
+ */
+fun <T : KoSourceDeclarationProvider> List<T>.withoutSourceDeclarationOf(kClass: KClass<*>, vararg kClasses: KClass<*>): List<T> =
+    filterNot {
+        val hasMatchingSourceDeclaration = if (kClasses.isNotEmpty()) {
+            kClasses.any { kClass -> it.hasSourceDeclarationOf(kClass) }
+        } else {
+            false
+        }
+
+        it.hasSourceDeclarationOf(kClass) || hasMatchingSourceDeclaration
+    }
+
+/**
  * List containing declarations with the specified source class.
  *
  * @param predicate The predicate function to determine if a source class satisfies a condition.
@@ -95,7 +131,7 @@ fun <T : KoSourceDeclarationProvider> List<T>.withoutSourceDeclaration(predicate
 fun <T : KoSourceDeclarationProvider> List<T>.withSourceClass(predicate: ((KoClassDeclaration) -> Boolean)? = null): List<T> =
     filter {
         when (predicate) {
-            null -> it.sourceClass != null
+            null -> it.hasSourceClass()
             else -> it.sourceClass?.let { sourceClass -> predicate(sourceClass) } ?: false
         }
     }
@@ -109,9 +145,45 @@ fun <T : KoSourceDeclarationProvider> List<T>.withSourceClass(predicate: ((KoCla
 fun <T : KoSourceDeclarationProvider> List<T>.withoutSourceClass(predicate: ((KoClassDeclaration) -> Boolean)? = null): List<T> =
     filterNot {
         when (predicate) {
-            null -> it.sourceClass != null
+            null -> it.hasSourceClass()
             else -> it.sourceClass?.let { sourceClass -> predicate(sourceClass) } ?: false
         }
+    }
+
+/**
+ * List containing declarations with source class of.
+ *
+ * @param kClass The Kotlin class representing the source class to include.
+ * @param kClasses The Kotlin class(es) representing the source class(es) to include.
+ * @return A list containing declarations with the source class of the specified Kotlin class(es).
+ */
+fun <T : KoSourceDeclarationProvider> List<T>.withSourceClassOf(kClass: KClass<*>, vararg kClasses: KClass<*>): List<T> =
+    filter {
+        val hasAllSourceClasses = if (kClasses.isNotEmpty()) {
+            kClasses.any { kClass -> it.hasSourceClassOf(kClass) }
+        } else {
+            false
+        }
+
+        it.hasSourceClassOf(kClass) || hasAllSourceClasses
+    }
+
+/**
+ * List containing declarations without source class of.
+ *
+ * @param kClass The Kotlin class representing the source class to exclude.
+ * @param kClasses The Kotlin class(es) representing the source class(s) to exclude.
+ * @return A list containing declarations without source class of the specified Kotlin class(es).
+ */
+fun <T : KoSourceDeclarationProvider> List<T>.withoutSourceClassOf(kClass: KClass<*>, vararg kClasses: KClass<*>): List<T> =
+    filterNot {
+        val hasAllSourceClasses = if (kClasses.isNotEmpty()) {
+            kClasses.any { kClass -> it.hasSourceClassOf(kClass) }
+        } else {
+            false
+        }
+
+        it.hasSourceClassOf(kClass) || hasAllSourceClasses
     }
 
 /**
@@ -123,7 +195,7 @@ fun <T : KoSourceDeclarationProvider> List<T>.withoutSourceClass(predicate: ((Ko
 fun <T : KoSourceDeclarationProvider> List<T>.withSourceObject(predicate: ((KoObjectDeclaration) -> Boolean)? = null): List<T> =
     filter {
         when (predicate) {
-            null -> it.sourceObject != null
+            null -> it.hasSourceObject()
             else -> it.sourceObject?.let { sourceObject -> predicate(sourceObject) } ?: false
         }
     }
@@ -137,9 +209,45 @@ fun <T : KoSourceDeclarationProvider> List<T>.withSourceObject(predicate: ((KoOb
 fun <T : KoSourceDeclarationProvider> List<T>.withoutSourceObject(predicate: ((KoObjectDeclaration) -> Boolean)? = null): List<T> =
     filterNot {
         when (predicate) {
-            null -> it.sourceObject != null
+            null -> it.hasSourceObject()
             else -> it.sourceObject?.let { sourceObject -> predicate(sourceObject) } ?: false
         }
+    }
+
+/**
+ * List containing declarations with source object of.
+ *
+ * @param kClass The Kotlin class representing the source object to include.
+ * @param kClasses The Kotlin class(es) representing the source object(s) to include.
+ * @return A list containing declarations with the source object of the specified Kotlin class(es).
+ */
+fun <T : KoSourceDeclarationProvider> List<T>.withSourceObjectOf(kClass: KClass<*>, vararg kClasses: KClass<*>): List<T> =
+    filter {
+        val hasAllSourceObjects = if (kClasses.isNotEmpty()) {
+            kClasses.any { kClass -> it.hasSourceObjectOf(kClass) }
+        } else {
+            false
+        }
+
+        it.hasSourceObjectOf(kClass) || hasAllSourceObjects
+    }
+
+/**
+ * List containing declarations without source object of.
+ *
+ * @param kClass The Kotlin class representing the source object to exclude.
+ * @param kClasses The Kotlin class(es) representing the source object(s) to exclude.
+ * @return A list containing declarations without source object of the specified Kotlin class(es).
+ */
+fun <T : KoSourceDeclarationProvider> List<T>.withoutSourceObjectOf(kClass: KClass<*>, vararg kClasses: KClass<*>): List<T> =
+    filterNot {
+        val hasAllSourceObjects = if (kClasses.isNotEmpty()) {
+            kClasses.any { kClass -> it.hasSourceObjectOf(kClass) }
+        } else {
+            false
+        }
+
+        it.hasSourceObjectOf(kClass) || hasAllSourceObjects
     }
 
 /**
@@ -151,7 +259,7 @@ fun <T : KoSourceDeclarationProvider> List<T>.withoutSourceObject(predicate: ((K
 fun <T : KoSourceDeclarationProvider> List<T>.withSourceInterface(predicate: ((KoInterfaceDeclaration) -> Boolean)? = null): List<T> =
     filter {
         when (predicate) {
-            null -> it.sourceInterface != null
+            null -> it.hasSourceInterface()
             else -> it.sourceInterface?.let { sourceInterface -> predicate(sourceInterface) } ?: false
         }
     }
@@ -165,9 +273,45 @@ fun <T : KoSourceDeclarationProvider> List<T>.withSourceInterface(predicate: ((K
 fun <T : KoSourceDeclarationProvider> List<T>.withoutSourceInterface(predicate: ((KoInterfaceDeclaration) -> Boolean)? = null): List<T> =
     filterNot {
         when (predicate) {
-            null -> it.sourceInterface != null
+            null -> it.hasSourceInterface()
             else -> it.sourceInterface?.let { sourceInterface -> predicate(sourceInterface) } ?: false
         }
+    }
+
+/**
+ * List containing declarations with source interface of.
+ *
+ * @param kClass The Kotlin class representing the source interface to include.
+ * @param kClasses The Kotlin class(es) representing the source interface(s) to include.
+ * @return A list containing declarations with the source interface of the specified Kotlin class(es).
+ */
+fun <T : KoSourceDeclarationProvider> List<T>.withSourceInterfaceOf(kClass: KClass<*>, vararg kClasses: KClass<*>): List<T> =
+    filter {
+        val hasAllSourceInterfaces = if (kClasses.isNotEmpty()) {
+            kClasses.any { kClass -> it.hasSourceInterfaceOf(kClass) }
+        } else {
+            false
+        }
+
+        it.hasSourceInterfaceOf(kClass) || hasAllSourceInterfaces
+    }
+
+/**
+ * List containing declarations without source interface of.
+ *
+ * @param kClass The Kotlin class representing the source interface to exclude.
+ * @param kClasses The Kotlin class(es) representing the source interface(s) to exclude.
+ * @return A list containing declarations without source interface of the specified Kotlin class(es).
+ */
+fun <T : KoSourceDeclarationProvider> List<T>.withoutSourceInterfaceOf(kClass: KClass<*>, vararg kClasses: KClass<*>): List<T> =
+    filterNot {
+        val hasAllSourceInterfaces = if (kClasses.isNotEmpty()) {
+            kClasses.any { kClass -> it.hasSourceInterfaceOf(kClass) }
+        } else {
+            false
+        }
+
+        it.hasSourceInterfaceOf(kClass) || hasAllSourceInterfaces
     }
 
 /**
@@ -179,7 +323,7 @@ fun <T : KoSourceDeclarationProvider> List<T>.withoutSourceInterface(predicate: 
 fun <T : KoSourceDeclarationProvider> List<T>.withSourceTypeAlias(predicate: ((KoTypeAliasDeclaration) -> Boolean)? = null): List<T> =
     filter {
         when (predicate) {
-            null -> it.sourceTypeAlias != null
+            null -> it.hasSourceTypeAlias()
             else -> it.sourceTypeAlias?.let { sourceTypeAlias -> predicate(sourceTypeAlias) } ?: false
         }
     }
@@ -193,7 +337,7 @@ fun <T : KoSourceDeclarationProvider> List<T>.withSourceTypeAlias(predicate: ((K
 fun <T : KoSourceDeclarationProvider> List<T>.withoutSourceTypeAlias(predicate: ((KoTypeAliasDeclaration) -> Boolean)? = null): List<T> =
     filterNot {
         when (predicate) {
-            null -> it.sourceTypeAlias != null
+            null -> it.hasSourceTypeAlias()
             else -> it.sourceTypeAlias?.let { sourceTypeAlias -> predicate(sourceTypeAlias) } ?: false
         }
     }
@@ -207,7 +351,7 @@ fun <T : KoSourceDeclarationProvider> List<T>.withoutSourceTypeAlias(predicate: 
 fun <T : KoSourceDeclarationProvider> List<T>.withSourceImportAlias(predicate: ((KoImportAliasDeclaration) -> Boolean)? = null): List<T> =
     filter {
         when (predicate) {
-            null -> it.sourceImportAlias != null
+            null -> it.hasSourceImportAlias()
             else -> it.sourceImportAlias?.let { sourceImportAlias -> predicate(sourceImportAlias) } ?: false
         }
     }
@@ -221,7 +365,7 @@ fun <T : KoSourceDeclarationProvider> List<T>.withSourceImportAlias(predicate: (
 fun <T : KoSourceDeclarationProvider> List<T>.withoutSourceImportAlias(predicate: ((KoImportAliasDeclaration) -> Boolean)? = null): List<T> =
     filterNot {
         when (predicate) {
-            null -> it.sourceImportAlias != null
+            null -> it.hasSourceImportAlias()
             else -> it.sourceImportAlias?.let { sourceImportAlias -> predicate(sourceImportAlias) } ?: false
         }
     }
@@ -235,7 +379,7 @@ fun <T : KoSourceDeclarationProvider> List<T>.withoutSourceImportAlias(predicate
 fun <T : KoSourceDeclarationProvider> List<T>.withSourceKotlinType(predicate: ((KoKotlinTypeDeclaration) -> Boolean)? = null): List<T> =
     filter {
         when (predicate) {
-            null -> it.sourceKotlinType != null
+            null -> it.hasSourceKotlinType()
             else -> it.sourceKotlinType?.let { sourceKotlinType -> predicate(sourceKotlinType) } ?: false
         }
     }
@@ -249,9 +393,45 @@ fun <T : KoSourceDeclarationProvider> List<T>.withSourceKotlinType(predicate: ((
 fun <T : KoSourceDeclarationProvider> List<T>.withoutSourceKotlinType(predicate: ((KoKotlinTypeDeclaration) -> Boolean)? = null): List<T> =
     filterNot {
         when (predicate) {
-            null -> it.sourceKotlinType != null
+            null -> it.hasSourceKotlinType()
             else -> it.sourceKotlinType?.let { sourceKotlinType -> predicate(sourceKotlinType) } ?: false
         }
+    }
+
+/**
+ * List containing declarations with source kotlin type of.
+ *
+ * @param kClass The Kotlin class representing the source kotlin type to include.
+ * @param kClasses The Kotlin class(es) representing the source kotlin type(s) to include.
+ * @return A list containing declarations with the source kotlin type of the specified Kotlin class(es).
+ */
+fun <T : KoSourceDeclarationProvider> List<T>.withSourceKotlinTypeOf(kClass: KClass<*>, vararg kClasses: KClass<*>): List<T> =
+    filter {
+        val hasAllSourceKotlinTypes = if (kClasses.isNotEmpty()) {
+            kClasses.any { kClass -> it.hasSourceKotlinTypeOf(kClass) }
+        } else {
+            false
+        }
+
+        it.hasSourceKotlinTypeOf(kClass) || hasAllSourceKotlinTypes
+    }
+
+/**
+ * List containing declarations without source kotlin type of.
+ *
+ * @param kClass The Kotlin class representing the source kotlin type to exclude.
+ * @param kClasses The Kotlin class(es) representing the source kotlin type(s) to exclude.
+ * @return A list containing declarations without source kotlin type of the specified Kotlin class(es).
+ */
+fun <T : KoSourceDeclarationProvider> List<T>.withoutSourceKotlinTypeOf(kClass: KClass<*>, vararg kClasses: KClass<*>): List<T> =
+    filterNot {
+        val hasAllSourceKotlinTypes = if (kClasses.isNotEmpty()) {
+            kClasses.any { kClass -> it.hasSourceKotlinTypeOf(kClass) }
+        } else {
+            false
+        }
+
+        it.hasSourceKotlinTypeOf(kClass) || hasAllSourceKotlinTypes
     }
 
 /**
@@ -263,7 +443,7 @@ fun <T : KoSourceDeclarationProvider> List<T>.withoutSourceKotlinType(predicate:
 fun <T : KoSourceDeclarationProvider> List<T>.withSourceFunctionType(predicate: ((KoFunctionTypeDeclaration) -> Boolean)? = null): List<T> =
     filter {
         when (predicate) {
-            null -> it.sourceFunctionType != null
+            null -> it.hasSourceFunctionType()
             else -> it.sourceFunctionType?.let { sourceFunctionType -> predicate(sourceFunctionType) } ?: false
         }
     }
@@ -277,7 +457,7 @@ fun <T : KoSourceDeclarationProvider> List<T>.withSourceFunctionType(predicate: 
 fun <T : KoSourceDeclarationProvider> List<T>.withoutSourceFunctionType(predicate: ((KoFunctionTypeDeclaration) -> Boolean)? = null): List<T> =
     filterNot {
         when (predicate) {
-            null -> it.sourceFunctionType != null
+            null -> it.hasSourceFunctionType()
             else -> it.sourceFunctionType?.let { sourceFunctionType -> predicate(sourceFunctionType) } ?: false
         }
     }
@@ -291,7 +471,7 @@ fun <T : KoSourceDeclarationProvider> List<T>.withoutSourceFunctionType(predicat
 fun <T : KoSourceDeclarationProvider> List<T>.withSourceExternalType(predicate: ((KoExternalDeclaration) -> Boolean)? = null): List<T> =
     filter {
         when (predicate) {
-            null -> it.sourceExternalType != null
+            null -> it.hasSourceExternalType()
             else -> it.sourceExternalType?.let { sourceExternalType -> predicate(sourceExternalType) } ?: false
         }
     }
@@ -305,7 +485,43 @@ fun <T : KoSourceDeclarationProvider> List<T>.withSourceExternalType(predicate: 
 fun <T : KoSourceDeclarationProvider> List<T>.withoutSourceExternalType(predicate: ((KoExternalDeclaration) -> Boolean)? = null): List<T> =
     filterNot {
         when (predicate) {
-            null -> it.sourceExternalType != null
+            null -> it.hasSourceExternalType()
             else -> it.sourceExternalType?.let { sourceExternalType -> predicate(sourceExternalType) } ?: false
         }
+    }
+
+/**
+ * List containing declarations with source external type of.
+ *
+ * @param kClass The Kotlin class representing the source external type to include.
+ * @param kClasses The Kotlin class(es) representing the source external type(s) to include.
+ * @return A list containing declarations with the source external type of the specified Kotlin class(es).
+ */
+fun <T : KoSourceDeclarationProvider> List<T>.withSourceExternalTypeOf(kClass: KClass<*>, vararg kClasses: KClass<*>): List<T> =
+    filter {
+        val hasAllSourceExternalTypes = if (kClasses.isNotEmpty()) {
+            kClasses.any { kClass -> it.hasSourceExternalTypeOf(kClass) }
+        } else {
+            false
+        }
+
+        it.hasSourceExternalTypeOf(kClass) || hasAllSourceExternalTypes
+    }
+
+/**
+ * List containing declarations without source external type of.
+ *
+ * @param kClass The Kotlin class representing the source external type to exclude.
+ * @param kClasses The Kotlin class(es) representing the source external type(s) to exclude.
+ * @return A list containing declarations without source external type of the specified Kotlin class(es).
+ */
+fun <T : KoSourceDeclarationProvider> List<T>.withoutSourceExternalTypeOf(kClass: KClass<*>, vararg kClasses: KClass<*>): List<T> =
+    filterNot {
+        val hasAllSourceExternalTypes = if (kClasses.isNotEmpty()) {
+            kClasses.any { kClass -> it.hasSourceExternalTypeOf(kClass) }
+        } else {
+            false
+        }
+
+        it.hasSourceExternalTypeOf(kClass) || hasAllSourceExternalTypes
     }

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/api/ext/list/KoSourceDeclarationProviderListExt.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/api/ext/list/KoSourceDeclarationProviderListExt.kt
@@ -1,3 +1,5 @@
+@file:Suppress("detekt.TooManyFunctions")
+
 package com.lemonappdev.konsist.api.ext.list
 
 import com.lemonappdev.konsist.api.declaration.KoClassDeclaration
@@ -9,9 +11,6 @@ import com.lemonappdev.konsist.api.declaration.KoTypeAliasDeclaration
 import com.lemonappdev.konsist.api.declaration.type.KoBaseTypeDeclaration
 import com.lemonappdev.konsist.api.declaration.type.KoFunctionTypeDeclaration
 import com.lemonappdev.konsist.api.declaration.type.KoKotlinTypeDeclaration
-import com.lemonappdev.konsist.api.declaration.type.KoTypeDeclaration
-import com.lemonappdev.konsist.api.provider.KoNonNullableTypeProvider
-import com.lemonappdev.konsist.api.provider.KoNullableTypeProvider
 import com.lemonappdev.konsist.api.provider.KoSourceDeclarationProvider
 import kotlin.reflect.KClass
 
@@ -97,11 +96,11 @@ fun <T : KoSourceDeclarationProvider> List<T>.withoutSourceDeclaration(predicate
 fun <T : KoSourceDeclarationProvider> List<T>.withSourceDeclarationOf(kClass: KClass<*>, vararg kClasses: KClass<*>): List<T> =
     filter {
         it.hasSourceDeclarationOf(kClass) ||
-                if (kClasses.isNotEmpty()) {
-                    kClasses.any { kClass -> it.hasSourceDeclarationOf(kClass) }
-                } else {
-                    false
-                }
+            if (kClasses.isNotEmpty()) {
+                kClasses.any { kClass -> it.hasSourceDeclarationOf(kClass) }
+            } else {
+                false
+            }
     }
 
 /**
@@ -362,7 +361,9 @@ fun <T : KoSourceDeclarationProvider> List<T>.withSourceImportAlias(predicate: (
  * @param predicate The predicate function to determine if a source import alias satisfies a condition.
  * @return A list containing declarations without the specified source import alias.
  */
-fun <T : KoSourceDeclarationProvider> List<T>.withoutSourceImportAlias(predicate: ((KoImportAliasDeclaration) -> Boolean)? = null): List<T> =
+fun <T : KoSourceDeclarationProvider> List<T>.withoutSourceImportAlias(
+    predicate: ((KoImportAliasDeclaration) -> Boolean)? = null,
+): List<T> =
     filterNot {
         when (predicate) {
             null -> it.hasSourceImportAlias()
@@ -454,7 +455,9 @@ fun <T : KoSourceDeclarationProvider> List<T>.withSourceFunctionType(predicate: 
  * @param predicate The predicate function to determine if a source function type satisfies a condition.
  * @return A list containing declarations without the specified source function type.
  */
-fun <T : KoSourceDeclarationProvider> List<T>.withoutSourceFunctionType(predicate: ((KoFunctionTypeDeclaration) -> Boolean)? = null): List<T> =
+fun <T : KoSourceDeclarationProvider> List<T>.withoutSourceFunctionType(
+    predicate: ((KoFunctionTypeDeclaration) -> Boolean)? = null,
+): List<T> =
     filterNot {
         when (predicate) {
             null -> it.hasSourceFunctionType()

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/api/ext/list/KoSourceDeclarationProviderListExt.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/api/ext/list/KoSourceDeclarationProviderListExt.kt
@@ -1,0 +1,311 @@
+package com.lemonappdev.konsist.api.ext.list
+
+import com.lemonappdev.konsist.api.declaration.KoClassDeclaration
+import com.lemonappdev.konsist.api.declaration.KoExternalDeclaration
+import com.lemonappdev.konsist.api.declaration.KoImportAliasDeclaration
+import com.lemonappdev.konsist.api.declaration.KoInterfaceDeclaration
+import com.lemonappdev.konsist.api.declaration.KoObjectDeclaration
+import com.lemonappdev.konsist.api.declaration.KoTypeAliasDeclaration
+import com.lemonappdev.konsist.api.declaration.type.KoBaseTypeDeclaration
+import com.lemonappdev.konsist.api.declaration.type.KoFunctionTypeDeclaration
+import com.lemonappdev.konsist.api.declaration.type.KoKotlinTypeDeclaration
+import com.lemonappdev.konsist.api.declaration.type.KoTypeDeclaration
+import com.lemonappdev.konsist.api.provider.KoNonNullableTypeProvider
+import com.lemonappdev.konsist.api.provider.KoNullableTypeProvider
+import com.lemonappdev.konsist.api.provider.KoSourceDeclarationProvider
+
+/**
+ * List containing source declarations associated with types.
+ */
+val <T : KoSourceDeclarationProvider> List<T>.sourceDeclarations: List<KoBaseTypeDeclaration>
+    get() = mapNotNull { it.sourceDeclaration }
+
+/**
+ * List containing source classes associated with types.
+ */
+val <T : KoSourceDeclarationProvider> List<T>.sourceClasses: List<KoClassDeclaration>
+    get() = mapNotNull { it.sourceClass }
+
+/**
+ * List containing source objects associated with types.
+ */
+val <T : KoSourceDeclarationProvider> List<T>.sourceObjects: List<KoObjectDeclaration>
+    get() = mapNotNull { it.sourceObject }
+
+/**
+ * List containing source interfaces associated with types.
+ */
+val <T : KoSourceDeclarationProvider> List<T>.sourceInterfaces: List<KoInterfaceDeclaration>
+    get() = mapNotNull { it.sourceInterface }
+
+/**
+ * List containing source type aliases associated with types.
+ */
+val <T : KoSourceDeclarationProvider> List<T>.sourceTypeAliases: List<KoTypeAliasDeclaration>
+    get() = mapNotNull { it.sourceTypeAlias }
+
+/**
+ * List containing source import aliases associated with types.
+ */
+val <T : KoSourceDeclarationProvider> List<T>.sourceImportAliases: List<KoImportAliasDeclaration>
+    get() = mapNotNull { it.sourceImportAlias }
+
+/**
+ * List containing source kotlin types associated with types.
+ */
+val <T : KoSourceDeclarationProvider> List<T>.sourceKotlinTypes: List<KoKotlinTypeDeclaration>
+    get() = mapNotNull { it.sourceKotlinType }
+
+/**
+ * List containing source function types associated with types.
+ */
+val <T : KoSourceDeclarationProvider> List<T>.sourceFunctionTypes: List<KoFunctionTypeDeclaration>
+    get() = mapNotNull { it.sourceFunctionType }
+
+/**
+ * List containing source external types associated with types.
+ */
+val <T : KoSourceDeclarationProvider> List<T>.sourceExternalTypes: List<KoExternalDeclaration>
+    get() = mapNotNull { it.sourceExternalType }
+
+/**
+ * List containing declarations with the specified source declaration.
+ *
+ * @param predicate The predicate function to determine if a source declaration satisfies a condition.
+ * @return A list containing declarations with the specified source declaration.
+ */
+fun <T : KoSourceDeclarationProvider> List<T>.withSourceDeclaration(predicate: (KoBaseTypeDeclaration) -> Boolean): List<T> =
+    filter { predicate(it.sourceDeclaration) }
+
+/**
+ * List containing declarations without the specified source declaration.
+ *
+ * @param predicate The predicate function to determine if a source declaration satisfies a condition.
+ * @return A list containing declarations without the specified source declaration.
+ */
+fun <T : KoSourceDeclarationProvider> List<T>.withoutSourceDeclaration(predicate: (KoBaseTypeDeclaration) -> Boolean): List<T> =
+    filterNot { predicate(it.sourceDeclaration) }
+
+/**
+ * List containing declarations with the specified source class.
+ *
+ * @param predicate The predicate function to determine if a source class satisfies a condition.
+ * @return A list containing declarations with the specified source class.
+ */
+fun <T : KoSourceDeclarationProvider> List<T>.withSourceClass(predicate: ((KoClassDeclaration) -> Boolean)? = null): List<T> =
+    filter {
+        when (predicate) {
+            null -> it.sourceClass != null
+            else -> it.sourceClass?.let { sourceClass -> predicate(sourceClass) } ?: false
+        }
+    }
+
+/**
+ * List containing declarations without the specified source class.
+ *
+ * @param predicate The predicate function to determine if a source class satisfies a condition.
+ * @return A list containing declarations without the specified source class.
+ */
+fun <T : KoSourceDeclarationProvider> List<T>.withoutSourceClass(predicate: ((KoClassDeclaration) -> Boolean)? = null): List<T> =
+    filterNot {
+        when (predicate) {
+            null -> it.sourceClass != null
+            else -> it.sourceClass?.let { sourceClass -> predicate(sourceClass) } ?: false
+        }
+    }
+
+/**
+ * List containing declarations with the specified source object.
+ *
+ * @param predicate The predicate function to determine if a source object satisfies a condition.
+ * @return A list containing declarations with the specified source object.
+ */
+fun <T : KoSourceDeclarationProvider> List<T>.withSourceObject(predicate: ((KoObjectDeclaration) -> Boolean)? = null): List<T> =
+    filter {
+        when (predicate) {
+            null -> it.sourceObject != null
+            else -> it.sourceObject?.let { sourceObject -> predicate(sourceObject) } ?: false
+        }
+    }
+
+/**
+ * List containing declarations without the specified source object.
+ *
+ * @param predicate The predicate function to determine if a source object satisfies a condition.
+ * @return A list containing declarations without the specified source object.
+ */
+fun <T : KoSourceDeclarationProvider> List<T>.withoutSourceObject(predicate: ((KoObjectDeclaration) -> Boolean)? = null): List<T> =
+    filterNot {
+        when (predicate) {
+            null -> it.sourceObject != null
+            else -> it.sourceObject?.let { sourceObject -> predicate(sourceObject) } ?: false
+        }
+    }
+
+/**
+ * List containing declarations with the specified source interface.
+ *
+ * @param predicate The predicate function to determine if a source interface satisfies a condition.
+ * @return A list containing declarations with the specified source interface.
+ */
+fun <T : KoSourceDeclarationProvider> List<T>.withSourceInterface(predicate: ((KoInterfaceDeclaration) -> Boolean)? = null): List<T> =
+    filter {
+        when (predicate) {
+            null -> it.sourceInterface != null
+            else -> it.sourceInterface?.let { sourceInterface -> predicate(sourceInterface) } ?: false
+        }
+    }
+
+/**
+ * List containing declarations without the specified source interface.
+ *
+ * @param predicate The predicate function to determine if a source interface satisfies a condition.
+ * @return A list containing declarations without the specified source interface.
+ */
+fun <T : KoSourceDeclarationProvider> List<T>.withoutSourceInterface(predicate: ((KoInterfaceDeclaration) -> Boolean)? = null): List<T> =
+    filterNot {
+        when (predicate) {
+            null -> it.sourceInterface != null
+            else -> it.sourceInterface?.let { sourceInterface -> predicate(sourceInterface) } ?: false
+        }
+    }
+
+/**
+ * List containing declarations with the specified source type alias.
+ *
+ * @param predicate The predicate function to determine if a source type alias satisfies a condition.
+ * @return A list containing declarations with the specified source type alias.
+ */
+fun <T : KoSourceDeclarationProvider> List<T>.withSourceTypeAlias(predicate: ((KoTypeAliasDeclaration) -> Boolean)? = null): List<T> =
+    filter {
+        when (predicate) {
+            null -> it.sourceTypeAlias != null
+            else -> it.sourceTypeAlias?.let { sourceTypeAlias -> predicate(sourceTypeAlias) } ?: false
+        }
+    }
+
+/**
+ * List containing declarations without the specified source type alias.
+ *
+ * @param predicate The predicate function to determine if a source type alias satisfies a condition.
+ * @return A list containing declarations without the specified source type alias.
+ */
+fun <T : KoSourceDeclarationProvider> List<T>.withoutSourceTypeAlias(predicate: ((KoTypeAliasDeclaration) -> Boolean)? = null): List<T> =
+    filterNot {
+        when (predicate) {
+            null -> it.sourceTypeAlias != null
+            else -> it.sourceTypeAlias?.let { sourceTypeAlias -> predicate(sourceTypeAlias) } ?: false
+        }
+    }
+
+/**
+ * List containing declarations with the specified source import alias.
+ *
+ * @param predicate The predicate function to determine if a source import alias satisfies a condition.
+ * @return A list containing declarations with the specified source import alias.
+ */
+fun <T : KoSourceDeclarationProvider> List<T>.withSourceImportAlias(predicate: ((KoImportAliasDeclaration) -> Boolean)? = null): List<T> =
+    filter {
+        when (predicate) {
+            null -> it.sourceImportAlias != null
+            else -> it.sourceImportAlias?.let { sourceImportAlias -> predicate(sourceImportAlias) } ?: false
+        }
+    }
+
+/**
+ * List containing declarations without the specified source import alias.
+ *
+ * @param predicate The predicate function to determine if a source import alias satisfies a condition.
+ * @return A list containing declarations without the specified source import alias.
+ */
+fun <T : KoSourceDeclarationProvider> List<T>.withoutSourceImportAlias(predicate: ((KoImportAliasDeclaration) -> Boolean)? = null): List<T> =
+    filterNot {
+        when (predicate) {
+            null -> it.sourceImportAlias != null
+            else -> it.sourceImportAlias?.let { sourceImportAlias -> predicate(sourceImportAlias) } ?: false
+        }
+    }
+
+/**
+ * List containing declarations with the specified source kotlin type.
+ *
+ * @param predicate The predicate function to determine if a source kotlin type satisfies a condition.
+ * @return A list containing declarations with the specified source kotlin type.
+ */
+fun <T : KoSourceDeclarationProvider> List<T>.withSourceKotlinType(predicate: ((KoKotlinTypeDeclaration) -> Boolean)? = null): List<T> =
+    filter {
+        when (predicate) {
+            null -> it.sourceKotlinType != null
+            else -> it.sourceKotlinType?.let { sourceKotlinType -> predicate(sourceKotlinType) } ?: false
+        }
+    }
+
+/**
+ * List containing declarations without the specified source kotlin type.
+ *
+ * @param predicate The predicate function to determine if a source kotlin type satisfies a condition.
+ * @return A list containing declarations without the specified source kotlin type.
+ */
+fun <T : KoSourceDeclarationProvider> List<T>.withoutSourceKotlinType(predicate: ((KoKotlinTypeDeclaration) -> Boolean)? = null): List<T> =
+    filterNot {
+        when (predicate) {
+            null -> it.sourceKotlinType != null
+            else -> it.sourceKotlinType?.let { sourceKotlinType -> predicate(sourceKotlinType) } ?: false
+        }
+    }
+
+/**
+ * List containing declarations with the specified source function type.
+ *
+ * @param predicate The predicate function to determine if a source function type satisfies a condition.
+ * @return A list containing declarations with the specified source function type.
+ */
+fun <T : KoSourceDeclarationProvider> List<T>.withSourceFunctionType(predicate: ((KoFunctionTypeDeclaration) -> Boolean)? = null): List<T> =
+    filter {
+        when (predicate) {
+            null -> it.sourceFunctionType != null
+            else -> it.sourceFunctionType?.let { sourceFunctionType -> predicate(sourceFunctionType) } ?: false
+        }
+    }
+
+/**
+ * List containing declarations without the specified source function type.
+ *
+ * @param predicate The predicate function to determine if a source function type satisfies a condition.
+ * @return A list containing declarations without the specified source function type.
+ */
+fun <T : KoSourceDeclarationProvider> List<T>.withoutSourceFunctionType(predicate: ((KoFunctionTypeDeclaration) -> Boolean)? = null): List<T> =
+    filterNot {
+        when (predicate) {
+            null -> it.sourceFunctionType != null
+            else -> it.sourceFunctionType?.let { sourceFunctionType -> predicate(sourceFunctionType) } ?: false
+        }
+    }
+
+/**
+ * List containing declarations with the specified source external type.
+ *
+ * @param predicate The predicate function to determine if a source external type satisfies a condition.
+ * @return A list containing declarations with the specified source external type.
+ */
+fun <T : KoSourceDeclarationProvider> List<T>.withSourceExternalType(predicate: ((KoExternalDeclaration) -> Boolean)? = null): List<T> =
+    filter {
+        when (predicate) {
+            null -> it.sourceExternalType != null
+            else -> it.sourceExternalType?.let { sourceExternalType -> predicate(sourceExternalType) } ?: false
+        }
+    }
+
+/**
+ * List containing declarations without the specified source external type.
+ *
+ * @param predicate The predicate function to determine if a source external type satisfies a condition.
+ * @return A list containing declarations without the specified source external type.
+ */
+fun <T : KoSourceDeclarationProvider> List<T>.withoutSourceExternalType(predicate: ((KoExternalDeclaration) -> Boolean)? = null): List<T> =
+    filterNot {
+        when (predicate) {
+            null -> it.sourceExternalType != null
+            else -> it.sourceExternalType?.let { sourceExternalType -> predicate(sourceExternalType) } ?: false
+        }
+    }

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/api/provider/KoSourceDeclarationProvider.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/api/provider/KoSourceDeclarationProvider.kt
@@ -1,6 +1,14 @@
 package com.lemonappdev.konsist.api.provider
 
+import com.lemonappdev.konsist.api.declaration.KoClassDeclaration
+import com.lemonappdev.konsist.api.declaration.KoExternalDeclaration
+import com.lemonappdev.konsist.api.declaration.KoImportAliasDeclaration
+import com.lemonappdev.konsist.api.declaration.KoInterfaceDeclaration
+import com.lemonappdev.konsist.api.declaration.KoObjectDeclaration
+import com.lemonappdev.konsist.api.declaration.KoTypeAliasDeclaration
 import com.lemonappdev.konsist.api.declaration.type.KoBaseTypeDeclaration
+import com.lemonappdev.konsist.api.declaration.type.KoFunctionTypeDeclaration
+import com.lemonappdev.konsist.api.declaration.type.KoKotlinTypeDeclaration
 
 /**
  * An interface representing a Kotlin declaration that provides the source declaration associated with this type.
@@ -16,4 +24,44 @@ interface KoSourceDeclarationProvider : KoBaseProvider {
      * annotations, and other relevant metadata.
      */
     val sourceDeclaration: KoBaseTypeDeclaration
+
+    /**
+     * Represents the source class declaration associated with this type.
+     */
+    val sourceClass: KoClassDeclaration?
+
+    /**
+     * Represents the source object declaration associated with this type.
+     */
+    val sourceObject: KoObjectDeclaration?
+
+    /**
+     * Represents the source interface declaration associated with this type.
+     */
+    val sourceInterface: KoInterfaceDeclaration?
+
+    /**
+     * Represents the source type alias declaration associated with this type.
+     */
+    val sourceTypeAlias: KoTypeAliasDeclaration?
+
+    /**
+     * Represents the source import alias declaration associated with this type.
+     */
+    val sourceImportAlias: KoImportAliasDeclaration?
+
+    /**
+     * Represents the source Kotlin type declaration associated with this type.
+     */
+    val sourceKotlinType: KoKotlinTypeDeclaration?
+
+    /**
+     * Represents the source function type declaration associated with this type.
+     */
+    val sourceFunctionType: KoFunctionTypeDeclaration?
+
+    /**
+     * Represents the source external declaration associated with this type.
+     */
+    val sourceExternalType: KoExternalDeclaration?
 }

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/api/provider/KoSourceDeclarationProvider.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/api/provider/KoSourceDeclarationProvider.kt
@@ -3,14 +3,12 @@ package com.lemonappdev.konsist.api.provider
 import com.lemonappdev.konsist.api.declaration.KoClassDeclaration
 import com.lemonappdev.konsist.api.declaration.KoExternalDeclaration
 import com.lemonappdev.konsist.api.declaration.KoImportAliasDeclaration
-import com.lemonappdev.konsist.api.declaration.KoImportDeclaration
 import com.lemonappdev.konsist.api.declaration.KoInterfaceDeclaration
 import com.lemonappdev.konsist.api.declaration.KoObjectDeclaration
 import com.lemonappdev.konsist.api.declaration.KoTypeAliasDeclaration
 import com.lemonappdev.konsist.api.declaration.type.KoBaseTypeDeclaration
 import com.lemonappdev.konsist.api.declaration.type.KoFunctionTypeDeclaration
 import com.lemonappdev.konsist.api.declaration.type.KoKotlinTypeDeclaration
-import com.lemonappdev.konsist.api.declaration.type.KoTypeDeclaration
 import kotlin.reflect.KClass
 
 /**
@@ -88,7 +86,8 @@ interface KoSourceDeclarationProvider : KoBaseProvider {
      * Whether type has a specified source class.
      *
      * @param predicate The predicate function used to determine if a source class satisfies a condition.
-     * @return `true` if the type has the specified source class (or any source class if [predicate] is `null`), `false` otherwise.
+     * @return `true` if the type has the specified source class (or any source class if [predicate] is `null`),
+     * `false` otherwise.
      */
     fun hasSourceClass(predicate: ((KoClassDeclaration) -> Boolean)? = null): Boolean
 
@@ -104,7 +103,8 @@ interface KoSourceDeclarationProvider : KoBaseProvider {
      * Whether type has a specified source object.
      *
      * @param predicate The predicate function used to determine if a source object satisfies a condition.
-     * @return `true` if the type has the specified source object (or any source object if [predicate] is `null`), `false` otherwise.
+     * @return `true` if the type has the specified source object (or any source object if [predicate] is `null`),
+     * `false` otherwise.
      */
     fun hasSourceObject(predicate: ((KoObjectDeclaration) -> Boolean)? = null): Boolean
 
@@ -120,7 +120,8 @@ interface KoSourceDeclarationProvider : KoBaseProvider {
      * Whether type has a specified source interface.
      *
      * @param predicate The predicate function used to determine if a source interface satisfies a condition.
-     * @return `true` if the type has the specified source interface (or any source interface if [predicate] is `null`), `false` otherwise.
+     * @return `true` if the type has the specified source interface (or any source interface if [predicate] is `null`),
+     * `false` otherwise.
      */
     fun hasSourceInterface(predicate: ((KoInterfaceDeclaration) -> Boolean)? = null): Boolean
 
@@ -136,7 +137,8 @@ interface KoSourceDeclarationProvider : KoBaseProvider {
      * Whether type has a specified source type alias.
      *
      * @param predicate The predicate function used to determine if a source type alias satisfies a condition.
-     * @return `true` if the type has the specified source type alias (or any source type alias if [predicate] is `null`), `false` otherwise.
+     * @return `true` if the type has the specified source type alias (or any source type alias if [predicate] is
+     * `null`), `false` otherwise.
      */
     fun hasSourceTypeAlias(predicate: ((KoTypeAliasDeclaration) -> Boolean)? = null): Boolean
 
@@ -144,7 +146,8 @@ interface KoSourceDeclarationProvider : KoBaseProvider {
      * Whether type has a specified source import alias.
      *
      * @param predicate The predicate function used to determine if a source import alias satisfies a condition.
-     * @return `true` if the type has the specified source import alias (or any source import alias if [predicate] is `null`), `false` otherwise.
+     * @return `true` if the type has the specified source import alias (or any source import alias if [predicate] is
+     * `null`), `false` otherwise.
      */
     fun hasSourceImportAlias(predicate: ((KoImportAliasDeclaration) -> Boolean)? = null): Boolean
 
@@ -152,7 +155,8 @@ interface KoSourceDeclarationProvider : KoBaseProvider {
      * Whether type has a specified source kotlin type.
      *
      * @param predicate The predicate function used to determine if a source kotlin type satisfies a condition.
-     * @return `true` if the type has the specified source kotlin type (or any source kotlin type if [predicate] is `null`), `false` otherwise.
+     * @return `true` if the type has the specified source kotlin type (or any source kotlin type if [predicate] is
+     * `null`), `false` otherwise.
      */
     fun hasSourceKotlinType(predicate: ((KoKotlinTypeDeclaration) -> Boolean)? = null): Boolean
 
@@ -168,7 +172,8 @@ interface KoSourceDeclarationProvider : KoBaseProvider {
      * Whether type has a specified source function type.
      *
      * @param predicate The predicate function used to determine if a source function type satisfies a condition.
-     * @return `true` if the type has the specified source function type (or any source function type if [predicate] is `null`), `false` otherwise.
+     * @return `true` if the type has the specified source function type (or any source function type if [predicate] is
+     * `null`), `false` otherwise.
      */
     fun hasSourceFunctionType(predicate: ((KoFunctionTypeDeclaration) -> Boolean)? = null): Boolean
 
@@ -176,7 +181,8 @@ interface KoSourceDeclarationProvider : KoBaseProvider {
      * Whether type has a specified source external type.
      *
      * @param predicate The predicate external used to determine if a source external type satisfies a condition.
-     * @return `true` if the type has the specified source external type (or any source external type if [predicate] is `null`), `false` otherwise.
+     * @return `true` if the type has the specified source external type (or any source external type if [predicate] is
+     * `null`), `false` otherwise.
      */
     fun hasSourceExternalType(predicate: ((KoExternalDeclaration) -> Boolean)? = null): Boolean
 

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/api/provider/KoSourceDeclarationProvider.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/api/provider/KoSourceDeclarationProvider.kt
@@ -3,12 +3,15 @@ package com.lemonappdev.konsist.api.provider
 import com.lemonappdev.konsist.api.declaration.KoClassDeclaration
 import com.lemonappdev.konsist.api.declaration.KoExternalDeclaration
 import com.lemonappdev.konsist.api.declaration.KoImportAliasDeclaration
+import com.lemonappdev.konsist.api.declaration.KoImportDeclaration
 import com.lemonappdev.konsist.api.declaration.KoInterfaceDeclaration
 import com.lemonappdev.konsist.api.declaration.KoObjectDeclaration
 import com.lemonappdev.konsist.api.declaration.KoTypeAliasDeclaration
 import com.lemonappdev.konsist.api.declaration.type.KoBaseTypeDeclaration
 import com.lemonappdev.konsist.api.declaration.type.KoFunctionTypeDeclaration
 import com.lemonappdev.konsist.api.declaration.type.KoKotlinTypeDeclaration
+import com.lemonappdev.konsist.api.declaration.type.KoTypeDeclaration
+import kotlin.reflect.KClass
 
 /**
  * An interface representing a Kotlin declaration that provides the source declaration associated with this type.
@@ -64,4 +67,116 @@ interface KoSourceDeclarationProvider : KoBaseProvider {
      * Represents the source external declaration associated with this type.
      */
     val sourceExternalType: KoExternalDeclaration?
+
+    /**
+     * Determines whatever type has a specified source declaration.
+     *
+     * @param predicate The predicate function used to determine if a source declaration satisfies a condition.
+     * @return `true` if the type has the specified source declaration, `false` otherwise.
+     */
+    fun hasSourceDeclaration(predicate: (KoBaseTypeDeclaration) -> Boolean): Boolean
+
+    /**
+     * Whether type has a specified source class.
+     *
+     * @param predicate The predicate function used to determine if a source class satisfies a condition.
+     * @return `true` if the type has the specified source class (or any source class if [predicate] is `null`), `false` otherwise.
+     */
+    fun hasSourceClass(predicate: ((KoClassDeclaration) -> Boolean)? = null): Boolean
+
+    /**
+     * Whether type has a source class of the specified Kotlin class.
+     *
+     * @param kClass The Kotlin class representing the source class to check for.
+     * @return `true` if the type has a source class matching the specified KClass, `false` otherwise.
+     */
+    fun hasSourceClassOf(kClass: KClass<*>): Boolean
+
+    /**
+     * Whether type has a specified source object.
+     *
+     * @param predicate The predicate function used to determine if a source object satisfies a condition.
+     * @return `true` if the type has the specified source object (or any source object if [predicate] is `null`), `false` otherwise.
+     */
+    fun hasSourceObject(predicate: ((KoObjectDeclaration) -> Boolean)? = null): Boolean
+
+    /**
+     * Whether type has a source object of the specified Kotlin class.
+     *
+     * @param kClass The Kotlin class representing the source object to check for.
+     * @return `true` if the type has a source object matching the specified KClass, `false` otherwise.
+     */
+    fun hasSourceObjectOf(kClass: KClass<*>): Boolean
+
+    /**
+     * Whether type has a specified source interface.
+     *
+     * @param predicate The predicate function used to determine if a source interface satisfies a condition.
+     * @return `true` if the type has the specified source interface (or any source interface if [predicate] is `null`), `false` otherwise.
+     */
+    fun hasSourceInterface(predicate: ((KoInterfaceDeclaration) -> Boolean)? = null): Boolean
+
+    /**
+     * Whether type has a source interface of the specified Kotlin class.
+     *
+     * @param kClass The Kotlin class representing the source interface to check for.
+     * @return `true` if the type has a source interface matching the specified KClass, `false` otherwise.
+     */
+    fun hasSourceInterfaceOf(kClass: KClass<*>): Boolean
+
+    /**
+     * Whether type has a specified source type alias.
+     *
+     * @param predicate The predicate function used to determine if a source type alias satisfies a condition.
+     * @return `true` if the type has the specified source type alias (or any source type alias if [predicate] is `null`), `false` otherwise.
+     */
+    fun hasSourceTypeAlias(predicate: ((KoTypeAliasDeclaration) -> Boolean)? = null): Boolean
+
+    /**
+     * Whether type has a specified source import alias.
+     *
+     * @param predicate The predicate function used to determine if a source import alias satisfies a condition.
+     * @return `true` if the type has the specified source import alias (or any source import alias if [predicate] is `null`), `false` otherwise.
+     */
+    fun hasSourceImportAlias(predicate: ((KoImportAliasDeclaration) -> Boolean)? = null): Boolean
+
+    /**
+     * Whether type has a specified source kotlin type.
+     *
+     * @param predicate The predicate function used to determine if a source kotlin type satisfies a condition.
+     * @return `true` if the type has the specified source kotlin type (or any source kotlin type if [predicate] is `null`), `false` otherwise.
+     */
+    fun hasSourceKotlinType(predicate: ((KoKotlinTypeDeclaration) -> Boolean)? = null): Boolean
+
+    /**
+     * Whether type has a source kotlin type of the specified Kotlin class.
+     *
+     * @param kClass The Kotlin class representing the source kotlin type to check for.
+     * @return `true` if the type has a source kotlin type matching the specified KClass, `false` otherwise.
+     */
+    fun hasSourceKotlinTypeOf(kClass: KClass<*>): Boolean
+
+    /**
+     * Whether type has a specified source function type.
+     *
+     * @param predicate The predicate function used to determine if a source function type satisfies a condition.
+     * @return `true` if the type has the specified source function type (or any source function type if [predicate] is `null`), `false` otherwise.
+     */
+    fun hasSourceFunctionType(predicate: ((KoFunctionTypeDeclaration) -> Boolean)? = null): Boolean
+
+    /**
+     * Whether type has a specified source external type.
+     *
+     * @param predicate The predicate external used to determine if a source external type satisfies a condition.
+     * @return `true` if the type has the specified source external type (or any source external type if [predicate] is `null`), `false` otherwise.
+     */
+    fun hasSourceExternalType(predicate: ((KoExternalDeclaration) -> Boolean)? = null): Boolean
+
+    /**
+     * Whether type has a source external type of the specified Kotlin class.
+     *
+     * @param kClass The Kotlin class representing the source external type to check for.
+     * @return `true` if the type has a source external type matching the specified KClass, `false` otherwise.
+     */
+    fun hasSourceExternalTypeOf(kClass: KClass<*>): Boolean
 }

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/api/provider/KoSourceDeclarationProvider.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/api/provider/KoSourceDeclarationProvider.kt
@@ -1,0 +1,19 @@
+package com.lemonappdev.konsist.api.provider
+
+import com.lemonappdev.konsist.api.declaration.type.KoBaseTypeDeclaration
+
+/**
+ * An interface representing a Kotlin declaration that provides the source declaration associated with this type.
+ */
+interface KoSourceDeclarationProvider : KoBaseProvider {
+    /**
+     * Represents the source declaration associated with this type.
+     *
+     * The `sourceDeclaration` property provides access to the declaration of the type within the Kotlin codebase.
+     * It points to an instance of [KoBaseTypeDeclaration], which serves as the base interface for various types of
+     * declarations in Kotlin.
+     * This allows retrieving additional information about the declaration, such as its properties, functions,
+     * annotations, and other relevant metadata.
+     */
+    val sourceDeclaration: KoBaseTypeDeclaration
+}

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/api/provider/KoSourceDeclarationProvider.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/api/provider/KoSourceDeclarationProvider.kt
@@ -77,6 +77,14 @@ interface KoSourceDeclarationProvider : KoBaseProvider {
     fun hasSourceDeclaration(predicate: (KoBaseTypeDeclaration) -> Boolean): Boolean
 
     /**
+     * Whether type has a source declaration of the specified Kotlin class.
+     *
+     * @param kClass The Kotlin class representing the source declaration to check for.
+     * @return `true` if the type has a source declaration matching the specified KClass, `false` otherwise.
+     */
+    fun hasSourceDeclarationOf(kClass: KClass<*>): Boolean
+
+    /**
      * Whether type has a specified source class.
      *
      * @param predicate The predicate function used to determine if a source class satisfies a condition.

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/core/declaration/type/KoTypeDeclarationCore.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/core/declaration/type/KoTypeDeclarationCore.kt
@@ -3,7 +3,6 @@ package com.lemonappdev.konsist.core.declaration.type
 import com.intellij.psi.PsiElement
 import com.lemonappdev.konsist.api.declaration.KoBaseDeclaration
 import com.lemonappdev.konsist.api.declaration.KoPackageDeclaration
-import com.lemonappdev.konsist.api.declaration.type.KoBaseTypeDeclaration
 import com.lemonappdev.konsist.api.declaration.type.KoTypeDeclaration
 import com.lemonappdev.konsist.core.cache.KoDeclarationCache
 import com.lemonappdev.konsist.core.provider.KoBaseProviderCore
@@ -22,11 +21,9 @@ import com.lemonappdev.konsist.core.provider.KoSourceDeclarationProviderCore
 import com.lemonappdev.konsist.core.provider.KoSourceSetProviderCore
 import com.lemonappdev.konsist.core.provider.KoTextProviderCore
 import com.lemonappdev.konsist.core.provider.packagee.KoPackageProviderCore
-import com.lemonappdev.konsist.core.util.TypeUtil
 import org.jetbrains.kotlin.psi.KtElement
 import org.jetbrains.kotlin.psi.KtNullableType
 import org.jetbrains.kotlin.psi.KtTypeReference
-import org.jetbrains.kotlin.psi.psiUtil.isExtensionDeclaration
 
 internal class KoTypeDeclarationCore private constructor(
     override val ktTypeReference: KtTypeReference,

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/core/declaration/type/KoTypeDeclarationCore.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/core/declaration/type/KoTypeDeclarationCore.kt
@@ -18,6 +18,7 @@ import com.lemonappdev.konsist.core.provider.KoNullableProviderCore
 import com.lemonappdev.konsist.core.provider.KoPathProviderCore
 import com.lemonappdev.konsist.core.provider.KoResideInPackageProviderCore
 import com.lemonappdev.konsist.core.provider.KoSourceAndAliasTypeProviderCore
+import com.lemonappdev.konsist.core.provider.KoSourceDeclarationProviderCore
 import com.lemonappdev.konsist.core.provider.KoSourceSetProviderCore
 import com.lemonappdev.konsist.core.provider.KoTextProviderCore
 import com.lemonappdev.konsist.core.provider.packagee.KoPackageProviderCore
@@ -28,7 +29,7 @@ import org.jetbrains.kotlin.psi.KtTypeReference
 import org.jetbrains.kotlin.psi.psiUtil.isExtensionDeclaration
 
 internal class KoTypeDeclarationCore private constructor(
-    private val ktTypeReference: KtTypeReference,
+    override val ktTypeReference: KtTypeReference,
     override val containingDeclaration: KoBaseDeclaration,
 ) :
     KoTypeDeclaration,
@@ -46,7 +47,8 @@ internal class KoTypeDeclarationCore private constructor(
     KoSourceAndAliasTypeProviderCore,
     KoGenericTypeProviderCore,
     KoPackageProviderCore,
-    KoResideInPackageProviderCore {
+    KoResideInPackageProviderCore,
+    KoSourceDeclarationProviderCore {
     override val psiElement: PsiElement by lazy { ktTypeReference }
 
     override val ktElement: KtElement by lazy { ktTypeReference }
@@ -67,15 +69,6 @@ internal class KoTypeDeclarationCore private constructor(
     }
 
     override val packagee: KoPackageDeclaration? by lazy { containingFile.packagee }
-
-    override val sourceDeclaration: KoBaseTypeDeclaration by lazy {
-        TypeUtil.getBasicType(
-            listOf(ktTypeReference),
-            ktTypeReference.isExtensionDeclaration(),
-            this,
-            containingFile,
-        ) ?: throw IllegalArgumentException("Declaration cannot be a null")
-    }
 
     override fun toString(): String = text
 

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/KoSourceDeclarationProviderCore.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/KoSourceDeclarationProviderCore.kt
@@ -9,7 +9,6 @@ import com.lemonappdev.konsist.api.declaration.KoTypeAliasDeclaration
 import com.lemonappdev.konsist.api.declaration.type.KoBaseTypeDeclaration
 import com.lemonappdev.konsist.api.declaration.type.KoFunctionTypeDeclaration
 import com.lemonappdev.konsist.api.declaration.type.KoKotlinTypeDeclaration
-import com.lemonappdev.konsist.api.declaration.type.KoTypeDeclaration
 import com.lemonappdev.konsist.api.provider.KoSourceDeclarationProvider
 import com.lemonappdev.konsist.core.ext.castToKoBaseDeclaration
 import com.lemonappdev.konsist.core.util.TypeUtil
@@ -59,7 +58,7 @@ internal interface KoSourceDeclarationProviderCore :
 
     override fun hasSourceDeclarationOf(kClass: KClass<*>): Boolean =
         hasSourceClassOf(kClass) || hasSourceObjectOf(kClass) || hasSourceInterfaceOf(kClass) || hasSourceKotlinTypeOf(
-            kClass
+            kClass,
         ) || hasSourceExternalTypeOf(kClass)
 
     override fun hasSourceClass(predicate: ((KoClassDeclaration) -> Boolean)?): Boolean =

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/KoSourceDeclarationProviderCore.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/KoSourceDeclarationProviderCore.kt
@@ -9,7 +9,6 @@ import com.lemonappdev.konsist.api.declaration.KoTypeAliasDeclaration
 import com.lemonappdev.konsist.api.declaration.type.KoBaseTypeDeclaration
 import com.lemonappdev.konsist.api.declaration.type.KoFunctionTypeDeclaration
 import com.lemonappdev.konsist.api.declaration.type.KoKotlinTypeDeclaration
-import com.lemonappdev.konsist.api.provider.KoAliasProvider
 import com.lemonappdev.konsist.api.provider.KoSourceDeclarationProvider
 import com.lemonappdev.konsist.core.ext.castToKoBaseDeclaration
 import com.lemonappdev.konsist.core.util.TypeUtil

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/KoSourceDeclarationProviderCore.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/KoSourceDeclarationProviderCore.kt
@@ -1,7 +1,14 @@
 package com.lemonappdev.konsist.core.provider
 
+import com.lemonappdev.konsist.api.declaration.KoClassDeclaration
+import com.lemonappdev.konsist.api.declaration.KoExternalDeclaration
 import com.lemonappdev.konsist.api.declaration.KoImportAliasDeclaration
+import com.lemonappdev.konsist.api.declaration.KoInterfaceDeclaration
+import com.lemonappdev.konsist.api.declaration.KoObjectDeclaration
+import com.lemonappdev.konsist.api.declaration.KoTypeAliasDeclaration
 import com.lemonappdev.konsist.api.declaration.type.KoBaseTypeDeclaration
+import com.lemonappdev.konsist.api.declaration.type.KoFunctionTypeDeclaration
+import com.lemonappdev.konsist.api.declaration.type.KoKotlinTypeDeclaration
 import com.lemonappdev.konsist.api.provider.KoAliasProvider
 import com.lemonappdev.konsist.api.provider.KoSourceDeclarationProvider
 import com.lemonappdev.konsist.core.ext.castToKoBaseDeclaration
@@ -21,4 +28,28 @@ internal interface KoSourceDeclarationProviderCore :
             this.castToKoBaseDeclaration(),
             containingFile,
         ) ?: throw IllegalArgumentException("Declaration cannot be a null")
+
+    override val sourceClass: KoClassDeclaration?
+        get() = sourceDeclaration as? KoClassDeclaration
+
+    override val sourceObject: KoObjectDeclaration?
+        get() = sourceDeclaration as? KoObjectDeclaration
+
+    override val sourceInterface: KoInterfaceDeclaration?
+        get() = sourceDeclaration as? KoInterfaceDeclaration
+
+    override val sourceTypeAlias: KoTypeAliasDeclaration?
+        get() = sourceDeclaration as? KoTypeAliasDeclaration
+
+    override val sourceImportAlias: KoImportAliasDeclaration?
+        get() = sourceDeclaration as? KoImportAliasDeclaration
+
+    override val sourceKotlinType: KoKotlinTypeDeclaration?
+        get() = sourceDeclaration as? KoKotlinTypeDeclaration
+
+    override val sourceFunctionType: KoFunctionTypeDeclaration?
+        get() = sourceDeclaration as? KoFunctionTypeDeclaration
+
+    override val sourceExternalType: KoExternalDeclaration?
+        get() = sourceDeclaration as? KoExternalDeclaration
 }

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/KoSourceDeclarationProviderCore.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/KoSourceDeclarationProviderCore.kt
@@ -9,11 +9,13 @@ import com.lemonappdev.konsist.api.declaration.KoTypeAliasDeclaration
 import com.lemonappdev.konsist.api.declaration.type.KoBaseTypeDeclaration
 import com.lemonappdev.konsist.api.declaration.type.KoFunctionTypeDeclaration
 import com.lemonappdev.konsist.api.declaration.type.KoKotlinTypeDeclaration
+import com.lemonappdev.konsist.api.declaration.type.KoTypeDeclaration
 import com.lemonappdev.konsist.api.provider.KoSourceDeclarationProvider
 import com.lemonappdev.konsist.core.ext.castToKoBaseDeclaration
 import com.lemonappdev.konsist.core.util.TypeUtil
 import org.jetbrains.kotlin.psi.KtTypeReference
 import org.jetbrains.kotlin.psi.psiUtil.isExtensionDeclaration
+import kotlin.reflect.KClass
 
 internal interface KoSourceDeclarationProviderCore :
     KoSourceDeclarationProvider,
@@ -51,4 +53,69 @@ internal interface KoSourceDeclarationProviderCore :
 
     override val sourceExternalType: KoExternalDeclaration?
         get() = sourceDeclaration as? KoExternalDeclaration
+
+    override fun hasSourceDeclaration(predicate: (KoBaseTypeDeclaration) -> Boolean): Boolean =
+        predicate(sourceDeclaration)
+
+    override fun hasSourceClass(predicate: ((KoClassDeclaration) -> Boolean)?): Boolean =
+        when (predicate) {
+            null -> sourceClass != null
+            else -> sourceClass?.let { predicate(it) } ?: false
+        }
+
+    override fun hasSourceClassOf(kClass: KClass<*>): Boolean = kClass.qualifiedName == sourceClass?.fullyQualifiedName
+
+    override fun hasSourceObject(predicate: ((KoObjectDeclaration) -> Boolean)?): Boolean =
+        when (predicate) {
+            null -> sourceObject != null
+            else -> sourceObject?.let { predicate(it) } ?: false
+        }
+
+    override fun hasSourceObjectOf(kClass: KClass<*>): Boolean =
+        kClass.qualifiedName == sourceObject?.fullyQualifiedName
+
+    override fun hasSourceInterface(predicate: ((KoInterfaceDeclaration) -> Boolean)?): Boolean =
+        when (predicate) {
+            null -> sourceInterface != null
+            else -> sourceInterface?.let { predicate(it) } ?: false
+        }
+
+    override fun hasSourceInterfaceOf(kClass: KClass<*>): Boolean =
+        kClass.qualifiedName == sourceInterface?.fullyQualifiedName
+
+    override fun hasSourceTypeAlias(predicate: ((KoTypeAliasDeclaration) -> Boolean)?): Boolean =
+        when (predicate) {
+            null -> sourceTypeAlias != null
+            else -> sourceTypeAlias?.let { predicate(it) } ?: false
+        }
+
+    override fun hasSourceImportAlias(predicate: ((KoImportAliasDeclaration) -> Boolean)?): Boolean =
+        when (predicate) {
+            null -> sourceImportAlias != null
+            else -> sourceImportAlias?.let { predicate(it) } ?: false
+        }
+
+    override fun hasSourceKotlinType(predicate: ((KoKotlinTypeDeclaration) -> Boolean)?): Boolean =
+        when (predicate) {
+            null -> sourceKotlinType != null
+            else -> sourceKotlinType?.let { predicate(it) } ?: false
+        }
+
+    override fun hasSourceKotlinTypeOf(kClass: KClass<*>): Boolean =
+        kClass.qualifiedName == sourceKotlinType?.fullyQualifiedName
+
+    override fun hasSourceFunctionType(predicate: ((KoFunctionTypeDeclaration) -> Boolean)?): Boolean =
+        when (predicate) {
+            null -> sourceFunctionType != null
+            else -> sourceFunctionType?.let { predicate(it) } ?: false
+        }
+
+    override fun hasSourceExternalType(predicate: ((KoExternalDeclaration) -> Boolean)?): Boolean =
+        when (predicate) {
+            null -> sourceExternalType != null
+            else -> sourceExternalType?.let { predicate(it) } ?: false
+        }
+
+    override fun hasSourceExternalTypeOf(kClass: KClass<*>): Boolean =
+        kClass.qualifiedName == sourceExternalType?.fullyQualifiedName
 }

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/KoSourceDeclarationProviderCore.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/KoSourceDeclarationProviderCore.kt
@@ -57,6 +57,11 @@ internal interface KoSourceDeclarationProviderCore :
     override fun hasSourceDeclaration(predicate: (KoBaseTypeDeclaration) -> Boolean): Boolean =
         predicate(sourceDeclaration)
 
+    override fun hasSourceDeclarationOf(kClass: KClass<*>): Boolean =
+        hasSourceClassOf(kClass) || hasSourceObjectOf(kClass) || hasSourceInterfaceOf(kClass) || hasSourceKotlinTypeOf(
+            kClass
+        ) || hasSourceExternalTypeOf(kClass)
+
     override fun hasSourceClass(predicate: ((KoClassDeclaration) -> Boolean)?): Boolean =
         when (predicate) {
             null -> sourceClass != null

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/KoSourceDeclarationProviderCore.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/KoSourceDeclarationProviderCore.kt
@@ -1,0 +1,24 @@
+package com.lemonappdev.konsist.core.provider
+
+import com.lemonappdev.konsist.api.declaration.KoImportAliasDeclaration
+import com.lemonappdev.konsist.api.declaration.type.KoBaseTypeDeclaration
+import com.lemonappdev.konsist.api.provider.KoAliasProvider
+import com.lemonappdev.konsist.api.provider.KoSourceDeclarationProvider
+import com.lemonappdev.konsist.core.ext.castToKoBaseDeclaration
+import com.lemonappdev.konsist.core.util.TypeUtil
+import org.jetbrains.kotlin.psi.KtTypeReference
+import org.jetbrains.kotlin.psi.psiUtil.isExtensionDeclaration
+
+internal interface KoSourceDeclarationProviderCore :
+    KoSourceDeclarationProvider,
+    KoBaseProviderCore,
+    KoContainingFileProviderCore {
+    val ktTypeReference: KtTypeReference
+    override val sourceDeclaration: KoBaseTypeDeclaration
+        get() = TypeUtil.getBasicType(
+            listOf(ktTypeReference),
+            ktTypeReference.isExtensionDeclaration(),
+            this.castToKoBaseDeclaration(),
+            containingFile,
+        ) ?: throw IllegalArgumentException("Declaration cannot be a null")
+}

--- a/lib/src/test/kotlin/com/lemonappdev/konsist/api/ext/list/KoSourceDeclarationProviderListExtTest.kt
+++ b/lib/src/test/kotlin/com/lemonappdev/konsist/api/ext/list/KoSourceDeclarationProviderListExtTest.kt
@@ -1,0 +1,1045 @@
+package com.lemonappdev.konsist.api.ext.list
+
+import com.lemonappdev.konsist.api.declaration.KoClassDeclaration
+import com.lemonappdev.konsist.api.declaration.KoExternalDeclaration
+import com.lemonappdev.konsist.api.declaration.KoImportAliasDeclaration
+import com.lemonappdev.konsist.api.declaration.KoInterfaceDeclaration
+import com.lemonappdev.konsist.api.declaration.KoObjectDeclaration
+import com.lemonappdev.konsist.api.declaration.KoTypeAliasDeclaration
+import com.lemonappdev.konsist.api.declaration.type.KoFunctionTypeDeclaration
+import com.lemonappdev.konsist.api.declaration.type.KoKotlinTypeDeclaration
+import com.lemonappdev.konsist.api.provider.KoSourceDeclarationProvider
+import io.mockk.every
+import io.mockk.mockk
+import org.amshove.kluent.shouldBeEqualTo
+import org.junit.jupiter.api.Test
+
+class KoSourceDeclarationProviderListExtTest {
+    @Test
+    fun `sourceDeclarations returns declarations from all declarations`() {
+        // given
+        val sourceDeclaration1: KoClassDeclaration = mockk()
+        val sourceDeclaration2: KoKotlinTypeDeclaration = mockk()
+        val sourceDeclaration3: KoExternalDeclaration = mockk()
+        val declaration1: KoSourceDeclarationProvider = mockk {
+            every { sourceDeclaration } returns sourceDeclaration1
+        }
+        val declaration2: KoSourceDeclarationProvider = mockk {
+            every { sourceDeclaration } returns sourceDeclaration2
+        }
+        val declaration3: KoSourceDeclarationProvider = mockk {
+            every { sourceDeclaration } returns sourceDeclaration3
+        }
+        val declarations = listOf(declaration1, declaration2, declaration3)
+
+        // when
+        val sut = declarations.sourceDeclarations
+
+        // then
+        sut shouldBeEqualTo listOf(sourceDeclaration1, sourceDeclaration2, sourceDeclaration3)
+    }
+
+    @Test
+    fun `sourceClasses returns classes from all declarations`() {
+        // given
+        val sourceDeclaration1: KoClassDeclaration = mockk()
+        val sourceDeclaration2: KoClassDeclaration = mockk()
+        val declaration1: KoSourceDeclarationProvider = mockk {
+            every { sourceClass } returns sourceDeclaration1
+        }
+        val declaration2: KoSourceDeclarationProvider = mockk {
+            every { sourceClass } returns sourceDeclaration2
+        }
+        val declaration3: KoSourceDeclarationProvider = mockk {
+            every { sourceClass } returns null
+        }
+        val declarations = listOf(declaration1, declaration2, declaration3)
+
+        // when
+        val sut = declarations.sourceClasses
+
+        // then
+        sut shouldBeEqualTo listOf(sourceDeclaration1, sourceDeclaration2)
+    }
+
+    @Test
+    fun `sourceObjects returns objects from all declarations`() {
+        // given
+        val sourceDeclaration1: KoObjectDeclaration = mockk()
+        val sourceDeclaration2: KoObjectDeclaration = mockk()
+        val declaration1: KoSourceDeclarationProvider = mockk {
+            every { sourceObject } returns sourceDeclaration1
+        }
+        val declaration2: KoSourceDeclarationProvider = mockk {
+            every { sourceObject } returns sourceDeclaration2
+        }
+        val declaration3: KoSourceDeclarationProvider = mockk {
+            every { sourceObject } returns null
+        }
+        val declarations = listOf(declaration1, declaration2, declaration3)
+
+        // when
+        val sut = declarations.sourceObjects
+
+        // then
+        sut shouldBeEqualTo listOf(sourceDeclaration1, sourceDeclaration2)
+    }
+
+    @Test
+    fun `sourceInterfaces returns interfaces from all declarations`() {
+        // given
+        val sourceDeclaration1: KoInterfaceDeclaration = mockk()
+        val sourceDeclaration2: KoInterfaceDeclaration = mockk()
+        val declaration1: KoSourceDeclarationProvider = mockk {
+            every { sourceInterface } returns sourceDeclaration1
+        }
+        val declaration2: KoSourceDeclarationProvider = mockk {
+            every { sourceInterface } returns sourceDeclaration2
+        }
+        val declaration3: KoSourceDeclarationProvider = mockk {
+            every { sourceInterface } returns null
+        }
+        val declarations = listOf(declaration1, declaration2, declaration3)
+
+        // when
+        val sut = declarations.sourceInterfaces
+
+        // then
+        sut shouldBeEqualTo listOf(sourceDeclaration1, sourceDeclaration2)
+    }
+
+    @Test
+    fun `sourceTypeAliases returns type aliases from all declarations`() {
+        // given
+        val sourceDeclaration1: KoTypeAliasDeclaration = mockk()
+        val sourceDeclaration2: KoTypeAliasDeclaration = mockk()
+        val declaration1: KoSourceDeclarationProvider = mockk {
+            every { sourceTypeAlias } returns sourceDeclaration1
+        }
+        val declaration2: KoSourceDeclarationProvider = mockk {
+            every { sourceTypeAlias } returns sourceDeclaration2
+        }
+        val declaration3: KoSourceDeclarationProvider = mockk {
+            every { sourceTypeAlias } returns null
+        }
+        val declarations = listOf(declaration1, declaration2, declaration3)
+
+        // when
+        val sut = declarations.sourceTypeAliases
+
+        // then
+        sut shouldBeEqualTo listOf(sourceDeclaration1, sourceDeclaration2)
+    }
+
+    @Test
+    fun `sourceImportAliases returns import aliases from all declarations`() {
+        // given
+        val sourceDeclaration1: KoImportAliasDeclaration = mockk()
+        val sourceDeclaration2: KoImportAliasDeclaration = mockk()
+        val declaration1: KoSourceDeclarationProvider = mockk {
+            every { sourceImportAlias } returns sourceDeclaration1
+        }
+        val declaration2: KoSourceDeclarationProvider = mockk {
+            every { sourceImportAlias } returns sourceDeclaration2
+        }
+        val declaration3: KoSourceDeclarationProvider = mockk {
+            every { sourceImportAlias } returns null
+        }
+        val declarations = listOf(declaration1, declaration2, declaration3)
+
+        // when
+        val sut = declarations.sourceImportAliases
+
+        // then
+        sut shouldBeEqualTo listOf(sourceDeclaration1, sourceDeclaration2)
+    }
+
+    @Test
+    fun `sourceKotlinTypes returns kotlin types from all declarations`() {
+        // given
+        val sourceDeclaration1: KoKotlinTypeDeclaration = mockk()
+        val sourceDeclaration2: KoKotlinTypeDeclaration = mockk()
+        val declaration1: KoSourceDeclarationProvider = mockk {
+            every { sourceKotlinType } returns sourceDeclaration1
+        }
+        val declaration2: KoSourceDeclarationProvider = mockk {
+            every { sourceKotlinType } returns sourceDeclaration2
+        }
+        val declaration3: KoSourceDeclarationProvider = mockk {
+            every { sourceKotlinType } returns null
+        }
+        val declarations = listOf(declaration1, declaration2, declaration3)
+
+        // when
+        val sut = declarations.sourceKotlinTypes
+
+        // then
+        sut shouldBeEqualTo listOf(sourceDeclaration1, sourceDeclaration2)
+    }
+
+    @Test
+    fun `sourceFunctionTypes returns kotlin types from all declarations`() {
+        // given
+        val sourceDeclaration1: KoFunctionTypeDeclaration = mockk()
+        val sourceDeclaration2: KoFunctionTypeDeclaration = mockk()
+        val declaration1: KoSourceDeclarationProvider = mockk {
+            every { sourceFunctionType } returns sourceDeclaration1
+        }
+        val declaration2: KoSourceDeclarationProvider = mockk {
+            every { sourceFunctionType } returns sourceDeclaration2
+        }
+        val declaration3: KoSourceDeclarationProvider = mockk {
+            every { sourceFunctionType } returns null
+        }
+        val declarations = listOf(declaration1, declaration2, declaration3)
+
+        // when
+        val sut = declarations.sourceFunctionTypes
+
+        // then
+        sut shouldBeEqualTo listOf(sourceDeclaration1, sourceDeclaration2)
+    }
+
+    @Test
+    fun `sourceExternalTypes returns kotlin types from all declarations`() {
+        // given
+        val sourceDeclaration1: KoExternalDeclaration = mockk()
+        val sourceDeclaration2: KoExternalDeclaration = mockk()
+        val declaration1: KoSourceDeclarationProvider = mockk {
+            every { sourceExternalType } returns sourceDeclaration1
+        }
+        val declaration2: KoSourceDeclarationProvider = mockk {
+            every { sourceExternalType } returns sourceDeclaration2
+        }
+        val declaration3: KoSourceDeclarationProvider = mockk {
+            every { sourceExternalType } returns null
+        }
+        val declarations = listOf(declaration1, declaration2, declaration3)
+
+        // when
+        val sut = declarations.sourceExternalTypes
+
+        // then
+        sut shouldBeEqualTo listOf(sourceDeclaration1, sourceDeclaration2)
+    }
+
+    @Test
+    fun `withSourceDeclaration{} returns declaration which satisfy predicate`() {
+        // given
+        val name1 = "name1"
+        val name2 = "name2"
+        val sourceDeclaration1: KoClassDeclaration = mockk {
+            every { name } returns name1
+        }
+        val sourceDeclaration2: KoKotlinTypeDeclaration = mockk {
+            every { name } returns name2
+        }
+        val declaration1: KoSourceDeclarationProvider = mockk {
+            every { sourceDeclaration } returns sourceDeclaration1
+        }
+        val declaration2: KoSourceDeclarationProvider = mockk {
+            every { sourceDeclaration } returns sourceDeclaration2
+        }
+        val declarations = listOf(declaration1, declaration2)
+
+        // when
+        val sut = declarations.withSourceDeclaration { it.name == name1 }
+
+        // then
+        sut shouldBeEqualTo listOf(declaration1)
+    }
+
+    @Test
+    fun `withoutSourceDeclaration{} returns declarations which not satisfy predicate`() {
+        // given
+        val name1 = "name1"
+        val name2 = "name2"
+        val sourceDeclaration1: KoClassDeclaration = mockk {
+            every { name } returns name1
+        }
+        val sourceDeclaration2: KoKotlinTypeDeclaration = mockk {
+            every { name } returns name2
+        }
+        val declaration1: KoSourceDeclarationProvider = mockk {
+            every { sourceDeclaration } returns sourceDeclaration1
+        }
+        val declaration2: KoSourceDeclarationProvider = mockk {
+            every { sourceDeclaration } returns sourceDeclaration2
+        }
+        val declarations = listOf(declaration1, declaration2)
+
+        // when
+        val sut = declarations.withoutSourceDeclaration { it.name == name1 }
+
+        // then
+        sut shouldBeEqualTo listOf(declaration2)
+    }
+
+    @Test
+    fun `withSourceClass() returns declaration with source class`() {
+        // given
+        val sourceDeclaration: KoClassDeclaration = mockk()
+        val declaration1: KoSourceDeclarationProvider = mockk {
+            every { sourceClass } returns sourceDeclaration
+        }
+        val declaration2: KoSourceDeclarationProvider = mockk {
+            every { sourceClass } returns null
+        }
+        val declarations = listOf(declaration1, declaration2)
+
+        // when
+        val sut = declarations.withSourceClass()
+
+        // then
+        sut shouldBeEqualTo listOf(declaration1)
+    }
+
+    @Test
+    fun `withSourceClass{} returns declaration which satisfy predicate`() {
+        // given
+        val name1 = "name1"
+        val name2 = "name2"
+        val sourceClass1: KoClassDeclaration = mockk {
+            every { name } returns name1
+        }
+        val sourceClass2: KoClassDeclaration = mockk {
+            every { name } returns name2
+        }
+        val declaration1: KoSourceDeclarationProvider = mockk {
+            every { sourceClass } returns sourceClass1
+        }
+        val declaration2: KoSourceDeclarationProvider = mockk {
+            every { sourceClass } returns sourceClass2
+        }
+        val declaration3: KoSourceDeclarationProvider = mockk {
+            every { sourceClass } returns null
+        }
+        val declarations = listOf(declaration1, declaration2, declaration3)
+
+        // when
+        val sut = declarations.withSourceClass { it.name == name1 }
+
+        // then
+        sut shouldBeEqualTo listOf(declaration1)
+    }
+
+    @Test
+    fun `withoutSourceClass() returns declaration without source class`() {
+        // given
+        val sourceDeclaration: KoClassDeclaration = mockk()
+        val declaration1: KoSourceDeclarationProvider = mockk {
+            every { sourceClass } returns sourceDeclaration
+        }
+        val declaration2: KoSourceDeclarationProvider = mockk {
+            every { sourceClass } returns null
+        }
+        val declarations = listOf(declaration1, declaration2)
+
+        // when
+        val sut = declarations.withoutSourceClass()
+
+        // then
+        sut shouldBeEqualTo listOf(declaration2)
+    }
+
+    @Test
+    fun `withoutSourceClass{} returns declarations which not satisfy predicate`() {
+        // given
+        val name1 = "name1"
+        val name2 = "name2"
+        val sourceClass1: KoClassDeclaration = mockk {
+            every { name } returns name1
+        }
+        val sourceClass2: KoClassDeclaration = mockk {
+            every { name } returns name2
+        }
+        val declaration1: KoSourceDeclarationProvider = mockk {
+            every { sourceClass } returns sourceClass1
+        }
+        val declaration2: KoSourceDeclarationProvider = mockk {
+            every { sourceClass } returns sourceClass2
+        }
+        val declaration3: KoSourceDeclarationProvider = mockk {
+            every { sourceClass } returns null
+        }
+        val declarations = listOf(declaration1, declaration2, declaration3)
+
+        // when
+        val sut = declarations.withoutSourceClass { it.name == name1 }
+
+        // then
+        sut shouldBeEqualTo listOf(declaration2, declaration3)
+    }
+
+    @Test
+    fun `withSourceObject() returns declaration with source object`() {
+        // given
+        val sourceDeclaration: KoObjectDeclaration = mockk()
+        val declaration1: KoSourceDeclarationProvider = mockk {
+            every { sourceObject } returns sourceDeclaration
+        }
+        val declaration2: KoSourceDeclarationProvider = mockk {
+            every { sourceObject } returns null
+        }
+        val declarations = listOf(declaration1, declaration2)
+
+        // when
+        val sut = declarations.withSourceObject()
+
+        // then
+        sut shouldBeEqualTo listOf(declaration1)
+    }
+
+    @Test
+    fun `withSourceObject{} returns declaration which satisfy predicate`() {
+        // given
+        val name1 = "name1"
+        val name2 = "name2"
+        val sourceObject1: KoObjectDeclaration = mockk {
+            every { name } returns name1
+        }
+        val sourceObject2: KoObjectDeclaration = mockk {
+            every { name } returns name2
+        }
+        val declaration1: KoSourceDeclarationProvider = mockk {
+            every { sourceObject } returns sourceObject1
+        }
+        val declaration2: KoSourceDeclarationProvider = mockk {
+            every { sourceObject } returns sourceObject2
+        }
+        val declaration3: KoSourceDeclarationProvider = mockk {
+            every { sourceObject } returns null
+        }
+        val declarations = listOf(declaration1, declaration2, declaration3)
+
+        // when
+        val sut = declarations.withSourceObject { it.name == name1 }
+
+        // then
+        sut shouldBeEqualTo listOf(declaration1)
+    }
+
+    @Test
+    fun `withoutSourceObject() returns declaration without source object`() {
+        // given
+        val sourceDeclaration: KoObjectDeclaration = mockk()
+        val declaration1: KoSourceDeclarationProvider = mockk {
+            every { sourceObject } returns sourceDeclaration
+        }
+        val declaration2: KoSourceDeclarationProvider = mockk {
+            every { sourceObject } returns null
+        }
+        val declarations = listOf(declaration1, declaration2)
+
+        // when
+        val sut = declarations.withoutSourceObject()
+
+        // then
+        sut shouldBeEqualTo listOf(declaration2)
+    }
+
+    @Test
+    fun `withoutSourceObject{} returns declarations which not satisfy predicate`() {
+        // given
+        val name1 = "name1"
+        val name2 = "name2"
+        val sourceObject1: KoObjectDeclaration = mockk {
+            every { name } returns name1
+        }
+        val sourceObject2: KoObjectDeclaration = mockk {
+            every { name } returns name2
+        }
+        val declaration1: KoSourceDeclarationProvider = mockk {
+            every { sourceObject } returns sourceObject1
+        }
+        val declaration2: KoSourceDeclarationProvider = mockk {
+            every { sourceObject } returns sourceObject2
+        }
+        val declaration3: KoSourceDeclarationProvider = mockk {
+            every { sourceObject } returns null
+        }
+        val declarations = listOf(declaration1, declaration2, declaration3)
+
+        // when
+        val sut = declarations.withoutSourceObject { it.name == name1 }
+
+        // then
+        sut shouldBeEqualTo listOf(declaration2, declaration3)
+    }
+
+    @Test
+    fun `withSourceInterface() returns declaration with source interface`() {
+        // given
+        val sourceDeclaration: KoInterfaceDeclaration = mockk()
+        val declaration1: KoSourceDeclarationProvider = mockk {
+            every { sourceInterface } returns sourceDeclaration
+        }
+        val declaration2: KoSourceDeclarationProvider = mockk {
+            every { sourceInterface } returns null
+        }
+        val declarations = listOf(declaration1, declaration2)
+
+        // when
+        val sut = declarations.withSourceInterface()
+
+        // then
+        sut shouldBeEqualTo listOf(declaration1)
+    }
+
+    @Test
+    fun `withSourceInterface{} returns declaration which satisfy predicate`() {
+        // given
+        val name1 = "name1"
+        val name2 = "name2"
+        val sourceInterface1: KoInterfaceDeclaration = mockk {
+            every { name } returns name1
+        }
+        val sourceInterface2: KoInterfaceDeclaration = mockk {
+            every { name } returns name2
+        }
+        val declaration1: KoSourceDeclarationProvider = mockk {
+            every { sourceInterface } returns sourceInterface1
+        }
+        val declaration2: KoSourceDeclarationProvider = mockk {
+            every { sourceInterface } returns sourceInterface2
+        }
+        val declaration3: KoSourceDeclarationProvider = mockk {
+            every { sourceInterface } returns null
+        }
+        val declarations = listOf(declaration1, declaration2, declaration3)
+
+        // when
+        val sut = declarations.withSourceInterface { it.name == name1 }
+
+        // then
+        sut shouldBeEqualTo listOf(declaration1)
+    }
+
+    @Test
+    fun `withoutSourceInterface() returns declaration without source interface`() {
+        // given
+        val sourceDeclaration: KoInterfaceDeclaration = mockk()
+        val declaration1: KoSourceDeclarationProvider = mockk {
+            every { sourceInterface } returns sourceDeclaration
+        }
+        val declaration2: KoSourceDeclarationProvider = mockk {
+            every { sourceInterface } returns null
+        }
+        val declarations = listOf(declaration1, declaration2)
+
+        // when
+        val sut = declarations.withoutSourceInterface()
+
+        // then
+        sut shouldBeEqualTo listOf(declaration2)
+    }
+
+    @Test
+    fun `withoutSourceInterface{} returns declarations which not satisfy predicate`() {
+        // given
+        val name1 = "name1"
+        val name2 = "name2"
+        val sourceInterface1: KoInterfaceDeclaration = mockk {
+            every { name } returns name1
+        }
+        val sourceInterface2: KoInterfaceDeclaration = mockk {
+            every { name } returns name2
+        }
+        val declaration1: KoSourceDeclarationProvider = mockk {
+            every { sourceInterface } returns sourceInterface1
+        }
+        val declaration2: KoSourceDeclarationProvider = mockk {
+            every { sourceInterface } returns sourceInterface2
+        }
+        val declaration3: KoSourceDeclarationProvider = mockk {
+            every { sourceInterface } returns null
+        }
+        val declarations = listOf(declaration1, declaration2, declaration3)
+
+        // when
+        val sut = declarations.withoutSourceInterface { it.name == name1 }
+
+        // then
+        sut shouldBeEqualTo listOf(declaration2, declaration3)
+    }
+
+    @Test
+    fun `withSourceTypeAlias() returns declaration with source type alias`() {
+        // given
+        val sourceDeclaration: KoTypeAliasDeclaration = mockk()
+        val declaration1: KoSourceDeclarationProvider = mockk {
+            every { sourceTypeAlias } returns sourceDeclaration
+        }
+        val declaration2: KoSourceDeclarationProvider = mockk {
+            every { sourceTypeAlias } returns null
+        }
+        val declarations = listOf(declaration1, declaration2)
+
+        // when
+        val sut = declarations.withSourceTypeAlias()
+
+        // then
+        sut shouldBeEqualTo listOf(declaration1)
+    }
+
+    @Test
+    fun `withSourceTypeAlias{} returns declaration which satisfy predicate`() {
+        // given
+        val name1 = "name1"
+        val name2 = "name2"
+        val sourceTypeAlias1: KoTypeAliasDeclaration = mockk {
+            every { name } returns name1
+        }
+        val sourceTypeAlias2: KoTypeAliasDeclaration = mockk {
+            every { name } returns name2
+        }
+        val declaration1: KoSourceDeclarationProvider = mockk {
+            every { sourceTypeAlias } returns sourceTypeAlias1
+        }
+        val declaration2: KoSourceDeclarationProvider = mockk {
+            every { sourceTypeAlias } returns sourceTypeAlias2
+        }
+        val declaration3: KoSourceDeclarationProvider = mockk {
+            every { sourceTypeAlias } returns null
+        }
+        val declarations = listOf(declaration1, declaration2, declaration3)
+
+        // when
+        val sut = declarations.withSourceTypeAlias { it.name == name1 }
+
+        // then
+        sut shouldBeEqualTo listOf(declaration1)
+    }
+
+    @Test
+    fun `withoutSourceTypeAlias() returns declaration without source type alias`() {
+        // given
+        val sourceDeclaration: KoTypeAliasDeclaration = mockk()
+        val declaration1: KoSourceDeclarationProvider = mockk {
+            every { sourceTypeAlias } returns sourceDeclaration
+        }
+        val declaration2: KoSourceDeclarationProvider = mockk {
+            every { sourceTypeAlias } returns null
+        }
+        val declarations = listOf(declaration1, declaration2)
+
+        // when
+        val sut = declarations.withoutSourceTypeAlias()
+
+        // then
+        sut shouldBeEqualTo listOf(declaration2)
+    }
+
+    @Test
+    fun `withoutSourceTypeAlias{} returns declarations which not satisfy predicate`() {
+        // given
+        val name1 = "name1"
+        val name2 = "name2"
+        val sourceTypeAlias1: KoTypeAliasDeclaration = mockk {
+            every { name } returns name1
+        }
+        val sourceTypeAlias2: KoTypeAliasDeclaration = mockk {
+            every { name } returns name2
+        }
+        val declaration1: KoSourceDeclarationProvider = mockk {
+            every { sourceTypeAlias } returns sourceTypeAlias1
+        }
+        val declaration2: KoSourceDeclarationProvider = mockk {
+            every { sourceTypeAlias } returns sourceTypeAlias2
+        }
+        val declaration3: KoSourceDeclarationProvider = mockk {
+            every { sourceTypeAlias } returns null
+        }
+        val declarations = listOf(declaration1, declaration2, declaration3)
+
+        // when
+        val sut = declarations.withoutSourceTypeAlias { it.name == name1 }
+
+        // then
+        sut shouldBeEqualTo listOf(declaration2, declaration3)
+    }
+
+    @Test
+    fun `withSourceImportAlias() returns declaration with source import alias`() {
+        // given
+        val sourceDeclaration: KoImportAliasDeclaration = mockk()
+        val declaration1: KoSourceDeclarationProvider = mockk {
+            every { sourceImportAlias } returns sourceDeclaration
+        }
+        val declaration2: KoSourceDeclarationProvider = mockk {
+            every { sourceImportAlias } returns null
+        }
+        val declarations = listOf(declaration1, declaration2)
+
+        // when
+        val sut = declarations.withSourceImportAlias()
+
+        // then
+        sut shouldBeEqualTo listOf(declaration1)
+    }
+
+    @Test
+    fun `withSourceImportAlias{} returns declaration which satisfy predicate`() {
+        // given
+        val name1 = "name1"
+        val name2 = "name2"
+        val sourceImportAlias1: KoImportAliasDeclaration = mockk {
+            every { name } returns name1
+        }
+        val sourceImportAlias2: KoImportAliasDeclaration = mockk {
+            every { name } returns name2
+        }
+        val declaration1: KoSourceDeclarationProvider = mockk {
+            every { sourceImportAlias } returns sourceImportAlias1
+        }
+        val declaration2: KoSourceDeclarationProvider = mockk {
+            every { sourceImportAlias } returns sourceImportAlias2
+        }
+        val declaration3: KoSourceDeclarationProvider = mockk {
+            every { sourceImportAlias } returns null
+        }
+        val declarations = listOf(declaration1, declaration2, declaration3)
+
+        // when
+        val sut = declarations.withSourceImportAlias { it.name == name1 }
+
+        // then
+        sut shouldBeEqualTo listOf(declaration1)
+    }
+
+    @Test
+    fun `withoutSourceImportAlias() returns declaration without source import alias`() {
+        // given
+        val sourceDeclaration: KoImportAliasDeclaration = mockk()
+        val declaration1: KoSourceDeclarationProvider = mockk {
+            every { sourceImportAlias } returns sourceDeclaration
+        }
+        val declaration2: KoSourceDeclarationProvider = mockk {
+            every { sourceImportAlias } returns null
+        }
+        val declarations = listOf(declaration1, declaration2)
+
+        // when
+        val sut = declarations.withoutSourceImportAlias()
+
+        // then
+        sut shouldBeEqualTo listOf(declaration2)
+    }
+
+    @Test
+    fun `withoutSourceImportAlias{} returns declarations which not satisfy predicate`() {
+        // given
+        val name1 = "name1"
+        val name2 = "name2"
+        val sourceImportAlias1: KoImportAliasDeclaration = mockk {
+            every { name } returns name1
+        }
+        val sourceImportAlias2: KoImportAliasDeclaration = mockk {
+            every { name } returns name2
+        }
+        val declaration1: KoSourceDeclarationProvider = mockk {
+            every { sourceImportAlias } returns sourceImportAlias1
+        }
+        val declaration2: KoSourceDeclarationProvider = mockk {
+            every { sourceImportAlias } returns sourceImportAlias2
+        }
+        val declaration3: KoSourceDeclarationProvider = mockk {
+            every { sourceImportAlias } returns null
+        }
+        val declarations = listOf(declaration1, declaration2, declaration3)
+
+        // when
+        val sut = declarations.withoutSourceImportAlias { it.name == name1 }
+
+        // then
+        sut shouldBeEqualTo listOf(declaration2, declaration3)
+    }
+
+    @Test
+    fun `withSourceKotlinType() returns declaration with source kotlin type`() {
+        // given
+        val sourceDeclaration: KoKotlinTypeDeclaration = mockk()
+        val declaration1: KoSourceDeclarationProvider = mockk {
+            every { sourceKotlinType } returns sourceDeclaration
+        }
+        val declaration2: KoSourceDeclarationProvider = mockk {
+            every { sourceKotlinType } returns null
+        }
+        val declarations = listOf(declaration1, declaration2)
+
+        // when
+        val sut = declarations.withSourceKotlinType()
+
+        // then
+        sut shouldBeEqualTo listOf(declaration1)
+    }
+
+    @Test
+    fun `withSourceKotlinType{} returns declaration which satisfy predicate`() {
+        // given
+        val name1 = "name1"
+        val name2 = "name2"
+        val sourceKotlinType1: KoKotlinTypeDeclaration = mockk {
+            every { name } returns name1
+        }
+        val sourceKotlinType2: KoKotlinTypeDeclaration = mockk {
+            every { name } returns name2
+        }
+        val declaration1: KoSourceDeclarationProvider = mockk {
+            every { sourceKotlinType } returns sourceKotlinType1
+        }
+        val declaration2: KoSourceDeclarationProvider = mockk {
+            every { sourceKotlinType } returns sourceKotlinType2
+        }
+        val declaration3: KoSourceDeclarationProvider = mockk {
+            every { sourceKotlinType } returns null
+        }
+        val declarations = listOf(declaration1, declaration2, declaration3)
+
+        // when
+        val sut = declarations.withSourceKotlinType { it.name == name1 }
+
+        // then
+        sut shouldBeEqualTo listOf(declaration1)
+    }
+
+    @Test
+    fun `withoutSourceKotlinType() returns declaration without source kotlin type`() {
+        // given
+        val sourceDeclaration: KoKotlinTypeDeclaration = mockk()
+        val declaration1: KoSourceDeclarationProvider = mockk {
+            every { sourceKotlinType } returns sourceDeclaration
+        }
+        val declaration2: KoSourceDeclarationProvider = mockk {
+            every { sourceKotlinType } returns null
+        }
+        val declarations = listOf(declaration1, declaration2)
+
+        // when
+        val sut = declarations.withoutSourceKotlinType()
+
+        // then
+        sut shouldBeEqualTo listOf(declaration2)
+    }
+
+    @Test
+    fun `withoutSourceKotlinType{} returns declarations which not satisfy predicate`() {
+        // given
+        val name1 = "name1"
+        val name2 = "name2"
+        val sourceKotlinType1: KoKotlinTypeDeclaration = mockk {
+            every { name } returns name1
+        }
+        val sourceKotlinType2: KoKotlinTypeDeclaration = mockk {
+            every { name } returns name2
+        }
+        val declaration1: KoSourceDeclarationProvider = mockk {
+            every { sourceKotlinType } returns sourceKotlinType1
+        }
+        val declaration2: KoSourceDeclarationProvider = mockk {
+            every { sourceKotlinType } returns sourceKotlinType2
+        }
+        val declaration3: KoSourceDeclarationProvider = mockk {
+            every { sourceKotlinType } returns null
+        }
+        val declarations = listOf(declaration1, declaration2, declaration3)
+
+        // when
+        val sut = declarations.withoutSourceKotlinType { it.name == name1 }
+
+        // then
+        sut shouldBeEqualTo listOf(declaration2, declaration3)
+    }
+
+    @Test
+    fun `withSourceFunctionType() returns declaration with source function type`() {
+        // given
+        val sourceDeclaration: KoFunctionTypeDeclaration = mockk()
+        val declaration1: KoSourceDeclarationProvider = mockk {
+            every { sourceFunctionType } returns sourceDeclaration
+        }
+        val declaration2: KoSourceDeclarationProvider = mockk {
+            every { sourceFunctionType } returns null
+        }
+        val declarations = listOf(declaration1, declaration2)
+
+        // when
+        val sut = declarations.withSourceFunctionType()
+
+        // then
+        sut shouldBeEqualTo listOf(declaration1)
+    }
+
+    @Test
+    fun `withSourceFunctionType{} returns declaration which satisfy predicate`() {
+        // given
+        val name1 = "name1"
+        val name2 = "name2"
+        val sourceFunctionType1: KoFunctionTypeDeclaration = mockk {
+            every { name } returns name1
+        }
+        val sourceFunctionType2: KoFunctionTypeDeclaration = mockk {
+            every { name } returns name2
+        }
+        val declaration1: KoSourceDeclarationProvider = mockk {
+            every { sourceFunctionType } returns sourceFunctionType1
+        }
+        val declaration2: KoSourceDeclarationProvider = mockk {
+            every { sourceFunctionType } returns sourceFunctionType2
+        }
+        val declaration3: KoSourceDeclarationProvider = mockk {
+            every { sourceFunctionType } returns null
+        }
+        val declarations = listOf(declaration1, declaration2, declaration3)
+
+        // when
+        val sut = declarations.withSourceFunctionType { it.name == name1 }
+
+        // then
+        sut shouldBeEqualTo listOf(declaration1)
+    }
+
+    @Test
+    fun `withoutSourceFunctionType() returns declaration without source function type`() {
+        // given
+        val sourceDeclaration: KoFunctionTypeDeclaration = mockk()
+        val declaration1: KoSourceDeclarationProvider = mockk {
+            every { sourceFunctionType } returns sourceDeclaration
+        }
+        val declaration2: KoSourceDeclarationProvider = mockk {
+            every { sourceFunctionType } returns null
+        }
+        val declarations = listOf(declaration1, declaration2)
+
+        // when
+        val sut = declarations.withoutSourceFunctionType()
+
+        // then
+        sut shouldBeEqualTo listOf(declaration2)
+    }
+
+    @Test
+    fun `withoutSourceFunctionType{} returns declarations which not satisfy predicate`() {
+        // given
+        val name1 = "name1"
+        val name2 = "name2"
+        val sourceFunctionType1: KoFunctionTypeDeclaration = mockk {
+            every { name } returns name1
+        }
+        val sourceFunctionType2: KoFunctionTypeDeclaration = mockk {
+            every { name } returns name2
+        }
+        val declaration1: KoSourceDeclarationProvider = mockk {
+            every { sourceFunctionType } returns sourceFunctionType1
+        }
+        val declaration2: KoSourceDeclarationProvider = mockk {
+            every { sourceFunctionType } returns sourceFunctionType2
+        }
+        val declaration3: KoSourceDeclarationProvider = mockk {
+            every { sourceFunctionType } returns null
+        }
+        val declarations = listOf(declaration1, declaration2, declaration3)
+
+        // when
+        val sut = declarations.withoutSourceFunctionType { it.name == name1 }
+
+        // then
+        sut shouldBeEqualTo listOf(declaration2, declaration3)
+    }
+
+    @Test
+    fun `withSourceExternalType() returns declaration with source external type`() {
+        // given
+        val sourceDeclaration: KoExternalDeclaration = mockk()
+        val declaration1: KoSourceDeclarationProvider = mockk {
+            every { sourceExternalType } returns sourceDeclaration
+        }
+        val declaration2: KoSourceDeclarationProvider = mockk {
+            every { sourceExternalType } returns null
+        }
+        val declarations = listOf(declaration1, declaration2)
+
+        // when
+        val sut = declarations.withSourceExternalType()
+
+        // then
+        sut shouldBeEqualTo listOf(declaration1)
+    }
+
+    @Test
+    fun `withSourceExternalType{} returns declaration which satisfy predicate`() {
+        // given
+        val name1 = "name1"
+        val name2 = "name2"
+        val sourceExternalType1: KoExternalDeclaration = mockk {
+            every { name } returns name1
+        }
+        val sourceExternalType2: KoExternalDeclaration = mockk {
+            every { name } returns name2
+        }
+        val declaration1: KoSourceDeclarationProvider = mockk {
+            every { sourceExternalType } returns sourceExternalType1
+        }
+        val declaration2: KoSourceDeclarationProvider = mockk {
+            every { sourceExternalType } returns sourceExternalType2
+        }
+        val declaration3: KoSourceDeclarationProvider = mockk {
+            every { sourceExternalType } returns null
+        }
+        val declarations = listOf(declaration1, declaration2, declaration3)
+
+        // when
+        val sut = declarations.withSourceExternalType { it.name == name1 }
+
+        // then
+        sut shouldBeEqualTo listOf(declaration1)
+    }
+
+    @Test
+    fun `withoutSourceExternalType() returns declaration without source external type`() {
+        // given
+        val sourceDeclaration: KoExternalDeclaration = mockk()
+        val declaration1: KoSourceDeclarationProvider = mockk {
+            every { sourceExternalType } returns sourceDeclaration
+        }
+        val declaration2: KoSourceDeclarationProvider = mockk {
+            every { sourceExternalType } returns null
+        }
+        val declarations = listOf(declaration1, declaration2)
+
+        // when
+        val sut = declarations.withoutSourceExternalType()
+
+        // then
+        sut shouldBeEqualTo listOf(declaration2)
+    }
+
+    @Test
+    fun `withoutSourceExternalType{} returns declarations which not satisfy predicate`() {
+        // given
+        val name1 = "name1"
+        val name2 = "name2"
+        val sourceExternalType1: KoExternalDeclaration = mockk {
+            every { name } returns name1
+        }
+        val sourceExternalType2: KoExternalDeclaration = mockk {
+            every { name } returns name2
+        }
+        val declaration1: KoSourceDeclarationProvider = mockk {
+            every { sourceExternalType } returns sourceExternalType1
+        }
+        val declaration2: KoSourceDeclarationProvider = mockk {
+            every { sourceExternalType } returns sourceExternalType2
+        }
+        val declaration3: KoSourceDeclarationProvider = mockk {
+            every { sourceExternalType } returns null
+        }
+        val declarations = listOf(declaration1, declaration2, declaration3)
+
+        // when
+        val sut = declarations.withoutSourceExternalType { it.name == name1 }
+
+        // then
+        sut shouldBeEqualTo listOf(declaration2, declaration3)
+    }
+}

--- a/lib/src/test/kotlin/com/lemonappdev/konsist/api/ext/list/KoSourceDeclarationProviderListExtTest.kt
+++ b/lib/src/test/kotlin/com/lemonappdev/konsist/api/ext/list/KoSourceDeclarationProviderListExtTest.kt
@@ -8,10 +8,7 @@ import com.lemonappdev.konsist.api.declaration.KoObjectDeclaration
 import com.lemonappdev.konsist.api.declaration.KoTypeAliasDeclaration
 import com.lemonappdev.konsist.api.declaration.type.KoFunctionTypeDeclaration
 import com.lemonappdev.konsist.api.declaration.type.KoKotlinTypeDeclaration
-import com.lemonappdev.konsist.api.provider.KoNonNullableTypeProvider
-import com.lemonappdev.konsist.api.provider.KoNullableTypeProvider
 import com.lemonappdev.konsist.api.provider.KoSourceDeclarationProvider
-import com.lemonappdev.konsist.core.util.TypeUtil.hasTypeOf
 import com.lemonappdev.konsist.testdata.SampleType1
 import com.lemonappdev.konsist.testdata.SampleType2
 import io.mockk.every
@@ -19,6 +16,7 @@ import io.mockk.mockk
 import org.amshove.kluent.shouldBeEqualTo
 import org.junit.jupiter.api.Test
 
+@Suppress("detekt.LargeClass")
 class KoSourceDeclarationProviderListExtTest {
     @Test
     fun `sourceDeclarations returns declarations from all declarations`() {

--- a/lib/src/test/kotlin/com/lemonappdev/konsist/api/ext/list/KoSourceDeclarationProviderListExtTest.kt
+++ b/lib/src/test/kotlin/com/lemonappdev/konsist/api/ext/list/KoSourceDeclarationProviderListExtTest.kt
@@ -8,7 +8,12 @@ import com.lemonappdev.konsist.api.declaration.KoObjectDeclaration
 import com.lemonappdev.konsist.api.declaration.KoTypeAliasDeclaration
 import com.lemonappdev.konsist.api.declaration.type.KoFunctionTypeDeclaration
 import com.lemonappdev.konsist.api.declaration.type.KoKotlinTypeDeclaration
+import com.lemonappdev.konsist.api.provider.KoNonNullableTypeProvider
+import com.lemonappdev.konsist.api.provider.KoNullableTypeProvider
 import com.lemonappdev.konsist.api.provider.KoSourceDeclarationProvider
+import com.lemonappdev.konsist.core.util.TypeUtil.hasTypeOf
+import com.lemonappdev.konsist.testdata.SampleType1
+import com.lemonappdev.konsist.testdata.SampleType2
 import io.mockk.every
 import io.mockk.mockk
 import org.amshove.kluent.shouldBeEqualTo
@@ -276,14 +281,97 @@ class KoSourceDeclarationProviderListExtTest {
     }
 
     @Test
-    fun `withSourceClass() returns declaration with source class`() {
+    fun `withSourceDeclarationOf(KClass) returns declaration with given source declaration`() {
         // given
-        val sourceDeclaration: KoClassDeclaration = mockk()
         val declaration1: KoSourceDeclarationProvider = mockk {
-            every { sourceClass } returns sourceDeclaration
+            every { hasSourceDeclarationOf(SampleType1::class) } returns true
         }
         val declaration2: KoSourceDeclarationProvider = mockk {
-            every { sourceClass } returns null
+            every { hasSourceDeclarationOf(SampleType1::class) } returns false
+        }
+        val declarations = listOf(declaration1, declaration2)
+
+        // when
+        val sut = declarations.withSourceDeclarationOf(SampleType1::class)
+
+        // then
+        sut shouldBeEqualTo listOf(declaration1)
+    }
+
+    @Test
+    fun `withSourceDeclarationOf(KClass) returns declarations with one of given source declarations`() {
+        // given
+        val declaration1: KoSourceDeclarationProvider = mockk {
+            every { hasSourceDeclarationOf(SampleType1::class) } returns true
+            every { hasSourceDeclarationOf(SampleType2::class) } returns false
+        }
+        val declaration2: KoSourceDeclarationProvider = mockk {
+            every { hasSourceDeclarationOf(SampleType1::class) } returns false
+            every { hasSourceDeclarationOf(SampleType2::class) } returns true
+        }
+        val declaration3: KoSourceDeclarationProvider = mockk {
+            every { hasSourceDeclarationOf(SampleType1::class) } returns false
+            every { hasSourceDeclarationOf(SampleType2::class) } returns false
+        }
+        val declarations = listOf(declaration1, declaration2, declaration3)
+
+        // when
+        val sut = declarations.withSourceDeclarationOf(SampleType1::class, SampleType2::class)
+
+        // then
+        sut shouldBeEqualTo listOf(declaration1, declaration2)
+    }
+
+    @Test
+    fun `withoutSourceDeclarationOf(KClass) returns declaration without given source declaration`() {
+        // given
+        val declaration1: KoSourceDeclarationProvider = mockk {
+            every { hasSourceDeclarationOf(SampleType1::class) } returns true
+        }
+        val declaration2: KoSourceDeclarationProvider = mockk {
+            every { hasSourceDeclarationOf(SampleType1::class) } returns false
+        }
+        val declarations = listOf(declaration1, declaration2)
+
+        // when
+        val sut = declarations.withoutSourceDeclarationOf(SampleType1::class)
+
+        // then
+        sut shouldBeEqualTo listOf(declaration2)
+    }
+
+    @Test
+    fun `withoutSourceDeclarationOf(KClass) returns declaration without any of given source declarations`() {
+        // given
+        val declaration1: KoSourceDeclarationProvider = mockk {
+            every { hasSourceDeclarationOf(SampleType1::class) } returns true
+            every { hasSourceDeclarationOf(SampleType2::class) } returns false
+        }
+        val declaration2: KoSourceDeclarationProvider = mockk {
+            every { hasSourceDeclarationOf(SampleType1::class) } returns false
+            every { hasSourceDeclarationOf(SampleType2::class) } returns true
+        }
+        val declaration3: KoSourceDeclarationProvider = mockk {
+            every { hasSourceDeclarationOf(SampleType1::class) } returns false
+            every { hasSourceDeclarationOf(SampleType2::class) } returns false
+        }
+        val declarations = listOf(declaration1, declaration2, declaration3)
+
+        // when
+        val sut = declarations.withoutSourceDeclarationOf(SampleType1::class, SampleType2::class)
+
+        // then
+        sut shouldBeEqualTo listOf(declaration3)
+    }
+
+    @Test
+    fun `withSourceClass() returns declaration with source class`() {
+        // given
+        val declaration1: KoSourceDeclarationProvider = mockk {
+            every { hasSourceClass() } returns true
+        }
+        val declaration2: KoSourceDeclarationProvider = mockk {
+            every { hasSourceClass() } returns false
         }
         val declarations = listOf(declaration1, declaration2)
 
@@ -326,12 +414,11 @@ class KoSourceDeclarationProviderListExtTest {
     @Test
     fun `withoutSourceClass() returns declaration without source class`() {
         // given
-        val sourceDeclaration: KoClassDeclaration = mockk()
         val declaration1: KoSourceDeclarationProvider = mockk {
-            every { sourceClass } returns sourceDeclaration
+            every { hasSourceClass() } returns true
         }
         val declaration2: KoSourceDeclarationProvider = mockk {
-            every { sourceClass } returns null
+            every { hasSourceClass() } returns false
         }
         val declarations = listOf(declaration1, declaration2)
 
@@ -372,14 +459,97 @@ class KoSourceDeclarationProviderListExtTest {
     }
 
     @Test
-    fun `withSourceObject() returns declaration with source object`() {
+    fun `withSourceClassOf(KClass) returns declaration with given source class`() {
         // given
-        val sourceDeclaration: KoObjectDeclaration = mockk()
         val declaration1: KoSourceDeclarationProvider = mockk {
-            every { sourceObject } returns sourceDeclaration
+            every { hasSourceClassOf(SampleType1::class) } returns true
         }
         val declaration2: KoSourceDeclarationProvider = mockk {
-            every { sourceObject } returns null
+            every { hasSourceClassOf(SampleType1::class) } returns false
+        }
+        val declarations = listOf(declaration1, declaration2)
+
+        // when
+        val sut = declarations.withSourceClassOf(SampleType1::class)
+
+        // then
+        sut shouldBeEqualTo listOf(declaration1)
+    }
+
+    @Test
+    fun `withSourceClassOf(KClass) returns declarations with one of given source classes`() {
+        // given
+        val declaration1: KoSourceDeclarationProvider = mockk {
+            every { hasSourceClassOf(SampleType1::class) } returns true
+            every { hasSourceClassOf(SampleType2::class) } returns false
+        }
+        val declaration2: KoSourceDeclarationProvider = mockk {
+            every { hasSourceClassOf(SampleType1::class) } returns false
+            every { hasSourceClassOf(SampleType2::class) } returns true
+        }
+        val declaration3: KoSourceDeclarationProvider = mockk {
+            every { hasSourceClassOf(SampleType1::class) } returns false
+            every { hasSourceClassOf(SampleType2::class) } returns false
+        }
+        val declarations = listOf(declaration1, declaration2, declaration3)
+
+        // when
+        val sut = declarations.withSourceClassOf(SampleType1::class, SampleType2::class)
+
+        // then
+        sut shouldBeEqualTo listOf(declaration1, declaration2)
+    }
+
+    @Test
+    fun `withoutSourceClassOf(KClass) returns declaration without given source class`() {
+        // given
+        val declaration1: KoSourceDeclarationProvider = mockk {
+            every { hasSourceClassOf(SampleType1::class) } returns true
+        }
+        val declaration2: KoSourceDeclarationProvider = mockk {
+            every { hasSourceClassOf(SampleType1::class) } returns false
+        }
+        val declarations = listOf(declaration1, declaration2)
+
+        // when
+        val sut = declarations.withoutSourceClassOf(SampleType1::class)
+
+        // then
+        sut shouldBeEqualTo listOf(declaration2)
+    }
+
+    @Test
+    fun `withoutSourceClassOf(KClass) returns declaration without any of given source classes`() {
+        // given
+        val declaration1: KoSourceDeclarationProvider = mockk {
+            every { hasSourceClassOf(SampleType1::class) } returns true
+            every { hasSourceClassOf(SampleType2::class) } returns false
+        }
+        val declaration2: KoSourceDeclarationProvider = mockk {
+            every { hasSourceClassOf(SampleType1::class) } returns false
+            every { hasSourceClassOf(SampleType2::class) } returns true
+        }
+        val declaration3: KoSourceDeclarationProvider = mockk {
+            every { hasSourceClassOf(SampleType1::class) } returns false
+            every { hasSourceClassOf(SampleType2::class) } returns false
+        }
+        val declarations = listOf(declaration1, declaration2, declaration3)
+
+        // when
+        val sut = declarations.withoutSourceClassOf(SampleType1::class, SampleType2::class)
+
+        // then
+        sut shouldBeEqualTo listOf(declaration3)
+    }
+
+    @Test
+    fun `withSourceObject() returns declaration with source object`() {
+        // given
+        val declaration1: KoSourceDeclarationProvider = mockk {
+            every { hasSourceObject() } returns true
+        }
+        val declaration2: KoSourceDeclarationProvider = mockk {
+            every { hasSourceObject() } returns false
         }
         val declarations = listOf(declaration1, declaration2)
 
@@ -422,12 +592,11 @@ class KoSourceDeclarationProviderListExtTest {
     @Test
     fun `withoutSourceObject() returns declaration without source object`() {
         // given
-        val sourceDeclaration: KoObjectDeclaration = mockk()
         val declaration1: KoSourceDeclarationProvider = mockk {
-            every { sourceObject } returns sourceDeclaration
+            every { hasSourceObject() } returns true
         }
         val declaration2: KoSourceDeclarationProvider = mockk {
-            every { sourceObject } returns null
+            every { hasSourceObject() } returns false
         }
         val declarations = listOf(declaration1, declaration2)
 
@@ -468,14 +637,97 @@ class KoSourceDeclarationProviderListExtTest {
     }
 
     @Test
-    fun `withSourceInterface() returns declaration with source interface`() {
+    fun `withSourceObjectOf(KClass) returns declaration with given source object`() {
         // given
-        val sourceDeclaration: KoInterfaceDeclaration = mockk()
         val declaration1: KoSourceDeclarationProvider = mockk {
-            every { sourceInterface } returns sourceDeclaration
+            every { hasSourceObjectOf(SampleType1::class) } returns true
         }
         val declaration2: KoSourceDeclarationProvider = mockk {
-            every { sourceInterface } returns null
+            every { hasSourceObjectOf(SampleType1::class) } returns false
+        }
+        val declarations = listOf(declaration1, declaration2)
+
+        // when
+        val sut = declarations.withSourceObjectOf(SampleType1::class)
+
+        // then
+        sut shouldBeEqualTo listOf(declaration1)
+    }
+
+    @Test
+    fun `withSourceObjectOf(KClass) returns declarations with one of given source objects`() {
+        // given
+        val declaration1: KoSourceDeclarationProvider = mockk {
+            every { hasSourceObjectOf(SampleType1::class) } returns true
+            every { hasSourceObjectOf(SampleType2::class) } returns false
+        }
+        val declaration2: KoSourceDeclarationProvider = mockk {
+            every { hasSourceObjectOf(SampleType1::class) } returns false
+            every { hasSourceObjectOf(SampleType2::class) } returns true
+        }
+        val declaration3: KoSourceDeclarationProvider = mockk {
+            every { hasSourceObjectOf(SampleType1::class) } returns false
+            every { hasSourceObjectOf(SampleType2::class) } returns false
+        }
+        val declarations = listOf(declaration1, declaration2, declaration3)
+
+        // when
+        val sut = declarations.withSourceObjectOf(SampleType1::class, SampleType2::class)
+
+        // then
+        sut shouldBeEqualTo listOf(declaration1, declaration2)
+    }
+
+    @Test
+    fun `withoutSourceObjectOf(KClass) returns declaration without given source object`() {
+        // given
+        val declaration1: KoSourceDeclarationProvider = mockk {
+            every { hasSourceObjectOf(SampleType1::class) } returns true
+        }
+        val declaration2: KoSourceDeclarationProvider = mockk {
+            every { hasSourceObjectOf(SampleType1::class) } returns false
+        }
+        val declarations = listOf(declaration1, declaration2)
+
+        // when
+        val sut = declarations.withoutSourceObjectOf(SampleType1::class)
+
+        // then
+        sut shouldBeEqualTo listOf(declaration2)
+    }
+
+    @Test
+    fun `withoutSourceObjectOf(KClass) returns declaration without any of given source objects`() {
+        // given
+        val declaration1: KoSourceDeclarationProvider = mockk {
+            every { hasSourceObjectOf(SampleType1::class) } returns true
+            every { hasSourceObjectOf(SampleType2::class) } returns false
+        }
+        val declaration2: KoSourceDeclarationProvider = mockk {
+            every { hasSourceObjectOf(SampleType1::class) } returns false
+            every { hasSourceObjectOf(SampleType2::class) } returns true
+        }
+        val declaration3: KoSourceDeclarationProvider = mockk {
+            every { hasSourceObjectOf(SampleType1::class) } returns false
+            every { hasSourceObjectOf(SampleType2::class) } returns false
+        }
+        val declarations = listOf(declaration1, declaration2, declaration3)
+
+        // when
+        val sut = declarations.withoutSourceObjectOf(SampleType1::class, SampleType2::class)
+
+        // then
+        sut shouldBeEqualTo listOf(declaration3)
+    }
+
+    @Test
+    fun `withSourceInterface() returns declaration with source interface`() {
+        // given
+        val declaration1: KoSourceDeclarationProvider = mockk {
+            every { hasSourceInterface() } returns true
+        }
+        val declaration2: KoSourceDeclarationProvider = mockk {
+            every { hasSourceInterface() } returns false
         }
         val declarations = listOf(declaration1, declaration2)
 
@@ -518,12 +770,11 @@ class KoSourceDeclarationProviderListExtTest {
     @Test
     fun `withoutSourceInterface() returns declaration without source interface`() {
         // given
-        val sourceDeclaration: KoInterfaceDeclaration = mockk()
         val declaration1: KoSourceDeclarationProvider = mockk {
-            every { sourceInterface } returns sourceDeclaration
+            every { hasSourceInterface() } returns true
         }
         val declaration2: KoSourceDeclarationProvider = mockk {
-            every { sourceInterface } returns null
+            every { hasSourceInterface() } returns false
         }
         val declarations = listOf(declaration1, declaration2)
 
@@ -564,14 +815,97 @@ class KoSourceDeclarationProviderListExtTest {
     }
 
     @Test
-    fun `withSourceTypeAlias() returns declaration with source type alias`() {
+    fun `withSourceInterfaceOf(KClass) returns declaration with given source interface`() {
         // given
-        val sourceDeclaration: KoTypeAliasDeclaration = mockk()
         val declaration1: KoSourceDeclarationProvider = mockk {
-            every { sourceTypeAlias } returns sourceDeclaration
+            every { hasSourceInterfaceOf(SampleType1::class) } returns true
         }
         val declaration2: KoSourceDeclarationProvider = mockk {
-            every { sourceTypeAlias } returns null
+            every { hasSourceInterfaceOf(SampleType1::class) } returns false
+        }
+        val declarations = listOf(declaration1, declaration2)
+
+        // when
+        val sut = declarations.withSourceInterfaceOf(SampleType1::class)
+
+        // then
+        sut shouldBeEqualTo listOf(declaration1)
+    }
+
+    @Test
+    fun `withSourceInterfaceOf(KClass) returns declarations with one of given source interfaces`() {
+        // given
+        val declaration1: KoSourceDeclarationProvider = mockk {
+            every { hasSourceInterfaceOf(SampleType1::class) } returns true
+            every { hasSourceInterfaceOf(SampleType2::class) } returns false
+        }
+        val declaration2: KoSourceDeclarationProvider = mockk {
+            every { hasSourceInterfaceOf(SampleType1::class) } returns false
+            every { hasSourceInterfaceOf(SampleType2::class) } returns true
+        }
+        val declaration3: KoSourceDeclarationProvider = mockk {
+            every { hasSourceInterfaceOf(SampleType1::class) } returns false
+            every { hasSourceInterfaceOf(SampleType2::class) } returns false
+        }
+        val declarations = listOf(declaration1, declaration2, declaration3)
+
+        // when
+        val sut = declarations.withSourceInterfaceOf(SampleType1::class, SampleType2::class)
+
+        // then
+        sut shouldBeEqualTo listOf(declaration1, declaration2)
+    }
+
+    @Test
+    fun `withoutSourceInterfaceOf(KClass) returns declaration without given source interface`() {
+        // given
+        val declaration1: KoSourceDeclarationProvider = mockk {
+            every { hasSourceInterfaceOf(SampleType1::class) } returns true
+        }
+        val declaration2: KoSourceDeclarationProvider = mockk {
+            every { hasSourceInterfaceOf(SampleType1::class) } returns false
+        }
+        val declarations = listOf(declaration1, declaration2)
+
+        // when
+        val sut = declarations.withoutSourceInterfaceOf(SampleType1::class)
+
+        // then
+        sut shouldBeEqualTo listOf(declaration2)
+    }
+
+    @Test
+    fun `withoutSourceInterfaceOf(KClass) returns declaration without any of given source interfaces`() {
+        // given
+        val declaration1: KoSourceDeclarationProvider = mockk {
+            every { hasSourceInterfaceOf(SampleType1::class) } returns true
+            every { hasSourceInterfaceOf(SampleType2::class) } returns false
+        }
+        val declaration2: KoSourceDeclarationProvider = mockk {
+            every { hasSourceInterfaceOf(SampleType1::class) } returns false
+            every { hasSourceInterfaceOf(SampleType2::class) } returns true
+        }
+        val declaration3: KoSourceDeclarationProvider = mockk {
+            every { hasSourceInterfaceOf(SampleType1::class) } returns false
+            every { hasSourceInterfaceOf(SampleType2::class) } returns false
+        }
+        val declarations = listOf(declaration1, declaration2, declaration3)
+
+        // when
+        val sut = declarations.withoutSourceInterfaceOf(SampleType1::class, SampleType2::class)
+
+        // then
+        sut shouldBeEqualTo listOf(declaration3)
+    }
+
+    @Test
+    fun `withSourceTypeAlias() returns declaration with source type alias`() {
+        // given
+        val declaration1: KoSourceDeclarationProvider = mockk {
+            every { hasSourceTypeAlias() } returns true
+        }
+        val declaration2: KoSourceDeclarationProvider = mockk {
+            every { hasSourceTypeAlias() } returns false
         }
         val declarations = listOf(declaration1, declaration2)
 
@@ -614,12 +948,11 @@ class KoSourceDeclarationProviderListExtTest {
     @Test
     fun `withoutSourceTypeAlias() returns declaration without source type alias`() {
         // given
-        val sourceDeclaration: KoTypeAliasDeclaration = mockk()
         val declaration1: KoSourceDeclarationProvider = mockk {
-            every { sourceTypeAlias } returns sourceDeclaration
+            every { hasSourceTypeAlias() } returns true
         }
         val declaration2: KoSourceDeclarationProvider = mockk {
-            every { sourceTypeAlias } returns null
+            every { hasSourceTypeAlias() } returns false
         }
         val declarations = listOf(declaration1, declaration2)
 
@@ -662,12 +995,11 @@ class KoSourceDeclarationProviderListExtTest {
     @Test
     fun `withSourceImportAlias() returns declaration with source import alias`() {
         // given
-        val sourceDeclaration: KoImportAliasDeclaration = mockk()
         val declaration1: KoSourceDeclarationProvider = mockk {
-            every { sourceImportAlias } returns sourceDeclaration
+            every { hasSourceImportAlias() } returns true
         }
         val declaration2: KoSourceDeclarationProvider = mockk {
-            every { sourceImportAlias } returns null
+            every { hasSourceImportAlias() } returns false
         }
         val declarations = listOf(declaration1, declaration2)
 
@@ -710,12 +1042,11 @@ class KoSourceDeclarationProviderListExtTest {
     @Test
     fun `withoutSourceImportAlias() returns declaration without source import alias`() {
         // given
-        val sourceDeclaration: KoImportAliasDeclaration = mockk()
         val declaration1: KoSourceDeclarationProvider = mockk {
-            every { sourceImportAlias } returns sourceDeclaration
+            every { hasSourceImportAlias() } returns true
         }
         val declaration2: KoSourceDeclarationProvider = mockk {
-            every { sourceImportAlias } returns null
+            every { hasSourceImportAlias() } returns false
         }
         val declarations = listOf(declaration1, declaration2)
 
@@ -758,12 +1089,11 @@ class KoSourceDeclarationProviderListExtTest {
     @Test
     fun `withSourceKotlinType() returns declaration with source kotlin type`() {
         // given
-        val sourceDeclaration: KoKotlinTypeDeclaration = mockk()
         val declaration1: KoSourceDeclarationProvider = mockk {
-            every { sourceKotlinType } returns sourceDeclaration
+            every { hasSourceKotlinType() } returns true
         }
         val declaration2: KoSourceDeclarationProvider = mockk {
-            every { sourceKotlinType } returns null
+            every { hasSourceKotlinType() } returns false
         }
         val declarations = listOf(declaration1, declaration2)
 
@@ -806,12 +1136,11 @@ class KoSourceDeclarationProviderListExtTest {
     @Test
     fun `withoutSourceKotlinType() returns declaration without source kotlin type`() {
         // given
-        val sourceDeclaration: KoKotlinTypeDeclaration = mockk()
         val declaration1: KoSourceDeclarationProvider = mockk {
-            every { sourceKotlinType } returns sourceDeclaration
+            every { hasSourceKotlinType() } returns true
         }
         val declaration2: KoSourceDeclarationProvider = mockk {
-            every { sourceKotlinType } returns null
+            every { hasSourceKotlinType() } returns false
         }
         val declarations = listOf(declaration1, declaration2)
 
@@ -852,14 +1181,97 @@ class KoSourceDeclarationProviderListExtTest {
     }
 
     @Test
-    fun `withSourceFunctionType() returns declaration with source function type`() {
+    fun `withSourceKotlinTypeOf(KClass) returns declaration with given source kotlin type`() {
         // given
-        val sourceDeclaration: KoFunctionTypeDeclaration = mockk()
         val declaration1: KoSourceDeclarationProvider = mockk {
-            every { sourceFunctionType } returns sourceDeclaration
+            every { hasSourceKotlinTypeOf(String::class) } returns true
         }
         val declaration2: KoSourceDeclarationProvider = mockk {
-            every { sourceFunctionType } returns null
+            every { hasSourceKotlinTypeOf(String::class) } returns false
+        }
+        val declarations = listOf(declaration1, declaration2)
+
+        // when
+        val sut = declarations.withSourceKotlinTypeOf(String::class)
+
+        // then
+        sut shouldBeEqualTo listOf(declaration1)
+    }
+
+    @Test
+    fun `withSourceKotlinTypeOf(KClass) returns declarations with one of given source kotlin types`() {
+        // given
+        val declaration1: KoSourceDeclarationProvider = mockk {
+            every { hasSourceKotlinTypeOf(String::class) } returns true
+            every { hasSourceKotlinTypeOf(Int::class) } returns false
+        }
+        val declaration2: KoSourceDeclarationProvider = mockk {
+            every { hasSourceKotlinTypeOf(String::class) } returns false
+            every { hasSourceKotlinTypeOf(Int::class) } returns true
+        }
+        val declaration3: KoSourceDeclarationProvider = mockk {
+            every { hasSourceKotlinTypeOf(String::class) } returns false
+            every { hasSourceKotlinTypeOf(Int::class) } returns false
+        }
+        val declarations = listOf(declaration1, declaration2, declaration3)
+
+        // when
+        val sut = declarations.withSourceKotlinTypeOf(String::class, Int::class)
+
+        // then
+        sut shouldBeEqualTo listOf(declaration1, declaration2)
+    }
+
+    @Test
+    fun `withoutSourceKotlinTypeOf(KClass) returns declaration without given source kotlin type`() {
+        // given
+        val declaration1: KoSourceDeclarationProvider = mockk {
+            every { hasSourceKotlinTypeOf(String::class) } returns true
+        }
+        val declaration2: KoSourceDeclarationProvider = mockk {
+            every { hasSourceKotlinTypeOf(String::class) } returns false
+        }
+        val declarations = listOf(declaration1, declaration2)
+
+        // when
+        val sut = declarations.withoutSourceKotlinTypeOf(String::class)
+
+        // then
+        sut shouldBeEqualTo listOf(declaration2)
+    }
+
+    @Test
+    fun `withoutSourceKotlinTypeOf(KClass) returns declaration without any of given source kotlin types`() {
+        // given
+        val declaration1: KoSourceDeclarationProvider = mockk {
+            every { hasSourceKotlinTypeOf(String::class) } returns true
+            every { hasSourceKotlinTypeOf(Int::class) } returns false
+        }
+        val declaration2: KoSourceDeclarationProvider = mockk {
+            every { hasSourceKotlinTypeOf(String::class) } returns false
+            every { hasSourceKotlinTypeOf(Int::class) } returns true
+        }
+        val declaration3: KoSourceDeclarationProvider = mockk {
+            every { hasSourceKotlinTypeOf(String::class) } returns false
+            every { hasSourceKotlinTypeOf(Int::class) } returns false
+        }
+        val declarations = listOf(declaration1, declaration2, declaration3)
+
+        // when
+        val sut = declarations.withoutSourceKotlinTypeOf(String::class, Int::class)
+
+        // then
+        sut shouldBeEqualTo listOf(declaration3)
+    }
+
+    @Test
+    fun `withSourceFunctionType() returns declaration with source function type`() {
+        // given
+        val declaration1: KoSourceDeclarationProvider = mockk {
+            every { hasSourceFunctionType() } returns true
+        }
+        val declaration2: KoSourceDeclarationProvider = mockk {
+            every { hasSourceFunctionType() } returns false
         }
         val declarations = listOf(declaration1, declaration2)
 
@@ -902,12 +1314,11 @@ class KoSourceDeclarationProviderListExtTest {
     @Test
     fun `withoutSourceFunctionType() returns declaration without source function type`() {
         // given
-        val sourceDeclaration: KoFunctionTypeDeclaration = mockk()
         val declaration1: KoSourceDeclarationProvider = mockk {
-            every { sourceFunctionType } returns sourceDeclaration
+            every { hasSourceFunctionType() } returns true
         }
         val declaration2: KoSourceDeclarationProvider = mockk {
-            every { sourceFunctionType } returns null
+            every { hasSourceFunctionType() } returns false
         }
         val declarations = listOf(declaration1, declaration2)
 
@@ -950,12 +1361,11 @@ class KoSourceDeclarationProviderListExtTest {
     @Test
     fun `withSourceExternalType() returns declaration with source external type`() {
         // given
-        val sourceDeclaration: KoExternalDeclaration = mockk()
         val declaration1: KoSourceDeclarationProvider = mockk {
-            every { sourceExternalType } returns sourceDeclaration
+            every { hasSourceExternalType() } returns true
         }
         val declaration2: KoSourceDeclarationProvider = mockk {
-            every { sourceExternalType } returns null
+            every { hasSourceExternalType() } returns false
         }
         val declarations = listOf(declaration1, declaration2)
 
@@ -998,12 +1408,11 @@ class KoSourceDeclarationProviderListExtTest {
     @Test
     fun `withoutSourceExternalType() returns declaration without source external type`() {
         // given
-        val sourceDeclaration: KoExternalDeclaration = mockk()
         val declaration1: KoSourceDeclarationProvider = mockk {
-            every { sourceExternalType } returns sourceDeclaration
+            every { hasSourceExternalType() } returns true
         }
         val declaration2: KoSourceDeclarationProvider = mockk {
-            every { sourceExternalType } returns null
+            every { hasSourceExternalType() } returns false
         }
         val declarations = listOf(declaration1, declaration2)
 
@@ -1041,5 +1450,89 @@ class KoSourceDeclarationProviderListExtTest {
 
         // then
         sut shouldBeEqualTo listOf(declaration2, declaration3)
+    }
+
+    @Test
+    fun `withSourceExternalTypeOf(KClass) returns declaration with given source external type`() {
+        // given
+        val declaration1: KoSourceDeclarationProvider = mockk {
+            every { hasSourceExternalTypeOf(SampleType1::class) } returns true
+        }
+        val declaration2: KoSourceDeclarationProvider = mockk {
+            every { hasSourceExternalTypeOf(SampleType1::class) } returns false
+        }
+        val declarations = listOf(declaration1, declaration2)
+
+        // when
+        val sut = declarations.withSourceExternalTypeOf(SampleType1::class)
+
+        // then
+        sut shouldBeEqualTo listOf(declaration1)
+    }
+
+    @Test
+    fun `withSourceExternalTypeOf(KClass) returns declarations with one of given source external types`() {
+        // given
+        val declaration1: KoSourceDeclarationProvider = mockk {
+            every { hasSourceExternalTypeOf(SampleType1::class) } returns true
+            every { hasSourceExternalTypeOf(SampleType2::class) } returns false
+        }
+        val declaration2: KoSourceDeclarationProvider = mockk {
+            every { hasSourceExternalTypeOf(SampleType1::class) } returns false
+            every { hasSourceExternalTypeOf(SampleType2::class) } returns true
+        }
+        val declaration3: KoSourceDeclarationProvider = mockk {
+            every { hasSourceExternalTypeOf(SampleType1::class) } returns false
+            every { hasSourceExternalTypeOf(SampleType2::class) } returns false
+        }
+        val declarations = listOf(declaration1, declaration2, declaration3)
+
+        // when
+        val sut = declarations.withSourceExternalTypeOf(SampleType1::class, SampleType2::class)
+
+        // then
+        sut shouldBeEqualTo listOf(declaration1, declaration2)
+    }
+
+    @Test
+    fun `withoutSourceExternalTypeOf(KClass) returns declaration without given source external type`() {
+        // given
+        val declaration1: KoSourceDeclarationProvider = mockk {
+            every { hasSourceExternalTypeOf(SampleType1::class) } returns true
+        }
+        val declaration2: KoSourceDeclarationProvider = mockk {
+            every { hasSourceExternalTypeOf(SampleType1::class) } returns false
+        }
+        val declarations = listOf(declaration1, declaration2)
+
+        // when
+        val sut = declarations.withoutSourceExternalTypeOf(SampleType1::class)
+
+        // then
+        sut shouldBeEqualTo listOf(declaration2)
+    }
+
+    @Test
+    fun `withoutSourceExternalTypeOf(KClass) returns declaration without any of given source external types`() {
+        // given
+        val declaration1: KoSourceDeclarationProvider = mockk {
+            every { hasSourceExternalTypeOf(SampleType1::class) } returns true
+            every { hasSourceExternalTypeOf(SampleType2::class) } returns false
+        }
+        val declaration2: KoSourceDeclarationProvider = mockk {
+            every { hasSourceExternalTypeOf(SampleType1::class) } returns false
+            every { hasSourceExternalTypeOf(SampleType2::class) } returns true
+        }
+        val declaration3: KoSourceDeclarationProvider = mockk {
+            every { hasSourceExternalTypeOf(SampleType1::class) } returns false
+            every { hasSourceExternalTypeOf(SampleType2::class) } returns false
+        }
+        val declarations = listOf(declaration1, declaration2, declaration3)
+
+        // when
+        val sut = declarations.withoutSourceExternalTypeOf(SampleType1::class, SampleType2::class)
+
+        // then
+        sut shouldBeEqualTo listOf(declaration3)
     }
 }


### PR DESCRIPTION
Now `KoTypeDeclaration` has access to properties:
- `sourceDeclaration: KoBaseTypeDeclaration`
- `sourceClass: KoClassDeclaration?`
- `sourceObject: KoObjectDeclaration?`
- `sourceInterface: KoInterfaceDeclaration?`
- `sourceTypeAlias: KoTypeAliasDeclaration?`
- `sourceImportAlias: KoImportAliasDeclaration?`
- `sourceKotlinType: KoKotlinTypeDeclaration?`
-  `sourceFunctionType: KoFunctionTypeDeclaration?`
- `sourceExternalType: KoExternalDeclaration?` . 

There is no need to cast `sourceDeclaration` to a specific type because Konsist provides us with dedicated properties.

Eg. Instead of writing:
```kotlin
scope
    .functions()
    .returnTypes
    .map { it.sourceDeclaration as? KoClassDeclaration }
    .assertTrue { // ... }
```

you can do in this way:
```kotlin
scope
    .functions()
    .returnTypes
    .sourceClasses
    .assertTrue { // ... }
```

Additionally, Konsist provides a set of extensions for the above properties, e.g. it can be used in this way:
```kotlin
scope
    .functions()
    .returnTypes
    .withSourceDeclarationOf(ViewModel::class)
    .assertTrue { // ... }
```