### PR TITLE
Add Missing Kotlin Basic Types - `Unit`, `Any` and `Nothing`

### DIFF
--- a/lib/src/main/kotlin/com/lemonappdev/konsist/core/util/TypeUtil.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/core/util/TypeUtil.kt
@@ -175,6 +175,9 @@ object TypeUtil {
                 "Boolean",
                 "Char",
                 "String",
+                "Unit",
+                "Any",
+                "Nothing",
             )
 
     // Collections in Kotlin are described here: https://kotlinlang.org/docs/collections-overview.html#collection


### PR DESCRIPTION
Added `Unit`, `Any` and `Nothing` to kotlin types