### PR TITLE
Use `sourceX` Properties

### DIFF
--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koimportalias/KoImportAliasDeclarationForKoContainingDeclarationProviderTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koimportalias/KoImportAliasDeclarationForKoContainingDeclarationProviderTest.kt
@@ -1,7 +1,6 @@
 package com.lemonappdev.konsist.core.declaration.koimportalias
 
 import com.lemonappdev.konsist.TestSnippetProvider
-import com.lemonappdev.konsist.api.declaration.KoImportAliasDeclaration
 import com.lemonappdev.konsist.api.provider.KoNameProvider
 import org.amshove.kluent.shouldBeEqualTo
 import org.junit.jupiter.params.ParameterizedTest
@@ -21,7 +20,7 @@ class KoImportAliasDeclarationForKoContainingDeclarationProviderTest {
                 ?.parameters
                 ?.first()
                 ?.type
-                ?.sourceDeclaration as? KoImportAliasDeclaration
+                ?.sourceImportAlias
 
         // then
         (sut?.containingDeclaration as? KoNameProvider)?.name shouldBeEqualTo "com.lemonappdev.konsist.testdata.SampleType"

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koimportalias/KoImportAliasDeclarationForKoContainingFileProviderTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koimportalias/KoImportAliasDeclarationForKoContainingFileProviderTest.kt
@@ -1,7 +1,6 @@
 package com.lemonappdev.konsist.core.declaration.koimportalias
 
 import com.lemonappdev.konsist.TestSnippetProvider
-import com.lemonappdev.konsist.api.declaration.KoImportAliasDeclaration
 import org.amshove.kluent.shouldBeEqualTo
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.Arguments.arguments
@@ -20,7 +19,7 @@ class KoImportAliasDeclarationForKoContainingFileProviderTest {
                 ?.parameters
                 ?.first()
                 ?.type
-                ?.sourceDeclaration as? KoImportAliasDeclaration
+                ?.sourceImportAlias
 
         // then
         sut?.containingFile?.nameWithExtension shouldBeEqualTo "$fileName.kt"

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koimportalias/KoImportAliasDeclarationForKoLocationProviderTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koimportalias/KoImportAliasDeclarationForKoLocationProviderTest.kt
@@ -1,7 +1,6 @@
 package com.lemonappdev.konsist.core.declaration.koimportalias
 
 import com.lemonappdev.konsist.TestSnippetProvider
-import com.lemonappdev.konsist.api.declaration.KoImportAliasDeclaration
 import org.amshove.kluent.shouldBeEqualTo
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.Arguments.arguments
@@ -20,7 +19,7 @@ class KoImportAliasDeclarationForKoLocationProviderTest {
                 ?.parameters
                 ?.first()
                 ?.type
-                ?.sourceDeclaration as? KoImportAliasDeclaration
+                ?.sourceImportAlias
 
         // then
         sut?.location shouldBeEqualTo "${sut?.path}:1:52"

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koimportalias/KoImportAliasDeclarationForKoNameProviderTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koimportalias/KoImportAliasDeclarationForKoNameProviderTest.kt
@@ -1,7 +1,6 @@
 package com.lemonappdev.konsist.core.declaration.koimportalias
 
 import com.lemonappdev.konsist.TestSnippetProvider
-import com.lemonappdev.konsist.api.declaration.KoImportAliasDeclaration
 import org.amshove.kluent.shouldBeEqualTo
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.Arguments.arguments
@@ -23,7 +22,7 @@ class KoImportAliasDeclarationForKoNameProviderTest {
                 ?.parameters
                 ?.first()
                 ?.type
-                ?.sourceDeclaration as? KoImportAliasDeclaration
+                ?.sourceImportAlias
 
         // then
         sut?.name shouldBeEqualTo value

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koimportalias/KoImportAliasDeclarationForKoPackageProviderTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koimportalias/KoImportAliasDeclarationForKoPackageProviderTest.kt
@@ -1,7 +1,6 @@
 package com.lemonappdev.konsist.core.declaration.koimportalias
 
 import com.lemonappdev.konsist.TestSnippetProvider
-import com.lemonappdev.konsist.api.declaration.KoImportAliasDeclaration
 import org.amshove.kluent.shouldBeEqualTo
 import org.junit.jupiter.api.Test
 
@@ -17,7 +16,7 @@ class KoImportAliasDeclarationForKoPackageProviderTest {
                 ?.parameters
                 ?.first()
                 ?.type
-                ?.sourceDeclaration as? KoImportAliasDeclaration
+                ?.sourceImportAlias
 
         // then
         sut?.packagee shouldBeEqualTo null
@@ -34,7 +33,7 @@ class KoImportAliasDeclarationForKoPackageProviderTest {
                 ?.parameters
                 ?.first()
                 ?.type
-                ?.sourceDeclaration as? KoImportAliasDeclaration
+                ?.sourceImportAlias
 
         // then
         sut?.packagee?.fullyQualifiedName shouldBeEqualTo "com.samplepackage"

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koimportalias/KoImportAliasDeclarationForKoPathProviderTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koimportalias/KoImportAliasDeclarationForKoPathProviderTest.kt
@@ -1,7 +1,6 @@
 package com.lemonappdev.konsist.core.declaration.koimportalias
 
 import com.lemonappdev.konsist.TestSnippetProvider
-import com.lemonappdev.konsist.api.declaration.KoImportAliasDeclaration
 import org.amshove.kluent.assertSoftly
 import org.amshove.kluent.shouldBeEqualTo
 import org.junit.jupiter.params.ParameterizedTest
@@ -21,7 +20,7 @@ class KoImportAliasDeclarationForKoPathProviderTest {
                 ?.parameters
                 ?.first()
                 ?.type
-                ?.sourceDeclaration as? KoImportAliasDeclaration
+                ?.sourceImportAlias
 
         // then
         assertSoftly(sut?.path) {
@@ -42,7 +41,7 @@ class KoImportAliasDeclarationForKoPathProviderTest {
                 ?.parameters
                 ?.first()
                 ?.type
-                ?.sourceDeclaration as? KoImportAliasDeclaration
+                ?.sourceImportAlias
 
         // then
         sut
@@ -65,7 +64,7 @@ class KoImportAliasDeclarationForKoPathProviderTest {
                 ?.parameters
                 ?.first()
                 ?.type
-                ?.sourceDeclaration as? KoImportAliasDeclaration
+                ?.sourceImportAlias
 
         // then
         assertSoftly(sut) {
@@ -88,7 +87,7 @@ class KoImportAliasDeclarationForKoPathProviderTest {
                 ?.parameters
                 ?.first()
                 ?.type
-                ?.sourceDeclaration as? KoImportAliasDeclaration
+                ?.sourceImportAlias
 
         // then
         assertSoftly(sut) {

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koimportalias/KoImportAliasDeclarationForKoResideInPackageProviderTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koimportalias/KoImportAliasDeclarationForKoResideInPackageProviderTest.kt
@@ -1,7 +1,6 @@
 package com.lemonappdev.konsist.core.declaration.koimportalias
 
 import com.lemonappdev.konsist.TestSnippetProvider
-import com.lemonappdev.konsist.api.declaration.KoImportAliasDeclaration
 import org.amshove.kluent.assertSoftly
 import org.amshove.kluent.shouldBeEqualTo
 import org.junit.jupiter.api.Test
@@ -18,7 +17,7 @@ class KoImportAliasDeclarationForKoResideInPackageProviderTest {
                 ?.parameters
                 ?.first()
                 ?.type
-                ?.sourceDeclaration as? KoImportAliasDeclaration
+                ?.sourceImportAlias
 
         // then
         assertSoftly(sut) {

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koimportalias/KoImportAliasDeclarationForKoTextProviderTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koimportalias/KoImportAliasDeclarationForKoTextProviderTest.kt
@@ -1,7 +1,6 @@
 package com.lemonappdev.konsist.core.declaration.koimportalias
 
 import com.lemonappdev.konsist.TestSnippetProvider
-import com.lemonappdev.konsist.api.declaration.KoImportAliasDeclaration
 import org.amshove.kluent.shouldBeEqualTo
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.Arguments.arguments
@@ -23,7 +22,7 @@ class KoImportAliasDeclarationForKoTextProviderTest {
                 ?.parameters
                 ?.first()
                 ?.type
-                ?.sourceDeclaration as? KoImportAliasDeclaration
+                ?.sourceImportAlias
 
         // then
         sut?.text shouldBeEqualTo value

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koimportalias/KoImportAliasDeclarationTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koimportalias/KoImportAliasDeclarationTest.kt
@@ -1,7 +1,6 @@
 package com.lemonappdev.konsist.core.declaration.koimportalias
 
 import com.lemonappdev.konsist.TestSnippetProvider
-import com.lemonappdev.konsist.api.declaration.KoImportAliasDeclaration
 import org.amshove.kluent.shouldBeEqualTo
 import org.junit.jupiter.api.Test
 
@@ -14,7 +13,7 @@ class KoImportAliasDeclarationTest {
                 .properties()
                 .first()
                 .type
-                ?.sourceDeclaration as? KoImportAliasDeclaration
+                ?.sourceImportAlias
 
         // then
         sut.toString() shouldBeEqualTo "ImportAlias"
@@ -28,7 +27,7 @@ class KoImportAliasDeclarationTest {
                 .properties()
                 .first()
                 .type
-                ?.sourceDeclaration as? KoImportAliasDeclaration
+                ?.sourceImportAlias
 
         // then
         sut?.importDirective?.name shouldBeEqualTo "com.lemonappdev.konsist.testdata.SampleType"

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/type/kofunctiontype/KoFunctionTypeDeclarationForKoContainingDeclarationProviderTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/type/kofunctiontype/KoFunctionTypeDeclarationForKoContainingDeclarationProviderTest.kt
@@ -1,7 +1,6 @@
 package com.lemonappdev.konsist.core.declaration.type.kofunctiontype
 
 import com.lemonappdev.konsist.TestSnippetProvider
-import com.lemonappdev.konsist.api.declaration.type.KoFunctionTypeDeclaration
 import com.lemonappdev.konsist.api.provider.KoNameProvider
 import org.amshove.kluent.shouldBeEqualTo
 import org.junit.jupiter.params.ParameterizedTest
@@ -21,7 +20,7 @@ class KoFunctionTypeDeclarationForKoContainingDeclarationProviderTest {
                 ?.parameters
                 ?.first()
                 ?.type
-                ?.sourceDeclaration as? KoFunctionTypeDeclaration
+                ?.sourceFunctionType
 
         // then
         (sut?.containingDeclaration as? KoNameProvider)?.name shouldBeEqualTo fileName

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/type/kofunctiontype/KoFunctionTypeDeclarationForKoContainingFileProviderTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/type/kofunctiontype/KoFunctionTypeDeclarationForKoContainingFileProviderTest.kt
@@ -1,7 +1,6 @@
 package com.lemonappdev.konsist.core.declaration.type.kofunctiontype
 
 import com.lemonappdev.konsist.TestSnippetProvider
-import com.lemonappdev.konsist.api.declaration.type.KoFunctionTypeDeclaration
 import org.amshove.kluent.shouldBeEqualTo
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.Arguments.arguments
@@ -20,7 +19,7 @@ class KoFunctionTypeDeclarationForKoContainingFileProviderTest {
                 ?.parameters
                 ?.first()
                 ?.type
-                ?.sourceDeclaration as? KoFunctionTypeDeclaration
+                ?.sourceFunctionType
 
         // then
         sut?.containingFile?.nameWithExtension shouldBeEqualTo "$fileName.kt"

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/type/kofunctiontype/KoFunctionTypeDeclarationForKoLocationProviderTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/type/kofunctiontype/KoFunctionTypeDeclarationForKoLocationProviderTest.kt
@@ -1,7 +1,6 @@
 package com.lemonappdev.konsist.core.declaration.type.kofunctiontype
 
 import com.lemonappdev.konsist.TestSnippetProvider
-import com.lemonappdev.konsist.api.declaration.type.KoFunctionTypeDeclaration
 import org.amshove.kluent.shouldBeEqualTo
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.Arguments.arguments
@@ -23,7 +22,7 @@ class KoFunctionTypeDeclarationForKoLocationProviderTest {
                 ?.parameters
                 ?.first()
                 ?.type
-                ?.sourceDeclaration as? KoFunctionTypeDeclaration
+                ?.sourceFunctionType
 
         // then
         sut?.location shouldBeEqualTo "${sut?.path}:$value"

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/type/kofunctiontype/KoFunctionTypeDeclarationForKoNameProviderTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/type/kofunctiontype/KoFunctionTypeDeclarationForKoNameProviderTest.kt
@@ -1,7 +1,6 @@
 package com.lemonappdev.konsist.core.declaration.type.kofunctiontype
 
 import com.lemonappdev.konsist.TestSnippetProvider
-import com.lemonappdev.konsist.api.declaration.type.KoFunctionTypeDeclaration
 import org.amshove.kluent.shouldBeEqualTo
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.Arguments.arguments
@@ -23,7 +22,7 @@ class KoFunctionTypeDeclarationForKoNameProviderTest {
                 ?.parameters
                 ?.first()
                 ?.type
-                ?.sourceDeclaration as? KoFunctionTypeDeclaration
+                ?.sourceFunctionType
 
         // then
         sut?.name shouldBeEqualTo value

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/type/kofunctiontype/KoFunctionTypeDeclarationForKoPackageProviderTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/type/kofunctiontype/KoFunctionTypeDeclarationForKoPackageProviderTest.kt
@@ -1,7 +1,6 @@
 package com.lemonappdev.konsist.core.declaration.type.kofunctiontype
 
 import com.lemonappdev.konsist.TestSnippetProvider
-import com.lemonappdev.konsist.api.declaration.type.KoFunctionTypeDeclaration
 import org.amshove.kluent.shouldBeEqualTo
 import org.junit.jupiter.api.Test
 
@@ -17,7 +16,7 @@ class KoFunctionTypeDeclarationForKoPackageProviderTest {
                 ?.parameters
                 ?.first()
                 ?.type
-                ?.sourceDeclaration as? KoFunctionTypeDeclaration
+                ?.sourceFunctionType
 
         // then
         sut?.packagee shouldBeEqualTo null
@@ -34,7 +33,7 @@ class KoFunctionTypeDeclarationForKoPackageProviderTest {
                 ?.parameters
                 ?.first()
                 ?.type
-                ?.sourceDeclaration as? KoFunctionTypeDeclaration
+                ?.sourceFunctionType
 
         // then
         sut?.packagee?.fullyQualifiedName shouldBeEqualTo "com.samplepackage"

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/type/kofunctiontype/KoFunctionTypeDeclarationForKoPathProviderTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/type/kofunctiontype/KoFunctionTypeDeclarationForKoPathProviderTest.kt
@@ -1,7 +1,6 @@
 package com.lemonappdev.konsist.core.declaration.type.kofunctiontype
 
 import com.lemonappdev.konsist.TestSnippetProvider
-import com.lemonappdev.konsist.api.declaration.type.KoFunctionTypeDeclaration
 import org.amshove.kluent.assertSoftly
 import org.amshove.kluent.shouldBeEqualTo
 import org.junit.jupiter.params.ParameterizedTest
@@ -21,7 +20,7 @@ class KoFunctionTypeDeclarationForKoPathProviderTest {
                 ?.parameters
                 ?.first()
                 ?.type
-                ?.sourceDeclaration as? KoFunctionTypeDeclaration
+                ?.sourceFunctionType
 
         // then
         assertSoftly(sut?.path) {
@@ -42,7 +41,7 @@ class KoFunctionTypeDeclarationForKoPathProviderTest {
                 ?.parameters
                 ?.first()
                 ?.type
-                ?.sourceDeclaration as? KoFunctionTypeDeclaration
+                ?.sourceFunctionType
 
         // then
         sut
@@ -65,7 +64,7 @@ class KoFunctionTypeDeclarationForKoPathProviderTest {
                 ?.parameters
                 ?.first()
                 ?.type
-                ?.sourceDeclaration as? KoFunctionTypeDeclaration
+                ?.sourceFunctionType
 
         // then
         assertSoftly(sut) {
@@ -88,7 +87,7 @@ class KoFunctionTypeDeclarationForKoPathProviderTest {
                 ?.parameters
                 ?.first()
                 ?.type
-                ?.sourceDeclaration as? KoFunctionTypeDeclaration
+                ?.sourceFunctionType
 
         // then
         assertSoftly(sut) {

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/type/kofunctiontype/KoFunctionTypeDeclarationForKoResideInPackageProviderTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/type/kofunctiontype/KoFunctionTypeDeclarationForKoResideInPackageProviderTest.kt
@@ -1,7 +1,6 @@
 package com.lemonappdev.konsist.core.declaration.type.kofunctiontype
 
 import com.lemonappdev.konsist.TestSnippetProvider
-import com.lemonappdev.konsist.api.declaration.type.KoFunctionTypeDeclaration
 import org.amshove.kluent.assertSoftly
 import org.amshove.kluent.shouldBeEqualTo
 import org.junit.jupiter.api.Test
@@ -18,7 +17,7 @@ class KoFunctionTypeDeclarationForKoResideInPackageProviderTest {
                 ?.parameters
                 ?.first()
                 ?.type
-                ?.sourceDeclaration as? KoFunctionTypeDeclaration
+                ?.sourceFunctionType
 
         // then
         assertSoftly(sut) {

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/type/kofunctiontype/KoFunctionTypeDeclarationForKoTextProviderTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/type/kofunctiontype/KoFunctionTypeDeclarationForKoTextProviderTest.kt
@@ -1,7 +1,6 @@
 package com.lemonappdev.konsist.core.declaration.type.kofunctiontype
 
 import com.lemonappdev.konsist.TestSnippetProvider
-import com.lemonappdev.konsist.api.declaration.type.KoFunctionTypeDeclaration
 import org.amshove.kluent.shouldBeEqualTo
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.Arguments.arguments
@@ -23,7 +22,7 @@ class KoFunctionTypeDeclarationForKoTextProviderTest {
                 ?.parameters
                 ?.first()
                 ?.type
-                ?.sourceDeclaration as? KoFunctionTypeDeclaration
+                ?.sourceFunctionType
 
         // then
         sut?.text shouldBeEqualTo value

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/type/kofunctiontype/KoFunctionTypeDeclarationTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/type/kofunctiontype/KoFunctionTypeDeclarationTest.kt
@@ -1,7 +1,6 @@
 package com.lemonappdev.konsist.core.declaration.type.kofunctiontype
 
 import com.lemonappdev.konsist.TestSnippetProvider
-import com.lemonappdev.konsist.api.declaration.type.KoFunctionTypeDeclaration
 import org.amshove.kluent.shouldBeEqualTo
 import org.junit.jupiter.api.Test
 
@@ -14,7 +13,7 @@ class KoFunctionTypeDeclarationTest {
                 .properties()
                 .first()
                 .type
-                ?.sourceDeclaration as? KoFunctionTypeDeclaration
+                ?.sourceFunctionType
 
         // then
         sut.toString() shouldBeEqualTo "() -> Unit"
@@ -28,7 +27,7 @@ class KoFunctionTypeDeclarationTest {
                 .properties()
                 .first()
                 .type
-                ?.sourceDeclaration as? KoFunctionTypeDeclaration
+                ?.sourceFunctionType
 
         // then
         sut?.parameterTypes shouldBeEqualTo emptyList()
@@ -42,7 +41,7 @@ class KoFunctionTypeDeclarationTest {
                 .properties()
                 .first()
                 .type
-                ?.sourceDeclaration as? KoFunctionTypeDeclaration
+                ?.sourceFunctionType
 
         // then
         sut?.parameterTypes?.map { it.type.name } shouldBeEqualTo listOf("String")
@@ -56,7 +55,7 @@ class KoFunctionTypeDeclarationTest {
                 .properties()
                 .first()
                 .type
-                ?.sourceDeclaration as? KoFunctionTypeDeclaration
+                ?.sourceFunctionType
 
         // then
         sut?.parameterTypes?.map { it.type.name } shouldBeEqualTo listOf("String", "List<Int>")
@@ -70,7 +69,7 @@ class KoFunctionTypeDeclarationTest {
                 .properties()
                 .first()
                 .type
-                ?.sourceDeclaration as? KoFunctionTypeDeclaration
+                ?.sourceFunctionType
 
         // then
         sut?.returnType?.name shouldBeEqualTo "Unit"
@@ -84,7 +83,7 @@ class KoFunctionTypeDeclarationTest {
                 .properties()
                 .first()
                 .type
-                ?.sourceDeclaration as? KoFunctionTypeDeclaration
+                ?.sourceFunctionType
 
         // then
         sut?.returnType?.name shouldBeEqualTo "List<String>"
@@ -98,7 +97,7 @@ class KoFunctionTypeDeclarationTest {
                 .properties()
                 .first()
                 .type
-                ?.sourceDeclaration as? KoFunctionTypeDeclaration
+                ?.sourceFunctionType
 
         // then
         sut?.returnType?.name shouldBeEqualTo "SampleClass"

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/type/kokotlintype/KoKotlinTypeDeclarationForKoFullyQualifiedNameProviderTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/type/kokotlintype/KoKotlinTypeDeclarationForKoFullyQualifiedNameProviderTest.kt
@@ -1,7 +1,6 @@
 package com.lemonappdev.konsist.core.declaration.type.kokotlintype
 
 import com.lemonappdev.konsist.TestSnippetProvider
-import com.lemonappdev.konsist.api.declaration.type.KoKotlinTypeDeclaration
 import org.amshove.kluent.shouldBeEqualTo
 import org.junit.jupiter.api.Test
 
@@ -14,7 +13,7 @@ class KoKotlinTypeDeclarationForKoFullyQualifiedNameProviderTest {
                 .properties()
                 .first()
                 .type
-                ?.sourceDeclaration as? KoKotlinTypeDeclaration
+                ?.sourceKotlinType
 
         // then
         sut?.fullyQualifiedName shouldBeEqualTo "kotlin.String"
@@ -28,7 +27,7 @@ class KoKotlinTypeDeclarationForKoFullyQualifiedNameProviderTest {
                 .properties()
                 .first()
                 .type
-                ?.sourceDeclaration as? KoKotlinTypeDeclaration
+                ?.sourceKotlinType
 
         // then
         sut?.fullyQualifiedName shouldBeEqualTo "kotlin.String"
@@ -42,7 +41,7 @@ class KoKotlinTypeDeclarationForKoFullyQualifiedNameProviderTest {
                 .properties()
                 .first()
                 .type
-                ?.sourceDeclaration as? KoKotlinTypeDeclaration
+                ?.sourceKotlinType
 
         // then
         sut?.fullyQualifiedName shouldBeEqualTo "kotlin.collections.List"
@@ -56,7 +55,7 @@ class KoKotlinTypeDeclarationForKoFullyQualifiedNameProviderTest {
                 .properties()
                 .first()
                 .type
-                ?.sourceDeclaration as? KoKotlinTypeDeclaration
+                ?.sourceKotlinType
 
         // then
         sut?.fullyQualifiedName shouldBeEqualTo "kotlin.collections.List"

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/type/kokotlintype/KoKotlinTypeDeclarationForKoNameProviderTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/type/kokotlintype/KoKotlinTypeDeclarationForKoNameProviderTest.kt
@@ -1,7 +1,6 @@
 package com.lemonappdev.konsist.core.declaration.type.kokotlintype
 
 import com.lemonappdev.konsist.TestSnippetProvider
-import com.lemonappdev.konsist.api.declaration.type.KoKotlinTypeDeclaration
 import org.amshove.kluent.shouldBeEqualTo
 import org.junit.jupiter.api.Test
 
@@ -14,7 +13,7 @@ class KoKotlinTypeDeclarationForKoNameProviderTest {
                 .properties()
                 .first()
                 .type
-                ?.sourceDeclaration as? KoKotlinTypeDeclaration
+                ?.sourceKotlinType
 
         // then
         sut?.name shouldBeEqualTo "String"
@@ -28,7 +27,7 @@ class KoKotlinTypeDeclarationForKoNameProviderTest {
                 .properties()
                 .first()
                 .type
-                ?.sourceDeclaration as? KoKotlinTypeDeclaration
+                ?.sourceKotlinType
 
         // then
         sut?.name shouldBeEqualTo "String"
@@ -42,7 +41,7 @@ class KoKotlinTypeDeclarationForKoNameProviderTest {
                 .properties()
                 .first()
                 .type
-                ?.sourceDeclaration as? KoKotlinTypeDeclaration
+                ?.sourceKotlinType
 
         // then
         sut?.name shouldBeEqualTo "List<String>"
@@ -56,7 +55,7 @@ class KoKotlinTypeDeclarationForKoNameProviderTest {
                 .properties()
                 .first()
                 .type
-                ?.sourceDeclaration as? KoKotlinTypeDeclaration
+                ?.sourceKotlinType
 
         // then
         sut?.name shouldBeEqualTo "List<String>"

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/type/kokotlintype/KoKotlinTypeDeclarationForKoPackageProviderTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/type/kokotlintype/KoKotlinTypeDeclarationForKoPackageProviderTest.kt
@@ -1,7 +1,6 @@
 package com.lemonappdev.konsist.core.declaration.type.kokotlintype
 
 import com.lemonappdev.konsist.TestSnippetProvider
-import com.lemonappdev.konsist.api.declaration.type.KoKotlinTypeDeclaration
 import org.amshove.kluent.shouldBeEqualTo
 import org.junit.jupiter.api.Test
 
@@ -14,7 +13,7 @@ class KoKotlinTypeDeclarationForKoPackageProviderTest {
                 .properties()
                 .first()
                 .type
-                ?.sourceDeclaration as? KoKotlinTypeDeclaration
+                ?.sourceKotlinType
 
         // then
         sut?.packagee?.fullyQualifiedName shouldBeEqualTo "kotlin"
@@ -28,7 +27,7 @@ class KoKotlinTypeDeclarationForKoPackageProviderTest {
                 .properties()
                 .first()
                 .type
-                ?.sourceDeclaration as? KoKotlinTypeDeclaration
+                ?.sourceKotlinType
 
         // then
         sut?.packagee?.fullyQualifiedName shouldBeEqualTo "kotlin"
@@ -42,7 +41,7 @@ class KoKotlinTypeDeclarationForKoPackageProviderTest {
                 .properties()
                 .first()
                 .type
-                ?.sourceDeclaration as? KoKotlinTypeDeclaration
+                ?.sourceKotlinType
 
         // then
         sut?.packagee?.fullyQualifiedName shouldBeEqualTo "kotlin.collections"
@@ -56,7 +55,7 @@ class KoKotlinTypeDeclarationForKoPackageProviderTest {
                 .properties()
                 .first()
                 .type
-                ?.sourceDeclaration as? KoKotlinTypeDeclaration
+                ?.sourceKotlinType
 
         // then
         sut?.packagee?.fullyQualifiedName shouldBeEqualTo "kotlin.collections"

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/type/kokotlintype/KoKotlinTypeDeclarationForKoResideInPackageProviderTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/type/kokotlintype/KoKotlinTypeDeclarationForKoResideInPackageProviderTest.kt
@@ -1,7 +1,6 @@
 package com.lemonappdev.konsist.core.declaration.type.kokotlintype
 
 import com.lemonappdev.konsist.TestSnippetProvider
-import com.lemonappdev.konsist.api.declaration.type.KoKotlinTypeDeclaration
 import org.amshove.kluent.assertSoftly
 import org.amshove.kluent.shouldBeEqualTo
 import org.junit.jupiter.api.Test
@@ -15,7 +14,7 @@ class KoKotlinTypeDeclarationForKoResideInPackageProviderTest {
                 .properties()
                 .first()
                 .type
-                ?.sourceDeclaration as? KoKotlinTypeDeclaration
+                ?.sourceKotlinType
 
         // then
         assertSoftly(sut) {
@@ -34,7 +33,7 @@ class KoKotlinTypeDeclarationForKoResideInPackageProviderTest {
                 .properties()
                 .first()
                 .type
-                ?.sourceDeclaration as? KoKotlinTypeDeclaration
+                ?.sourceKotlinType
 
         // then
         assertSoftly(sut) {
@@ -53,7 +52,7 @@ class KoKotlinTypeDeclarationForKoResideInPackageProviderTest {
                 .properties()
                 .first()
                 .type
-                ?.sourceDeclaration as? KoKotlinTypeDeclaration
+                ?.sourceKotlinType
 
         // then
         assertSoftly(sut) {
@@ -72,7 +71,7 @@ class KoKotlinTypeDeclarationForKoResideInPackageProviderTest {
                 .properties()
                 .first()
                 .type
-                ?.sourceDeclaration as? KoKotlinTypeDeclaration
+                ?.sourceKotlinType
 
         // then
         assertSoftly(sut) {

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/type/kokotlintype/KoKotlinTypeDeclarationForKoTextProviderTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/type/kokotlintype/KoKotlinTypeDeclarationForKoTextProviderTest.kt
@@ -1,7 +1,6 @@
 package com.lemonappdev.konsist.core.declaration.type.kokotlintype
 
 import com.lemonappdev.konsist.TestSnippetProvider
-import com.lemonappdev.konsist.api.declaration.type.KoKotlinTypeDeclaration
 import org.amshove.kluent.shouldBeEqualTo
 import org.junit.jupiter.api.Test
 
@@ -14,7 +13,7 @@ class KoKotlinTypeDeclarationForKoTextProviderTest {
                 .properties()
                 .first()
                 .type
-                ?.sourceDeclaration as? KoKotlinTypeDeclaration
+                ?.sourceKotlinType
 
         // then
         sut?.text shouldBeEqualTo "String"
@@ -28,7 +27,7 @@ class KoKotlinTypeDeclarationForKoTextProviderTest {
                 .properties()
                 .first()
                 .type
-                ?.sourceDeclaration as? KoKotlinTypeDeclaration
+                ?.sourceKotlinType
 
         // then
         sut?.text shouldBeEqualTo "String"
@@ -42,7 +41,7 @@ class KoKotlinTypeDeclarationForKoTextProviderTest {
                 .properties()
                 .first()
                 .type
-                ?.sourceDeclaration as? KoKotlinTypeDeclaration
+                ?.sourceKotlinType
 
         // then
         sut?.text shouldBeEqualTo "List<String>"
@@ -56,7 +55,7 @@ class KoKotlinTypeDeclarationForKoTextProviderTest {
                 .properties()
                 .first()
                 .type
-                ?.sourceDeclaration as? KoKotlinTypeDeclaration
+                ?.sourceKotlinType
 
         // then
         sut?.text shouldBeEqualTo "List<String>"

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/type/kokotlintype/KoKotlinTypeDeclarationTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/type/kokotlintype/KoKotlinTypeDeclarationTest.kt
@@ -1,7 +1,6 @@
 package com.lemonappdev.konsist.core.declaration.type.kokotlintype
 
 import com.lemonappdev.konsist.TestSnippetProvider
-import com.lemonappdev.konsist.api.declaration.type.KoKotlinTypeDeclaration
 import org.amshove.kluent.shouldBeEqualTo
 import org.junit.jupiter.api.Test
 
@@ -14,7 +13,7 @@ class KoKotlinTypeDeclarationTest {
                 .properties()
                 .first()
                 .type
-                ?.sourceDeclaration as? KoKotlinTypeDeclaration
+                ?.sourceKotlinType
 
         // then
         sut?.toString() shouldBeEqualTo "String"
@@ -28,7 +27,7 @@ class KoKotlinTypeDeclarationTest {
                 .properties()
                 .first()
                 .type
-                ?.sourceDeclaration as? KoKotlinTypeDeclaration
+                ?.sourceKotlinType
 
         // then
         sut?.toString() shouldBeEqualTo "String"
@@ -42,7 +41,7 @@ class KoKotlinTypeDeclarationTest {
                 .properties()
                 .first()
                 .type
-                ?.sourceDeclaration as? KoKotlinTypeDeclaration
+                ?.sourceKotlinType
 
         // then
         sut?.toString() shouldBeEqualTo "List<String>"
@@ -56,7 +55,7 @@ class KoKotlinTypeDeclarationTest {
                 .properties()
                 .first()
                 .type
-                ?.sourceDeclaration as? KoKotlinTypeDeclaration
+                ?.sourceKotlinType
 
         // then
         sut?.toString() shouldBeEqualTo "List<String>"

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/KoGenericTypeProviderCore.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/KoGenericTypeProviderCore.kt
@@ -1,6 +1,5 @@
 package com.lemonappdev.konsist.core.provider
 
-import com.lemonappdev.konsist.api.declaration.KoTypeAliasDeclaration
 import com.lemonappdev.konsist.api.declaration.type.KoTypeDeclaration
 import com.lemonappdev.konsist.api.provider.KoGenericTypeProvider
 
@@ -13,7 +12,7 @@ internal interface KoGenericTypeProviderCore :
             val regex = "\\w+<[^<>]+>".toRegex()
 
             val type =
-                if ((this as? KoTypeDeclaration)?.sourceDeclaration is KoTypeAliasDeclaration) {
+                if ((this as? KoTypeDeclaration)?.isTypeAlias == true) {
                     bareSourceType
                 } else {
                     sourceType

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/KoSourceAndAliasTypeProviderCore.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/KoSourceAndAliasTypeProviderCore.kt
@@ -1,8 +1,6 @@
 package com.lemonappdev.konsist.core.provider
 
 import com.lemonappdev.konsist.api.declaration.KoFileDeclaration
-import com.lemonappdev.konsist.api.declaration.KoImportAliasDeclaration
-import com.lemonappdev.konsist.api.declaration.KoTypeAliasDeclaration
 import com.lemonappdev.konsist.api.declaration.type.KoTypeDeclaration
 import com.lemonappdev.konsist.api.provider.KoSourceAndAliasTypeProvider
 import com.lemonappdev.konsist.core.declaration.KoFileDeclarationCore
@@ -18,7 +16,7 @@ internal interface KoSourceAndAliasTypeProviderCore :
         get() = KoFileDeclarationCore(ktElement.containingKtFile)
 
     override val isAlias: Boolean
-        get() = (this as? KoTypeDeclaration)?.sourceDeclaration is KoImportAliasDeclaration
+        get() = (this as? KoTypeDeclaration)?.isImportAlias == true
 
     override val sourceType: String
         get() =
@@ -36,8 +34,8 @@ internal interface KoSourceAndAliasTypeProviderCore :
 
     override val bareSourceType: String
         get() =
-            if ((this as? KoTypeDeclaration)?.sourceDeclaration is KoTypeAliasDeclaration) {
-                ((this as? KoTypeDeclaration)?.sourceDeclaration as? KoTypeAliasDeclaration)?.type?.text ?: text
+            if ((this as? KoTypeDeclaration)?.isTypeAlias == true) {
+                ((this as? KoTypeDeclaration)?.sourceTypeAlias)?.type?.text ?: text
             } else {
                 sourceType
                     .removeGenericTypeArguments()

--- a/test-projects/konsist-declaration-tester/app/src/integrationTest/kotlin/com/lemonappdev/konsist/declaration/koimportalias/KoImportAliasForKoModuleProviderTest.kt
+++ b/test-projects/konsist-declaration-tester/app/src/integrationTest/kotlin/com/lemonappdev/konsist/declaration/koimportalias/KoImportAliasForKoModuleProviderTest.kt
@@ -23,7 +23,7 @@ class KoImportAliasForKoModuleProviderTest {
             .properties()
             .first { it.name == "appPropertyWithImportAliasType" }
             .type
-            ?.sourceDeclaration as KoImportAliasDeclaration
+            ?.sourceImportAlias
 
         // then
         assertSoftly(sut) {
@@ -41,7 +41,7 @@ class KoImportAliasForKoModuleProviderTest {
             .properties()
             .first { it.name == "libPropertyWithImportAliasType" }
             .type
-            ?.sourceDeclaration as KoImportAliasDeclaration
+            ?.sourceImportAlias
 
         // then
         assertSoftly(sut) {
@@ -59,7 +59,7 @@ class KoImportAliasForKoModuleProviderTest {
             .properties()
             .first { it.name == "rootPropertyWithImportAliasType" }
             .type
-            ?.sourceDeclaration as KoImportAliasDeclaration
+            ?.sourceImportAlias
 
         // then
         assertSoftly(sut) {

--- a/test-projects/konsist-declaration-tester/app/src/integrationTest/kotlin/com/lemonappdev/konsist/declaration/koimportalias/KoImportAliasForKoModuleProviderTest.kt
+++ b/test-projects/konsist-declaration-tester/app/src/integrationTest/kotlin/com/lemonappdev/konsist/declaration/koimportalias/KoImportAliasForKoModuleProviderTest.kt
@@ -27,9 +27,9 @@ class KoImportAliasForKoModuleProviderTest {
 
         // then
         assertSoftly(sut) {
-            moduleName shouldBeEqualTo app
-            resideInModule(app) shouldBeEqualTo true
-            resideInModule(data) shouldBeEqualTo false
+            it?.moduleName shouldBeEqualTo app
+            it?.resideInModule(app) shouldBeEqualTo true
+            it?.resideInModule(data) shouldBeEqualTo false
         }
     }
 
@@ -45,9 +45,9 @@ class KoImportAliasForKoModuleProviderTest {
 
         // then
         assertSoftly(sut) {
-            moduleName shouldBeEqualTo data
-            resideInModule(data) shouldBeEqualTo true
-            resideInModule(app) shouldBeEqualTo false
+            it?.moduleName shouldBeEqualTo data
+            it?.resideInModule(data) shouldBeEqualTo true
+            it?.resideInModule(app) shouldBeEqualTo false
         }
     }
 
@@ -63,9 +63,9 @@ class KoImportAliasForKoModuleProviderTest {
 
         // then
         assertSoftly(sut) {
-            moduleName shouldBeEqualTo root
-            resideInModule(root) shouldBeEqualTo true
-            resideInModule(app) shouldBeEqualTo false
+            it?.moduleName shouldBeEqualTo root
+            it?.resideInModule(root) shouldBeEqualTo true
+            it?.resideInModule(app) shouldBeEqualTo false
         }
     }
 }

--- a/test-projects/konsist-declaration-tester/app/src/integrationTest/kotlin/com/lemonappdev/konsist/declaration/koimportalias/KoImportAliasForKoSourceSetProviderTest.kt
+++ b/test-projects/konsist-declaration-tester/app/src/integrationTest/kotlin/com/lemonappdev/konsist/declaration/koimportalias/KoImportAliasForKoSourceSetProviderTest.kt
@@ -21,7 +21,7 @@ class KoImportAliasForKoSourceSetProviderTest {
             .properties()
             .first { it.name == "appPropertyWithImportAliasType" }
             .type
-            ?.sourceDeclaration as KoImportAliasDeclaration
+            ?.sourceImportAlias
 
         // then
         assertSoftly(sut) {
@@ -39,7 +39,7 @@ class KoImportAliasForKoSourceSetProviderTest {
             .properties()
             .first { it.name == "appPropertyWithImportAliasTypeTest" }
             .type
-            ?.sourceDeclaration as KoImportAliasDeclaration
+            ?.sourceImportAlias
 
         // then
         assertSoftly(sut) {
@@ -57,7 +57,7 @@ class KoImportAliasForKoSourceSetProviderTest {
             .properties()
             .first { it.name == "libPropertyWithImportAliasType" }
             .type
-            ?.sourceDeclaration as KoImportAliasDeclaration
+            ?.sourceImportAlias
 
         // then
         assertSoftly(sut) {
@@ -75,7 +75,7 @@ class KoImportAliasForKoSourceSetProviderTest {
             .properties()
             .first { it.name == "libPropertyWithImportAliasTypeTest" }
             .type
-            ?.sourceDeclaration as KoImportAliasDeclaration
+            ?.sourceImportAlias
 
         // then
         assertSoftly(sut) {
@@ -93,7 +93,7 @@ class KoImportAliasForKoSourceSetProviderTest {
             .properties()
             .first { it.name == "rootPropertyWithImportAliasType" }
             .type
-            ?.sourceDeclaration as KoImportAliasDeclaration
+            ?.sourceImportAlias
 
         // then
         assertSoftly(sut) {
@@ -111,7 +111,7 @@ class KoImportAliasForKoSourceSetProviderTest {
             .properties()
             .first { it.name == "rootSrcPropertyWithImportAliasType" }
             .type
-            ?.sourceDeclaration as KoImportAliasDeclaration
+            ?.sourceImportAlias
 
         // then
         assertSoftly(sut) {

--- a/test-projects/konsist-declaration-tester/app/src/integrationTest/kotlin/com/lemonappdev/konsist/declaration/koimportalias/KoImportAliasForKoSourceSetProviderTest.kt
+++ b/test-projects/konsist-declaration-tester/app/src/integrationTest/kotlin/com/lemonappdev/konsist/declaration/koimportalias/KoImportAliasForKoSourceSetProviderTest.kt
@@ -25,9 +25,9 @@ class KoImportAliasForKoSourceSetProviderTest {
 
         // then
         assertSoftly(sut) {
-            sourceSetName shouldBeEqualTo MAIN
-            resideInSourceSet(MAIN) shouldBeEqualTo true
-            resideInSourceSet(TEST) shouldBeEqualTo false
+            it?.sourceSetName shouldBeEqualTo MAIN
+            it?.resideInSourceSet(MAIN) shouldBeEqualTo true
+            it?.resideInSourceSet(TEST) shouldBeEqualTo false
         }
     }
 
@@ -43,9 +43,9 @@ class KoImportAliasForKoSourceSetProviderTest {
 
         // then
         assertSoftly(sut) {
-            sourceSetName shouldBeEqualTo INTEGRATION_TEST
-            resideInSourceSet(INTEGRATION_TEST) shouldBeEqualTo true
-            resideInSourceSet(TEST) shouldBeEqualTo false
+            it?.sourceSetName shouldBeEqualTo INTEGRATION_TEST
+            it?.resideInSourceSet(INTEGRATION_TEST) shouldBeEqualTo true
+            it?.resideInSourceSet(TEST) shouldBeEqualTo false
         }
     }
 
@@ -61,9 +61,9 @@ class KoImportAliasForKoSourceSetProviderTest {
 
         // then
         assertSoftly(sut) {
-            sourceSetName shouldBeEqualTo MAIN
-            resideInSourceSet(MAIN) shouldBeEqualTo true
-            resideInSourceSet(TEST) shouldBeEqualTo false
+            it?.sourceSetName shouldBeEqualTo MAIN
+            it?.resideInSourceSet(MAIN) shouldBeEqualTo true
+            it?.resideInSourceSet(TEST) shouldBeEqualTo false
         }
     }
 
@@ -79,9 +79,9 @@ class KoImportAliasForKoSourceSetProviderTest {
 
         // then
         assertSoftly(sut) {
-            sourceSetName shouldBeEqualTo TEST
-            resideInSourceSet(TEST) shouldBeEqualTo true
-            resideInSourceSet(INTEGRATION_TEST) shouldBeEqualTo false
+            it?.sourceSetName shouldBeEqualTo TEST
+            it?.resideInSourceSet(TEST) shouldBeEqualTo true
+            it?.resideInSourceSet(INTEGRATION_TEST) shouldBeEqualTo false
         }
     }
 
@@ -97,9 +97,9 @@ class KoImportAliasForKoSourceSetProviderTest {
 
         // then
         assertSoftly(sut) {
-            sourceSetName shouldBeEqualTo MAIN
-            resideInSourceSet(MAIN) shouldBeEqualTo true
-            resideInSourceSet(TEST) shouldBeEqualTo false
+            it?.sourceSetName shouldBeEqualTo MAIN
+            it?.resideInSourceSet(MAIN) shouldBeEqualTo true
+            it?.resideInSourceSet(TEST) shouldBeEqualTo false
         }
     }
 
@@ -115,9 +115,9 @@ class KoImportAliasForKoSourceSetProviderTest {
 
         // then
         assertSoftly(sut) {
-            sourceSetName shouldBeEqualTo MAIN
-            resideInSourceSet(MAIN) shouldBeEqualTo true
-            resideInSourceSet(TEST) shouldBeEqualTo false
+            it?.sourceSetName shouldBeEqualTo MAIN
+            it?.resideInSourceSet(MAIN) shouldBeEqualTo true
+            it?.resideInSourceSet(TEST) shouldBeEqualTo false
         }
     }
 

--- a/test-projects/konsist-declaration-tester/app/src/integrationTest/kotlin/com/lemonappdev/konsist/declaration/type/kofunctiontype/KoFunctionTypeForKoModuleProviderTest.kt
+++ b/test-projects/konsist-declaration-tester/app/src/integrationTest/kotlin/com/lemonappdev/konsist/declaration/type/kofunctiontype/KoFunctionTypeForKoModuleProviderTest.kt
@@ -28,9 +28,9 @@ class KoFunctionTypeForKoModuleProviderTest {
 
         // then
         assertSoftly(sut) {
-            moduleName shouldBeEqualTo app
-            resideInModule(app) shouldBeEqualTo true
-            resideInModule(data) shouldBeEqualTo false
+            it?.moduleName shouldBeEqualTo app
+            it?.resideInModule(app) shouldBeEqualTo true
+            it?.resideInModule(data) shouldBeEqualTo false
         }
     }
 
@@ -46,9 +46,9 @@ class KoFunctionTypeForKoModuleProviderTest {
 
         // then
         assertSoftly(sut) {
-            moduleName shouldBeEqualTo data
-            resideInModule(data) shouldBeEqualTo true
-            resideInModule(app) shouldBeEqualTo false
+            it?.moduleName shouldBeEqualTo data
+            it?.resideInModule(data) shouldBeEqualTo true
+            it?.resideInModule(app) shouldBeEqualTo false
         }
     }
 
@@ -64,9 +64,9 @@ class KoFunctionTypeForKoModuleProviderTest {
 
         // then
         assertSoftly(sut) {
-            moduleName shouldBeEqualTo root
-            resideInModule(root) shouldBeEqualTo true
-            resideInModule(app) shouldBeEqualTo false
+            it?.moduleName shouldBeEqualTo root
+            it?.resideInModule(root) shouldBeEqualTo true
+            it?.resideInModule(app) shouldBeEqualTo false
         }
     }
 }

--- a/test-projects/konsist-declaration-tester/app/src/integrationTest/kotlin/com/lemonappdev/konsist/declaration/type/kofunctiontype/KoFunctionTypeForKoModuleProviderTest.kt
+++ b/test-projects/konsist-declaration-tester/app/src/integrationTest/kotlin/com/lemonappdev/konsist/declaration/type/kofunctiontype/KoFunctionTypeForKoModuleProviderTest.kt
@@ -24,7 +24,7 @@ class KoFunctionTypeForKoModuleProviderTest {
             .properties()
             .first { it.name == "appPropertyWithFunctionType" }
             .type
-            ?.sourceDeclaration as KoFunctionTypeDeclaration
+            ?.sourceFunctionType
 
         // then
         assertSoftly(sut) {
@@ -42,7 +42,7 @@ class KoFunctionTypeForKoModuleProviderTest {
             .properties()
             .first { it.name == "libPropertyWithFunctionType" }
             .type
-            ?.sourceDeclaration as KoFunctionTypeDeclaration
+            ?.sourceFunctionType
 
         // then
         assertSoftly(sut) {
@@ -60,7 +60,7 @@ class KoFunctionTypeForKoModuleProviderTest {
             .properties()
             .first { it.name == "rootPropertyWithFunctionType" }
             .type
-            ?.sourceDeclaration as KoFunctionTypeDeclaration
+            ?.sourceFunctionType
 
         // then
         assertSoftly(sut) {

--- a/test-projects/konsist-declaration-tester/app/src/integrationTest/kotlin/com/lemonappdev/konsist/declaration/type/kofunctiontype/KoFunctionTypeForKoSourceSetProviderTest.kt
+++ b/test-projects/konsist-declaration-tester/app/src/integrationTest/kotlin/com/lemonappdev/konsist/declaration/type/kofunctiontype/KoFunctionTypeForKoSourceSetProviderTest.kt
@@ -25,9 +25,9 @@ class KoFunctionTypeForKoSourceSetProviderTest {
 
         // then
         assertSoftly(sut) {
-            sourceSetName shouldBeEqualTo MAIN
-            resideInSourceSet(MAIN) shouldBeEqualTo true
-            resideInSourceSet(TEST) shouldBeEqualTo false
+            it?.sourceSetName shouldBeEqualTo MAIN
+            it?.resideInSourceSet(MAIN) shouldBeEqualTo true
+            it?.resideInSourceSet(TEST) shouldBeEqualTo false
         }
     }
 
@@ -43,9 +43,9 @@ class KoFunctionTypeForKoSourceSetProviderTest {
 
         // then
         assertSoftly(sut) {
-            sourceSetName shouldBeEqualTo INTEGRATION_TEST
-            resideInSourceSet(INTEGRATION_TEST) shouldBeEqualTo true
-            resideInSourceSet(TEST) shouldBeEqualTo false
+            it?.sourceSetName shouldBeEqualTo INTEGRATION_TEST
+            it?.resideInSourceSet(INTEGRATION_TEST) shouldBeEqualTo true
+            it?.resideInSourceSet(TEST) shouldBeEqualTo false
         }
     }
 
@@ -61,9 +61,9 @@ class KoFunctionTypeForKoSourceSetProviderTest {
 
         // then
         assertSoftly(sut) {
-            sourceSetName shouldBeEqualTo MAIN
-            resideInSourceSet(MAIN) shouldBeEqualTo true
-            resideInSourceSet(TEST) shouldBeEqualTo false
+            it?.sourceSetName shouldBeEqualTo MAIN
+            it?.resideInSourceSet(MAIN) shouldBeEqualTo true
+            it?.resideInSourceSet(TEST) shouldBeEqualTo false
         }
     }
 
@@ -79,9 +79,9 @@ class KoFunctionTypeForKoSourceSetProviderTest {
 
         // then
         assertSoftly(sut) {
-            sourceSetName shouldBeEqualTo TEST
-            resideInSourceSet(TEST) shouldBeEqualTo true
-            resideInSourceSet(INTEGRATION_TEST) shouldBeEqualTo false
+            it?.sourceSetName shouldBeEqualTo TEST
+            it?.resideInSourceSet(TEST) shouldBeEqualTo true
+            it?.resideInSourceSet(INTEGRATION_TEST) shouldBeEqualTo false
         }
     }
 
@@ -97,9 +97,9 @@ class KoFunctionTypeForKoSourceSetProviderTest {
 
         // then
         assertSoftly(sut) {
-            sourceSetName shouldBeEqualTo MAIN
-            resideInSourceSet(MAIN) shouldBeEqualTo true
-            resideInSourceSet(TEST) shouldBeEqualTo false
+            it?.sourceSetName shouldBeEqualTo MAIN
+            it?.resideInSourceSet(MAIN) shouldBeEqualTo true
+            it?.resideInSourceSet(TEST) shouldBeEqualTo false
         }
     }
 
@@ -115,9 +115,9 @@ class KoFunctionTypeForKoSourceSetProviderTest {
 
         // then
         assertSoftly(sut) {
-            sourceSetName shouldBeEqualTo MAIN
-            resideInSourceSet(MAIN) shouldBeEqualTo true
-            resideInSourceSet(TEST) shouldBeEqualTo false
+            it?.sourceSetName shouldBeEqualTo MAIN
+            it?.resideInSourceSet(MAIN) shouldBeEqualTo true
+            it?.resideInSourceSet(TEST) shouldBeEqualTo false
         }
     }
 

--- a/test-projects/konsist-declaration-tester/app/src/integrationTest/kotlin/com/lemonappdev/konsist/declaration/type/kofunctiontype/KoFunctionTypeForKoSourceSetProviderTest.kt
+++ b/test-projects/konsist-declaration-tester/app/src/integrationTest/kotlin/com/lemonappdev/konsist/declaration/type/kofunctiontype/KoFunctionTypeForKoSourceSetProviderTest.kt
@@ -21,7 +21,7 @@ class KoFunctionTypeForKoSourceSetProviderTest {
             .properties()
             .first { it.name == "appPropertyWithFunctionType" }
             .type
-            ?.sourceDeclaration as KoFunctionTypeDeclaration
+            ?.sourceFunctionType
 
         // then
         assertSoftly(sut) {
@@ -39,7 +39,7 @@ class KoFunctionTypeForKoSourceSetProviderTest {
             .properties()
             .first { it.name == "appPropertyWithFunctionTypeTest" }
             .type
-            ?.sourceDeclaration as KoFunctionTypeDeclaration
+            ?.sourceFunctionType
 
         // then
         assertSoftly(sut) {
@@ -57,7 +57,7 @@ class KoFunctionTypeForKoSourceSetProviderTest {
             .properties()
             .first { it.name == "libPropertyWithFunctionType" }
             .type
-            ?.sourceDeclaration as KoFunctionTypeDeclaration
+            ?.sourceFunctionType
 
         // then
         assertSoftly(sut) {
@@ -75,7 +75,7 @@ class KoFunctionTypeForKoSourceSetProviderTest {
             .properties()
             .first { it.name == "libPropertyWithFunctionTypeTest" }
             .type
-            ?.sourceDeclaration as KoFunctionTypeDeclaration
+            ?.sourceFunctionType
 
         // then
         assertSoftly(sut) {
@@ -93,7 +93,7 @@ class KoFunctionTypeForKoSourceSetProviderTest {
             .properties()
             .first { it.name == "rootPropertyWithFunctionType" }
             .type
-            ?.sourceDeclaration as KoFunctionTypeDeclaration
+            ?.sourceFunctionType
 
         // then
         assertSoftly(sut) {
@@ -111,7 +111,7 @@ class KoFunctionTypeForKoSourceSetProviderTest {
             .properties()
             .first { it.name == "rootSrcPropertyWithFunctionType" }
             .type
-            ?.sourceDeclaration as KoFunctionTypeDeclaration
+            ?.sourceFunctionType
 
         // then
         assertSoftly(sut) {


### PR DESCRIPTION
Use into a Konsist code dedicated properties `sourceX` instead of `?.sourceDeclaration as? KoXDeclaration`