### PR TITLE
KON-616 Add ability to pass collections to functions in providers

### DIFF
--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koannotation/KoAnnotationDeclarationForKoArgumentProviderTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koannotation/KoAnnotationDeclarationForKoArgumentProviderTest.kt
@@ -22,8 +22,16 @@ class KoAnnotationDeclarationForKoArgumentProviderTest {
             numArguments shouldBeEqualTo 0
             countArguments { it.value == "text" } shouldBeEqualTo 0
             hasArguments() shouldBeEqualTo false
+            hasArgumentWithName(emptyList()) shouldBeEqualTo false
+            hasArgumentWithName(emptySet()) shouldBeEqualTo false
+            hasArgumentsWithAllNames(emptyList()) shouldBeEqualTo false
+            hasArgumentsWithAllNames(emptySet()) shouldBeEqualTo false
             hasArgumentWithName("sampleArgument") shouldBeEqualTo false
+            hasArgumentWithName(listOf("sampleArgument")) shouldBeEqualTo false
+            hasArgumentWithName(setOf("sampleArgument")) shouldBeEqualTo false
             hasArgumentsWithAllNames("sampleArgument1", "sampleArgument2") shouldBeEqualTo false
+            hasArgumentsWithAllNames(listOf("sampleArgument1", "sampleArgument2")) shouldBeEqualTo false
+            hasArgumentsWithAllNames(setOf("sampleArgument1", "sampleArgument2")) shouldBeEqualTo false
             hasArgument { it.value == "text" } shouldBeEqualTo false
             hasAllArguments { it.value == "text" } shouldBeEqualTo true
         }
@@ -44,8 +52,16 @@ class KoAnnotationDeclarationForKoArgumentProviderTest {
             numArguments shouldBeEqualTo 0
             countArguments { it.value == "text" } shouldBeEqualTo 0
             hasArguments() shouldBeEqualTo false
+            hasArgumentWithName(emptyList()) shouldBeEqualTo false
+            hasArgumentWithName(emptySet()) shouldBeEqualTo false
+            hasArgumentsWithAllNames(emptyList()) shouldBeEqualTo false
+            hasArgumentsWithAllNames(emptySet()) shouldBeEqualTo false
             hasArgumentWithName("sampleArgument") shouldBeEqualTo false
+            hasArgumentWithName(listOf("sampleArgument")) shouldBeEqualTo false
+            hasArgumentWithName(setOf("sampleArgument")) shouldBeEqualTo false
             hasArgumentsWithAllNames("sampleArgument1", "sampleArgument2") shouldBeEqualTo false
+            hasArgumentsWithAllNames(listOf("sampleArgument1", "sampleArgument2")) shouldBeEqualTo false
+            hasArgumentsWithAllNames(setOf("sampleArgument1", "sampleArgument2")) shouldBeEqualTo false
             hasArgument { it.value == "text" } shouldBeEqualTo false
             hasAllArguments { it.value == "text" } shouldBeEqualTo true
         }
@@ -67,11 +83,25 @@ class KoAnnotationDeclarationForKoArgumentProviderTest {
             countArguments { it.value == "text" } shouldBeEqualTo 1
             countArguments { it.value == "other" } shouldBeEqualTo 0
             hasArguments() shouldBeEqualTo true
+            hasArgumentWithName(emptyList()) shouldBeEqualTo true
+            hasArgumentWithName(emptySet()) shouldBeEqualTo true
+            hasArgumentsWithAllNames(emptyList()) shouldBeEqualTo true
+            hasArgumentsWithAllNames(emptySet()) shouldBeEqualTo true
             hasArgumentWithName("sampleParameter") shouldBeEqualTo true
             hasArgumentWithName("otherParameter") shouldBeEqualTo false
             hasArgumentWithName("sampleParameter", "otherParameter") shouldBeEqualTo true
+            hasArgumentWithName(listOf("sampleParameter")) shouldBeEqualTo true
+            hasArgumentWithName(listOf("otherParameter")) shouldBeEqualTo false
+            hasArgumentWithName(listOf("sampleParameter", "otherParameter")) shouldBeEqualTo true
+            hasArgumentWithName(setOf("sampleParameter")) shouldBeEqualTo true
+            hasArgumentWithName(setOf("otherParameter")) shouldBeEqualTo false
+            hasArgumentWithName(setOf("sampleParameter", "otherParameter")) shouldBeEqualTo true
             hasArgumentsWithAllNames("sampleParameter") shouldBeEqualTo true
             hasArgumentsWithAllNames("sampleParameter", "otherParameter") shouldBeEqualTo false
+            hasArgumentsWithAllNames(listOf("sampleParameter")) shouldBeEqualTo true
+            hasArgumentsWithAllNames(listOf("sampleParameter", "otherParameter")) shouldBeEqualTo false
+            hasArgumentsWithAllNames(setOf("sampleParameter")) shouldBeEqualTo true
+            hasArgumentsWithAllNames(setOf("sampleParameter", "otherParameter")) shouldBeEqualTo false
             hasArgument { it.value == "text" } shouldBeEqualTo true
             hasArgument { it.value == "other" } shouldBeEqualTo false
             hasAllArguments { it.value == "text" } shouldBeEqualTo true
@@ -95,12 +125,28 @@ class KoAnnotationDeclarationForKoArgumentProviderTest {
             countArguments { it.value?.startsWith("t") ?: false } shouldBeEqualTo 2
             countArguments { it.value == "text" } shouldBeEqualTo 1
             hasArguments() shouldBeEqualTo true
+            hasArgumentWithName(emptyList()) shouldBeEqualTo true
+            hasArgumentWithName(emptySet()) shouldBeEqualTo true
+            hasArgumentsWithAllNames(emptyList()) shouldBeEqualTo true
+            hasArgumentsWithAllNames(emptySet()) shouldBeEqualTo true
             hasArgumentWithName("sampleParameter1") shouldBeEqualTo true
             hasArgumentWithName("otherParameter") shouldBeEqualTo false
             hasArgumentWithName("sampleParameter1", "otherName") shouldBeEqualTo true
+            hasArgumentWithName(listOf("sampleParameter1")) shouldBeEqualTo true
+            hasArgumentWithName(listOf("otherParameter")) shouldBeEqualTo false
+            hasArgumentWithName(listOf("sampleParameter1", "otherName")) shouldBeEqualTo true
+            hasArgumentWithName(setOf("sampleParameter1")) shouldBeEqualTo true
+            hasArgumentWithName(setOf("otherParameter")) shouldBeEqualTo false
+            hasArgumentWithName(setOf("sampleParameter1", "otherName")) shouldBeEqualTo true
             hasArgumentsWithAllNames("sampleParameter1") shouldBeEqualTo true
             hasArgumentsWithAllNames("sampleParameter1", "sampleParameter2") shouldBeEqualTo false
             hasArgumentsWithAllNames("sampleParameter1", "otherParameter") shouldBeEqualTo false
+            hasArgumentsWithAllNames(listOf("sampleParameter1")) shouldBeEqualTo true
+            hasArgumentsWithAllNames(listOf("sampleParameter1", "sampleParameter2")) shouldBeEqualTo false
+            hasArgumentsWithAllNames(listOf("sampleParameter1", "otherParameter")) shouldBeEqualTo false
+            hasArgumentsWithAllNames(setOf("sampleParameter1")) shouldBeEqualTo true
+            hasArgumentsWithAllNames(setOf("sampleParameter1", "sampleParameter2")) shouldBeEqualTo false
+            hasArgumentsWithAllNames(setOf("sampleParameter1", "otherParameter")) shouldBeEqualTo false
             hasArgument { it.value == "text" } shouldBeEqualTo true
             hasArgument { it.value == "other" } shouldBeEqualTo false
             hasAllArguments { it.value?.startsWith("t") ?: false } shouldBeEqualTo true

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koclass/KoClassDeclarationForKoAnnotationProviderTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koclass/KoClassDeclarationForKoAnnotationProviderTest.kt
@@ -25,12 +25,28 @@ class KoClassDeclarationForKoAnnotationProviderTest {
             numAnnotations shouldBeEqualTo 0
             countAnnotations { it.name == "NonExistingAnnotation" } shouldBeEqualTo 0
             hasAnnotations() shouldBeEqualTo false
+            hasAnnotationWithName(emptyList()) shouldBeEqualTo false
+            hasAnnotationWithName(emptySet()) shouldBeEqualTo false
+            hasAnnotationsWithAllNames(emptyList()) shouldBeEqualTo false
+            hasAnnotationsWithAllNames(emptySet()) shouldBeEqualTo false
             hasAnnotationWithName("SampleAnnotation") shouldBeEqualTo false
+            hasAnnotationWithName(listOf("SampleAnnotation")) shouldBeEqualTo false
+            hasAnnotationWithName(setOf("SampleAnnotation")) shouldBeEqualTo false
             hasAnnotationsWithAllNames("SampleAnnotation1", "SampleAnnotation2") shouldBeEqualTo false
+            hasAnnotationsWithAllNames(listOf("SampleAnnotation1", "SampleAnnotation2")) shouldBeEqualTo false
+            hasAnnotationsWithAllNames(setOf("SampleAnnotation1", "SampleAnnotation2")) shouldBeEqualTo false
             hasAnnotation { it.hasArguments() } shouldBeEqualTo false
             hasAllAnnotations { it.hasArguments() } shouldBeEqualTo true
+            hasAnnotationOf(emptyList()) shouldBeEqualTo false
+            hasAnnotationOf(emptySet()) shouldBeEqualTo false
+            hasAllAnnotationsOf(emptyList()) shouldBeEqualTo false
+            hasAllAnnotationsOf(emptySet()) shouldBeEqualTo false
             hasAnnotationOf(SampleAnnotation::class) shouldBeEqualTo false
+            hasAnnotationOf(listOf(SampleAnnotation::class)) shouldBeEqualTo false
+            hasAnnotationOf(setOf(SampleAnnotation::class)) shouldBeEqualTo false
             hasAllAnnotationsOf(SampleAnnotation1::class, SampleAnnotation2::class) shouldBeEqualTo false
+            hasAllAnnotationsOf(listOf(SampleAnnotation1::class, SampleAnnotation2::class)) shouldBeEqualTo false
+            hasAllAnnotationsOf(setOf(SampleAnnotation1::class, SampleAnnotation2::class)) shouldBeEqualTo false
             hasAnnotations("SampleAnnotation") shouldBeEqualTo false
         }
     }
@@ -49,6 +65,10 @@ class KoClassDeclarationForKoAnnotationProviderTest {
             countAnnotations { it.name == "SampleAnnotation" } shouldBeEqualTo 1
             countAnnotations { it.name == "NonExistingAnnotation" } shouldBeEqualTo 0
             hasAnnotations() shouldBeEqualTo true
+            hasAnnotationWithName(emptyList()) shouldBeEqualTo true
+            hasAnnotationWithName(emptySet()) shouldBeEqualTo true
+            hasAnnotationsWithAllNames(emptyList()) shouldBeEqualTo true
+            hasAnnotationsWithAllNames(emptySet()) shouldBeEqualTo true
             hasAnnotationWithName("SampleAnnotation") shouldBeEqualTo true
             hasAnnotationWithName("OtherAnnotation") shouldBeEqualTo false
             hasAnnotationWithName("SampleAnnotation", "OtherAnnotation") shouldBeEqualTo true
@@ -58,6 +78,24 @@ class KoClassDeclarationForKoAnnotationProviderTest {
                 "com.lemonappdev.konsist.testdata.SampleAnnotation",
                 "com.lemonappdev.konsist.testdata.NonExistingAnnotation",
             ).shouldBeEqualTo(true)
+            hasAnnotationWithName(listOf("SampleAnnotation")) shouldBeEqualTo true
+            hasAnnotationWithName(listOf("OtherAnnotation")) shouldBeEqualTo false
+            hasAnnotationWithName(listOf("SampleAnnotation", "OtherAnnotation")) shouldBeEqualTo true
+            hasAnnotationWithName(listOf("com.lemonappdev.konsist.testdata.SampleAnnotation")) shouldBeEqualTo true
+            hasAnnotationWithName(listOf("com.lemonappdev.konsist.testdata.NonExistingAnnotation")) shouldBeEqualTo false
+            hasAnnotationWithName(listOf(
+                "com.lemonappdev.konsist.testdata.SampleAnnotation",
+                "com.lemonappdev.konsist.testdata.NonExistingAnnotation",
+            )).shouldBeEqualTo(true)
+            hasAnnotationWithName(setOf("SampleAnnotation")) shouldBeEqualTo true
+            hasAnnotationWithName(setOf("OtherAnnotation")) shouldBeEqualTo false
+            hasAnnotationWithName(setOf("SampleAnnotation", "OtherAnnotation")) shouldBeEqualTo true
+            hasAnnotationWithName(setOf("com.lemonappdev.konsist.testdata.SampleAnnotation")) shouldBeEqualTo true
+            hasAnnotationWithName(setOf("com.lemonappdev.konsist.testdata.NonExistingAnnotation")) shouldBeEqualTo false
+            hasAnnotationWithName(setOf(
+                "com.lemonappdev.konsist.testdata.SampleAnnotation",
+                "com.lemonappdev.konsist.testdata.NonExistingAnnotation",
+            )).shouldBeEqualTo(true)
             hasAnnotationsWithAllNames("SampleAnnotation") shouldBeEqualTo true
             hasAnnotationsWithAllNames("SampleAnnotation", "OtherAnnotation") shouldBeEqualTo false
             hasAnnotationsWithAllNames("com.lemonappdev.konsist.testdata.SampleAnnotation") shouldBeEqualTo true
@@ -65,15 +103,35 @@ class KoClassDeclarationForKoAnnotationProviderTest {
                 "com.lemonappdev.konsist.testdata.SampleAnnotation",
                 "com.lemonappdev.konsist.testdata.NonExistingAnnotation",
             ).shouldBeEqualTo(false)
+            hasAnnotationsWithAllNames(listOf("SampleAnnotation")) shouldBeEqualTo true
+            hasAnnotationsWithAllNames(listOf("SampleAnnotation", "OtherAnnotation")) shouldBeEqualTo false
+            hasAnnotationsWithAllNames(listOf("com.lemonappdev.konsist.testdata.SampleAnnotation")) shouldBeEqualTo true
+            hasAnnotationsWithAllNames(listOf(
+                "com.lemonappdev.konsist.testdata.SampleAnnotation",
+                "com.lemonappdev.konsist.testdata.NonExistingAnnotation",
+            )).shouldBeEqualTo(false)
             hasAnnotation { it.hasNameStartingWith("Sample") } shouldBeEqualTo true
             hasAnnotation { it.hasNameStartingWith("Other") } shouldBeEqualTo false
             hasAllAnnotations { it.hasNameStartingWith("Sample") } shouldBeEqualTo true
-            hasAnnotationOf(SampleAnnotation::class) shouldBeEqualTo true
-            hasAnnotationOf(NonExistingAnnotation::class) shouldBeEqualTo false
-            hasAnnotationOf(SampleAnnotation::class, NonExistingAnnotation::class) shouldBeEqualTo true
+            hasAnnotationOf(emptyList()) shouldBeEqualTo true
+            hasAnnotationOf(emptySet()) shouldBeEqualTo true
+            hasAllAnnotationsOf(emptyList()) shouldBeEqualTo true
+            hasAllAnnotationsOf(emptySet()) shouldBeEqualTo true
+            hasAnnotationOf(listOf(SampleAnnotation::class)) shouldBeEqualTo true
+            hasAnnotationOf(listOf(NonExistingAnnotation::class)) shouldBeEqualTo false
+            hasAnnotationOf(listOf(SampleAnnotation::class, NonExistingAnnotation::class)) shouldBeEqualTo true
+            hasAnnotationOf(setOf(SampleAnnotation::class)) shouldBeEqualTo true
+            hasAnnotationOf(setOf(NonExistingAnnotation::class)) shouldBeEqualTo false
+            hasAnnotationOf(setOf(SampleAnnotation::class, NonExistingAnnotation::class)) shouldBeEqualTo true
             hasAllAnnotationsOf(SampleAnnotation::class) shouldBeEqualTo true
             hasAllAnnotationsOf(NonExistingAnnotation::class) shouldBeEqualTo false
             hasAllAnnotationsOf(SampleAnnotation::class, NonExistingAnnotation::class) shouldBeEqualTo false
+            hasAllAnnotationsOf(listOf(SampleAnnotation::class)) shouldBeEqualTo true
+            hasAllAnnotationsOf(listOf(NonExistingAnnotation::class)) shouldBeEqualTo false
+            hasAllAnnotationsOf(listOf(SampleAnnotation::class, NonExistingAnnotation::class)) shouldBeEqualTo false
+            hasAllAnnotationsOf(setOf(SampleAnnotation::class)) shouldBeEqualTo true
+            hasAllAnnotationsOf(setOf(NonExistingAnnotation::class)) shouldBeEqualTo false
+            hasAllAnnotationsOf(setOf(SampleAnnotation::class, NonExistingAnnotation::class)) shouldBeEqualTo false
             hasAnnotations("SampleAnnotation") shouldBeEqualTo true
             hasAnnotations("NonExistingAnnotation") shouldBeEqualTo false
             hasAnnotations("com.lemonappdev.konsist.testdata.SampleAnnotation") shouldBeEqualTo true
@@ -97,6 +155,10 @@ class KoClassDeclarationForKoAnnotationProviderTest {
             countAnnotations { it.hasNameStartingWith("Sample") } shouldBeEqualTo 2
             countAnnotations { it.name == "SampleAnnotation1" } shouldBeEqualTo 1
             hasAnnotations() shouldBeEqualTo true
+            hasAnnotationOf(emptyList()) shouldBeEqualTo true
+            hasAnnotationOf(emptySet()) shouldBeEqualTo true
+            hasAllAnnotationsOf(emptyList()) shouldBeEqualTo true
+            hasAllAnnotationsOf(emptySet()) shouldBeEqualTo true
             hasAnnotationWithName("SampleAnnotation1") shouldBeEqualTo true
             hasAnnotationWithName("OtherAnnotation") shouldBeEqualTo false
             hasAnnotationWithName("SampleAnnotation1", "OtherAnnotation") shouldBeEqualTo true
@@ -106,6 +168,24 @@ class KoClassDeclarationForKoAnnotationProviderTest {
                 "com.lemonappdev.konsist.testdata.SampleAnnotation1",
                 "com.lemonappdev.konsist.testdata.NonExistingAnnotation",
             ).shouldBeEqualTo(true)
+            hasAnnotationWithName(listOf("SampleAnnotation1")) shouldBeEqualTo true
+            hasAnnotationWithName(listOf("OtherAnnotation")) shouldBeEqualTo false
+            hasAnnotationWithName(listOf("SampleAnnotation1", "OtherAnnotation")) shouldBeEqualTo true
+            hasAnnotationWithName(listOf("com.lemonappdev.konsist.testdata.SampleAnnotation1")) shouldBeEqualTo true
+            hasAnnotationWithName(listOf("com.lemonappdev.konsist.testdata.NonExistingAnnotation")) shouldBeEqualTo false
+            hasAnnotationWithName(listOf(
+                "com.lemonappdev.konsist.testdata.SampleAnnotation1",
+                "com.lemonappdev.konsist.testdata.NonExistingAnnotation",
+            )).shouldBeEqualTo(true)
+            hasAnnotationWithName(setOf("SampleAnnotation1")) shouldBeEqualTo true
+            hasAnnotationWithName(setOf("OtherAnnotation")) shouldBeEqualTo false
+            hasAnnotationWithName(setOf("SampleAnnotation1", "OtherAnnotation")) shouldBeEqualTo true
+            hasAnnotationWithName(setOf("com.lemonappdev.konsist.testdata.SampleAnnotation1")) shouldBeEqualTo true
+            hasAnnotationWithName(setOf("com.lemonappdev.konsist.testdata.NonExistingAnnotation")) shouldBeEqualTo false
+            hasAnnotationWithName(setOf(
+                "com.lemonappdev.konsist.testdata.SampleAnnotation1",
+                "com.lemonappdev.konsist.testdata.NonExistingAnnotation",
+            )).shouldBeEqualTo(true)
             hasAnnotationsWithAllNames("SampleAnnotation1") shouldBeEqualTo true
             hasAnnotationsWithAllNames("SampleAnnotation1", "SampleAnnotation2") shouldBeEqualTo true
             hasAnnotationsWithAllNames("SampleAnnotation1", "OtherAnnotation") shouldBeEqualTo false
@@ -118,17 +198,48 @@ class KoClassDeclarationForKoAnnotationProviderTest {
                 "com.lemonappdev.konsist.testdata.SampleAnnotation1",
                 "com.lemonappdev.konsist.testdata.SampleAnnotation2",
             ).shouldBeEqualTo(true)
+
+            hasAnnotationsWithAllNames(listOf("SampleAnnotation1")) shouldBeEqualTo true
+            hasAnnotationsWithAllNames(listOf("SampleAnnotation1", "SampleAnnotation2")) shouldBeEqualTo true
+            hasAnnotationsWithAllNames(listOf("SampleAnnotation1", "OtherAnnotation")) shouldBeEqualTo false
+            hasAnnotationsWithAllNames(listOf("com.lemonappdev.konsist.testdata.SampleAnnotation1")) shouldBeEqualTo true
+            hasAnnotationsWithAllNames(listOf(
+                "com.lemonappdev.konsist.testdata.SampleAnnotation1",
+                "com.lemonappdev.konsist.testdata.NonExistingAnnotation",
+            )).shouldBeEqualTo(false)
+            hasAnnotationsWithAllNames(listOf(
+                "com.lemonappdev.konsist.testdata.SampleAnnotation1",
+                "com.lemonappdev.konsist.testdata.SampleAnnotation2",
+            )).shouldBeEqualTo(true)
             hasAnnotation { it.name == "SampleAnnotation1" } shouldBeEqualTo true
             hasAnnotation { it.name == "OtherAnnotation1" } shouldBeEqualTo false
             hasAllAnnotations { !it.hasArguments() } shouldBeEqualTo true
             hasAllAnnotations { it.hasNameEndingWith("tion1") } shouldBeEqualTo false
+            hasAnnotationOf(emptyList()) shouldBeEqualTo true
+            hasAnnotationOf(emptySet()) shouldBeEqualTo true
+            hasAllAnnotationsOf(emptyList()) shouldBeEqualTo true
+            hasAllAnnotationsOf(emptySet()) shouldBeEqualTo true
             hasAnnotationOf(SampleAnnotation1::class) shouldBeEqualTo true
             hasAnnotationOf(NonExistingAnnotation::class) shouldBeEqualTo false
             hasAnnotationOf(SampleAnnotation1::class, NonExistingAnnotation::class) shouldBeEqualTo true
+            hasAnnotationOf(listOf(SampleAnnotation1::class)) shouldBeEqualTo true
+            hasAnnotationOf(listOf(NonExistingAnnotation::class)) shouldBeEqualTo false
+            hasAnnotationOf(listOf(SampleAnnotation1::class, NonExistingAnnotation::class)) shouldBeEqualTo true
+            hasAnnotationOf(setOf(SampleAnnotation1::class)) shouldBeEqualTo true
+            hasAnnotationOf(setOf(NonExistingAnnotation::class)) shouldBeEqualTo false
+            hasAnnotationOf(setOf(SampleAnnotation1::class, NonExistingAnnotation::class)) shouldBeEqualTo true
             hasAllAnnotationsOf(SampleAnnotation1::class) shouldBeEqualTo true
             hasAllAnnotationsOf(NonExistingAnnotation::class) shouldBeEqualTo false
             hasAllAnnotationsOf(SampleAnnotation1::class, SampleAnnotation2::class) shouldBeEqualTo true
             hasAllAnnotationsOf(SampleAnnotation1::class, NonExistingAnnotation::class) shouldBeEqualTo false
+            hasAllAnnotationsOf(listOf(SampleAnnotation1::class)) shouldBeEqualTo true
+            hasAllAnnotationsOf(listOf(NonExistingAnnotation::class)) shouldBeEqualTo false
+            hasAllAnnotationsOf(listOf(SampleAnnotation1::class, SampleAnnotation2::class)) shouldBeEqualTo true
+            hasAllAnnotationsOf(listOf(SampleAnnotation1::class, NonExistingAnnotation::class)) shouldBeEqualTo false
+            hasAllAnnotationsOf(setOf(SampleAnnotation1::class)) shouldBeEqualTo true
+            hasAllAnnotationsOf(setOf(NonExistingAnnotation::class)) shouldBeEqualTo false
+            hasAllAnnotationsOf(setOf(SampleAnnotation1::class, SampleAnnotation2::class)) shouldBeEqualTo true
+            hasAllAnnotationsOf(setOf(SampleAnnotation1::class, NonExistingAnnotation::class)) shouldBeEqualTo false
             hasAnnotations("SampleAnnotation1") shouldBeEqualTo true
             hasAnnotations("SampleAnnotation2") shouldBeEqualTo true
             hasAnnotations("NonExistingAnnotation") shouldBeEqualTo false

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koclass/KoClassDeclarationForKoAnnotationProviderTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koclass/KoClassDeclarationForKoAnnotationProviderTest.kt
@@ -10,6 +10,7 @@ import org.amshove.kluent.assertSoftly
 import org.amshove.kluent.shouldBeEqualTo
 import org.junit.jupiter.api.Test
 
+@Suppress("detekt.LongMethod")
 class KoClassDeclarationForKoAnnotationProviderTest {
     @Test
     fun `class-has-no-annotation`() {
@@ -83,19 +84,23 @@ class KoClassDeclarationForKoAnnotationProviderTest {
             hasAnnotationWithName(listOf("SampleAnnotation", "OtherAnnotation")) shouldBeEqualTo true
             hasAnnotationWithName(listOf("com.lemonappdev.konsist.testdata.SampleAnnotation")) shouldBeEqualTo true
             hasAnnotationWithName(listOf("com.lemonappdev.konsist.testdata.NonExistingAnnotation")) shouldBeEqualTo false
-            hasAnnotationWithName(listOf(
-                "com.lemonappdev.konsist.testdata.SampleAnnotation",
-                "com.lemonappdev.konsist.testdata.NonExistingAnnotation",
-            )).shouldBeEqualTo(true)
+            hasAnnotationWithName(
+                listOf(
+                    "com.lemonappdev.konsist.testdata.SampleAnnotation",
+                    "com.lemonappdev.konsist.testdata.NonExistingAnnotation",
+                ),
+            ).shouldBeEqualTo(true)
             hasAnnotationWithName(setOf("SampleAnnotation")) shouldBeEqualTo true
             hasAnnotationWithName(setOf("OtherAnnotation")) shouldBeEqualTo false
             hasAnnotationWithName(setOf("SampleAnnotation", "OtherAnnotation")) shouldBeEqualTo true
             hasAnnotationWithName(setOf("com.lemonappdev.konsist.testdata.SampleAnnotation")) shouldBeEqualTo true
             hasAnnotationWithName(setOf("com.lemonappdev.konsist.testdata.NonExistingAnnotation")) shouldBeEqualTo false
-            hasAnnotationWithName(setOf(
-                "com.lemonappdev.konsist.testdata.SampleAnnotation",
-                "com.lemonappdev.konsist.testdata.NonExistingAnnotation",
-            )).shouldBeEqualTo(true)
+            hasAnnotationWithName(
+                setOf(
+                    "com.lemonappdev.konsist.testdata.SampleAnnotation",
+                    "com.lemonappdev.konsist.testdata.NonExistingAnnotation",
+                ),
+            ).shouldBeEqualTo(true)
             hasAnnotationsWithAllNames("SampleAnnotation") shouldBeEqualTo true
             hasAnnotationsWithAllNames("SampleAnnotation", "OtherAnnotation") shouldBeEqualTo false
             hasAnnotationsWithAllNames("com.lemonappdev.konsist.testdata.SampleAnnotation") shouldBeEqualTo true
@@ -106,10 +111,12 @@ class KoClassDeclarationForKoAnnotationProviderTest {
             hasAnnotationsWithAllNames(listOf("SampleAnnotation")) shouldBeEqualTo true
             hasAnnotationsWithAllNames(listOf("SampleAnnotation", "OtherAnnotation")) shouldBeEqualTo false
             hasAnnotationsWithAllNames(listOf("com.lemonappdev.konsist.testdata.SampleAnnotation")) shouldBeEqualTo true
-            hasAnnotationsWithAllNames(listOf(
-                "com.lemonappdev.konsist.testdata.SampleAnnotation",
-                "com.lemonappdev.konsist.testdata.NonExistingAnnotation",
-            )).shouldBeEqualTo(false)
+            hasAnnotationsWithAllNames(
+                listOf(
+                    "com.lemonappdev.konsist.testdata.SampleAnnotation",
+                    "com.lemonappdev.konsist.testdata.NonExistingAnnotation",
+                ),
+            ).shouldBeEqualTo(false)
             hasAnnotation { it.hasNameStartingWith("Sample") } shouldBeEqualTo true
             hasAnnotation { it.hasNameStartingWith("Other") } shouldBeEqualTo false
             hasAllAnnotations { it.hasNameStartingWith("Sample") } shouldBeEqualTo true
@@ -173,19 +180,23 @@ class KoClassDeclarationForKoAnnotationProviderTest {
             hasAnnotationWithName(listOf("SampleAnnotation1", "OtherAnnotation")) shouldBeEqualTo true
             hasAnnotationWithName(listOf("com.lemonappdev.konsist.testdata.SampleAnnotation1")) shouldBeEqualTo true
             hasAnnotationWithName(listOf("com.lemonappdev.konsist.testdata.NonExistingAnnotation")) shouldBeEqualTo false
-            hasAnnotationWithName(listOf(
-                "com.lemonappdev.konsist.testdata.SampleAnnotation1",
-                "com.lemonappdev.konsist.testdata.NonExistingAnnotation",
-            )).shouldBeEqualTo(true)
+            hasAnnotationWithName(
+                listOf(
+                    "com.lemonappdev.konsist.testdata.SampleAnnotation1",
+                    "com.lemonappdev.konsist.testdata.NonExistingAnnotation",
+                ),
+            ).shouldBeEqualTo(true)
             hasAnnotationWithName(setOf("SampleAnnotation1")) shouldBeEqualTo true
             hasAnnotationWithName(setOf("OtherAnnotation")) shouldBeEqualTo false
             hasAnnotationWithName(setOf("SampleAnnotation1", "OtherAnnotation")) shouldBeEqualTo true
             hasAnnotationWithName(setOf("com.lemonappdev.konsist.testdata.SampleAnnotation1")) shouldBeEqualTo true
             hasAnnotationWithName(setOf("com.lemonappdev.konsist.testdata.NonExistingAnnotation")) shouldBeEqualTo false
-            hasAnnotationWithName(setOf(
-                "com.lemonappdev.konsist.testdata.SampleAnnotation1",
-                "com.lemonappdev.konsist.testdata.NonExistingAnnotation",
-            )).shouldBeEqualTo(true)
+            hasAnnotationWithName(
+                setOf(
+                    "com.lemonappdev.konsist.testdata.SampleAnnotation1",
+                    "com.lemonappdev.konsist.testdata.NonExistingAnnotation",
+                ),
+            ).shouldBeEqualTo(true)
             hasAnnotationsWithAllNames("SampleAnnotation1") shouldBeEqualTo true
             hasAnnotationsWithAllNames("SampleAnnotation1", "SampleAnnotation2") shouldBeEqualTo true
             hasAnnotationsWithAllNames("SampleAnnotation1", "OtherAnnotation") shouldBeEqualTo false
@@ -203,14 +214,18 @@ class KoClassDeclarationForKoAnnotationProviderTest {
             hasAnnotationsWithAllNames(listOf("SampleAnnotation1", "SampleAnnotation2")) shouldBeEqualTo true
             hasAnnotationsWithAllNames(listOf("SampleAnnotation1", "OtherAnnotation")) shouldBeEqualTo false
             hasAnnotationsWithAllNames(listOf("com.lemonappdev.konsist.testdata.SampleAnnotation1")) shouldBeEqualTo true
-            hasAnnotationsWithAllNames(listOf(
-                "com.lemonappdev.konsist.testdata.SampleAnnotation1",
-                "com.lemonappdev.konsist.testdata.NonExistingAnnotation",
-            )).shouldBeEqualTo(false)
-            hasAnnotationsWithAllNames(listOf(
-                "com.lemonappdev.konsist.testdata.SampleAnnotation1",
-                "com.lemonappdev.konsist.testdata.SampleAnnotation2",
-            )).shouldBeEqualTo(true)
+            hasAnnotationsWithAllNames(
+                listOf(
+                    "com.lemonappdev.konsist.testdata.SampleAnnotation1",
+                    "com.lemonappdev.konsist.testdata.NonExistingAnnotation",
+                ),
+            ).shouldBeEqualTo(false)
+            hasAnnotationsWithAllNames(
+                listOf(
+                    "com.lemonappdev.konsist.testdata.SampleAnnotation1",
+                    "com.lemonappdev.konsist.testdata.SampleAnnotation2",
+                ),
+            ).shouldBeEqualTo(true)
             hasAnnotation { it.name == "SampleAnnotation1" } shouldBeEqualTo true
             hasAnnotation { it.name == "OtherAnnotation1" } shouldBeEqualTo false
             hasAllAnnotations { !it.hasArguments() } shouldBeEqualTo true

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koclass/KoClassDeclarationForKoClassProviderTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koclass/KoClassDeclarationForKoClassProviderTest.kt
@@ -22,8 +22,16 @@ class KoClassDeclarationForKoClassProviderTest {
         assertSoftly(sut) {
             classes() shouldBeEqualTo emptyList()
             hasClasses() shouldBeEqualTo false
+            hasClassWithName(emptyList()) shouldBeEqualTo false
+            hasClassWithName(emptySet()) shouldBeEqualTo false
+            hasClassesWithAllNames(emptyList()) shouldBeEqualTo false
+            hasClassesWithAllNames(emptySet()) shouldBeEqualTo false
             hasClassWithName("SampleClass") shouldBeEqualTo false
+            hasClassWithName(listOf("SampleClass")) shouldBeEqualTo false
+            hasClassWithName(setOf("SampleClass")) shouldBeEqualTo false
             hasClassesWithAllNames("SampleClass1", "SampleClass2") shouldBeEqualTo false
+            hasClassesWithAllNames(listOf("SampleClass1", "SampleClass2")) shouldBeEqualTo false
+            hasClassesWithAllNames(setOf("SampleClass1", "SampleClass2")) shouldBeEqualTo false
             hasClass { it.name == "SampleClass" } shouldBeEqualTo false
             hasAllClasses { it.hasNameStartingWith("Sample") } shouldBeEqualTo true
         }
@@ -40,11 +48,25 @@ class KoClassDeclarationForKoClassProviderTest {
         // then
         assertSoftly(sut) {
             hasClasses() shouldBeEqualTo true
+            hasClassWithName(emptyList()) shouldBeEqualTo true
+            hasClassWithName(emptySet()) shouldBeEqualTo true
+            hasClassesWithAllNames(emptyList()) shouldBeEqualTo true
+            hasClassesWithAllNames(emptySet()) shouldBeEqualTo true
             hasClassWithName("SampleClass1") shouldBeEqualTo true
             hasClassWithName("SampleClass1", "OtherClass") shouldBeEqualTo true
+            hasClassWithName(listOf("SampleClass1")) shouldBeEqualTo true
+            hasClassWithName(listOf("SampleClass1", "OtherClass")) shouldBeEqualTo true
+            hasClassWithName(setOf("SampleClass1")) shouldBeEqualTo true
+            hasClassWithName(setOf("SampleClass1", "OtherClass")) shouldBeEqualTo true
             hasClassesWithAllNames("SampleClass1") shouldBeEqualTo true
             hasClassesWithAllNames("SampleClass1", "SampleClass2") shouldBeEqualTo true
             hasClassesWithAllNames("SampleClass1", "OtherClass") shouldBeEqualTo false
+            hasClassesWithAllNames(listOf("SampleClass1")) shouldBeEqualTo true
+            hasClassesWithAllNames(listOf("SampleClass1", "SampleClass2")) shouldBeEqualTo true
+            hasClassesWithAllNames(listOf("SampleClass1", "OtherClass")) shouldBeEqualTo false
+            hasClassesWithAllNames(setOf("SampleClass1")) shouldBeEqualTo true
+            hasClassesWithAllNames(setOf("SampleClass1", "SampleClass2")) shouldBeEqualTo true
+            hasClassesWithAllNames(setOf("SampleClass1", "OtherClass")) shouldBeEqualTo false
             hasClass { it.name == "SampleClass1" } shouldBeEqualTo true
             hasClass { it.hasNameEndingWith("Class1") } shouldBeEqualTo true
             hasAllClasses { it.hasNameStartingWith("Sample") } shouldBeEqualTo true

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koclass/KoClassDeclarationForKoEnumConstantProviderTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koclass/KoClassDeclarationForKoEnumConstantProviderTest.kt
@@ -20,8 +20,16 @@ class KoClassDeclarationForKoEnumConstantProviderTest {
             numEnumConstants shouldBeEqualTo 0
             countEnumConstants { it.hasNameStartingWith("SAMPLE") } shouldBeEqualTo 0
             hasEnumConstants() shouldBeEqualTo false
+            hasEnumConstantWithName(emptyList()) shouldBeEqualTo false
+            hasEnumConstantWithName(emptySet()) shouldBeEqualTo false
+            hasEnumConstantsWithAllNames(emptyList()) shouldBeEqualTo false
+            hasEnumConstantsWithAllNames(emptySet()) shouldBeEqualTo false
             hasEnumConstantWithName("SAMPLE_CONSTANT") shouldBeEqualTo false
+            hasEnumConstantWithName(listOf("SAMPLE_CONSTANT")) shouldBeEqualTo false
+            hasEnumConstantWithName(setOf("SAMPLE_CONSTANT")) shouldBeEqualTo false
             hasEnumConstantsWithAllNames("SAMPLE_CONSTANT1", "SAMPLE_CONSTANT2") shouldBeEqualTo false
+            hasEnumConstantsWithAllNames(listOf("SAMPLE_CONSTANT1", "SAMPLE_CONSTANT2")) shouldBeEqualTo false
+            hasEnumConstantsWithAllNames(setOf("SAMPLE_CONSTANT1", "SAMPLE_CONSTANT2")) shouldBeEqualTo false
             hasEnumConstant { it.hasNameStartingWith("SAMPLE") } shouldBeEqualTo false
             hasAllEnumConstants { it.hasNameStartingWith("SAMPLE") } shouldBeEqualTo true
             hasEnumConstants("SAMPLE_CONSTANT") shouldBeEqualTo false
@@ -42,11 +50,25 @@ class KoClassDeclarationForKoEnumConstantProviderTest {
             numEnumConstants shouldBeEqualTo 1
             countEnumConstants { it.hasNameStartingWith("SAMPLE") } shouldBeEqualTo 1
             hasEnumConstants() shouldBeEqualTo true
+            hasEnumConstantWithName(emptyList()) shouldBeEqualTo true
+            hasEnumConstantWithName(emptySet()) shouldBeEqualTo true
+            hasEnumConstantsWithAllNames(emptyList()) shouldBeEqualTo true
+            hasEnumConstantsWithAllNames(emptySet()) shouldBeEqualTo true
             hasEnumConstantWithName("SAMPLE_CONSTANT") shouldBeEqualTo true
             hasEnumConstantWithName("OTHER_CONSTANT") shouldBeEqualTo false
             hasEnumConstantWithName("SAMPLE_CONSTANT", "OTHER_CONSTANT") shouldBeEqualTo true
+            hasEnumConstantWithName(listOf("SAMPLE_CONSTANT")) shouldBeEqualTo true
+            hasEnumConstantWithName(listOf("OTHER_CONSTANT")) shouldBeEqualTo false
+            hasEnumConstantWithName(listOf("SAMPLE_CONSTANT", "OTHER_CONSTANT")) shouldBeEqualTo true
+            hasEnumConstantWithName(setOf("SAMPLE_CONSTANT")) shouldBeEqualTo true
+            hasEnumConstantWithName(setOf("OTHER_CONSTANT")) shouldBeEqualTo false
+            hasEnumConstantWithName(setOf("SAMPLE_CONSTANT", "OTHER_CONSTANT")) shouldBeEqualTo true
             hasEnumConstantsWithAllNames("SAMPLE_CONSTANT") shouldBeEqualTo true
             hasEnumConstantsWithAllNames("SAMPLE_CONSTANT", "OTHER_CONSTANT") shouldBeEqualTo false
+            hasEnumConstantsWithAllNames(listOf("SAMPLE_CONSTANT")) shouldBeEqualTo true
+            hasEnumConstantsWithAllNames(listOf("SAMPLE_CONSTANT", "OTHER_CONSTANT")) shouldBeEqualTo false
+            hasEnumConstantsWithAllNames(setOf("SAMPLE_CONSTANT")) shouldBeEqualTo true
+            hasEnumConstantsWithAllNames(setOf("SAMPLE_CONSTANT", "OTHER_CONSTANT")) shouldBeEqualTo false
             hasEnumConstant { it.hasNameStartingWith("SAMPLE") } shouldBeEqualTo true
             hasEnumConstant { it.name == "OTHER_CONSTANT" } shouldBeEqualTo false
             hasAllEnumConstants { it.hasNameStartingWith("SAMPLE") } shouldBeEqualTo true
@@ -67,12 +89,28 @@ class KoClassDeclarationForKoEnumConstantProviderTest {
             countEnumConstants { it.hasNameStartingWith("SAMPLE") } shouldBeEqualTo 2
             countEnumConstants { it.name == "SAMPLE_CONSTANT_1" } shouldBeEqualTo 1
             hasEnumConstants() shouldBeEqualTo true
+            hasEnumConstantWithName(emptyList()) shouldBeEqualTo true
+            hasEnumConstantWithName(emptySet()) shouldBeEqualTo true
+            hasEnumConstantsWithAllNames(emptyList()) shouldBeEqualTo true
+            hasEnumConstantsWithAllNames(emptySet()) shouldBeEqualTo true
             hasEnumConstantWithName("SAMPLE_CONSTANT_1") shouldBeEqualTo true
             hasEnumConstantWithName("OTHER_CONSTANT") shouldBeEqualTo false
             hasEnumConstantWithName("SAMPLE_CONSTANT_1", "otherName") shouldBeEqualTo true
+            hasEnumConstantWithName(listOf("SAMPLE_CONSTANT_1")) shouldBeEqualTo true
+            hasEnumConstantWithName(listOf("OTHER_CONSTANT")) shouldBeEqualTo false
+            hasEnumConstantWithName(listOf("SAMPLE_CONSTANT_1", "otherName")) shouldBeEqualTo true
+            hasEnumConstantWithName(setOf("SAMPLE_CONSTANT_1")) shouldBeEqualTo true
+            hasEnumConstantWithName(setOf("OTHER_CONSTANT")) shouldBeEqualTo false
+            hasEnumConstantWithName(setOf("SAMPLE_CONSTANT_1", "otherName")) shouldBeEqualTo true
             hasEnumConstantsWithAllNames("SAMPLE_CONSTANT_1") shouldBeEqualTo true
             hasEnumConstantsWithAllNames("SAMPLE_CONSTANT_1", "SAMPLE_CONSTANT_2") shouldBeEqualTo true
             hasEnumConstantsWithAllNames("SAMPLE_CONSTANT_1", "OTHER_CONSTANT") shouldBeEqualTo false
+            hasEnumConstantsWithAllNames(listOf("SAMPLE_CONSTANT_1")) shouldBeEqualTo true
+            hasEnumConstantsWithAllNames(listOf("SAMPLE_CONSTANT_1", "SAMPLE_CONSTANT_2")) shouldBeEqualTo true
+            hasEnumConstantsWithAllNames(listOf("SAMPLE_CONSTANT_1", "OTHER_CONSTANT")) shouldBeEqualTo false
+            hasEnumConstantsWithAllNames(setOf("SAMPLE_CONSTANT_1")) shouldBeEqualTo true
+            hasEnumConstantsWithAllNames(setOf("SAMPLE_CONSTANT_1", "SAMPLE_CONSTANT_2")) shouldBeEqualTo true
+            hasEnumConstantsWithAllNames(setOf("SAMPLE_CONSTANT_1", "OTHER_CONSTANT")) shouldBeEqualTo false
             hasEnumConstant { it.name == "SAMPLE_CONSTANT_1" } shouldBeEqualTo true
             hasEnumConstant { it.name == "OTHER_CONSTANT_1" } shouldBeEqualTo false
             hasAllEnumConstants { it.name == "SAMPLE_CONSTANT_1" } shouldBeEqualTo false

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koclass/KoClassDeclarationForKoExternalParentProviderTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koclass/KoClassDeclarationForKoExternalParentProviderTest.kt
@@ -11,6 +11,7 @@ import org.amshove.kluent.assertSoftly
 import org.amshove.kluent.shouldBeEqualTo
 import org.junit.jupiter.api.Test
 
+@Suppress("detekt.LongMethod")
 class KoClassDeclarationForKoExternalParentProviderTest {
     @Test
     fun `class-has-no-external-parent`() {
@@ -192,10 +193,10 @@ class KoClassDeclarationForKoExternalParentProviderTest {
         assertSoftly(sut) {
             externalParents(indirectParents = false) shouldBeEqualTo emptyList()
             externalParents(indirectParents = true).map { it.name } shouldBeEqualTo
-                    listOf(
-                        "SampleExternalClass",
-                        "SampleExternalInterface",
-                    )
+                listOf(
+                    "SampleExternalClass",
+                    "SampleExternalInterface",
+                )
             numExternalParents(indirectParents = false) shouldBeEqualTo 0
             numExternalParents(indirectParents = true) shouldBeEqualTo 2
             countExternalParents(indirectParents = false) { it.name == "SampleExternalInterface" } shouldBeEqualTo 0
@@ -226,14 +227,18 @@ class KoClassDeclarationForKoExternalParentProviderTest {
             ) shouldBeEqualTo true
             hasExternalParentWithName(listOf("SampleExternalInterface"), indirectParents = true) shouldBeEqualTo true
             hasExternalParentWithName(listOf("OtherInterface"), indirectParents = true) shouldBeEqualTo false
-            hasExternalParentWithName(listOf(
-                "SampleExternalInterface",
-                "SampleExternalClass"),
+            hasExternalParentWithName(
+                listOf(
+                    "SampleExternalInterface",
+                    "SampleExternalClass",
+                ),
                 indirectParents = true,
             ) shouldBeEqualTo true
-            hasExternalParentWithName(listOf(
-                "SampleExternalInterface",
-                "OtherInterface"),
+            hasExternalParentWithName(
+                listOf(
+                    "SampleExternalInterface",
+                    "OtherInterface",
+                ),
                 indirectParents = true,
             ) shouldBeEqualTo true
             hasExternalParentsWithAllNames("SampleExternalInterface", indirectParents = true) shouldBeEqualTo true
@@ -251,14 +256,18 @@ class KoClassDeclarationForKoExternalParentProviderTest {
 
             hasExternalParentsWithAllNames(listOf("SampleExternalInterface"), indirectParents = true) shouldBeEqualTo true
             hasExternalParentsWithAllNames(listOf("OtherInterface"), indirectParents = true) shouldBeEqualTo false
-            hasExternalParentsWithAllNames(listOf(
-                "SampleExternalInterface",
-                "SampleExternalClass"),
+            hasExternalParentsWithAllNames(
+                listOf(
+                    "SampleExternalInterface",
+                    "SampleExternalClass",
+                ),
                 indirectParents = true,
             ) shouldBeEqualTo true
-            hasExternalParentsWithAllNames(listOf(
-                "SampleExternalInterface",
-                "OtherInterface"),
+            hasExternalParentsWithAllNames(
+                listOf(
+                    "SampleExternalInterface",
+                    "OtherInterface",
+                ),
                 indirectParents = true,
             ) shouldBeEqualTo false
             hasExternalParent(indirectParents = true) { it.name == "SampleExternalInterface" } shouldBeEqualTo true
@@ -273,9 +282,11 @@ class KoClassDeclarationForKoExternalParentProviderTest {
                 indirectParents = true,
             ) shouldBeEqualTo true
             hasExternalParentOf(listOf(SampleExternalInterface::class), indirectParents = true) shouldBeEqualTo true
-            hasExternalParentOf(listOf(
-                SampleExternalInterface::class,
-                SampleParentClass::class),
+            hasExternalParentOf(
+                listOf(
+                    SampleExternalInterface::class,
+                    SampleParentClass::class,
+                ),
                 indirectParents = true,
             ) shouldBeEqualTo true
             hasAllExternalParentsOf(SampleExternalInterface::class, indirectParents = true) shouldBeEqualTo true
@@ -291,14 +302,18 @@ class KoClassDeclarationForKoExternalParentProviderTest {
             ) shouldBeEqualTo true
 
             hasAllExternalParentsOf(listOf(SampleExternalInterface::class), indirectParents = true) shouldBeEqualTo true
-            hasAllExternalParentsOf(listOf(
-                SampleExternalInterface::class,
-                SampleParentClass::class),
+            hasAllExternalParentsOf(
+                listOf(
+                    SampleExternalInterface::class,
+                    SampleParentClass::class,
+                ),
                 indirectParents = true,
             ) shouldBeEqualTo false
-            hasAllExternalParentsOf(listOf(
-                SampleExternalInterface::class,
-                SampleExternalClass::class),
+            hasAllExternalParentsOf(
+                listOf(
+                    SampleExternalInterface::class,
+                    SampleExternalClass::class,
+                ),
                 indirectParents = true,
             ) shouldBeEqualTo true
         }

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koclass/KoClassDeclarationForKoExternalParentProviderTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koclass/KoClassDeclarationForKoExternalParentProviderTest.kt
@@ -26,12 +26,24 @@ class KoClassDeclarationForKoExternalParentProviderTest {
             numExternalParents() shouldBeEqualTo 0
             countExternalParents { it.name == "SampleExternalParent" } shouldBeEqualTo 0
             hasExternalParents() shouldBeEqualTo false
+            hasExternalParentWithName(emptyList()) shouldBeEqualTo false
+            hasExternalParentWithName(emptySet()) shouldBeEqualTo false
+            hasExternalParentsWithAllNames(emptyList()) shouldBeEqualTo false
+            hasExternalParentsWithAllNames(emptySet()) shouldBeEqualTo false
             hasExternalParentWithName("SampleExternalClass", "SampleExternalInterface") shouldBeEqualTo false
+            hasExternalParentWithName(listOf("SampleExternalClass", "SampleExternalInterface")) shouldBeEqualTo false
+            hasExternalParentWithName(setOf("SampleExternalClass", "SampleExternalInterface")) shouldBeEqualTo false
             hasExternalParentsWithAllNames("SampleExternalClass", "SampleExternalInterface") shouldBeEqualTo false
+            hasExternalParentsWithAllNames(listOf("SampleExternalClass", "SampleExternalInterface")) shouldBeEqualTo false
+            hasExternalParentsWithAllNames(setOf("SampleExternalClass", "SampleExternalInterface")) shouldBeEqualTo false
             hasExternalParent { it.name == "SampleExternalParent" } shouldBeEqualTo false
             hasAllExternalParents { it.hasNameStartingWith("Sample") } shouldBeEqualTo true
             hasExternalParentOf(SampleParentInterface1::class) shouldBeEqualTo false
+            hasExternalParentOf(listOf(SampleParentInterface1::class)) shouldBeEqualTo false
+            hasExternalParentOf(setOf(SampleParentInterface1::class)) shouldBeEqualTo false
             hasAllExternalParentsOf(SampleParentInterface1::class, SampleParentInterface2::class) shouldBeEqualTo false
+            hasAllExternalParentsOf(listOf(SampleParentInterface1::class, SampleParentInterface2::class)) shouldBeEqualTo false
+            hasAllExternalParentsOf(setOf(SampleParentInterface1::class, SampleParentInterface2::class)) shouldBeEqualTo false
         }
     }
 
@@ -50,14 +62,34 @@ class KoClassDeclarationForKoExternalParentProviderTest {
             countExternalParents { it.name == "SampleExternalClass" } shouldBeEqualTo 1
             countExternalParents { it.hasNameStartingWith("SampleExternal") } shouldBeEqualTo 2
             hasExternalParents() shouldBeEqualTo true
+            hasExternalParentWithName(emptyList()) shouldBeEqualTo true
+            hasExternalParentWithName(emptySet()) shouldBeEqualTo true
+            hasExternalParentsWithAllNames(emptyList()) shouldBeEqualTo true
+            hasExternalParentsWithAllNames(emptySet()) shouldBeEqualTo true
             hasExternalParentWithName("SampleExternalClass") shouldBeEqualTo true
             hasExternalParentWithName("OtherInterface") shouldBeEqualTo false
             hasExternalParentWithName("SampleExternalClass", "SampleExternalInterface") shouldBeEqualTo true
             hasExternalParentWithName("SampleExternalClass", "OtherInterface") shouldBeEqualTo true
+            hasExternalParentWithName(listOf("SampleExternalClass")) shouldBeEqualTo true
+            hasExternalParentWithName(listOf("OtherInterface")) shouldBeEqualTo false
+            hasExternalParentWithName(listOf("SampleExternalClass", "SampleExternalInterface")) shouldBeEqualTo true
+            hasExternalParentWithName(listOf("SampleExternalClass", "OtherInterface")) shouldBeEqualTo true
+            hasExternalParentWithName(setOf("SampleExternalClass")) shouldBeEqualTo true
+            hasExternalParentWithName(setOf("OtherInterface")) shouldBeEqualTo false
+            hasExternalParentWithName(setOf("SampleExternalClass", "SampleExternalInterface")) shouldBeEqualTo true
+            hasExternalParentWithName(setOf("SampleExternalClass", "OtherInterface")) shouldBeEqualTo true
             hasExternalParentsWithAllNames("SampleExternalClass") shouldBeEqualTo true
             hasExternalParentsWithAllNames("OtherInterface") shouldBeEqualTo false
             hasExternalParentsWithAllNames("SampleExternalClass", "SampleExternalInterface") shouldBeEqualTo true
             hasExternalParentsWithAllNames("SampleExternalClass", "OtherInterface") shouldBeEqualTo false
+            hasExternalParentsWithAllNames(listOf("SampleExternalClass")) shouldBeEqualTo true
+            hasExternalParentsWithAllNames(listOf("OtherInterface")) shouldBeEqualTo false
+            hasExternalParentsWithAllNames(listOf("SampleExternalClass", "SampleExternalInterface")) shouldBeEqualTo true
+            hasExternalParentsWithAllNames(listOf("SampleExternalClass", "OtherInterface")) shouldBeEqualTo false
+            hasExternalParentsWithAllNames(setOf("SampleExternalClass")) shouldBeEqualTo true
+            hasExternalParentsWithAllNames(setOf("OtherInterface")) shouldBeEqualTo false
+            hasExternalParentsWithAllNames(setOf("SampleExternalClass", "SampleExternalInterface")) shouldBeEqualTo true
+            hasExternalParentsWithAllNames(setOf("SampleExternalClass", "OtherInterface")) shouldBeEqualTo false
             hasExternalParent { it.name == "SampleExternalClass" } shouldBeEqualTo true
             hasExternalParent { it.name == "OtherInterface" } shouldBeEqualTo false
             hasAllExternalParents { it.name == "SampleExternalClass" } shouldBeEqualTo false
@@ -65,9 +97,19 @@ class KoClassDeclarationForKoExternalParentProviderTest {
             hasAllExternalParents { it.hasNameStartingWith("Other") } shouldBeEqualTo false
             hasExternalParentOf(SampleExternalClass::class) shouldBeEqualTo true
             hasExternalParentOf(SampleExternalClass::class, SampleParentClass::class) shouldBeEqualTo true
+            hasExternalParentOf(listOf(SampleExternalClass::class)) shouldBeEqualTo true
+            hasExternalParentOf(listOf(SampleExternalClass::class, SampleParentClass::class)) shouldBeEqualTo true
+            hasExternalParentOf(setOf(SampleExternalClass::class)) shouldBeEqualTo true
+            hasExternalParentOf(setOf(SampleExternalClass::class, SampleParentClass::class)) shouldBeEqualTo true
             hasAllExternalParentsOf(SampleExternalClass::class) shouldBeEqualTo true
             hasAllExternalParentsOf(SampleExternalClass::class, SampleParentClass::class) shouldBeEqualTo false
             hasAllExternalParentsOf(SampleExternalClass::class, SampleExternalInterface::class) shouldBeEqualTo true
+            hasAllExternalParentsOf(listOf(SampleExternalClass::class)) shouldBeEqualTo true
+            hasAllExternalParentsOf(listOf(SampleExternalClass::class, SampleParentClass::class)) shouldBeEqualTo false
+            hasAllExternalParentsOf(listOf(SampleExternalClass::class, SampleExternalInterface::class)) shouldBeEqualTo true
+            hasAllExternalParentsOf(setOf(SampleExternalClass::class)) shouldBeEqualTo true
+            hasAllExternalParentsOf(setOf(SampleExternalClass::class, SampleParentClass::class)) shouldBeEqualTo false
+            hasAllExternalParentsOf(setOf(SampleExternalClass::class, SampleExternalInterface::class)) shouldBeEqualTo true
         }
     }
 
@@ -81,26 +123,39 @@ class KoClassDeclarationForKoExternalParentProviderTest {
 
         // then
         assertSoftly(sut) {
-            externalParents().map { it.name } shouldBeEqualTo
-                listOf(
-                    "SampleExternalInterface",
-                    "SampleExternalGenericInterface",
-                )
+            externalParents().map { it.name } shouldBeEqualTo listOf("SampleExternalInterface", "SampleExternalGenericInterface")
             numExternalParents() shouldBeEqualTo 2
             countExternalParents { it.name == "SampleExternalInterface" } shouldBeEqualTo 1
             countExternalParents { it.hasNameStartingWith("SampleExternal") } shouldBeEqualTo 2
             hasExternalParents() shouldBeEqualTo true
+            hasExternalParentWithName(emptyList()) shouldBeEqualTo true
+            hasExternalParentWithName(emptySet()) shouldBeEqualTo true
+            hasExternalParentsWithAllNames(emptyList()) shouldBeEqualTo true
+            hasExternalParentsWithAllNames(emptySet()) shouldBeEqualTo true
             hasExternalParentWithName("SampleExternalInterface") shouldBeEqualTo true
             hasExternalParentWithName("OtherInterface") shouldBeEqualTo false
             hasExternalParentWithName("SampleExternalInterface", "SampleExternalGenericInterface") shouldBeEqualTo true
             hasExternalParentWithName("SampleExternalInterface", "OtherInterface") shouldBeEqualTo true
+            hasExternalParentWithName(listOf("SampleExternalInterface")) shouldBeEqualTo true
+            hasExternalParentWithName(listOf("OtherInterface")) shouldBeEqualTo false
+            hasExternalParentWithName(listOf("SampleExternalInterface", "SampleExternalGenericInterface")) shouldBeEqualTo true
+            hasExternalParentWithName(listOf("SampleExternalInterface", "OtherInterface")) shouldBeEqualTo true
+            hasExternalParentWithName(setOf("SampleExternalInterface")) shouldBeEqualTo true
+            hasExternalParentWithName(setOf("OtherInterface")) shouldBeEqualTo false
+            hasExternalParentWithName(setOf("SampleExternalInterface", "SampleExternalGenericInterface")) shouldBeEqualTo true
+            hasExternalParentWithName(setOf("SampleExternalInterface", "OtherInterface")) shouldBeEqualTo true
             hasExternalParentsWithAllNames("SampleExternalInterface") shouldBeEqualTo true
             hasExternalParentsWithAllNames("OtherInterface") shouldBeEqualTo false
-            hasExternalParentsWithAllNames(
-                "SampleExternalInterface",
-                "SampleExternalGenericInterface",
-            ) shouldBeEqualTo true
+            hasExternalParentsWithAllNames("SampleExternalInterface", "SampleExternalGenericInterface") shouldBeEqualTo true
             hasExternalParentsWithAllNames("SampleExternalInterface", "OtherInterface") shouldBeEqualTo false
+            hasExternalParentsWithAllNames(listOf("SampleExternalInterface")) shouldBeEqualTo true
+            hasExternalParentsWithAllNames(listOf("OtherInterface")) shouldBeEqualTo false
+            hasExternalParentsWithAllNames(listOf("SampleExternalInterface", "SampleExternalGenericInterface")) shouldBeEqualTo true
+            hasExternalParentsWithAllNames(listOf("SampleExternalInterface", "OtherInterface")) shouldBeEqualTo false
+            hasExternalParentsWithAllNames(setOf("SampleExternalInterface")) shouldBeEqualTo true
+            hasExternalParentsWithAllNames(setOf("OtherInterface")) shouldBeEqualTo false
+            hasExternalParentsWithAllNames(setOf("SampleExternalInterface", "SampleExternalGenericInterface")) shouldBeEqualTo true
+            hasExternalParentsWithAllNames(setOf("SampleExternalInterface", "OtherInterface")) shouldBeEqualTo false
             hasExternalParent { it.name == "SampleExternalInterface" } shouldBeEqualTo true
             hasExternalParent { it.name == "OtherInterface" } shouldBeEqualTo false
             hasAllExternalParents { it.name == "SampleExternalInterface" } shouldBeEqualTo false
@@ -108,12 +163,19 @@ class KoClassDeclarationForKoExternalParentProviderTest {
             hasAllExternalParents { it.hasNameStartingWith("Other") } shouldBeEqualTo false
             hasExternalParentOf(SampleExternalInterface::class) shouldBeEqualTo true
             hasExternalParentOf(SampleExternalInterface::class, SampleParentClass::class) shouldBeEqualTo true
+            hasExternalParentOf(listOf(SampleExternalInterface::class)) shouldBeEqualTo true
+            hasExternalParentOf(listOf(SampleExternalInterface::class, SampleParentClass::class)) shouldBeEqualTo true
+            hasExternalParentOf(setOf(SampleExternalInterface::class)) shouldBeEqualTo true
+            hasExternalParentOf(setOf(SampleExternalInterface::class, SampleParentClass::class)) shouldBeEqualTo true
             hasAllExternalParentsOf(SampleExternalInterface::class) shouldBeEqualTo true
             hasAllExternalParentsOf(SampleExternalInterface::class, SampleParentClass::class) shouldBeEqualTo false
-            hasAllExternalParentsOf(
-                SampleExternalInterface::class,
-                SampleExternalGenericInterface::class,
-            ) shouldBeEqualTo true
+            hasAllExternalParentsOf(SampleExternalInterface::class, SampleExternalGenericInterface::class) shouldBeEqualTo true
+            hasAllExternalParentsOf(listOf(SampleExternalInterface::class)) shouldBeEqualTo true
+            hasAllExternalParentsOf(listOf(SampleExternalInterface::class, SampleParentClass::class)) shouldBeEqualTo false
+            hasAllExternalParentsOf(listOf(SampleExternalInterface::class, SampleExternalGenericInterface::class)) shouldBeEqualTo true
+            hasAllExternalParentsOf(setOf(SampleExternalInterface::class)) shouldBeEqualTo true
+            hasAllExternalParentsOf(setOf(SampleExternalInterface::class, SampleParentClass::class)) shouldBeEqualTo false
+            hasAllExternalParentsOf(setOf(SampleExternalInterface::class, SampleExternalGenericInterface::class)) shouldBeEqualTo true
         }
     }
 
@@ -130,62 +192,113 @@ class KoClassDeclarationForKoExternalParentProviderTest {
         assertSoftly(sut) {
             externalParents(indirectParents = false) shouldBeEqualTo emptyList()
             externalParents(indirectParents = true).map { it.name } shouldBeEqualTo
-                listOf(
-                    "SampleExternalClass",
-                    "SampleExternalInterface",
-                )
+                    listOf(
+                        "SampleExternalClass",
+                        "SampleExternalInterface",
+                    )
             numExternalParents(indirectParents = false) shouldBeEqualTo 0
             numExternalParents(indirectParents = true) shouldBeEqualTo 2
-            countExternalParents(indirectParents = false) { it.name == "SampleExternalClass" } shouldBeEqualTo 0
-            countExternalParents(indirectParents = true) { it.name == "SampleExternalClass" } shouldBeEqualTo 1
+            countExternalParents(indirectParents = false) { it.name == "SampleExternalInterface" } shouldBeEqualTo 0
+            countExternalParents(indirectParents = true) { it.name == "SampleExternalInterface" } shouldBeEqualTo 1
             countExternalParents(indirectParents = false) { it.hasNameStartingWith("SampleExternal") } shouldBeEqualTo 0
             countExternalParents(indirectParents = true) { it.hasNameStartingWith("SampleExternal") } shouldBeEqualTo 2
             hasExternalParents(indirectParents = false) shouldBeEqualTo false
             hasExternalParents(indirectParents = true) shouldBeEqualTo true
-            hasExternalParentWithName("SampleExternalClass", indirectParents = true) shouldBeEqualTo true
+            hasExternalParentWithName(emptyList(), indirectParents = false) shouldBeEqualTo false
+            hasExternalParentWithName(emptySet(), indirectParents = false) shouldBeEqualTo false
+            hasExternalParentsWithAllNames(emptyList(), indirectParents = false) shouldBeEqualTo false
+            hasExternalParentsWithAllNames(emptySet(), indirectParents = false) shouldBeEqualTo false
+            hasExternalParentWithName(emptyList(), indirectParents = true) shouldBeEqualTo true
+            hasExternalParentWithName(emptySet(), indirectParents = true) shouldBeEqualTo true
+            hasExternalParentsWithAllNames(emptyList(), indirectParents = true) shouldBeEqualTo true
+            hasExternalParentsWithAllNames(emptySet(), indirectParents = true) shouldBeEqualTo true
+            hasExternalParentWithName("SampleExternalInterface", indirectParents = true) shouldBeEqualTo true
             hasExternalParentWithName("OtherInterface", indirectParents = true) shouldBeEqualTo false
             hasExternalParentWithName(
-                "SampleExternalClass",
                 "SampleExternalInterface",
+                "SampleExternalClass",
                 indirectParents = true,
             ) shouldBeEqualTo true
             hasExternalParentWithName(
-                "SampleExternalClass",
+                "SampleExternalInterface",
                 "OtherInterface",
                 indirectParents = true,
             ) shouldBeEqualTo true
-            hasExternalParentsWithAllNames("SampleExternalClass", indirectParents = true) shouldBeEqualTo true
+            hasExternalParentWithName(listOf("SampleExternalInterface"), indirectParents = true) shouldBeEqualTo true
+            hasExternalParentWithName(listOf("OtherInterface"), indirectParents = true) shouldBeEqualTo false
+            hasExternalParentWithName(listOf(
+                "SampleExternalInterface",
+                "SampleExternalClass"),
+                indirectParents = true,
+            ) shouldBeEqualTo true
+            hasExternalParentWithName(listOf(
+                "SampleExternalInterface",
+                "OtherInterface"),
+                indirectParents = true,
+            ) shouldBeEqualTo true
+            hasExternalParentsWithAllNames("SampleExternalInterface", indirectParents = true) shouldBeEqualTo true
             hasExternalParentsWithAllNames("OtherInterface", indirectParents = true) shouldBeEqualTo false
             hasExternalParentsWithAllNames(
-                "SampleExternalClass",
                 "SampleExternalInterface",
+                "SampleExternalClass",
                 indirectParents = true,
             ) shouldBeEqualTo true
             hasExternalParentsWithAllNames(
-                "SampleExternalClass",
+                "SampleExternalInterface",
                 "OtherInterface",
                 indirectParents = true,
             ) shouldBeEqualTo false
-            hasExternalParent(indirectParents = true) { it.name == "SampleExternalClass" } shouldBeEqualTo true
+
+            hasExternalParentsWithAllNames(listOf("SampleExternalInterface"), indirectParents = true) shouldBeEqualTo true
+            hasExternalParentsWithAllNames(listOf("OtherInterface"), indirectParents = true) shouldBeEqualTo false
+            hasExternalParentsWithAllNames(listOf(
+                "SampleExternalInterface",
+                "SampleExternalClass"),
+                indirectParents = true,
+            ) shouldBeEqualTo true
+            hasExternalParentsWithAllNames(listOf(
+                "SampleExternalInterface",
+                "OtherInterface"),
+                indirectParents = true,
+            ) shouldBeEqualTo false
+            hasExternalParent(indirectParents = true) { it.name == "SampleExternalInterface" } shouldBeEqualTo true
             hasExternalParent(indirectParents = true) { it.name == "OtherInterface" } shouldBeEqualTo false
-            hasAllExternalParents(indirectParents = true) { it.name == "SampleExternalClass" } shouldBeEqualTo false
+            hasAllExternalParents(indirectParents = true) { it.name == "SampleExternalInterface" } shouldBeEqualTo false
             hasAllExternalParents(indirectParents = true) { it.hasNameStartingWith("Sample") } shouldBeEqualTo true
             hasAllExternalParents(indirectParents = true) { it.hasNameStartingWith("Other") } shouldBeEqualTo false
-            hasExternalParentOf(SampleExternalClass::class, indirectParents = true) shouldBeEqualTo true
+            hasExternalParentOf(SampleExternalInterface::class, indirectParents = true) shouldBeEqualTo true
             hasExternalParentOf(
-                SampleExternalClass::class,
+                SampleExternalInterface::class,
                 SampleParentClass::class,
                 indirectParents = true,
             ) shouldBeEqualTo true
-            hasAllExternalParentsOf(SampleExternalClass::class, indirectParents = true) shouldBeEqualTo true
+            hasExternalParentOf(listOf(SampleExternalInterface::class), indirectParents = true) shouldBeEqualTo true
+            hasExternalParentOf(listOf(
+                SampleExternalInterface::class,
+                SampleParentClass::class),
+                indirectParents = true,
+            ) shouldBeEqualTo true
+            hasAllExternalParentsOf(SampleExternalInterface::class, indirectParents = true) shouldBeEqualTo true
             hasAllExternalParentsOf(
-                SampleExternalClass::class,
+                SampleExternalInterface::class,
                 SampleParentClass::class,
                 indirectParents = true,
             ) shouldBeEqualTo false
             hasAllExternalParentsOf(
-                SampleExternalClass::class,
                 SampleExternalInterface::class,
+                SampleExternalClass::class,
+                indirectParents = true,
+            ) shouldBeEqualTo true
+
+            hasAllExternalParentsOf(listOf(SampleExternalInterface::class), indirectParents = true) shouldBeEqualTo true
+            hasAllExternalParentsOf(listOf(
+                SampleExternalInterface::class,
+                SampleParentClass::class),
+                indirectParents = true,
+            ) shouldBeEqualTo false
+            hasAllExternalParentsOf(listOf(
+                SampleExternalInterface::class,
+                SampleExternalClass::class),
                 indirectParents = true,
             ) shouldBeEqualTo true
         }

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koclass/KoClassDeclarationForKoFunctionProviderTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koclass/KoClassDeclarationForKoFunctionProviderTest.kt
@@ -21,8 +21,16 @@ class KoClassDeclarationForKoFunctionProviderTest {
         assertSoftly(sut) {
             functions() shouldBeEqualTo emptyList()
             hasFunctions() shouldBeEqualTo false
+            hasFunctionWithName(emptyList()) shouldBeEqualTo false
+            hasFunctionWithName(emptySet()) shouldBeEqualTo false
+            hasFunctionsWithAllNames(emptyList()) shouldBeEqualTo false
+            hasFunctionsWithAllNames(emptySet()) shouldBeEqualTo false
             hasFunctionWithName("sampleFunction") shouldBeEqualTo false
+            hasFunctionWithName(listOf("sampleFunction")) shouldBeEqualTo false
+            hasFunctionWithName(setOf("sampleFunction")) shouldBeEqualTo false
             hasFunctionsWithAllNames("sampleFunction1", "sampleFunction2") shouldBeEqualTo false
+            hasFunctionsWithAllNames(listOf("sampleFunction1", "sampleFunction2")) shouldBeEqualTo false
+            hasFunctionsWithAllNames(setOf("sampleFunction1", "sampleFunction2")) shouldBeEqualTo false
             hasFunction { it.name == "sampleFunction" } shouldBeEqualTo false
             hasAllFunctions { it.hasNameStartingWith("sample") } shouldBeEqualTo true
         }
@@ -39,11 +47,25 @@ class KoClassDeclarationForKoFunctionProviderTest {
         // then
         assertSoftly(sut) {
             hasFunctions() shouldBeEqualTo true
+            hasFunctionWithName(emptyList()) shouldBeEqualTo true
+            hasFunctionWithName(emptySet()) shouldBeEqualTo true
+            hasFunctionsWithAllNames(emptyList()) shouldBeEqualTo true
+            hasFunctionsWithAllNames(emptySet()) shouldBeEqualTo true
             hasFunctionWithName("sampleFunction1") shouldBeEqualTo true
             hasFunctionWithName("sampleFunction1", "otherFunction") shouldBeEqualTo true
+            hasFunctionWithName(listOf("sampleFunction1")) shouldBeEqualTo true
+            hasFunctionWithName(listOf("sampleFunction1", "otherFunction")) shouldBeEqualTo true
+            hasFunctionWithName(setOf("sampleFunction1")) shouldBeEqualTo true
+            hasFunctionWithName(setOf("sampleFunction1", "otherFunction")) shouldBeEqualTo true
             hasFunctionsWithAllNames("sampleFunction1") shouldBeEqualTo true
             hasFunctionsWithAllNames("sampleFunction1", "sampleFunction2") shouldBeEqualTo true
             hasFunctionsWithAllNames("sampleFunction1", "otherFunction") shouldBeEqualTo false
+            hasFunctionsWithAllNames(listOf("sampleFunction1")) shouldBeEqualTo true
+            hasFunctionsWithAllNames(listOf("sampleFunction1", "sampleFunction2")) shouldBeEqualTo true
+            hasFunctionsWithAllNames(listOf("sampleFunction1", "otherFunction")) shouldBeEqualTo false
+            hasFunctionsWithAllNames(setOf("sampleFunction1")) shouldBeEqualTo true
+            hasFunctionsWithAllNames(setOf("sampleFunction1", "sampleFunction2")) shouldBeEqualTo true
+            hasFunctionsWithAllNames(setOf("sampleFunction1", "otherFunction")) shouldBeEqualTo false
             hasFunction { it.name == "sampleFunction1" } shouldBeEqualTo true
             hasFunction { it.hasNameEndingWith("Function1") } shouldBeEqualTo true
             hasAllFunctions { it.hasNameStartingWith("sample") } shouldBeEqualTo true

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koclass/KoClassDeclarationForKoInterfaceProviderTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koclass/KoClassDeclarationForKoInterfaceProviderTest.kt
@@ -21,8 +21,16 @@ class KoClassDeclarationForKoInterfaceProviderTest {
         assertSoftly(sut) {
             interfaces() shouldBeEqualTo emptyList()
             hasInterfaces() shouldBeEqualTo false
+            hasInterfaceWithName(emptyList()) shouldBeEqualTo false
+            hasInterfaceWithName(emptySet()) shouldBeEqualTo false
+            hasInterfacesWithAllNames(emptyList()) shouldBeEqualTo false
+            hasInterfacesWithAllNames(emptySet()) shouldBeEqualTo false
             hasInterfaceWithName("SampleInterface") shouldBeEqualTo false
+            hasInterfaceWithName(listOf("SampleInterface")) shouldBeEqualTo false
+            hasInterfaceWithName(setOf("SampleInterface")) shouldBeEqualTo false
             hasInterfacesWithAllNames("SampleInterface1", "SampleInterface2") shouldBeEqualTo false
+            hasInterfacesWithAllNames(listOf("SampleInterface1", "SampleInterface2")) shouldBeEqualTo false
+            hasInterfacesWithAllNames(setOf("SampleInterface1", "SampleInterface2")) shouldBeEqualTo false
             hasInterface { it.name == "SampleInterface" } shouldBeEqualTo false
             hasAllInterfaces { it.hasNameStartingWith("Sample") } shouldBeEqualTo true
         }
@@ -39,11 +47,25 @@ class KoClassDeclarationForKoInterfaceProviderTest {
         // then
         assertSoftly(sut) {
             hasInterfaces() shouldBeEqualTo true
+            hasInterfaceWithName(emptyList()) shouldBeEqualTo true
+            hasInterfaceWithName(emptySet()) shouldBeEqualTo true
+            hasInterfacesWithAllNames(emptyList()) shouldBeEqualTo true
+            hasInterfacesWithAllNames(emptySet()) shouldBeEqualTo true
             hasInterfaceWithName("SampleInterface1") shouldBeEqualTo true
             hasInterfaceWithName("SampleInterface1", "OtherInterface") shouldBeEqualTo true
+            hasInterfaceWithName(listOf("SampleInterface1")) shouldBeEqualTo true
+            hasInterfaceWithName(listOf("SampleInterface1", "OtherInterface")) shouldBeEqualTo true
+            hasInterfaceWithName(setOf("SampleInterface1")) shouldBeEqualTo true
+            hasInterfaceWithName(setOf("SampleInterface1", "OtherInterface")) shouldBeEqualTo true
             hasInterfacesWithAllNames("SampleInterface1") shouldBeEqualTo true
             hasInterfacesWithAllNames("SampleInterface1", "SampleInterface2") shouldBeEqualTo true
             hasInterfacesWithAllNames("SampleInterface1", "OtherInterface") shouldBeEqualTo false
+            hasInterfacesWithAllNames(listOf("SampleInterface1")) shouldBeEqualTo true
+            hasInterfacesWithAllNames(listOf("SampleInterface1", "SampleInterface2")) shouldBeEqualTo true
+            hasInterfacesWithAllNames(listOf("SampleInterface1", "OtherInterface")) shouldBeEqualTo false
+            hasInterfacesWithAllNames(setOf("SampleInterface1")) shouldBeEqualTo true
+            hasInterfacesWithAllNames(setOf("SampleInterface1", "SampleInterface2")) shouldBeEqualTo true
+            hasInterfacesWithAllNames(setOf("SampleInterface1", "OtherInterface")) shouldBeEqualTo false
             hasInterface { it.name == "SampleInterface1" } shouldBeEqualTo true
             hasInterface { it.hasNameEndingWith("Interface1") } shouldBeEqualTo true
             hasAllInterfaces { it.hasNameStartingWith("Sample") } shouldBeEqualTo true

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koclass/KoClassDeclarationForKoObjectProviderTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koclass/KoClassDeclarationForKoObjectProviderTest.kt
@@ -21,8 +21,16 @@ class KoClassDeclarationForKoObjectProviderTest {
         assertSoftly(sut) {
             objects() shouldBeEqualTo emptyList()
             hasObjects() shouldBeEqualTo false
+            hasObjectWithName(emptyList()) shouldBeEqualTo false
+            hasObjectWithName(emptySet()) shouldBeEqualTo false
+            hasObjectsWithAllNames(emptyList()) shouldBeEqualTo false
+            hasObjectsWithAllNames(emptySet()) shouldBeEqualTo false
             hasObjectWithName("SampleObject") shouldBeEqualTo false
+            hasObjectWithName(listOf("SampleObject")) shouldBeEqualTo false
+            hasObjectWithName(setOf("SampleObject")) shouldBeEqualTo false
             hasObjectsWithAllNames("SampleObject1", "SampleObject2") shouldBeEqualTo false
+            hasObjectsWithAllNames(listOf("SampleObject1", "SampleObject2")) shouldBeEqualTo false
+            hasObjectsWithAllNames(setOf("SampleObject1", "SampleObject2")) shouldBeEqualTo false
             hasObject { it.name == "SampleObject" } shouldBeEqualTo false
             hasAllObjects { it.hasNameStartingWith("Sample") } shouldBeEqualTo true
         }
@@ -39,11 +47,25 @@ class KoClassDeclarationForKoObjectProviderTest {
         // then
         assertSoftly(sut) {
             hasObjects() shouldBeEqualTo true
+            hasObjectWithName(emptyList()) shouldBeEqualTo true
+            hasObjectWithName(emptySet()) shouldBeEqualTo true
+            hasObjectsWithAllNames(emptyList()) shouldBeEqualTo true
+            hasObjectsWithAllNames(emptySet()) shouldBeEqualTo true
             hasObjectWithName("SampleObject1") shouldBeEqualTo true
             hasObjectWithName("SampleObject1", "OtherObject") shouldBeEqualTo true
+            hasObjectWithName(listOf("SampleObject1")) shouldBeEqualTo true
+            hasObjectWithName(listOf("SampleObject1", "OtherObject")) shouldBeEqualTo true
+            hasObjectWithName(setOf("SampleObject1")) shouldBeEqualTo true
+            hasObjectWithName(setOf("SampleObject1", "OtherObject")) shouldBeEqualTo true
             hasObjectsWithAllNames("SampleObject1") shouldBeEqualTo true
             hasObjectsWithAllNames("SampleObject1", "SampleObject2") shouldBeEqualTo true
             hasObjectsWithAllNames("SampleObject1", "OtherObject") shouldBeEqualTo false
+            hasObjectsWithAllNames(listOf("SampleObject1")) shouldBeEqualTo true
+            hasObjectsWithAllNames(listOf("SampleObject1", "SampleObject2")) shouldBeEqualTo true
+            hasObjectsWithAllNames(listOf("SampleObject1", "OtherObject")) shouldBeEqualTo false
+            hasObjectsWithAllNames(setOf("SampleObject1")) shouldBeEqualTo true
+            hasObjectsWithAllNames(setOf("SampleObject1", "SampleObject2")) shouldBeEqualTo true
+            hasObjectsWithAllNames(setOf("SampleObject1", "OtherObject")) shouldBeEqualTo false
             hasObject { it.name == "SampleObject1" } shouldBeEqualTo true
             hasObject { it.hasNameEndingWith("Object1") } shouldBeEqualTo true
             hasAllObjects { it.hasNameStartingWith("Sample") } shouldBeEqualTo true

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koclass/KoClassDeclarationForKoParentClassProviderTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koclass/KoClassDeclarationForKoParentClassProviderTest.kt
@@ -258,26 +258,34 @@ class KoClassDeclarationForKoParentClassProviderTest {
             ) shouldBeEqualTo true
             hasParentClassWithName(listOf("SampleParentClass1"), indirectParents = true) shouldBeEqualTo true
             hasParentClassWithName(listOf("OtherClass"), indirectParents = true) shouldBeEqualTo false
-            hasParentClassWithName(listOf(
-                "SampleParentClass1",
-                "SampleParentClass2"),
+            hasParentClassWithName(
+                listOf(
+                    "SampleParentClass1",
+                    "SampleParentClass2",
+                ),
                 indirectParents = true,
             ) shouldBeEqualTo true
-            hasParentClassWithName(listOf(
-                "SampleParentClass1",
-                "OtherClass"),
+            hasParentClassWithName(
+                listOf(
+                    "SampleParentClass1",
+                    "OtherClass",
+                ),
                 indirectParents = true,
             ) shouldBeEqualTo true
             hasParentClassWithName(setOf("SampleParentClass1"), indirectParents = true) shouldBeEqualTo true
             hasParentClassWithName(setOf("OtherClass"), indirectParents = true) shouldBeEqualTo false
-            hasParentClassWithName(setOf(
-                "SampleParentClass1",
-                "SampleParentClass2"),
+            hasParentClassWithName(
+                setOf(
+                    "SampleParentClass1",
+                    "SampleParentClass2",
+                ),
                 indirectParents = true,
             ) shouldBeEqualTo true
-            hasParentClassWithName(setOf(
-                "SampleParentClass1",
-                "OtherClass"),
+            hasParentClassWithName(
+                setOf(
+                    "SampleParentClass1",
+                    "OtherClass",
+                ),
                 indirectParents = true,
             ) shouldBeEqualTo true
             hasParentClassesWithAllNames("SampleParentClass1", indirectParents = true) shouldBeEqualTo true
@@ -294,26 +302,34 @@ class KoClassDeclarationForKoParentClassProviderTest {
             ) shouldBeEqualTo false
             hasParentClassesWithAllNames(listOf("SampleParentClass1"), indirectParents = true) shouldBeEqualTo true
             hasParentClassesWithAllNames(listOf("OtherClass"), indirectParents = true) shouldBeEqualTo false
-            hasParentClassesWithAllNames(listOf(
-                "SampleParentClass1",
-                "SampleParentClass2"),
+            hasParentClassesWithAllNames(
+                listOf(
+                    "SampleParentClass1",
+                    "SampleParentClass2",
+                ),
                 indirectParents = true,
             ) shouldBeEqualTo true
-            hasParentClassesWithAllNames(listOf(
-                "SampleParentClass1",
-                "OtherClass"),
+            hasParentClassesWithAllNames(
+                listOf(
+                    "SampleParentClass1",
+                    "OtherClass",
+                ),
                 indirectParents = true,
             ) shouldBeEqualTo false
             hasParentClassesWithAllNames(setOf("SampleParentClass1"), indirectParents = true) shouldBeEqualTo true
             hasParentClassesWithAllNames(setOf("OtherClass"), indirectParents = true) shouldBeEqualTo false
-            hasParentClassesWithAllNames(setOf(
-                "SampleParentClass1",
-                "SampleParentClass2"),
+            hasParentClassesWithAllNames(
+                setOf(
+                    "SampleParentClass1",
+                    "SampleParentClass2",
+                ),
                 indirectParents = true,
             ) shouldBeEqualTo true
-            hasParentClassesWithAllNames(setOf(
-                "SampleParentClass1",
-                "OtherClass"),
+            hasParentClassesWithAllNames(
+                setOf(
+                    "SampleParentClass1",
+                    "OtherClass",
+                ),
                 indirectParents = true,
             ) shouldBeEqualTo false
             hasParentClass(indirectParents = true) { it.name == "SampleParentClass1" } shouldBeEqualTo true
@@ -331,15 +347,19 @@ class KoClassDeclarationForKoParentClassProviderTest {
                 indirectParents = true,
             ) shouldBeEqualTo false
             hasAllParentClassesOf(listOf(SampleParentClass2::class), indirectParents = true) shouldBeEqualTo true
-            hasAllParentClassesOf(listOf(
-                SampleParentClass2::class,
-                SampleClass::class),
+            hasAllParentClassesOf(
+                listOf(
+                    SampleParentClass2::class,
+                    SampleClass::class,
+                ),
                 indirectParents = true,
             ) shouldBeEqualTo false
             hasAllParentClassesOf(setOf(SampleParentClass2::class), indirectParents = true) shouldBeEqualTo true
-            hasAllParentClassesOf(setOf(
-                SampleParentClass2::class,
-                SampleClass::class),
+            hasAllParentClassesOf(
+                setOf(
+                    SampleParentClass2::class,
+                    SampleClass::class,
+                ),
                 indirectParents = true,
             ) shouldBeEqualTo false
         }

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koclass/KoClassDeclarationForKoParentClassProviderTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koclass/KoClassDeclarationForKoParentClassProviderTest.kt
@@ -8,6 +8,7 @@ import org.amshove.kluent.assertSoftly
 import org.amshove.kluent.shouldBeEqualTo
 import org.junit.jupiter.api.Test
 
+@Suppress("detekt.LongMethod")
 class KoClassDeclarationForKoParentClassProviderTest {
     @Test
     fun `class-has-no-parent-class`() {
@@ -26,15 +27,35 @@ class KoClassDeclarationForKoParentClassProviderTest {
             hasParentClass() shouldBeEqualTo false
             hasParentClass { it.name == "SampleParentClass" } shouldBeEqualTo false
             hasParentClasses() shouldBeEqualTo false
+            hasParentClassWithName(emptyList()) shouldBeEqualTo false
+            hasParentClassWithName(emptySet()) shouldBeEqualTo false
+            hasParentClassesWithAllNames(emptyList()) shouldBeEqualTo false
+            hasParentClassesWithAllNames(emptySet()) shouldBeEqualTo false
             hasAllParentClasses { it.hasPrivateModifier } shouldBeEqualTo true
             hasParentClassWithName("SampleParentClass") shouldBeEqualTo false
             hasParentClassWithName("SampleParentClass", "OtherClass") shouldBeEqualTo false
+            hasParentClassWithName(listOf("SampleParentClass")) shouldBeEqualTo false
+            hasParentClassWithName(listOf("SampleParentClass", "OtherClass")) shouldBeEqualTo false
+            hasParentClassWithName(setOf("SampleParentClass")) shouldBeEqualTo false
+            hasParentClassWithName(setOf("SampleParentClass", "OtherClass")) shouldBeEqualTo false
             hasParentClassesWithAllNames("SampleParentClass") shouldBeEqualTo false
             hasParentClassesWithAllNames("SampleParentClass", "OtherClass") shouldBeEqualTo false
+            hasParentClassesWithAllNames(listOf("SampleParentClass")) shouldBeEqualTo false
+            hasParentClassesWithAllNames(listOf("SampleParentClass", "OtherClass")) shouldBeEqualTo false
+            hasParentClassesWithAllNames(setOf("SampleParentClass")) shouldBeEqualTo false
+            hasParentClassesWithAllNames(setOf("SampleParentClass", "OtherClass")) shouldBeEqualTo false
             hasParentClassOf(SampleParentClass::class) shouldBeEqualTo false
             hasParentClassOf(SampleParentClass::class, SampleClass::class) shouldBeEqualTo false
+            hasParentClassOf(listOf(SampleParentClass::class)) shouldBeEqualTo false
+            hasParentClassOf(listOf(SampleParentClass::class, SampleClass::class)) shouldBeEqualTo false
+            hasParentClassOf(setOf(SampleParentClass::class)) shouldBeEqualTo false
+            hasParentClassOf(setOf(SampleParentClass::class, SampleClass::class)) shouldBeEqualTo false
             hasAllParentClassesOf(SampleParentClass::class) shouldBeEqualTo false
             hasAllParentClassesOf(SampleParentClass::class, SampleClass::class) shouldBeEqualTo false
+            hasAllParentClassesOf(listOf(SampleParentClass::class)) shouldBeEqualTo false
+            hasAllParentClassesOf(listOf(SampleParentClass::class, SampleClass::class)) shouldBeEqualTo false
+            hasAllParentClassesOf(setOf(SampleParentClass::class)) shouldBeEqualTo false
+            hasAllParentClassesOf(setOf(SampleParentClass::class, SampleClass::class)) shouldBeEqualTo false
             hasParentClass("SampleParentClass") shouldBeEqualTo false
         }
     }
@@ -58,20 +79,48 @@ class KoClassDeclarationForKoParentClassProviderTest {
             hasParentClass { it.name == "SampleParentClass" } shouldBeEqualTo true
             hasParentClass { it.name == "OtherClass" } shouldBeEqualTo false
             hasParentClasses() shouldBeEqualTo true
+            hasParentClassWithName(emptyList()) shouldBeEqualTo true
+            hasParentClassWithName(emptySet()) shouldBeEqualTo true
+            hasParentClassesWithAllNames(emptyList()) shouldBeEqualTo true
+            hasParentClassesWithAllNames(emptySet()) shouldBeEqualTo true
             hasAllParentClasses { it.hasNameStartingWith("Sample") } shouldBeEqualTo true
             hasAllParentClasses { it.hasPrivateModifier } shouldBeEqualTo false
             hasParentClassWithName("SampleParentClass") shouldBeEqualTo true
             hasParentClassWithName("OtherClass") shouldBeEqualTo false
             hasParentClassWithName("SampleParentClass", "OtherClass") shouldBeEqualTo true
+            hasParentClassWithName(listOf("SampleParentClass")) shouldBeEqualTo true
+            hasParentClassWithName(listOf("OtherClass")) shouldBeEqualTo false
+            hasParentClassWithName(listOf("SampleParentClass", "OtherClass")) shouldBeEqualTo true
+            hasParentClassWithName(setOf("SampleParentClass")) shouldBeEqualTo true
+            hasParentClassWithName(setOf("OtherClass")) shouldBeEqualTo false
+            hasParentClassWithName(setOf("SampleParentClass", "OtherClass")) shouldBeEqualTo true
             hasParentClassesWithAllNames("SampleParentClass") shouldBeEqualTo true
             hasParentClassesWithAllNames("OtherClass") shouldBeEqualTo false
             hasParentClassesWithAllNames("SampleParentClass", "OtherClass") shouldBeEqualTo false
+            hasParentClassesWithAllNames(listOf("SampleParentClass")) shouldBeEqualTo true
+            hasParentClassesWithAllNames(listOf("OtherClass")) shouldBeEqualTo false
+            hasParentClassesWithAllNames(listOf("SampleParentClass", "OtherClass")) shouldBeEqualTo false
+            hasParentClassesWithAllNames(setOf("SampleParentClass")) shouldBeEqualTo true
+            hasParentClassesWithAllNames(setOf("OtherClass")) shouldBeEqualTo false
+            hasParentClassesWithAllNames(setOf("SampleParentClass", "OtherClass")) shouldBeEqualTo false
             hasParentClassOf(SampleParentClass::class) shouldBeEqualTo true
             hasParentClassOf(SampleClass::class) shouldBeEqualTo false
             hasParentClassOf(SampleParentClass::class, SampleClass::class) shouldBeEqualTo true
+            hasParentClassOf(listOf(SampleParentClass::class)) shouldBeEqualTo true
+            hasParentClassOf(listOf(SampleClass::class)) shouldBeEqualTo false
+            hasParentClassOf(listOf(SampleParentClass::class, SampleClass::class)) shouldBeEqualTo true
+            hasParentClassOf(setOf(SampleParentClass::class)) shouldBeEqualTo true
+            hasParentClassOf(setOf(SampleClass::class)) shouldBeEqualTo false
+            hasParentClassOf(setOf(SampleParentClass::class, SampleClass::class)) shouldBeEqualTo true
             hasAllParentClassesOf(SampleParentClass::class) shouldBeEqualTo true
             hasAllParentClassesOf(SampleClass::class) shouldBeEqualTo false
             hasAllParentClassesOf(SampleParentClass::class, SampleClass::class) shouldBeEqualTo false
+            hasAllParentClassesOf(listOf(SampleParentClass::class)) shouldBeEqualTo true
+            hasAllParentClassesOf(listOf(SampleClass::class)) shouldBeEqualTo false
+            hasAllParentClassesOf(listOf(SampleParentClass::class, SampleClass::class)) shouldBeEqualTo false
+            hasAllParentClassesOf(setOf(SampleParentClass::class)) shouldBeEqualTo true
+            hasAllParentClassesOf(setOf(SampleClass::class)) shouldBeEqualTo false
+            hasAllParentClassesOf(setOf(SampleParentClass::class, SampleClass::class)) shouldBeEqualTo false
             hasParentClass("SampleParentClass") shouldBeEqualTo true
             hasParentClass("OtherClass") shouldBeEqualTo false
         }
@@ -96,20 +145,48 @@ class KoClassDeclarationForKoParentClassProviderTest {
             hasParentClass { it.name == "SampleParentClass" } shouldBeEqualTo true
             hasParentClass { it.name == "OtherClass" } shouldBeEqualTo false
             hasParentClasses() shouldBeEqualTo true
+            hasParentClassWithName(emptyList()) shouldBeEqualTo true
+            hasParentClassWithName(emptySet()) shouldBeEqualTo true
+            hasParentClassesWithAllNames(emptyList()) shouldBeEqualTo true
+            hasParentClassesWithAllNames(emptySet()) shouldBeEqualTo true
             hasAllParentClasses { it.hasNameStartingWith("Sample") } shouldBeEqualTo true
             hasAllParentClasses { it.hasPrivateModifier } shouldBeEqualTo false
             hasParentClassWithName("SampleParentClass") shouldBeEqualTo true
             hasParentClassWithName("OtherClass") shouldBeEqualTo false
             hasParentClassWithName("SampleParentClass", "OtherClass") shouldBeEqualTo true
+            hasParentClassWithName(listOf("SampleParentClass")) shouldBeEqualTo true
+            hasParentClassWithName(listOf("OtherClass")) shouldBeEqualTo false
+            hasParentClassWithName(listOf("SampleParentClass", "OtherClass")) shouldBeEqualTo true
+            hasParentClassWithName(setOf("SampleParentClass")) shouldBeEqualTo true
+            hasParentClassWithName(setOf("OtherClass")) shouldBeEqualTo false
+            hasParentClassWithName(setOf("SampleParentClass", "OtherClass")) shouldBeEqualTo true
             hasParentClassesWithAllNames("SampleParentClass") shouldBeEqualTo true
             hasParentClassesWithAllNames("OtherClass") shouldBeEqualTo false
             hasParentClassesWithAllNames("SampleParentClass", "OtherClass") shouldBeEqualTo false
+            hasParentClassesWithAllNames(listOf("SampleParentClass")) shouldBeEqualTo true
+            hasParentClassesWithAllNames(listOf("OtherClass")) shouldBeEqualTo false
+            hasParentClassesWithAllNames(listOf("SampleParentClass", "OtherClass")) shouldBeEqualTo false
+            hasParentClassesWithAllNames(setOf("SampleParentClass")) shouldBeEqualTo true
+            hasParentClassesWithAllNames(setOf("OtherClass")) shouldBeEqualTo false
+            hasParentClassesWithAllNames(setOf("SampleParentClass", "OtherClass")) shouldBeEqualTo false
             hasParentClassOf(SampleParentClass::class) shouldBeEqualTo true
             hasParentClassOf(SampleClass::class) shouldBeEqualTo false
             hasParentClassOf(SampleParentClass::class, SampleClass::class) shouldBeEqualTo true
+            hasParentClassOf(listOf(SampleParentClass::class)) shouldBeEqualTo true
+            hasParentClassOf(listOf(SampleClass::class)) shouldBeEqualTo false
+            hasParentClassOf(listOf(SampleParentClass::class, SampleClass::class)) shouldBeEqualTo true
+            hasParentClassOf(setOf(SampleParentClass::class)) shouldBeEqualTo true
+            hasParentClassOf(setOf(SampleClass::class)) shouldBeEqualTo false
+            hasParentClassOf(setOf(SampleParentClass::class, SampleClass::class)) shouldBeEqualTo true
             hasAllParentClassesOf(SampleParentClass::class) shouldBeEqualTo true
             hasAllParentClassesOf(SampleClass::class) shouldBeEqualTo false
             hasAllParentClassesOf(SampleParentClass::class, SampleClass::class) shouldBeEqualTo false
+            hasAllParentClassesOf(listOf(SampleParentClass::class)) shouldBeEqualTo true
+            hasAllParentClassesOf(listOf(SampleClass::class)) shouldBeEqualTo false
+            hasAllParentClassesOf(listOf(SampleParentClass::class, SampleClass::class)) shouldBeEqualTo false
+            hasAllParentClassesOf(setOf(SampleParentClass::class)) shouldBeEqualTo true
+            hasAllParentClassesOf(setOf(SampleClass::class)) shouldBeEqualTo false
+            hasAllParentClassesOf(setOf(SampleParentClass::class, SampleClass::class)) shouldBeEqualTo false
             hasParentClass("SampleParentClass") shouldBeEqualTo true
             hasParentClass("OtherClass") shouldBeEqualTo false
         }
@@ -137,7 +214,6 @@ class KoClassDeclarationForKoParentClassProviderTest {
         }
     }
 
-    @Suppress("detekt.LongMethod")
     @Test
     fun `class-has-indirect-parent-classes`() {
         // given
@@ -164,6 +240,10 @@ class KoClassDeclarationForKoParentClassProviderTest {
             hasParentClass() shouldBeEqualTo true
             hasParentClasses(indirectParents = false) shouldBeEqualTo true
             hasParentClasses(indirectParents = true) shouldBeEqualTo true
+            hasParentClassWithName(emptyList(), indirectParents = false) shouldBeEqualTo true
+            hasParentClassWithName(emptySet(), indirectParents = false) shouldBeEqualTo true
+            hasParentClassesWithAllNames(emptyList(), indirectParents = false) shouldBeEqualTo true
+            hasParentClassesWithAllNames(emptySet(), indirectParents = false) shouldBeEqualTo true
             hasParentClassWithName("SampleParentClass1", indirectParents = true) shouldBeEqualTo true
             hasParentClassWithName("OtherClass", indirectParents = true) shouldBeEqualTo false
             hasParentClassWithName(
@@ -174,6 +254,30 @@ class KoClassDeclarationForKoParentClassProviderTest {
             hasParentClassWithName(
                 "SampleParentClass1",
                 "OtherClass",
+                indirectParents = true,
+            ) shouldBeEqualTo true
+            hasParentClassWithName(listOf("SampleParentClass1"), indirectParents = true) shouldBeEqualTo true
+            hasParentClassWithName(listOf("OtherClass"), indirectParents = true) shouldBeEqualTo false
+            hasParentClassWithName(listOf(
+                "SampleParentClass1",
+                "SampleParentClass2"),
+                indirectParents = true,
+            ) shouldBeEqualTo true
+            hasParentClassWithName(listOf(
+                "SampleParentClass1",
+                "OtherClass"),
+                indirectParents = true,
+            ) shouldBeEqualTo true
+            hasParentClassWithName(setOf("SampleParentClass1"), indirectParents = true) shouldBeEqualTo true
+            hasParentClassWithName(setOf("OtherClass"), indirectParents = true) shouldBeEqualTo false
+            hasParentClassWithName(setOf(
+                "SampleParentClass1",
+                "SampleParentClass2"),
+                indirectParents = true,
+            ) shouldBeEqualTo true
+            hasParentClassWithName(setOf(
+                "SampleParentClass1",
+                "OtherClass"),
                 indirectParents = true,
             ) shouldBeEqualTo true
             hasParentClassesWithAllNames("SampleParentClass1", indirectParents = true) shouldBeEqualTo true
@@ -188,16 +292,54 @@ class KoClassDeclarationForKoParentClassProviderTest {
                 "OtherClass",
                 indirectParents = true,
             ) shouldBeEqualTo false
+            hasParentClassesWithAllNames(listOf("SampleParentClass1"), indirectParents = true) shouldBeEqualTo true
+            hasParentClassesWithAllNames(listOf("OtherClass"), indirectParents = true) shouldBeEqualTo false
+            hasParentClassesWithAllNames(listOf(
+                "SampleParentClass1",
+                "SampleParentClass2"),
+                indirectParents = true,
+            ) shouldBeEqualTo true
+            hasParentClassesWithAllNames(listOf(
+                "SampleParentClass1",
+                "OtherClass"),
+                indirectParents = true,
+            ) shouldBeEqualTo false
+            hasParentClassesWithAllNames(setOf("SampleParentClass1"), indirectParents = true) shouldBeEqualTo true
+            hasParentClassesWithAllNames(setOf("OtherClass"), indirectParents = true) shouldBeEqualTo false
+            hasParentClassesWithAllNames(setOf(
+                "SampleParentClass1",
+                "SampleParentClass2"),
+                indirectParents = true,
+            ) shouldBeEqualTo true
+            hasParentClassesWithAllNames(setOf(
+                "SampleParentClass1",
+                "OtherClass"),
+                indirectParents = true,
+            ) shouldBeEqualTo false
             hasParentClass(indirectParents = true) { it.name == "SampleParentClass1" } shouldBeEqualTo true
             hasParentClass(indirectParents = true) { it.name == "OtherClass" } shouldBeEqualTo false
             hasAllParentClasses(indirectParents = true) { it.name == "SampleParentClass1" } shouldBeEqualTo false
             hasAllParentClasses(indirectParents = true) { it.hasNameStartingWith("Sample") } shouldBeEqualTo true
             hasAllParentClasses(indirectParents = true) { it.hasNameStartingWith("Other") } shouldBeEqualTo false
             hasParentClassOf(SampleParentClass2::class, indirectParents = true) shouldBeEqualTo true
+            hasParentClassOf(listOf(SampleParentClass2::class), indirectParents = true) shouldBeEqualTo true
+            hasParentClassOf(setOf(SampleParentClass2::class), indirectParents = true) shouldBeEqualTo true
             hasAllParentClassesOf(SampleParentClass2::class, indirectParents = true) shouldBeEqualTo true
             hasAllParentClassesOf(
                 SampleParentClass2::class,
                 SampleClass::class,
+                indirectParents = true,
+            ) shouldBeEqualTo false
+            hasAllParentClassesOf(listOf(SampleParentClass2::class), indirectParents = true) shouldBeEqualTo true
+            hasAllParentClassesOf(listOf(
+                SampleParentClass2::class,
+                SampleClass::class),
+                indirectParents = true,
+            ) shouldBeEqualTo false
+            hasAllParentClassesOf(setOf(SampleParentClass2::class), indirectParents = true) shouldBeEqualTo true
+            hasAllParentClassesOf(setOf(
+                SampleParentClass2::class,
+                SampleClass::class),
                 indirectParents = true,
             ) shouldBeEqualTo false
         }

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koclass/KoClassDeclarationForKoParentInterfaceProviderTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koclass/KoClassDeclarationForKoParentInterfaceProviderTest.kt
@@ -22,16 +22,26 @@ class KoClassDeclarationForKoParentInterfaceProviderTest {
         assertSoftly(sut) {
             parentInterfaces shouldBeEqualTo emptyList()
             numParentInterfaces shouldBeEqualTo 0
-            parentInterfaces() shouldBeEqualTo emptyList()
-            numParentInterfaces() shouldBeEqualTo 0
             countParentInterfaces { it.name == "SampleParentInterface" } shouldBeEqualTo 0
             hasParentInterfaces() shouldBeEqualTo false
+            hasParentInterfaceWithName(emptyList()) shouldBeEqualTo false
+            hasParentInterfaceWithName(emptySet()) shouldBeEqualTo false
+            hasParentInterfacesWithAllNames(emptyList()) shouldBeEqualTo false
+            hasParentInterfacesWithAllNames(emptySet()) shouldBeEqualTo false
             hasParentInterfaceWithName("SampleParentInterface1", "SampleParentInterface2") shouldBeEqualTo false
+            hasParentInterfaceWithName(listOf("SampleParentInterface1", "SampleParentInterface2")) shouldBeEqualTo false
+            hasParentInterfaceWithName(setOf("SampleParentInterface1", "SampleParentInterface2")) shouldBeEqualTo false
             hasParentInterfacesWithAllNames("SampleParentInterface1", "SampleParentInterface2") shouldBeEqualTo false
+            hasParentInterfacesWithAllNames(listOf("SampleParentInterface1", "SampleParentInterface2")) shouldBeEqualTo false
+            hasParentInterfacesWithAllNames(setOf("SampleParentInterface1", "SampleParentInterface2")) shouldBeEqualTo false
             hasParentInterface { it.name == "SampleParentInterface" } shouldBeEqualTo false
             hasAllParentInterfaces { it.hasNameStartingWith("Sample") } shouldBeEqualTo true
             hasParentInterfaceOf(SampleParentInterface1::class) shouldBeEqualTo false
+            hasParentInterfaceOf(listOf(SampleParentInterface1::class)) shouldBeEqualTo false
+            hasParentInterfaceOf(setOf(SampleParentInterface1::class)) shouldBeEqualTo false
             hasAllParentInterfacesOf(SampleParentInterface1::class, SampleParentInterface2::class) shouldBeEqualTo false
+            hasAllParentInterfacesOf(listOf(SampleParentInterface1::class, SampleParentInterface2::class)) shouldBeEqualTo false
+            hasAllParentInterfacesOf(setOf(SampleParentInterface1::class, SampleParentInterface2::class)) shouldBeEqualTo false
             hasParentInterfaces("SampleParentInterface") shouldBeEqualTo false
         }
     }
@@ -48,19 +58,37 @@ class KoClassDeclarationForKoParentInterfaceProviderTest {
         assertSoftly(sut) {
             parentInterfaces.map { it.name } shouldBeEqualTo listOf("SampleParentInterface1", "SampleParentInterface2")
             numParentInterfaces shouldBeEqualTo 2
-            parentInterfaces().map { it.name } shouldBeEqualTo listOf("SampleParentInterface1", "SampleParentInterface2")
-            numParentInterfaces() shouldBeEqualTo 2
             countParentInterfaces { it.name == "SampleParentInterface1" } shouldBeEqualTo 1
             countParentInterfaces { it.hasNameStartingWith("SampleParentInterface") } shouldBeEqualTo 2
             hasParentInterfaces() shouldBeEqualTo true
+            hasParentInterfaceWithName(emptyList()) shouldBeEqualTo true
+            hasParentInterfaceWithName(emptySet()) shouldBeEqualTo true
+            hasParentInterfacesWithAllNames(emptyList()) shouldBeEqualTo true
+            hasParentInterfacesWithAllNames(emptySet()) shouldBeEqualTo true
             hasParentInterfaceWithName("SampleParentInterface1") shouldBeEqualTo true
             hasParentInterfaceWithName("OtherInterface") shouldBeEqualTo false
             hasParentInterfaceWithName("SampleParentInterface1", "SampleParentInterface2") shouldBeEqualTo true
             hasParentInterfaceWithName("SampleParentInterface1", "OtherInterface") shouldBeEqualTo true
+            hasParentInterfaceWithName(listOf("SampleParentInterface1")) shouldBeEqualTo true
+            hasParentInterfaceWithName(listOf("OtherInterface")) shouldBeEqualTo false
+            hasParentInterfaceWithName(listOf("SampleParentInterface1", "SampleParentInterface2")) shouldBeEqualTo true
+            hasParentInterfaceWithName(listOf("SampleParentInterface1", "OtherInterface")) shouldBeEqualTo true
+            hasParentInterfaceWithName(setOf("SampleParentInterface1")) shouldBeEqualTo true
+            hasParentInterfaceWithName(setOf("OtherInterface")) shouldBeEqualTo false
+            hasParentInterfaceWithName(setOf("SampleParentInterface1", "SampleParentInterface2")) shouldBeEqualTo true
+            hasParentInterfaceWithName(setOf("SampleParentInterface1", "OtherInterface")) shouldBeEqualTo true
             hasParentInterfacesWithAllNames("SampleParentInterface1") shouldBeEqualTo true
             hasParentInterfacesWithAllNames("OtherInterface") shouldBeEqualTo false
             hasParentInterfacesWithAllNames("SampleParentInterface1", "SampleParentInterface2") shouldBeEqualTo true
             hasParentInterfacesWithAllNames("SampleParentInterface1", "OtherInterface") shouldBeEqualTo false
+            hasParentInterfacesWithAllNames(listOf("SampleParentInterface1")) shouldBeEqualTo true
+            hasParentInterfacesWithAllNames(listOf("OtherInterface")) shouldBeEqualTo false
+            hasParentInterfacesWithAllNames(listOf("SampleParentInterface1", "SampleParentInterface2")) shouldBeEqualTo true
+            hasParentInterfacesWithAllNames(listOf("SampleParentInterface1", "OtherInterface")) shouldBeEqualTo false
+            hasParentInterfacesWithAllNames(setOf("SampleParentInterface1")) shouldBeEqualTo true
+            hasParentInterfacesWithAllNames(setOf("OtherInterface")) shouldBeEqualTo false
+            hasParentInterfacesWithAllNames(setOf("SampleParentInterface1", "SampleParentInterface2")) shouldBeEqualTo true
+            hasParentInterfacesWithAllNames(setOf("SampleParentInterface1", "OtherInterface")) shouldBeEqualTo false
             hasParentInterface { it.name == "SampleParentInterface1" } shouldBeEqualTo true
             hasParentInterface { it.name == "OtherInterface" } shouldBeEqualTo false
             hasAllParentInterfaces { it.name == "SampleParentInterface1" } shouldBeEqualTo false
@@ -68,9 +96,19 @@ class KoClassDeclarationForKoParentInterfaceProviderTest {
             hasAllParentInterfaces { it.hasNameStartingWith("Other") } shouldBeEqualTo false
             hasParentInterfaceOf(SampleParentInterface1::class) shouldBeEqualTo true
             hasParentInterfaceOf(SampleParentInterface1::class, SampleParentClass::class) shouldBeEqualTo true
+            hasParentInterfaceOf(listOf(SampleParentInterface1::class)) shouldBeEqualTo true
+            hasParentInterfaceOf(listOf(SampleParentInterface1::class, SampleParentClass::class)) shouldBeEqualTo true
+            hasParentInterfaceOf(setOf(SampleParentInterface1::class)) shouldBeEqualTo true
+            hasParentInterfaceOf(setOf(SampleParentInterface1::class, SampleParentClass::class)) shouldBeEqualTo true
             hasAllParentInterfacesOf(SampleParentInterface1::class) shouldBeEqualTo true
             hasAllParentInterfacesOf(SampleParentInterface1::class, SampleParentClass::class) shouldBeEqualTo false
             hasAllParentInterfacesOf(SampleParentInterface1::class, SampleParentInterface2::class) shouldBeEqualTo true
+            hasAllParentInterfacesOf(listOf(SampleParentInterface1::class)) shouldBeEqualTo true
+            hasAllParentInterfacesOf(listOf(SampleParentInterface1::class, SampleParentClass::class)) shouldBeEqualTo false
+            hasAllParentInterfacesOf(listOf(SampleParentInterface1::class, SampleParentInterface2::class)) shouldBeEqualTo true
+            hasAllParentInterfacesOf(setOf(SampleParentInterface1::class)) shouldBeEqualTo true
+            hasAllParentInterfacesOf(setOf(SampleParentInterface1::class, SampleParentClass::class)) shouldBeEqualTo false
+            hasAllParentInterfacesOf(setOf(SampleParentInterface1::class, SampleParentInterface2::class)) shouldBeEqualTo true
             hasParentInterfaces("SampleParentInterface1") shouldBeEqualTo true
             hasParentInterfaces("OtherInterface") shouldBeEqualTo false
             hasParentInterfaces("SampleParentInterface1", "SampleParentInterface2") shouldBeEqualTo true
@@ -88,35 +126,63 @@ class KoClassDeclarationForKoParentInterfaceProviderTest {
 
         // then
         assertSoftly(sut) {
-            parentInterfaces.map { it.name } shouldBeEqualTo listOf("SampleParentInterface1", "SampleParentInterface2")
-            numParentInterfaces shouldBeEqualTo 2
-            parentInterfaces().map { it.name } shouldBeEqualTo listOf("SampleParentInterface1", "SampleParentInterface2")
-            numParentInterfaces() shouldBeEqualTo 2
-            countParentInterfaces { it.name == "SampleParentInterface1" } shouldBeEqualTo 1
-            countParentInterfaces { it.hasNameStartingWith("SampleParentInterface") } shouldBeEqualTo 2
-            hasParentInterfaces() shouldBeEqualTo true
-            hasParentInterfaceWithName("SampleParentInterface1") shouldBeEqualTo true
-            hasParentInterfaceWithName("OtherInterface") shouldBeEqualTo false
-            hasParentInterfaceWithName("SampleParentInterface1", "SampleParentInterface2") shouldBeEqualTo true
-            hasParentInterfaceWithName("SampleParentInterface1", "OtherInterface") shouldBeEqualTo true
-            hasParentInterfacesWithAllNames("SampleParentInterface1") shouldBeEqualTo true
-            hasParentInterfacesWithAllNames("OtherInterface") shouldBeEqualTo false
-            hasParentInterfacesWithAllNames("SampleParentInterface1", "SampleParentInterface2") shouldBeEqualTo true
-            hasParentInterfacesWithAllNames("SampleParentInterface1", "OtherInterface") shouldBeEqualTo false
-            hasParentInterface { it.name == "SampleParentInterface1" } shouldBeEqualTo true
-            hasParentInterface { it.name == "OtherInterface" } shouldBeEqualTo false
-            hasAllParentInterfaces { it.name == "SampleParentInterface1" } shouldBeEqualTo false
-            hasAllParentInterfaces { it.hasNameStartingWith("Sample") } shouldBeEqualTo true
-            hasAllParentInterfaces { it.hasNameStartingWith("Other") } shouldBeEqualTo false
-            hasParentInterfaceOf(SampleParentInterface1::class) shouldBeEqualTo true
-            hasParentInterfaceOf(SampleParentInterface1::class, SampleParentClass::class) shouldBeEqualTo true
-            hasAllParentInterfacesOf(SampleParentInterface1::class) shouldBeEqualTo true
-            hasAllParentInterfacesOf(SampleParentInterface1::class, SampleParentClass::class) shouldBeEqualTo false
-            hasAllParentInterfacesOf(SampleParentInterface1::class, SampleParentInterface2::class) shouldBeEqualTo true
-            hasParentInterfaces("SampleParentInterface1") shouldBeEqualTo true
-            hasParentInterfaces("OtherInterface") shouldBeEqualTo false
-            hasParentInterfaces("SampleParentInterface1", "SampleParentInterface2") shouldBeEqualTo true
-            hasParentInterfaces("SampleParentInterface1", "OtherInterface") shouldBeEqualTo false
+                parentInterfaces.map { it.name } shouldBeEqualTo listOf("SampleParentInterface1", "SampleParentInterface2")
+                numParentInterfaces shouldBeEqualTo 2
+                countParentInterfaces { it.name == "SampleParentInterface1" } shouldBeEqualTo 1
+                countParentInterfaces { it.hasNameStartingWith("SampleParentInterface") } shouldBeEqualTo 2
+                hasParentInterfaces() shouldBeEqualTo true
+                hasParentInterfaceWithName(emptyList()) shouldBeEqualTo true
+                hasParentInterfaceWithName(emptySet()) shouldBeEqualTo true
+                hasParentInterfacesWithAllNames(emptyList()) shouldBeEqualTo true
+                hasParentInterfacesWithAllNames(emptySet()) shouldBeEqualTo true
+                hasParentInterfaceWithName("SampleParentInterface1") shouldBeEqualTo true
+                hasParentInterfaceWithName("OtherInterface") shouldBeEqualTo false
+                hasParentInterfaceWithName("SampleParentInterface1", "SampleParentInterface2") shouldBeEqualTo true
+                hasParentInterfaceWithName("SampleParentInterface1", "OtherInterface") shouldBeEqualTo true
+                hasParentInterfaceWithName(listOf("SampleParentInterface1")) shouldBeEqualTo true
+                hasParentInterfaceWithName(listOf("OtherInterface")) shouldBeEqualTo false
+                hasParentInterfaceWithName(listOf("SampleParentInterface1", "SampleParentInterface2")) shouldBeEqualTo true
+                hasParentInterfaceWithName(listOf("SampleParentInterface1", "OtherInterface")) shouldBeEqualTo true
+                hasParentInterfaceWithName(setOf("SampleParentInterface1")) shouldBeEqualTo true
+                hasParentInterfaceWithName(setOf("OtherInterface")) shouldBeEqualTo false
+                hasParentInterfaceWithName(setOf("SampleParentInterface1", "SampleParentInterface2")) shouldBeEqualTo true
+                hasParentInterfaceWithName(setOf("SampleParentInterface1", "OtherInterface")) shouldBeEqualTo true
+                hasParentInterfacesWithAllNames("SampleParentInterface1") shouldBeEqualTo true
+                hasParentInterfacesWithAllNames("OtherInterface") shouldBeEqualTo false
+                hasParentInterfacesWithAllNames("SampleParentInterface1", "SampleParentInterface2") shouldBeEqualTo true
+                hasParentInterfacesWithAllNames("SampleParentInterface1", "OtherInterface") shouldBeEqualTo false
+                hasParentInterfacesWithAllNames(listOf("SampleParentInterface1")) shouldBeEqualTo true
+                hasParentInterfacesWithAllNames(listOf("OtherInterface")) shouldBeEqualTo false
+                hasParentInterfacesWithAllNames(listOf("SampleParentInterface1", "SampleParentInterface2")) shouldBeEqualTo true
+                hasParentInterfacesWithAllNames(listOf("SampleParentInterface1", "OtherInterface")) shouldBeEqualTo false
+                hasParentInterfacesWithAllNames(setOf("SampleParentInterface1")) shouldBeEqualTo true
+                hasParentInterfacesWithAllNames(setOf("OtherInterface")) shouldBeEqualTo false
+                hasParentInterfacesWithAllNames(setOf("SampleParentInterface1", "SampleParentInterface2")) shouldBeEqualTo true
+                hasParentInterfacesWithAllNames(setOf("SampleParentInterface1", "OtherInterface")) shouldBeEqualTo false
+                hasParentInterface { it.name == "SampleParentInterface1" } shouldBeEqualTo true
+                hasParentInterface { it.name == "OtherInterface" } shouldBeEqualTo false
+                hasAllParentInterfaces { it.name == "SampleParentInterface1" } shouldBeEqualTo false
+                hasAllParentInterfaces { it.hasNameStartingWith("Sample") } shouldBeEqualTo true
+                hasAllParentInterfaces { it.hasNameStartingWith("Other") } shouldBeEqualTo false
+                hasParentInterfaceOf(SampleParentInterface1::class) shouldBeEqualTo true
+                hasParentInterfaceOf(SampleParentInterface1::class, SampleParentClass::class) shouldBeEqualTo true
+                hasParentInterfaceOf(listOf(SampleParentInterface1::class)) shouldBeEqualTo true
+                hasParentInterfaceOf(listOf(SampleParentInterface1::class, SampleParentClass::class)) shouldBeEqualTo true
+                hasParentInterfaceOf(setOf(SampleParentInterface1::class)) shouldBeEqualTo true
+                hasParentInterfaceOf(setOf(SampleParentInterface1::class, SampleParentClass::class)) shouldBeEqualTo true
+                hasAllParentInterfacesOf(SampleParentInterface1::class) shouldBeEqualTo true
+                hasAllParentInterfacesOf(SampleParentInterface1::class, SampleParentClass::class) shouldBeEqualTo false
+                hasAllParentInterfacesOf(SampleParentInterface1::class, SampleParentInterface2::class) shouldBeEqualTo true
+                hasAllParentInterfacesOf(listOf(SampleParentInterface1::class)) shouldBeEqualTo true
+                hasAllParentInterfacesOf(listOf(SampleParentInterface1::class, SampleParentClass::class)) shouldBeEqualTo false
+                hasAllParentInterfacesOf(listOf(SampleParentInterface1::class, SampleParentInterface2::class)) shouldBeEqualTo true
+                hasAllParentInterfacesOf(setOf(SampleParentInterface1::class)) shouldBeEqualTo true
+                hasAllParentInterfacesOf(setOf(SampleParentInterface1::class, SampleParentClass::class)) shouldBeEqualTo false
+                hasAllParentInterfacesOf(setOf(SampleParentInterface1::class, SampleParentInterface2::class)) shouldBeEqualTo true
+                hasParentInterfaces("SampleParentInterface1") shouldBeEqualTo true
+                hasParentInterfaces("OtherInterface") shouldBeEqualTo false
+                hasParentInterfaces("SampleParentInterface1", "SampleParentInterface2") shouldBeEqualTo true
+                hasParentInterfaces("SampleParentInterface1", "OtherInterface") shouldBeEqualTo false
         }
     }
 
@@ -133,10 +199,10 @@ class KoClassDeclarationForKoParentInterfaceProviderTest {
         assertSoftly(sut) {
             parentInterfaces(indirectParents = false) shouldBeEqualTo emptyList()
             parentInterfaces(indirectParents = true).map { it.name } shouldBeEqualTo
-                listOf(
-                    "SampleParentInterface1",
-                    "SampleParentInterface2",
-                )
+                    listOf(
+                        "SampleParentInterface1",
+                        "SampleParentInterface2",
+                    )
             numParentInterfaces(indirectParents = false) shouldBeEqualTo 0
             numParentInterfaces(indirectParents = true) shouldBeEqualTo 2
             countParentInterfaces(indirectParents = false) { it.name == "SampleParentInterface1" } shouldBeEqualTo 0
@@ -145,6 +211,14 @@ class KoClassDeclarationForKoParentInterfaceProviderTest {
             countParentInterfaces(indirectParents = true) { it.hasNameStartingWith("SampleParent") } shouldBeEqualTo 2
             hasParentInterfaces(indirectParents = false) shouldBeEqualTo false
             hasParentInterfaces(indirectParents = true) shouldBeEqualTo true
+            hasParentInterfaceWithName(emptyList(), indirectParents = false) shouldBeEqualTo false
+            hasParentInterfaceWithName(emptySet(), indirectParents = false) shouldBeEqualTo false
+            hasParentInterfacesWithAllNames(emptyList(), indirectParents = false) shouldBeEqualTo false
+            hasParentInterfacesWithAllNames(emptySet(), indirectParents = false) shouldBeEqualTo false
+            hasParentInterfaceWithName(emptyList(), indirectParents = true) shouldBeEqualTo true
+            hasParentInterfaceWithName(emptySet(), indirectParents = true) shouldBeEqualTo true
+            hasParentInterfacesWithAllNames(emptyList(), indirectParents = true) shouldBeEqualTo true
+            hasParentInterfacesWithAllNames(emptySet(), indirectParents = true) shouldBeEqualTo true
             hasParentInterfaceWithName("SampleParentInterface1", indirectParents = true) shouldBeEqualTo true
             hasParentInterfaceWithName("OtherInterface", indirectParents = true) shouldBeEqualTo false
             hasParentInterfaceWithName(
@@ -155,6 +229,18 @@ class KoClassDeclarationForKoParentInterfaceProviderTest {
             hasParentInterfaceWithName(
                 "SampleParentInterface1",
                 "OtherInterface",
+                indirectParents = true,
+            ) shouldBeEqualTo true
+            hasParentInterfaceWithName(listOf("SampleParentInterface1"), indirectParents = true) shouldBeEqualTo true
+            hasParentInterfaceWithName(listOf("OtherInterface"), indirectParents = true) shouldBeEqualTo false
+            hasParentInterfaceWithName(listOf(
+                "SampleParentInterface1",
+                "SampleParentInterface2"),
+                indirectParents = true,
+            ) shouldBeEqualTo true
+            hasParentInterfaceWithName(listOf(
+                "SampleParentInterface1",
+                "OtherInterface"),
                 indirectParents = true,
             ) shouldBeEqualTo true
             hasParentInterfacesWithAllNames("SampleParentInterface1", indirectParents = true) shouldBeEqualTo true
@@ -169,16 +255,35 @@ class KoClassDeclarationForKoParentInterfaceProviderTest {
                 "OtherInterface",
                 indirectParents = true,
             ) shouldBeEqualTo false
+            hasParentInterfacesWithAllNames(listOf("SampleParentInterface1"), indirectParents = true) shouldBeEqualTo true
+            hasParentInterfacesWithAllNames(listOf("OtherInterface"), indirectParents = true) shouldBeEqualTo false
+            hasParentInterfacesWithAllNames(listOf(
+                "SampleParentInterface1",
+                "SampleParentInterface2"),
+                indirectParents = true,
+            ) shouldBeEqualTo true
+            hasParentInterfacesWithAllNames(listOf(
+                "SampleParentInterface1",
+                "OtherInterface"),
+                indirectParents = true,
+            ) shouldBeEqualTo false
             hasParentInterface(indirectParents = true) { it.name == "SampleParentInterface1" } shouldBeEqualTo true
             hasParentInterface(indirectParents = true) { it.name == "OtherInterface" } shouldBeEqualTo false
             hasAllParentInterfaces(indirectParents = true) { it.name == "SampleParentInterface1" } shouldBeEqualTo false
             hasAllParentInterfaces(indirectParents = true) { it.hasNameStartingWith("Sample") } shouldBeEqualTo true
             hasAllParentInterfaces(indirectParents = true) { it.hasNameStartingWith("Other") } shouldBeEqualTo false
             hasParentInterfaceOf(SampleParentInterface2::class, indirectParents = true) shouldBeEqualTo true
+            hasParentInterfaceOf(listOf(SampleParentInterface2::class), indirectParents = true) shouldBeEqualTo true
             hasAllParentInterfacesOf(SampleParentInterface2::class, indirectParents = true) shouldBeEqualTo true
             hasAllParentInterfacesOf(
                 SampleParentInterface2::class,
                 SampleParentInterface::class,
+                indirectParents = true,
+            ) shouldBeEqualTo false
+            hasAllParentInterfacesOf(listOf(SampleParentInterface2::class), indirectParents = true) shouldBeEqualTo true
+            hasAllParentInterfacesOf(listOf(
+                SampleParentInterface2::class,
+                SampleParentInterface::class),
                 indirectParents = true,
             ) shouldBeEqualTo false
         }

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koclass/KoClassDeclarationForKoParentInterfaceProviderTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koclass/KoClassDeclarationForKoParentInterfaceProviderTest.kt
@@ -126,63 +126,63 @@ class KoClassDeclarationForKoParentInterfaceProviderTest {
 
         // then
         assertSoftly(sut) {
-                parentInterfaces.map { it.name } shouldBeEqualTo listOf("SampleParentInterface1", "SampleParentInterface2")
-                numParentInterfaces shouldBeEqualTo 2
-                countParentInterfaces { it.name == "SampleParentInterface1" } shouldBeEqualTo 1
-                countParentInterfaces { it.hasNameStartingWith("SampleParentInterface") } shouldBeEqualTo 2
-                hasParentInterfaces() shouldBeEqualTo true
-                hasParentInterfaceWithName(emptyList()) shouldBeEqualTo true
-                hasParentInterfaceWithName(emptySet()) shouldBeEqualTo true
-                hasParentInterfacesWithAllNames(emptyList()) shouldBeEqualTo true
-                hasParentInterfacesWithAllNames(emptySet()) shouldBeEqualTo true
-                hasParentInterfaceWithName("SampleParentInterface1") shouldBeEqualTo true
-                hasParentInterfaceWithName("OtherInterface") shouldBeEqualTo false
-                hasParentInterfaceWithName("SampleParentInterface1", "SampleParentInterface2") shouldBeEqualTo true
-                hasParentInterfaceWithName("SampleParentInterface1", "OtherInterface") shouldBeEqualTo true
-                hasParentInterfaceWithName(listOf("SampleParentInterface1")) shouldBeEqualTo true
-                hasParentInterfaceWithName(listOf("OtherInterface")) shouldBeEqualTo false
-                hasParentInterfaceWithName(listOf("SampleParentInterface1", "SampleParentInterface2")) shouldBeEqualTo true
-                hasParentInterfaceWithName(listOf("SampleParentInterface1", "OtherInterface")) shouldBeEqualTo true
-                hasParentInterfaceWithName(setOf("SampleParentInterface1")) shouldBeEqualTo true
-                hasParentInterfaceWithName(setOf("OtherInterface")) shouldBeEqualTo false
-                hasParentInterfaceWithName(setOf("SampleParentInterface1", "SampleParentInterface2")) shouldBeEqualTo true
-                hasParentInterfaceWithName(setOf("SampleParentInterface1", "OtherInterface")) shouldBeEqualTo true
-                hasParentInterfacesWithAllNames("SampleParentInterface1") shouldBeEqualTo true
-                hasParentInterfacesWithAllNames("OtherInterface") shouldBeEqualTo false
-                hasParentInterfacesWithAllNames("SampleParentInterface1", "SampleParentInterface2") shouldBeEqualTo true
-                hasParentInterfacesWithAllNames("SampleParentInterface1", "OtherInterface") shouldBeEqualTo false
-                hasParentInterfacesWithAllNames(listOf("SampleParentInterface1")) shouldBeEqualTo true
-                hasParentInterfacesWithAllNames(listOf("OtherInterface")) shouldBeEqualTo false
-                hasParentInterfacesWithAllNames(listOf("SampleParentInterface1", "SampleParentInterface2")) shouldBeEqualTo true
-                hasParentInterfacesWithAllNames(listOf("SampleParentInterface1", "OtherInterface")) shouldBeEqualTo false
-                hasParentInterfacesWithAllNames(setOf("SampleParentInterface1")) shouldBeEqualTo true
-                hasParentInterfacesWithAllNames(setOf("OtherInterface")) shouldBeEqualTo false
-                hasParentInterfacesWithAllNames(setOf("SampleParentInterface1", "SampleParentInterface2")) shouldBeEqualTo true
-                hasParentInterfacesWithAllNames(setOf("SampleParentInterface1", "OtherInterface")) shouldBeEqualTo false
-                hasParentInterface { it.name == "SampleParentInterface1" } shouldBeEqualTo true
-                hasParentInterface { it.name == "OtherInterface" } shouldBeEqualTo false
-                hasAllParentInterfaces { it.name == "SampleParentInterface1" } shouldBeEqualTo false
-                hasAllParentInterfaces { it.hasNameStartingWith("Sample") } shouldBeEqualTo true
-                hasAllParentInterfaces { it.hasNameStartingWith("Other") } shouldBeEqualTo false
-                hasParentInterfaceOf(SampleParentInterface1::class) shouldBeEqualTo true
-                hasParentInterfaceOf(SampleParentInterface1::class, SampleParentClass::class) shouldBeEqualTo true
-                hasParentInterfaceOf(listOf(SampleParentInterface1::class)) shouldBeEqualTo true
-                hasParentInterfaceOf(listOf(SampleParentInterface1::class, SampleParentClass::class)) shouldBeEqualTo true
-                hasParentInterfaceOf(setOf(SampleParentInterface1::class)) shouldBeEqualTo true
-                hasParentInterfaceOf(setOf(SampleParentInterface1::class, SampleParentClass::class)) shouldBeEqualTo true
-                hasAllParentInterfacesOf(SampleParentInterface1::class) shouldBeEqualTo true
-                hasAllParentInterfacesOf(SampleParentInterface1::class, SampleParentClass::class) shouldBeEqualTo false
-                hasAllParentInterfacesOf(SampleParentInterface1::class, SampleParentInterface2::class) shouldBeEqualTo true
-                hasAllParentInterfacesOf(listOf(SampleParentInterface1::class)) shouldBeEqualTo true
-                hasAllParentInterfacesOf(listOf(SampleParentInterface1::class, SampleParentClass::class)) shouldBeEqualTo false
-                hasAllParentInterfacesOf(listOf(SampleParentInterface1::class, SampleParentInterface2::class)) shouldBeEqualTo true
-                hasAllParentInterfacesOf(setOf(SampleParentInterface1::class)) shouldBeEqualTo true
-                hasAllParentInterfacesOf(setOf(SampleParentInterface1::class, SampleParentClass::class)) shouldBeEqualTo false
-                hasAllParentInterfacesOf(setOf(SampleParentInterface1::class, SampleParentInterface2::class)) shouldBeEqualTo true
-                hasParentInterfaces("SampleParentInterface1") shouldBeEqualTo true
-                hasParentInterfaces("OtherInterface") shouldBeEqualTo false
-                hasParentInterfaces("SampleParentInterface1", "SampleParentInterface2") shouldBeEqualTo true
-                hasParentInterfaces("SampleParentInterface1", "OtherInterface") shouldBeEqualTo false
+            parentInterfaces.map { it.name } shouldBeEqualTo listOf("SampleParentInterface1", "SampleParentInterface2")
+            numParentInterfaces shouldBeEqualTo 2
+            countParentInterfaces { it.name == "SampleParentInterface1" } shouldBeEqualTo 1
+            countParentInterfaces { it.hasNameStartingWith("SampleParentInterface") } shouldBeEqualTo 2
+            hasParentInterfaces() shouldBeEqualTo true
+            hasParentInterfaceWithName(emptyList()) shouldBeEqualTo true
+            hasParentInterfaceWithName(emptySet()) shouldBeEqualTo true
+            hasParentInterfacesWithAllNames(emptyList()) shouldBeEqualTo true
+            hasParentInterfacesWithAllNames(emptySet()) shouldBeEqualTo true
+            hasParentInterfaceWithName("SampleParentInterface1") shouldBeEqualTo true
+            hasParentInterfaceWithName("OtherInterface") shouldBeEqualTo false
+            hasParentInterfaceWithName("SampleParentInterface1", "SampleParentInterface2") shouldBeEqualTo true
+            hasParentInterfaceWithName("SampleParentInterface1", "OtherInterface") shouldBeEqualTo true
+            hasParentInterfaceWithName(listOf("SampleParentInterface1")) shouldBeEqualTo true
+            hasParentInterfaceWithName(listOf("OtherInterface")) shouldBeEqualTo false
+            hasParentInterfaceWithName(listOf("SampleParentInterface1", "SampleParentInterface2")) shouldBeEqualTo true
+            hasParentInterfaceWithName(listOf("SampleParentInterface1", "OtherInterface")) shouldBeEqualTo true
+            hasParentInterfaceWithName(setOf("SampleParentInterface1")) shouldBeEqualTo true
+            hasParentInterfaceWithName(setOf("OtherInterface")) shouldBeEqualTo false
+            hasParentInterfaceWithName(setOf("SampleParentInterface1", "SampleParentInterface2")) shouldBeEqualTo true
+            hasParentInterfaceWithName(setOf("SampleParentInterface1", "OtherInterface")) shouldBeEqualTo true
+            hasParentInterfacesWithAllNames("SampleParentInterface1") shouldBeEqualTo true
+            hasParentInterfacesWithAllNames("OtherInterface") shouldBeEqualTo false
+            hasParentInterfacesWithAllNames("SampleParentInterface1", "SampleParentInterface2") shouldBeEqualTo true
+            hasParentInterfacesWithAllNames("SampleParentInterface1", "OtherInterface") shouldBeEqualTo false
+            hasParentInterfacesWithAllNames(listOf("SampleParentInterface1")) shouldBeEqualTo true
+            hasParentInterfacesWithAllNames(listOf("OtherInterface")) shouldBeEqualTo false
+            hasParentInterfacesWithAllNames(listOf("SampleParentInterface1", "SampleParentInterface2")) shouldBeEqualTo true
+            hasParentInterfacesWithAllNames(listOf("SampleParentInterface1", "OtherInterface")) shouldBeEqualTo false
+            hasParentInterfacesWithAllNames(setOf("SampleParentInterface1")) shouldBeEqualTo true
+            hasParentInterfacesWithAllNames(setOf("OtherInterface")) shouldBeEqualTo false
+            hasParentInterfacesWithAllNames(setOf("SampleParentInterface1", "SampleParentInterface2")) shouldBeEqualTo true
+            hasParentInterfacesWithAllNames(setOf("SampleParentInterface1", "OtherInterface")) shouldBeEqualTo false
+            hasParentInterface { it.name == "SampleParentInterface1" } shouldBeEqualTo true
+            hasParentInterface { it.name == "OtherInterface" } shouldBeEqualTo false
+            hasAllParentInterfaces { it.name == "SampleParentInterface1" } shouldBeEqualTo false
+            hasAllParentInterfaces { it.hasNameStartingWith("Sample") } shouldBeEqualTo true
+            hasAllParentInterfaces { it.hasNameStartingWith("Other") } shouldBeEqualTo false
+            hasParentInterfaceOf(SampleParentInterface1::class) shouldBeEqualTo true
+            hasParentInterfaceOf(SampleParentInterface1::class, SampleParentClass::class) shouldBeEqualTo true
+            hasParentInterfaceOf(listOf(SampleParentInterface1::class)) shouldBeEqualTo true
+            hasParentInterfaceOf(listOf(SampleParentInterface1::class, SampleParentClass::class)) shouldBeEqualTo true
+            hasParentInterfaceOf(setOf(SampleParentInterface1::class)) shouldBeEqualTo true
+            hasParentInterfaceOf(setOf(SampleParentInterface1::class, SampleParentClass::class)) shouldBeEqualTo true
+            hasAllParentInterfacesOf(SampleParentInterface1::class) shouldBeEqualTo true
+            hasAllParentInterfacesOf(SampleParentInterface1::class, SampleParentClass::class) shouldBeEqualTo false
+            hasAllParentInterfacesOf(SampleParentInterface1::class, SampleParentInterface2::class) shouldBeEqualTo true
+            hasAllParentInterfacesOf(listOf(SampleParentInterface1::class)) shouldBeEqualTo true
+            hasAllParentInterfacesOf(listOf(SampleParentInterface1::class, SampleParentClass::class)) shouldBeEqualTo false
+            hasAllParentInterfacesOf(listOf(SampleParentInterface1::class, SampleParentInterface2::class)) shouldBeEqualTo true
+            hasAllParentInterfacesOf(setOf(SampleParentInterface1::class)) shouldBeEqualTo true
+            hasAllParentInterfacesOf(setOf(SampleParentInterface1::class, SampleParentClass::class)) shouldBeEqualTo false
+            hasAllParentInterfacesOf(setOf(SampleParentInterface1::class, SampleParentInterface2::class)) shouldBeEqualTo true
+            hasParentInterfaces("SampleParentInterface1") shouldBeEqualTo true
+            hasParentInterfaces("OtherInterface") shouldBeEqualTo false
+            hasParentInterfaces("SampleParentInterface1", "SampleParentInterface2") shouldBeEqualTo true
+            hasParentInterfaces("SampleParentInterface1", "OtherInterface") shouldBeEqualTo false
         }
     }
 
@@ -199,10 +199,10 @@ class KoClassDeclarationForKoParentInterfaceProviderTest {
         assertSoftly(sut) {
             parentInterfaces(indirectParents = false) shouldBeEqualTo emptyList()
             parentInterfaces(indirectParents = true).map { it.name } shouldBeEqualTo
-                    listOf(
-                        "SampleParentInterface1",
-                        "SampleParentInterface2",
-                    )
+                listOf(
+                    "SampleParentInterface1",
+                    "SampleParentInterface2",
+                )
             numParentInterfaces(indirectParents = false) shouldBeEqualTo 0
             numParentInterfaces(indirectParents = true) shouldBeEqualTo 2
             countParentInterfaces(indirectParents = false) { it.name == "SampleParentInterface1" } shouldBeEqualTo 0
@@ -233,14 +233,18 @@ class KoClassDeclarationForKoParentInterfaceProviderTest {
             ) shouldBeEqualTo true
             hasParentInterfaceWithName(listOf("SampleParentInterface1"), indirectParents = true) shouldBeEqualTo true
             hasParentInterfaceWithName(listOf("OtherInterface"), indirectParents = true) shouldBeEqualTo false
-            hasParentInterfaceWithName(listOf(
-                "SampleParentInterface1",
-                "SampleParentInterface2"),
+            hasParentInterfaceWithName(
+                listOf(
+                    "SampleParentInterface1",
+                    "SampleParentInterface2",
+                ),
                 indirectParents = true,
             ) shouldBeEqualTo true
-            hasParentInterfaceWithName(listOf(
-                "SampleParentInterface1",
-                "OtherInterface"),
+            hasParentInterfaceWithName(
+                listOf(
+                    "SampleParentInterface1",
+                    "OtherInterface",
+                ),
                 indirectParents = true,
             ) shouldBeEqualTo true
             hasParentInterfacesWithAllNames("SampleParentInterface1", indirectParents = true) shouldBeEqualTo true
@@ -257,14 +261,18 @@ class KoClassDeclarationForKoParentInterfaceProviderTest {
             ) shouldBeEqualTo false
             hasParentInterfacesWithAllNames(listOf("SampleParentInterface1"), indirectParents = true) shouldBeEqualTo true
             hasParentInterfacesWithAllNames(listOf("OtherInterface"), indirectParents = true) shouldBeEqualTo false
-            hasParentInterfacesWithAllNames(listOf(
-                "SampleParentInterface1",
-                "SampleParentInterface2"),
+            hasParentInterfacesWithAllNames(
+                listOf(
+                    "SampleParentInterface1",
+                    "SampleParentInterface2",
+                ),
                 indirectParents = true,
             ) shouldBeEqualTo true
-            hasParentInterfacesWithAllNames(listOf(
-                "SampleParentInterface1",
-                "OtherInterface"),
+            hasParentInterfacesWithAllNames(
+                listOf(
+                    "SampleParentInterface1",
+                    "OtherInterface",
+                ),
                 indirectParents = true,
             ) shouldBeEqualTo false
             hasParentInterface(indirectParents = true) { it.name == "SampleParentInterface1" } shouldBeEqualTo true
@@ -281,9 +289,11 @@ class KoClassDeclarationForKoParentInterfaceProviderTest {
                 indirectParents = true,
             ) shouldBeEqualTo false
             hasAllParentInterfacesOf(listOf(SampleParentInterface2::class), indirectParents = true) shouldBeEqualTo true
-            hasAllParentInterfacesOf(listOf(
-                SampleParentInterface2::class,
-                SampleParentInterface::class),
+            hasAllParentInterfacesOf(
+                listOf(
+                    SampleParentInterface2::class,
+                    SampleParentInterface::class,
+                ),
                 indirectParents = true,
             ) shouldBeEqualTo false
         }

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koclass/KoClassDeclarationForKoParentInterfaceProviderTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koclass/KoClassDeclarationForKoParentInterfaceProviderTest.kt
@@ -9,6 +9,7 @@ import org.amshove.kluent.assertSoftly
 import org.amshove.kluent.shouldBeEqualTo
 import org.junit.jupiter.api.Test
 
+@Suppress("detekt.LongMethod")
 class KoClassDeclarationForKoParentInterfaceProviderTest {
     @Test
     fun `class-has-no-parent-interface`() {

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koclass/KoClassDeclarationForKoParentProviderTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koclass/KoClassDeclarationForKoParentProviderTest.kt
@@ -24,16 +24,26 @@ class KoClassDeclarationForKoParentProviderTest {
         assertSoftly(sut) {
             parents shouldBeEqualTo emptyList()
             numParents shouldBeEqualTo 0
-            parents() shouldBeEqualTo emptyList()
-            numParents() shouldBeEqualTo 0
             countParents { it.name == "SampleParentClass" } shouldBeEqualTo 0
             hasParents() shouldBeEqualTo false
+            hasParentWithName(emptyList()) shouldBeEqualTo false
+            hasParentWithName(emptySet()) shouldBeEqualTo false
+            hasParentsWithAllNames(emptyList()) shouldBeEqualTo false
+            hasParentsWithAllNames(emptySet()) shouldBeEqualTo false
             hasParentWithName("SampleParentClass") shouldBeEqualTo false
+            hasParentWithName(listOf("SampleParentClass")) shouldBeEqualTo false
+            hasParentWithName(setOf("SampleParentClass")) shouldBeEqualTo false
             hasParentsWithAllNames("SampleParentClass", "SampleParentInterface") shouldBeEqualTo false
+            hasParentsWithAllNames(listOf("SampleParentClass", "SampleParentInterface")) shouldBeEqualTo false
+            hasParentsWithAllNames(setOf("SampleParentClass", "SampleParentInterface")) shouldBeEqualTo false
             hasParent { it.name == "SampleParentClass" } shouldBeEqualTo false
             hasAllParents { it.hasNameStartingWith("Sample") } shouldBeEqualTo true
             hasParentOf(SampleParentClass::class) shouldBeEqualTo false
+            hasParentOf(listOf(SampleParentClass::class)) shouldBeEqualTo false
+            hasParentOf(setOf(SampleParentClass::class)) shouldBeEqualTo false
             hasAllParentsOf(SampleParentClass::class, SampleParentInterface::class) shouldBeEqualTo false
+            hasAllParentsOf(listOf(SampleParentClass::class, SampleParentInterface::class)) shouldBeEqualTo false
+            hasAllParentsOf(setOf(SampleParentClass::class, SampleParentInterface::class)) shouldBeEqualTo false
             hasParents("SampleParentClass") shouldBeEqualTo false
         }
     }
@@ -49,31 +59,42 @@ class KoClassDeclarationForKoParentProviderTest {
         // then
         assertSoftly(sut) {
             parents.map { it.name } shouldBeEqualTo
-                listOf(
-                    "SampleParentClass",
-                    "SampleParentInterface1",
-                    "SampleParentInterface2",
-                    "SampleExternalInterface",
-                )
+                    parents.map { it.name } shouldBeEqualTo
+                    listOf(
+                        "SampleParentClass",
+                        "SampleParentInterface1",
+                        "SampleParentInterface2",
+                        "SampleExternalInterface",
+                    )
             numParents shouldBeEqualTo 4
-            parents().map { it.name } shouldBeEqualTo
-                listOf(
-                    "SampleParentClass",
-                    "SampleParentInterface1",
-                    "SampleParentInterface2",
-                    "SampleExternalInterface",
-                )
-            numParents() shouldBeEqualTo 4
             countParents { it.name == "SampleParentClass" } shouldBeEqualTo 1
             countParents { it.hasNameStartingWith("SampleParentInterface") } shouldBeEqualTo 2
             hasParents() shouldBeEqualTo true
+            hasParentWithName(emptyList()) shouldBeEqualTo true
+            hasParentWithName(emptySet()) shouldBeEqualTo true
+            hasParentsWithAllNames(emptyList()) shouldBeEqualTo true
+            hasParentsWithAllNames(emptySet()) shouldBeEqualTo true
             hasParentWithName("SampleParentClass") shouldBeEqualTo true
             hasParentWithName("OtherInterface") shouldBeEqualTo false
             hasParentWithName("SampleParentClass", "OtherInterface") shouldBeEqualTo true
+            hasParentWithName(listOf("SampleParentClass")) shouldBeEqualTo true
+            hasParentWithName(listOf("OtherInterface")) shouldBeEqualTo false
+            hasParentWithName(listOf("SampleParentClass", "OtherInterface")) shouldBeEqualTo true
+            hasParentWithName(setOf("SampleParentClass")) shouldBeEqualTo true
+            hasParentWithName(setOf("OtherInterface")) shouldBeEqualTo false
+            hasParentWithName(setOf("SampleParentClass", "OtherInterface")) shouldBeEqualTo true
             hasParentsWithAllNames("SampleParentClass") shouldBeEqualTo true
             hasParentsWithAllNames("OtherInterface") shouldBeEqualTo false
             hasParentsWithAllNames("SampleParentClass", "SampleParentInterface1") shouldBeEqualTo true
             hasParentsWithAllNames("SampleParentClass", "OtherInterface") shouldBeEqualTo false
+            hasParentsWithAllNames(listOf("SampleParentClass")) shouldBeEqualTo true
+            hasParentsWithAllNames(listOf("OtherInterface")) shouldBeEqualTo false
+            hasParentsWithAllNames(listOf("SampleParentClass", "SampleParentInterface1")) shouldBeEqualTo true
+            hasParentsWithAllNames(listOf("SampleParentClass", "OtherInterface")) shouldBeEqualTo false
+            hasParentsWithAllNames(setOf("SampleParentClass")) shouldBeEqualTo true
+            hasParentsWithAllNames(setOf("OtherInterface")) shouldBeEqualTo false
+            hasParentsWithAllNames(setOf("SampleParentClass", "SampleParentInterface1")) shouldBeEqualTo true
+            hasParentsWithAllNames(setOf("SampleParentClass", "OtherInterface")) shouldBeEqualTo false
             hasParent { it.name == "SampleParentClass" } shouldBeEqualTo true
             hasParent { it.name == "OtherClass" } shouldBeEqualTo false
             hasAllParents { it.name == "SampleParentClass" } shouldBeEqualTo false
@@ -81,9 +102,19 @@ class KoClassDeclarationForKoParentProviderTest {
             hasAllParents { it.hasNameStartingWith("Other") } shouldBeEqualTo false
             hasParentOf(SampleParentClass::class) shouldBeEqualTo true
             hasParentOf(SampleParentClass::class, SampleInterface::class) shouldBeEqualTo true
+            hasParentOf(listOf(SampleParentClass::class)) shouldBeEqualTo true
+            hasParentOf(listOf(SampleParentClass::class, SampleInterface::class)) shouldBeEqualTo true
+            hasParentOf(setOf(SampleParentClass::class)) shouldBeEqualTo true
+            hasParentOf(setOf(SampleParentClass::class, SampleInterface::class)) shouldBeEqualTo true
             hasAllParentsOf(SampleParentClass::class) shouldBeEqualTo true
             hasAllParentsOf(SampleParentClass::class, SampleInterface::class) shouldBeEqualTo false
             hasAllParentsOf(SampleParentClass::class, SampleParentInterface1::class) shouldBeEqualTo true
+            hasAllParentsOf(listOf(SampleParentClass::class)) shouldBeEqualTo true
+            hasAllParentsOf(listOf(SampleParentClass::class, SampleInterface::class)) shouldBeEqualTo false
+            hasAllParentsOf(listOf(SampleParentClass::class, SampleParentInterface1::class)) shouldBeEqualTo true
+            hasAllParentsOf(setOf(SampleParentClass::class)) shouldBeEqualTo true
+            hasAllParentsOf(setOf(SampleParentClass::class, SampleInterface::class)) shouldBeEqualTo false
+            hasAllParentsOf(setOf(SampleParentClass::class, SampleParentInterface1::class)) shouldBeEqualTo true
             hasParents("SampleParentClass") shouldBeEqualTo true
             hasParents("OtherInterface") shouldBeEqualTo false
             hasParents("SampleParentClass", "SampleParentInterface1") shouldBeEqualTo true
@@ -102,26 +133,36 @@ class KoClassDeclarationForKoParentProviderTest {
         // then
         assertSoftly(sut) {
             parents().map { it.name } shouldBeEqualTo
-                listOf(
-                    "SampleParentClass",
-                    "SampleParentInterface1",
-                    "SampleExternalInterface",
-                )
+                    listOf(
+                        "SampleParentClass",
+                        "SampleParentInterface1",
+                        "SampleExternalInterface",
+                    )
             numParents(indirectParents = false) shouldBeEqualTo 3
             parents(indirectParents = true).map { it.name } shouldBeEqualTo
-                listOf(
-                    "SampleParentClass",
-                    "SampleParentInterface1",
-                    "SampleExternalInterface",
-                    "SampleParentInterface2",
-                )
+                    listOf(
+                        "SampleParentClass",
+                        "SampleParentInterface1",
+                        "SampleExternalInterface",
+                        "SampleParentInterface2",
+                    )
             numParents(indirectParents = true) shouldBeEqualTo 4
             countParents(indirectParents = true) { it.name == "SampleParentInterface2" } shouldBeEqualTo 1
             countParents(indirectParents = true) { it.hasNameStartingWith("SampleParentInterface") } shouldBeEqualTo 2
             hasParents(indirectParents = true) shouldBeEqualTo true
+            hasParentWithName(emptyList(), indirectParents = true) shouldBeEqualTo true
+            hasParentWithName(emptySet(), indirectParents = true) shouldBeEqualTo true
+            hasParentsWithAllNames(emptyList(), indirectParents = true) shouldBeEqualTo true
+            hasParentsWithAllNames(emptySet(), indirectParents = true) shouldBeEqualTo true
             hasParentWithName("SampleParentInterface2", indirectParents = true) shouldBeEqualTo true
             hasParentWithName("OtherInterface", indirectParents = true) shouldBeEqualTo false
             hasParentWithName("SampleParentInterface2", "OtherInterface", indirectParents = true) shouldBeEqualTo true
+            hasParentWithName(listOf("SampleParentInterface2"), indirectParents = true) shouldBeEqualTo true
+            hasParentWithName(listOf("OtherInterface"), indirectParents = true) shouldBeEqualTo false
+            hasParentWithName(listOf("SampleParentInterface2", "OtherInterface"), indirectParents = true) shouldBeEqualTo true
+            hasParentWithName(setOf("SampleParentInterface2"), indirectParents = true) shouldBeEqualTo true
+            hasParentWithName(setOf("OtherInterface"), indirectParents = true) shouldBeEqualTo false
+            hasParentWithName(setOf("SampleParentInterface2", "OtherInterface"), indirectParents = true) shouldBeEqualTo true
             hasParentsWithAllNames("SampleParentInterface2", indirectParents = true) shouldBeEqualTo true
             hasParentsWithAllNames("OtherInterface", indirectParents = true) shouldBeEqualTo false
             hasParentsWithAllNames(
@@ -130,6 +171,22 @@ class KoClassDeclarationForKoParentProviderTest {
                 indirectParents = true,
             ) shouldBeEqualTo true
             hasParentsWithAllNames("SampleParentInterface2", "OtherInterface", indirectParents = true) shouldBeEqualTo false
+            hasParentsWithAllNames(listOf("SampleParentInterface2"), indirectParents = true) shouldBeEqualTo true
+            hasParentsWithAllNames(listOf("OtherInterface"), indirectParents = true) shouldBeEqualTo false
+            hasParentsWithAllNames(listOf(
+                "SampleParentInterface2",
+                "SampleParentInterface1"),
+                indirectParents = true,
+            ) shouldBeEqualTo true
+            hasParentsWithAllNames(listOf("SampleParentInterface2", "OtherInterface"), indirectParents = true) shouldBeEqualTo false
+            hasParentsWithAllNames(setOf("SampleParentInterface2"), indirectParents = true) shouldBeEqualTo true
+            hasParentsWithAllNames(setOf("OtherInterface"), indirectParents = true) shouldBeEqualTo false
+            hasParentsWithAllNames(setOf(
+                "SampleParentInterface2",
+                "SampleParentInterface1"),
+                indirectParents = true,
+            ) shouldBeEqualTo true
+            hasParentsWithAllNames(setOf("SampleParentInterface2", "OtherInterface"), indirectParents = true) shouldBeEqualTo false
             hasParent(indirectParents = true) { it.name == "SampleParentInterface2" } shouldBeEqualTo true
             hasParent(indirectParents = true) { it.name == "OtherClass" } shouldBeEqualTo false
             hasAllParents(indirectParents = true) { it.name == "SampleParentInterface2" } shouldBeEqualTo false
@@ -137,10 +194,26 @@ class KoClassDeclarationForKoParentProviderTest {
             hasAllParents(indirectParents = true) { it.hasNameStartingWith("Other") } shouldBeEqualTo false
             hasParentOf(SampleParentInterface2::class, indirectParents = true) shouldBeEqualTo true
             hasParentOf(SampleParentInterface2::class, SampleInterface::class, indirectParents = true) shouldBeEqualTo true
+            hasParentOf(listOf(SampleParentInterface2::class), indirectParents = true) shouldBeEqualTo true
+            hasParentOf(listOf(SampleParentInterface2::class, SampleInterface::class), indirectParents = true) shouldBeEqualTo true
+            hasParentOf(setOf(SampleParentInterface2::class), indirectParents = true) shouldBeEqualTo true
+            hasParentOf(setOf(SampleParentInterface2::class, SampleInterface::class), indirectParents = true) shouldBeEqualTo true
             hasAllParentsOf(SampleParentInterface2::class, indirectParents = true) shouldBeEqualTo true
             hasAllParentsOf(
                 SampleParentInterface2::class,
                 SampleInterface::class,
+                indirectParents = true,
+            ) shouldBeEqualTo false
+            hasAllParentsOf(listOf(SampleParentInterface2::class), indirectParents = true) shouldBeEqualTo true
+            hasAllParentsOf(listOf(
+                SampleParentInterface2::class,
+                SampleInterface::class),
+                indirectParents = true,
+            ) shouldBeEqualTo false
+            hasAllParentsOf(setOf(SampleParentInterface2::class), indirectParents = true) shouldBeEqualTo true
+            hasAllParentsOf(setOf(
+                SampleParentInterface2::class,
+                SampleInterface::class),
                 indirectParents = true,
             ) shouldBeEqualTo false
         }

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koclass/KoClassDeclarationForKoParentProviderTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koclass/KoClassDeclarationForKoParentProviderTest.kt
@@ -11,6 +11,7 @@ import org.amshove.kluent.assertSoftly
 import org.amshove.kluent.shouldBeEqualTo
 import org.junit.jupiter.api.Test
 
+@Suppress("detekt.LongMethod")
 class KoClassDeclarationForKoParentProviderTest {
     @Test
     fun `class-has-no-parents`() {
@@ -59,13 +60,13 @@ class KoClassDeclarationForKoParentProviderTest {
         // then
         assertSoftly(sut) {
             parents.map { it.name } shouldBeEqualTo
-                    parents.map { it.name } shouldBeEqualTo
-                    listOf(
-                        "SampleParentClass",
-                        "SampleParentInterface1",
-                        "SampleParentInterface2",
-                        "SampleExternalInterface",
-                    )
+                parents.map { it.name } shouldBeEqualTo
+                listOf(
+                    "SampleParentClass",
+                    "SampleParentInterface1",
+                    "SampleParentInterface2",
+                    "SampleExternalInterface",
+                )
             numParents shouldBeEqualTo 4
             countParents { it.name == "SampleParentClass" } shouldBeEqualTo 1
             countParents { it.hasNameStartingWith("SampleParentInterface") } shouldBeEqualTo 2
@@ -133,19 +134,19 @@ class KoClassDeclarationForKoParentProviderTest {
         // then
         assertSoftly(sut) {
             parents().map { it.name } shouldBeEqualTo
-                    listOf(
-                        "SampleParentClass",
-                        "SampleParentInterface1",
-                        "SampleExternalInterface",
-                    )
+                listOf(
+                    "SampleParentClass",
+                    "SampleParentInterface1",
+                    "SampleExternalInterface",
+                )
             numParents(indirectParents = false) shouldBeEqualTo 3
             parents(indirectParents = true).map { it.name } shouldBeEqualTo
-                    listOf(
-                        "SampleParentClass",
-                        "SampleParentInterface1",
-                        "SampleExternalInterface",
-                        "SampleParentInterface2",
-                    )
+                listOf(
+                    "SampleParentClass",
+                    "SampleParentInterface1",
+                    "SampleExternalInterface",
+                    "SampleParentInterface2",
+                )
             numParents(indirectParents = true) shouldBeEqualTo 4
             countParents(indirectParents = true) { it.name == "SampleParentInterface2" } shouldBeEqualTo 1
             countParents(indirectParents = true) { it.hasNameStartingWith("SampleParentInterface") } shouldBeEqualTo 2
@@ -173,17 +174,21 @@ class KoClassDeclarationForKoParentProviderTest {
             hasParentsWithAllNames("SampleParentInterface2", "OtherInterface", indirectParents = true) shouldBeEqualTo false
             hasParentsWithAllNames(listOf("SampleParentInterface2"), indirectParents = true) shouldBeEqualTo true
             hasParentsWithAllNames(listOf("OtherInterface"), indirectParents = true) shouldBeEqualTo false
-            hasParentsWithAllNames(listOf(
-                "SampleParentInterface2",
-                "SampleParentInterface1"),
+            hasParentsWithAllNames(
+                listOf(
+                    "SampleParentInterface2",
+                    "SampleParentInterface1",
+                ),
                 indirectParents = true,
             ) shouldBeEqualTo true
             hasParentsWithAllNames(listOf("SampleParentInterface2", "OtherInterface"), indirectParents = true) shouldBeEqualTo false
             hasParentsWithAllNames(setOf("SampleParentInterface2"), indirectParents = true) shouldBeEqualTo true
             hasParentsWithAllNames(setOf("OtherInterface"), indirectParents = true) shouldBeEqualTo false
-            hasParentsWithAllNames(setOf(
-                "SampleParentInterface2",
-                "SampleParentInterface1"),
+            hasParentsWithAllNames(
+                setOf(
+                    "SampleParentInterface2",
+                    "SampleParentInterface1",
+                ),
                 indirectParents = true,
             ) shouldBeEqualTo true
             hasParentsWithAllNames(setOf("SampleParentInterface2", "OtherInterface"), indirectParents = true) shouldBeEqualTo false
@@ -205,15 +210,19 @@ class KoClassDeclarationForKoParentProviderTest {
                 indirectParents = true,
             ) shouldBeEqualTo false
             hasAllParentsOf(listOf(SampleParentInterface2::class), indirectParents = true) shouldBeEqualTo true
-            hasAllParentsOf(listOf(
-                SampleParentInterface2::class,
-                SampleInterface::class),
+            hasAllParentsOf(
+                listOf(
+                    SampleParentInterface2::class,
+                    SampleInterface::class,
+                ),
                 indirectParents = true,
             ) shouldBeEqualTo false
             hasAllParentsOf(setOf(SampleParentInterface2::class), indirectParents = true) shouldBeEqualTo true
-            hasAllParentsOf(setOf(
-                SampleParentInterface2::class,
-                SampleInterface::class),
+            hasAllParentsOf(
+                setOf(
+                    SampleParentInterface2::class,
+                    SampleInterface::class,
+                ),
                 indirectParents = true,
             ) shouldBeEqualTo false
         }

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koclass/KoClassDeclarationForKoPropertyProviderTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koclass/KoClassDeclarationForKoPropertyProviderTest.kt
@@ -21,8 +21,16 @@ class KoClassDeclarationForKoPropertyProviderTest {
         assertSoftly(sut) {
             properties() shouldBeEqualTo emptyList()
             hasProperties() shouldBeEqualTo false
+            hasPropertyWithName(emptyList()) shouldBeEqualTo false
+            hasPropertyWithName(emptySet()) shouldBeEqualTo false
+            hasPropertiesWithAllNames(emptyList()) shouldBeEqualTo false
+            hasPropertiesWithAllNames(emptySet()) shouldBeEqualTo false
             hasPropertyWithName("sampleProperty") shouldBeEqualTo false
+            hasPropertyWithName(listOf("sampleProperty")) shouldBeEqualTo false
+            hasPropertyWithName(setOf("sampleProperty")) shouldBeEqualTo false
             hasPropertiesWithAllNames("sampleProperty1", "sampleProperty2") shouldBeEqualTo false
+            hasPropertiesWithAllNames(listOf("sampleProperty1", "sampleProperty2")) shouldBeEqualTo false
+            hasPropertiesWithAllNames(setOf("sampleProperty1", "sampleProperty2")) shouldBeEqualTo false
             hasProperty { it.name == "sampleProperty" } shouldBeEqualTo false
             hasAllProperties { it.hasNameStartingWith("sample") } shouldBeEqualTo true
         }
@@ -39,11 +47,25 @@ class KoClassDeclarationForKoPropertyProviderTest {
         // then
         assertSoftly(sut) {
             hasProperties() shouldBeEqualTo true
+            hasPropertyWithName(emptyList()) shouldBeEqualTo true
+            hasPropertyWithName(emptySet()) shouldBeEqualTo true
+            hasPropertiesWithAllNames(emptyList()) shouldBeEqualTo true
+            hasPropertiesWithAllNames(emptySet()) shouldBeEqualTo true
             hasPropertyWithName("sampleProperty1") shouldBeEqualTo true
             hasPropertyWithName("sampleProperty1", "otherProperty") shouldBeEqualTo true
+            hasPropertyWithName(listOf("sampleProperty1")) shouldBeEqualTo true
+            hasPropertyWithName(listOf("sampleProperty1", "otherProperty")) shouldBeEqualTo true
+            hasPropertyWithName(setOf("sampleProperty1")) shouldBeEqualTo true
+            hasPropertyWithName(setOf("sampleProperty1", "otherProperty")) shouldBeEqualTo true
             hasPropertiesWithAllNames("sampleProperty1") shouldBeEqualTo true
             hasPropertiesWithAllNames("sampleProperty1", "sampleProperty2") shouldBeEqualTo true
             hasPropertiesWithAllNames("sampleProperty1", "otherProperty") shouldBeEqualTo false
+            hasPropertiesWithAllNames(listOf("sampleProperty1")) shouldBeEqualTo true
+            hasPropertiesWithAllNames(listOf("sampleProperty1", "sampleProperty2")) shouldBeEqualTo true
+            hasPropertiesWithAllNames(listOf("sampleProperty1", "otherProperty")) shouldBeEqualTo false
+            hasPropertiesWithAllNames(setOf("sampleProperty1")) shouldBeEqualTo true
+            hasPropertiesWithAllNames(setOf("sampleProperty1", "sampleProperty2")) shouldBeEqualTo true
+            hasPropertiesWithAllNames(setOf("sampleProperty1", "otherProperty")) shouldBeEqualTo false
             hasProperty { it.name == "sampleProperty1" } shouldBeEqualTo true
             hasProperty { it.hasNameEndingWith("Property1") } shouldBeEqualTo true
             hasAllProperties { it.hasNameStartingWith("sample") } shouldBeEqualTo true

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koclass/forkomodifier/KoClassDeclarationForKoModifierProviderTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koclass/forkomodifier/KoClassDeclarationForKoModifierProviderTest.kt
@@ -27,10 +27,22 @@ class KoClassDeclarationForKoModifierProviderTest {
             modifiers shouldBeEqualTo emptyList()
             numModifiers shouldBeEqualTo 0
             hasModifiers() shouldBeEqualTo false
+            hasModifier(emptyList()) shouldBeEqualTo false
+            hasModifier(emptySet()) shouldBeEqualTo false
+            hasAllModifiers(emptyList()) shouldBeEqualTo false
+            hasAllModifiers(emptySet()) shouldBeEqualTo false
             hasModifier(OPEN) shouldBeEqualTo false
             hasModifier(OPEN, DATA) shouldBeEqualTo false
+            hasModifier(listOf(OPEN)) shouldBeEqualTo false
+            hasModifier(listOf(OPEN, DATA)) shouldBeEqualTo false
+            hasModifier(setOf(OPEN)) shouldBeEqualTo false
+            hasModifier(setOf(OPEN, DATA)) shouldBeEqualTo false
             hasAllModifiers(OPEN) shouldBeEqualTo false
             hasAllModifiers(OPEN, DATA) shouldBeEqualTo false
+            hasAllModifiers(listOf(OPEN)) shouldBeEqualTo false
+            hasAllModifiers(listOf(OPEN, DATA)) shouldBeEqualTo false
+            hasAllModifiers(setOf(OPEN)) shouldBeEqualTo false
+            hasAllModifiers(setOf(OPEN, DATA)) shouldBeEqualTo false
             hasModifiers(OPEN) shouldBeEqualTo false
             hasModifiers(OPEN, DATA) shouldBeEqualTo false
         }
@@ -47,14 +59,32 @@ class KoClassDeclarationForKoModifierProviderTest {
         // then
         assertSoftly(sut) {
             hasModifiers() shouldBeEqualTo true
+            hasModifier(emptyList()) shouldBeEqualTo true
+            hasModifier(emptySet()) shouldBeEqualTo true
+            hasAllModifiers(emptyList()) shouldBeEqualTo true
+            hasAllModifiers(emptySet()) shouldBeEqualTo true
             numModifiers shouldBeEqualTo 2
             hasModifier(OPEN) shouldBeEqualTo true
             hasModifier(DATA) shouldBeEqualTo false
             hasModifier(OPEN, DATA) shouldBeEqualTo true
+            hasModifier(listOf( OPEN)) shouldBeEqualTo true
+            hasModifier(listOf( DATA)) shouldBeEqualTo false
+            hasModifier(listOf( OPEN, DATA)) shouldBeEqualTo true
+            hasModifier(setOf( OPEN)) shouldBeEqualTo true
+            hasModifier(setOf( DATA)) shouldBeEqualTo false
+            hasModifier(setOf( OPEN, DATA)) shouldBeEqualTo true
             hasAllModifiers(OPEN) shouldBeEqualTo true
             hasAllModifiers(DATA) shouldBeEqualTo false
             hasAllModifiers(OPEN, DATA) shouldBeEqualTo false
             hasAllModifiers(OPEN, PRIVATE) shouldBeEqualTo true
+            hasAllModifiers(listOf(OPEN)) shouldBeEqualTo true
+            hasAllModifiers(listOf(DATA)) shouldBeEqualTo false
+            hasAllModifiers(listOf(OPEN, DATA)) shouldBeEqualTo false
+            hasAllModifiers(listOf(OPEN, PRIVATE)) shouldBeEqualTo true
+            hasAllModifiers(setOf(OPEN)) shouldBeEqualTo true
+            hasAllModifiers(setOf(DATA)) shouldBeEqualTo false
+            hasAllModifiers(setOf(OPEN, DATA)) shouldBeEqualTo false
+            hasAllModifiers(setOf(OPEN, PRIVATE)) shouldBeEqualTo true
             hasModifiers(PRIVATE) shouldBeEqualTo true
             hasModifiers(OPEN) shouldBeEqualTo true
             hasModifiers(PROTECTED) shouldBeEqualTo false

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koclass/forkomodifier/KoClassDeclarationForKoModifierProviderTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koclass/forkomodifier/KoClassDeclarationForKoModifierProviderTest.kt
@@ -67,12 +67,12 @@ class KoClassDeclarationForKoModifierProviderTest {
             hasModifier(OPEN) shouldBeEqualTo true
             hasModifier(DATA) shouldBeEqualTo false
             hasModifier(OPEN, DATA) shouldBeEqualTo true
-            hasModifier(listOf( OPEN)) shouldBeEqualTo true
-            hasModifier(listOf( DATA)) shouldBeEqualTo false
-            hasModifier(listOf( OPEN, DATA)) shouldBeEqualTo true
-            hasModifier(setOf( OPEN)) shouldBeEqualTo true
-            hasModifier(setOf( DATA)) shouldBeEqualTo false
-            hasModifier(setOf( OPEN, DATA)) shouldBeEqualTo true
+            hasModifier(listOf(OPEN)) shouldBeEqualTo true
+            hasModifier(listOf(DATA)) shouldBeEqualTo false
+            hasModifier(listOf(OPEN, DATA)) shouldBeEqualTo true
+            hasModifier(setOf(OPEN)) shouldBeEqualTo true
+            hasModifier(setOf(DATA)) shouldBeEqualTo false
+            hasModifier(setOf(OPEN, DATA)) shouldBeEqualTo true
             hasAllModifiers(OPEN) shouldBeEqualTo true
             hasAllModifiers(DATA) shouldBeEqualTo false
             hasAllModifiers(OPEN, DATA) shouldBeEqualTo false

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koconstructor/KoConstructorDeclarationForKoAnnotationProviderTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koconstructor/KoConstructorDeclarationForKoAnnotationProviderTest.kt
@@ -9,6 +9,7 @@ import org.amshove.kluent.assertSoftly
 import org.amshove.kluent.shouldBeEqualTo
 import org.junit.jupiter.api.Test
 
+@Suppress("detekt.LongMethod")
 class KoConstructorDeclarationForKoAnnotationProviderTest {
     @Test
     fun `constructor-has-no-annotation`() {
@@ -86,19 +87,23 @@ class KoConstructorDeclarationForKoAnnotationProviderTest {
             hasAnnotationWithName(listOf("SampleAnnotation", "OtherAnnotation")) shouldBeEqualTo true
             hasAnnotationWithName(listOf("com.lemonappdev.konsist.testdata.SampleAnnotation")) shouldBeEqualTo true
             hasAnnotationWithName(listOf("com.lemonappdev.konsist.testdata.NonExistingAnnotation")) shouldBeEqualTo false
-            hasAnnotationWithName(listOf(
-                "com.lemonappdev.konsist.testdata.SampleAnnotation",
-                "com.lemonappdev.konsist.testdata.NonExistingAnnotation",
-            )).shouldBeEqualTo(true)
+            hasAnnotationWithName(
+                listOf(
+                    "com.lemonappdev.konsist.testdata.SampleAnnotation",
+                    "com.lemonappdev.konsist.testdata.NonExistingAnnotation",
+                ),
+            ).shouldBeEqualTo(true)
             hasAnnotationWithName(setOf("SampleAnnotation")) shouldBeEqualTo true
             hasAnnotationWithName(setOf("OtherAnnotation")) shouldBeEqualTo false
             hasAnnotationWithName(setOf("SampleAnnotation", "OtherAnnotation")) shouldBeEqualTo true
             hasAnnotationWithName(setOf("com.lemonappdev.konsist.testdata.SampleAnnotation")) shouldBeEqualTo true
             hasAnnotationWithName(setOf("com.lemonappdev.konsist.testdata.NonExistingAnnotation")) shouldBeEqualTo false
-            hasAnnotationWithName(setOf(
-                "com.lemonappdev.konsist.testdata.SampleAnnotation",
-                "com.lemonappdev.konsist.testdata.NonExistingAnnotation",
-            )).shouldBeEqualTo(true)
+            hasAnnotationWithName(
+                setOf(
+                    "com.lemonappdev.konsist.testdata.SampleAnnotation",
+                    "com.lemonappdev.konsist.testdata.NonExistingAnnotation",
+                ),
+            ).shouldBeEqualTo(true)
             hasAnnotationsWithAllNames("SampleAnnotation") shouldBeEqualTo true
             hasAnnotationsWithAllNames("SampleAnnotation", "OtherAnnotation") shouldBeEqualTo false
             hasAnnotationsWithAllNames("com.lemonappdev.konsist.testdata.SampleAnnotation") shouldBeEqualTo true
@@ -109,10 +114,12 @@ class KoConstructorDeclarationForKoAnnotationProviderTest {
             hasAnnotationsWithAllNames(listOf("SampleAnnotation")) shouldBeEqualTo true
             hasAnnotationsWithAllNames(listOf("SampleAnnotation", "OtherAnnotation")) shouldBeEqualTo false
             hasAnnotationsWithAllNames(listOf("com.lemonappdev.konsist.testdata.SampleAnnotation")) shouldBeEqualTo true
-            hasAnnotationsWithAllNames(listOf(
-                "com.lemonappdev.konsist.testdata.SampleAnnotation",
-                "com.lemonappdev.konsist.testdata.NonExistingAnnotation",
-            )).shouldBeEqualTo(false)
+            hasAnnotationsWithAllNames(
+                listOf(
+                    "com.lemonappdev.konsist.testdata.SampleAnnotation",
+                    "com.lemonappdev.konsist.testdata.NonExistingAnnotation",
+                ),
+            ).shouldBeEqualTo(false)
             hasAnnotation { it.hasNameStartingWith("Sample") } shouldBeEqualTo true
             hasAnnotation { it.hasNameStartingWith("Other") } shouldBeEqualTo false
             hasAllAnnotations { it.hasNameStartingWith("Sample") } shouldBeEqualTo true
@@ -178,19 +185,23 @@ class KoConstructorDeclarationForKoAnnotationProviderTest {
             hasAnnotationWithName(listOf("SampleAnnotation1", "OtherAnnotation")) shouldBeEqualTo true
             hasAnnotationWithName(listOf("com.lemonappdev.konsist.testdata.SampleAnnotation1")) shouldBeEqualTo true
             hasAnnotationWithName(listOf("com.lemonappdev.konsist.testdata.NonExistingAnnotation")) shouldBeEqualTo false
-            hasAnnotationWithName(listOf(
-                "com.lemonappdev.konsist.testdata.SampleAnnotation1",
-                "com.lemonappdev.konsist.testdata.NonExistingAnnotation",
-            )).shouldBeEqualTo(true)
+            hasAnnotationWithName(
+                listOf(
+                    "com.lemonappdev.konsist.testdata.SampleAnnotation1",
+                    "com.lemonappdev.konsist.testdata.NonExistingAnnotation",
+                ),
+            ).shouldBeEqualTo(true)
             hasAnnotationWithName(setOf("SampleAnnotation1")) shouldBeEqualTo true
             hasAnnotationWithName(setOf("OtherAnnotation")) shouldBeEqualTo false
             hasAnnotationWithName(setOf("SampleAnnotation1", "OtherAnnotation")) shouldBeEqualTo true
             hasAnnotationWithName(setOf("com.lemonappdev.konsist.testdata.SampleAnnotation1")) shouldBeEqualTo true
             hasAnnotationWithName(setOf("com.lemonappdev.konsist.testdata.NonExistingAnnotation")) shouldBeEqualTo false
-            hasAnnotationWithName(setOf(
-                "com.lemonappdev.konsist.testdata.SampleAnnotation1",
-                "com.lemonappdev.konsist.testdata.NonExistingAnnotation",
-            )).shouldBeEqualTo(true)
+            hasAnnotationWithName(
+                setOf(
+                    "com.lemonappdev.konsist.testdata.SampleAnnotation1",
+                    "com.lemonappdev.konsist.testdata.NonExistingAnnotation",
+                ),
+            ).shouldBeEqualTo(true)
             hasAnnotationsWithAllNames("SampleAnnotation1") shouldBeEqualTo true
             hasAnnotationsWithAllNames("SampleAnnotation1", "SampleAnnotation2") shouldBeEqualTo true
             hasAnnotationsWithAllNames("SampleAnnotation1", "OtherAnnotation") shouldBeEqualTo false
@@ -208,14 +219,18 @@ class KoConstructorDeclarationForKoAnnotationProviderTest {
             hasAnnotationsWithAllNames(listOf("SampleAnnotation1", "SampleAnnotation2")) shouldBeEqualTo true
             hasAnnotationsWithAllNames(listOf("SampleAnnotation1", "OtherAnnotation")) shouldBeEqualTo false
             hasAnnotationsWithAllNames(listOf("com.lemonappdev.konsist.testdata.SampleAnnotation1")) shouldBeEqualTo true
-            hasAnnotationsWithAllNames(listOf(
-                "com.lemonappdev.konsist.testdata.SampleAnnotation1",
-                "com.lemonappdev.konsist.testdata.NonExistingAnnotation",
-            )).shouldBeEqualTo(false)
-            hasAnnotationsWithAllNames(listOf(
-                "com.lemonappdev.konsist.testdata.SampleAnnotation1",
-                "com.lemonappdev.konsist.testdata.SampleAnnotation2",
-            )).shouldBeEqualTo(true)
+            hasAnnotationsWithAllNames(
+                listOf(
+                    "com.lemonappdev.konsist.testdata.SampleAnnotation1",
+                    "com.lemonappdev.konsist.testdata.NonExistingAnnotation",
+                ),
+            ).shouldBeEqualTo(false)
+            hasAnnotationsWithAllNames(
+                listOf(
+                    "com.lemonappdev.konsist.testdata.SampleAnnotation1",
+                    "com.lemonappdev.konsist.testdata.SampleAnnotation2",
+                ),
+            ).shouldBeEqualTo(true)
             hasAnnotation { it.name == "SampleAnnotation1" } shouldBeEqualTo true
             hasAnnotation { it.name == "OtherAnnotation1" } shouldBeEqualTo false
             hasAllAnnotations { !it.hasArguments() } shouldBeEqualTo true

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koconstructor/KoConstructorDeclarationForKoAnnotationProviderTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koconstructor/KoConstructorDeclarationForKoAnnotationProviderTest.kt
@@ -26,12 +26,28 @@ class KoConstructorDeclarationForKoAnnotationProviderTest {
             numAnnotations shouldBeEqualTo 0
             countAnnotations { it.name == "NonExistingAnnotation" } shouldBeEqualTo 0
             hasAnnotations() shouldBeEqualTo false
+            hasAnnotationWithName(emptyList()) shouldBeEqualTo false
+            hasAnnotationWithName(emptySet()) shouldBeEqualTo false
+            hasAnnotationsWithAllNames(emptyList()) shouldBeEqualTo false
+            hasAnnotationsWithAllNames(emptySet()) shouldBeEqualTo false
             hasAnnotationWithName("SampleAnnotation") shouldBeEqualTo false
+            hasAnnotationWithName(listOf("SampleAnnotation")) shouldBeEqualTo false
+            hasAnnotationWithName(setOf("SampleAnnotation")) shouldBeEqualTo false
             hasAnnotationsWithAllNames("SampleAnnotation1", "SampleAnnotation2") shouldBeEqualTo false
+            hasAnnotationsWithAllNames(listOf("SampleAnnotation1", "SampleAnnotation2")) shouldBeEqualTo false
+            hasAnnotationsWithAllNames(setOf("SampleAnnotation1", "SampleAnnotation2")) shouldBeEqualTo false
             hasAnnotation { it.hasArguments() } shouldBeEqualTo false
             hasAllAnnotations { it.hasArguments() } shouldBeEqualTo true
+            hasAnnotationOf(emptyList()) shouldBeEqualTo false
+            hasAnnotationOf(emptySet()) shouldBeEqualTo false
+            hasAllAnnotationsOf(emptyList()) shouldBeEqualTo false
+            hasAllAnnotationsOf(emptySet()) shouldBeEqualTo false
             hasAnnotationOf(SampleAnnotation::class) shouldBeEqualTo false
+            hasAnnotationOf(listOf(SampleAnnotation::class)) shouldBeEqualTo false
+            hasAnnotationOf(setOf(SampleAnnotation::class)) shouldBeEqualTo false
             hasAllAnnotationsOf(SampleAnnotation1::class, SampleAnnotation2::class) shouldBeEqualTo false
+            hasAllAnnotationsOf(listOf(SampleAnnotation1::class, SampleAnnotation2::class)) shouldBeEqualTo false
+            hasAllAnnotationsOf(setOf(SampleAnnotation1::class, SampleAnnotation2::class)) shouldBeEqualTo false
             hasAnnotations("SampleAnnotation") shouldBeEqualTo false
         }
     }
@@ -52,6 +68,10 @@ class KoConstructorDeclarationForKoAnnotationProviderTest {
             countAnnotations { it.name == "SampleAnnotation" } shouldBeEqualTo 1
             countAnnotations { it.name == "NonExistingAnnotation" } shouldBeEqualTo 0
             hasAnnotations() shouldBeEqualTo true
+            hasAnnotationWithName(emptyList()) shouldBeEqualTo true
+            hasAnnotationWithName(emptySet()) shouldBeEqualTo true
+            hasAnnotationsWithAllNames(emptyList()) shouldBeEqualTo true
+            hasAnnotationsWithAllNames(emptySet()) shouldBeEqualTo true
             hasAnnotationWithName("SampleAnnotation") shouldBeEqualTo true
             hasAnnotationWithName("OtherAnnotation") shouldBeEqualTo false
             hasAnnotationWithName("SampleAnnotation", "OtherAnnotation") shouldBeEqualTo true
@@ -61,6 +81,24 @@ class KoConstructorDeclarationForKoAnnotationProviderTest {
                 "com.lemonappdev.konsist.testdata.SampleAnnotation",
                 "com.lemonappdev.konsist.testdata.NonExistingAnnotation",
             ).shouldBeEqualTo(true)
+            hasAnnotationWithName(listOf("SampleAnnotation")) shouldBeEqualTo true
+            hasAnnotationWithName(listOf("OtherAnnotation")) shouldBeEqualTo false
+            hasAnnotationWithName(listOf("SampleAnnotation", "OtherAnnotation")) shouldBeEqualTo true
+            hasAnnotationWithName(listOf("com.lemonappdev.konsist.testdata.SampleAnnotation")) shouldBeEqualTo true
+            hasAnnotationWithName(listOf("com.lemonappdev.konsist.testdata.NonExistingAnnotation")) shouldBeEqualTo false
+            hasAnnotationWithName(listOf(
+                "com.lemonappdev.konsist.testdata.SampleAnnotation",
+                "com.lemonappdev.konsist.testdata.NonExistingAnnotation",
+            )).shouldBeEqualTo(true)
+            hasAnnotationWithName(setOf("SampleAnnotation")) shouldBeEqualTo true
+            hasAnnotationWithName(setOf("OtherAnnotation")) shouldBeEqualTo false
+            hasAnnotationWithName(setOf("SampleAnnotation", "OtherAnnotation")) shouldBeEqualTo true
+            hasAnnotationWithName(setOf("com.lemonappdev.konsist.testdata.SampleAnnotation")) shouldBeEqualTo true
+            hasAnnotationWithName(setOf("com.lemonappdev.konsist.testdata.NonExistingAnnotation")) shouldBeEqualTo false
+            hasAnnotationWithName(setOf(
+                "com.lemonappdev.konsist.testdata.SampleAnnotation",
+                "com.lemonappdev.konsist.testdata.NonExistingAnnotation",
+            )).shouldBeEqualTo(true)
             hasAnnotationsWithAllNames("SampleAnnotation") shouldBeEqualTo true
             hasAnnotationsWithAllNames("SampleAnnotation", "OtherAnnotation") shouldBeEqualTo false
             hasAnnotationsWithAllNames("com.lemonappdev.konsist.testdata.SampleAnnotation") shouldBeEqualTo true
@@ -68,15 +106,35 @@ class KoConstructorDeclarationForKoAnnotationProviderTest {
                 "com.lemonappdev.konsist.testdata.SampleAnnotation",
                 "com.lemonappdev.konsist.testdata.NonExistingAnnotation",
             ).shouldBeEqualTo(false)
+            hasAnnotationsWithAllNames(listOf("SampleAnnotation")) shouldBeEqualTo true
+            hasAnnotationsWithAllNames(listOf("SampleAnnotation", "OtherAnnotation")) shouldBeEqualTo false
+            hasAnnotationsWithAllNames(listOf("com.lemonappdev.konsist.testdata.SampleAnnotation")) shouldBeEqualTo true
+            hasAnnotationsWithAllNames(listOf(
+                "com.lemonappdev.konsist.testdata.SampleAnnotation",
+                "com.lemonappdev.konsist.testdata.NonExistingAnnotation",
+            )).shouldBeEqualTo(false)
             hasAnnotation { it.hasNameStartingWith("Sample") } shouldBeEqualTo true
             hasAnnotation { it.hasNameStartingWith("Other") } shouldBeEqualTo false
             hasAllAnnotations { it.hasNameStartingWith("Sample") } shouldBeEqualTo true
-            hasAnnotationOf(SampleAnnotation::class) shouldBeEqualTo true
-            hasAnnotationOf(NonExistingAnnotation::class) shouldBeEqualTo false
-            hasAnnotationOf(SampleAnnotation::class, NonExistingAnnotation::class) shouldBeEqualTo true
+            hasAnnotationOf(emptyList()) shouldBeEqualTo true
+            hasAnnotationOf(emptySet()) shouldBeEqualTo true
+            hasAllAnnotationsOf(emptyList()) shouldBeEqualTo true
+            hasAllAnnotationsOf(emptySet()) shouldBeEqualTo true
+            hasAnnotationOf(listOf(SampleAnnotation::class)) shouldBeEqualTo true
+            hasAnnotationOf(listOf(NonExistingAnnotation::class)) shouldBeEqualTo false
+            hasAnnotationOf(listOf(SampleAnnotation::class, NonExistingAnnotation::class)) shouldBeEqualTo true
+            hasAnnotationOf(setOf(SampleAnnotation::class)) shouldBeEqualTo true
+            hasAnnotationOf(setOf(NonExistingAnnotation::class)) shouldBeEqualTo false
+            hasAnnotationOf(setOf(SampleAnnotation::class, NonExistingAnnotation::class)) shouldBeEqualTo true
             hasAllAnnotationsOf(SampleAnnotation::class) shouldBeEqualTo true
             hasAllAnnotationsOf(NonExistingAnnotation::class) shouldBeEqualTo false
             hasAllAnnotationsOf(SampleAnnotation::class, NonExistingAnnotation::class) shouldBeEqualTo false
+            hasAllAnnotationsOf(listOf(SampleAnnotation::class)) shouldBeEqualTo true
+            hasAllAnnotationsOf(listOf(NonExistingAnnotation::class)) shouldBeEqualTo false
+            hasAllAnnotationsOf(listOf(SampleAnnotation::class, NonExistingAnnotation::class)) shouldBeEqualTo false
+            hasAllAnnotationsOf(setOf(SampleAnnotation::class)) shouldBeEqualTo true
+            hasAllAnnotationsOf(setOf(NonExistingAnnotation::class)) shouldBeEqualTo false
+            hasAllAnnotationsOf(setOf(SampleAnnotation::class, NonExistingAnnotation::class)) shouldBeEqualTo false
             hasAnnotations("SampleAnnotation") shouldBeEqualTo true
             hasAnnotations("NonExistingAnnotation") shouldBeEqualTo false
             hasAnnotations("com.lemonappdev.konsist.testdata.SampleAnnotation") shouldBeEqualTo true
@@ -102,6 +160,10 @@ class KoConstructorDeclarationForKoAnnotationProviderTest {
             countAnnotations { it.hasNameStartingWith("Sample") } shouldBeEqualTo 2
             countAnnotations { it.name == "SampleAnnotation1" } shouldBeEqualTo 1
             hasAnnotations() shouldBeEqualTo true
+            hasAnnotationOf(emptyList()) shouldBeEqualTo true
+            hasAnnotationOf(emptySet()) shouldBeEqualTo true
+            hasAllAnnotationsOf(emptyList()) shouldBeEqualTo true
+            hasAllAnnotationsOf(emptySet()) shouldBeEqualTo true
             hasAnnotationWithName("SampleAnnotation1") shouldBeEqualTo true
             hasAnnotationWithName("OtherAnnotation") shouldBeEqualTo false
             hasAnnotationWithName("SampleAnnotation1", "OtherAnnotation") shouldBeEqualTo true
@@ -111,6 +173,24 @@ class KoConstructorDeclarationForKoAnnotationProviderTest {
                 "com.lemonappdev.konsist.testdata.SampleAnnotation1",
                 "com.lemonappdev.konsist.testdata.NonExistingAnnotation",
             ).shouldBeEqualTo(true)
+            hasAnnotationWithName(listOf("SampleAnnotation1")) shouldBeEqualTo true
+            hasAnnotationWithName(listOf("OtherAnnotation")) shouldBeEqualTo false
+            hasAnnotationWithName(listOf("SampleAnnotation1", "OtherAnnotation")) shouldBeEqualTo true
+            hasAnnotationWithName(listOf("com.lemonappdev.konsist.testdata.SampleAnnotation1")) shouldBeEqualTo true
+            hasAnnotationWithName(listOf("com.lemonappdev.konsist.testdata.NonExistingAnnotation")) shouldBeEqualTo false
+            hasAnnotationWithName(listOf(
+                "com.lemonappdev.konsist.testdata.SampleAnnotation1",
+                "com.lemonappdev.konsist.testdata.NonExistingAnnotation",
+            )).shouldBeEqualTo(true)
+            hasAnnotationWithName(setOf("SampleAnnotation1")) shouldBeEqualTo true
+            hasAnnotationWithName(setOf("OtherAnnotation")) shouldBeEqualTo false
+            hasAnnotationWithName(setOf("SampleAnnotation1", "OtherAnnotation")) shouldBeEqualTo true
+            hasAnnotationWithName(setOf("com.lemonappdev.konsist.testdata.SampleAnnotation1")) shouldBeEqualTo true
+            hasAnnotationWithName(setOf("com.lemonappdev.konsist.testdata.NonExistingAnnotation")) shouldBeEqualTo false
+            hasAnnotationWithName(setOf(
+                "com.lemonappdev.konsist.testdata.SampleAnnotation1",
+                "com.lemonappdev.konsist.testdata.NonExistingAnnotation",
+            )).shouldBeEqualTo(true)
             hasAnnotationsWithAllNames("SampleAnnotation1") shouldBeEqualTo true
             hasAnnotationsWithAllNames("SampleAnnotation1", "SampleAnnotation2") shouldBeEqualTo true
             hasAnnotationsWithAllNames("SampleAnnotation1", "OtherAnnotation") shouldBeEqualTo false
@@ -123,17 +203,48 @@ class KoConstructorDeclarationForKoAnnotationProviderTest {
                 "com.lemonappdev.konsist.testdata.SampleAnnotation1",
                 "com.lemonappdev.konsist.testdata.SampleAnnotation2",
             ).shouldBeEqualTo(true)
+
+            hasAnnotationsWithAllNames(listOf("SampleAnnotation1")) shouldBeEqualTo true
+            hasAnnotationsWithAllNames(listOf("SampleAnnotation1", "SampleAnnotation2")) shouldBeEqualTo true
+            hasAnnotationsWithAllNames(listOf("SampleAnnotation1", "OtherAnnotation")) shouldBeEqualTo false
+            hasAnnotationsWithAllNames(listOf("com.lemonappdev.konsist.testdata.SampleAnnotation1")) shouldBeEqualTo true
+            hasAnnotationsWithAllNames(listOf(
+                "com.lemonappdev.konsist.testdata.SampleAnnotation1",
+                "com.lemonappdev.konsist.testdata.NonExistingAnnotation",
+            )).shouldBeEqualTo(false)
+            hasAnnotationsWithAllNames(listOf(
+                "com.lemonappdev.konsist.testdata.SampleAnnotation1",
+                "com.lemonappdev.konsist.testdata.SampleAnnotation2",
+            )).shouldBeEqualTo(true)
             hasAnnotation { it.name == "SampleAnnotation1" } shouldBeEqualTo true
             hasAnnotation { it.name == "OtherAnnotation1" } shouldBeEqualTo false
             hasAllAnnotations { !it.hasArguments() } shouldBeEqualTo true
             hasAllAnnotations { it.hasNameEndingWith("tion1") } shouldBeEqualTo false
+            hasAnnotationOf(emptyList()) shouldBeEqualTo true
+            hasAnnotationOf(emptySet()) shouldBeEqualTo true
+            hasAllAnnotationsOf(emptyList()) shouldBeEqualTo true
+            hasAllAnnotationsOf(emptySet()) shouldBeEqualTo true
             hasAnnotationOf(SampleAnnotation1::class) shouldBeEqualTo true
             hasAnnotationOf(NonExistingAnnotation::class) shouldBeEqualTo false
             hasAnnotationOf(SampleAnnotation1::class, NonExistingAnnotation::class) shouldBeEqualTo true
+            hasAnnotationOf(listOf(SampleAnnotation1::class)) shouldBeEqualTo true
+            hasAnnotationOf(listOf(NonExistingAnnotation::class)) shouldBeEqualTo false
+            hasAnnotationOf(listOf(SampleAnnotation1::class, NonExistingAnnotation::class)) shouldBeEqualTo true
+            hasAnnotationOf(setOf(SampleAnnotation1::class)) shouldBeEqualTo true
+            hasAnnotationOf(setOf(NonExistingAnnotation::class)) shouldBeEqualTo false
+            hasAnnotationOf(setOf(SampleAnnotation1::class, NonExistingAnnotation::class)) shouldBeEqualTo true
             hasAllAnnotationsOf(SampleAnnotation1::class) shouldBeEqualTo true
             hasAllAnnotationsOf(NonExistingAnnotation::class) shouldBeEqualTo false
             hasAllAnnotationsOf(SampleAnnotation1::class, SampleAnnotation2::class) shouldBeEqualTo true
             hasAllAnnotationsOf(SampleAnnotation1::class, NonExistingAnnotation::class) shouldBeEqualTo false
+            hasAllAnnotationsOf(listOf(SampleAnnotation1::class)) shouldBeEqualTo true
+            hasAllAnnotationsOf(listOf(NonExistingAnnotation::class)) shouldBeEqualTo false
+            hasAllAnnotationsOf(listOf(SampleAnnotation1::class, SampleAnnotation2::class)) shouldBeEqualTo true
+            hasAllAnnotationsOf(listOf(SampleAnnotation1::class, NonExistingAnnotation::class)) shouldBeEqualTo false
+            hasAllAnnotationsOf(setOf(SampleAnnotation1::class)) shouldBeEqualTo true
+            hasAllAnnotationsOf(setOf(NonExistingAnnotation::class)) shouldBeEqualTo false
+            hasAllAnnotationsOf(setOf(SampleAnnotation1::class, SampleAnnotation2::class)) shouldBeEqualTo true
+            hasAllAnnotationsOf(setOf(SampleAnnotation1::class, NonExistingAnnotation::class)) shouldBeEqualTo false
             hasAnnotations("SampleAnnotation1") shouldBeEqualTo true
             hasAnnotations("SampleAnnotation2") shouldBeEqualTo true
             hasAnnotations("NonExistingAnnotation") shouldBeEqualTo false

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koconstructor/KoConstructorDeclarationForKoParametersProviderTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koconstructor/KoConstructorDeclarationForKoParametersProviderTest.kt
@@ -22,9 +22,17 @@ class KoConstructorDeclarationForKoParametersProviderTest {
             numParameters shouldBeEqualTo 0
             countParameters { it.hasNameStartingWith("sample") } shouldBeEqualTo 0
             hasParameters() shouldBeEqualTo false
+            hasParameterWithName(emptyList()) shouldBeEqualTo false
+            hasParameterWithName(emptySet()) shouldBeEqualTo false
+            hasParametersWithAllNames(emptyList()) shouldBeEqualTo false
+            hasParametersWithAllNames(emptySet()) shouldBeEqualTo false
             hasParameterWithName("sampleParameter") shouldBeEqualTo false
+            hasParameterWithName(listOf("sampleParameter")) shouldBeEqualTo false
+            hasParameterWithName(setOf("sampleParameter")) shouldBeEqualTo false
             hasParametersWithAllNames("sampleParameter1", "sampleParameter2") shouldBeEqualTo false
-            hasParameter { it.hasNameStartingWith("sample") } shouldBeEqualTo false
+            hasParametersWithAllNames(listOf("sampleParameter1", "sampleParameter2")) shouldBeEqualTo false
+            hasParametersWithAllNames(setOf("sampleParameter1", "sampleParameter2")) shouldBeEqualTo false
+            hasParameter { it.hasNameStartingWith("other") } shouldBeEqualTo false
             hasAllParameters { it.hasNameStartingWith("sample") } shouldBeEqualTo true
         }
     }
@@ -45,11 +53,25 @@ class KoConstructorDeclarationForKoParametersProviderTest {
             numParameters shouldBeEqualTo 1
             countParameters { it.hasNameStartingWith("sample") } shouldBeEqualTo 1
             hasParameters() shouldBeEqualTo true
+            hasParameterWithName(emptyList()) shouldBeEqualTo true
+            hasParameterWithName(emptySet()) shouldBeEqualTo true
+            hasParametersWithAllNames(emptyList()) shouldBeEqualTo true
+            hasParametersWithAllNames(emptySet()) shouldBeEqualTo true
             hasParameterWithName("sampleParameter") shouldBeEqualTo true
             hasParameterWithName("otherParameter") shouldBeEqualTo false
             hasParameterWithName("sampleParameter", "otherParameter") shouldBeEqualTo true
+            hasParameterWithName(listOf("sampleParameter")) shouldBeEqualTo true
+            hasParameterWithName(listOf("otherParameter")) shouldBeEqualTo false
+            hasParameterWithName(listOf("sampleParameter", "otherParameter")) shouldBeEqualTo true
+            hasParameterWithName(setOf("sampleParameter")) shouldBeEqualTo true
+            hasParameterWithName(setOf("otherParameter")) shouldBeEqualTo false
+            hasParameterWithName(setOf("sampleParameter", "otherParameter")) shouldBeEqualTo true
             hasParametersWithAllNames("sampleParameter") shouldBeEqualTo true
             hasParametersWithAllNames("sampleParameter", "otherParameter") shouldBeEqualTo false
+            hasParametersWithAllNames(listOf("sampleParameter")) shouldBeEqualTo true
+            hasParametersWithAllNames(listOf("sampleParameter", "otherParameter")) shouldBeEqualTo false
+            hasParametersWithAllNames(setOf("sampleParameter")) shouldBeEqualTo true
+            hasParametersWithAllNames(setOf("sampleParameter", "otherParameter")) shouldBeEqualTo false
             hasParameter { it.hasNameStartingWith("sample") } shouldBeEqualTo true
             hasParameter { it.hasNameStartingWith("other") } shouldBeEqualTo false
             hasAllParameters { it.hasNameStartingWith("sample") } shouldBeEqualTo true
@@ -73,12 +95,28 @@ class KoConstructorDeclarationForKoParametersProviderTest {
             countParameters { it.hasNameStartingWith("sample") } shouldBeEqualTo 2
             countParameters { param -> param.hasType { it.name == "Int" } } shouldBeEqualTo 1
             hasParameters() shouldBeEqualTo true
+            hasParameterWithName(emptyList()) shouldBeEqualTo true
+            hasParameterWithName(emptySet()) shouldBeEqualTo true
+            hasParametersWithAllNames(emptyList()) shouldBeEqualTo true
+            hasParametersWithAllNames(emptySet()) shouldBeEqualTo true
             hasParameterWithName("sampleParameter1") shouldBeEqualTo true
             hasParameterWithName("otherParameter") shouldBeEqualTo false
             hasParameterWithName("sampleParameter1", "otherName") shouldBeEqualTo true
+            hasParameterWithName(listOf("sampleParameter1")) shouldBeEqualTo true
+            hasParameterWithName(listOf("otherParameter")) shouldBeEqualTo false
+            hasParameterWithName(listOf("sampleParameter1", "otherName")) shouldBeEqualTo true
+            hasParameterWithName(setOf("sampleParameter1")) shouldBeEqualTo true
+            hasParameterWithName(setOf("otherParameter")) shouldBeEqualTo false
+            hasParameterWithName(setOf("sampleParameter1", "otherName")) shouldBeEqualTo true
             hasParametersWithAllNames("sampleParameter1") shouldBeEqualTo true
             hasParametersWithAllNames("sampleParameter1", "sampleParameter2") shouldBeEqualTo true
             hasParametersWithAllNames("sampleParameter1", "otherParameter") shouldBeEqualTo false
+            hasParametersWithAllNames(listOf("sampleParameter1")) shouldBeEqualTo true
+            hasParametersWithAllNames(listOf("sampleParameter1", "sampleParameter2")) shouldBeEqualTo true
+            hasParametersWithAllNames(listOf("sampleParameter1", "otherParameter")) shouldBeEqualTo false
+            hasParametersWithAllNames(setOf("sampleParameter1")) shouldBeEqualTo true
+            hasParametersWithAllNames(setOf("sampleParameter1", "sampleParameter2")) shouldBeEqualTo true
+            hasParametersWithAllNames(setOf("sampleParameter1", "otherParameter")) shouldBeEqualTo false
             hasParameter { it.hasNameStartingWith("sample") } shouldBeEqualTo true
             hasParameter { param -> param.hasType { it.name == "Int" } } shouldBeEqualTo true
             hasAllParameters { it.hasNameStartingWith("sample") } shouldBeEqualTo true

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koconstructor/forkomodifier/KoConstructorDeclarationForKoModifierProviderTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koconstructor/forkomodifier/KoConstructorDeclarationForKoModifierProviderTest.kt
@@ -28,10 +28,22 @@ class KoConstructorDeclarationForKoModifierProviderTest {
             modifiers shouldBeEqualTo emptyList()
             numModifiers shouldBeEqualTo 0
             hasModifiers() shouldBeEqualTo false
+            hasModifier(emptyList()) shouldBeEqualTo false
+            hasModifier(emptySet()) shouldBeEqualTo false
+            hasAllModifiers(emptyList()) shouldBeEqualTo false
+            hasAllModifiers(emptySet()) shouldBeEqualTo false
             hasModifier(OPEN) shouldBeEqualTo false
             hasModifier(OPEN, DATA) shouldBeEqualTo false
+            hasModifier(listOf(OPEN)) shouldBeEqualTo false
+            hasModifier(listOf(OPEN, DATA)) shouldBeEqualTo false
+            hasModifier(setOf(OPEN)) shouldBeEqualTo false
+            hasModifier(setOf(OPEN, DATA)) shouldBeEqualTo false
             hasAllModifiers(OPEN) shouldBeEqualTo false
             hasAllModifiers(OPEN, DATA) shouldBeEqualTo false
+            hasAllModifiers(listOf(OPEN)) shouldBeEqualTo false
+            hasAllModifiers(listOf(OPEN, DATA)) shouldBeEqualTo false
+            hasAllModifiers(setOf(OPEN)) shouldBeEqualTo false
+            hasAllModifiers(setOf(OPEN, DATA)) shouldBeEqualTo false
             hasModifiers(OPEN) shouldBeEqualTo false
             hasModifiers(OPEN, DATA) shouldBeEqualTo false
         }
@@ -52,12 +64,29 @@ class KoConstructorDeclarationForKoModifierProviderTest {
         assertSoftly(sut) {
             modifiers shouldBeEqualTo listOf(PRIVATE)
             numModifiers shouldBeEqualTo 1
+            hasModifiers() shouldBeEqualTo true
+            hasModifier(emptyList()) shouldBeEqualTo true
+            hasModifier(emptySet()) shouldBeEqualTo true
+            hasAllModifiers(emptyList()) shouldBeEqualTo true
+            hasAllModifiers(emptySet()) shouldBeEqualTo true
             hasModifier(PRIVATE) shouldBeEqualTo true
             hasModifier(PROTECTED) shouldBeEqualTo false
             hasModifier(PRIVATE, DATA) shouldBeEqualTo true
+            hasModifier(listOf(PRIVATE)) shouldBeEqualTo true
+            hasModifier(listOf(PROTECTED)) shouldBeEqualTo false
+            hasModifier(listOf(PRIVATE, DATA)) shouldBeEqualTo true
+            hasModifier(setOf(PRIVATE)) shouldBeEqualTo true
+            hasModifier(setOf(PROTECTED)) shouldBeEqualTo false
+            hasModifier(setOf(PRIVATE, DATA)) shouldBeEqualTo true
             hasAllModifiers(PRIVATE) shouldBeEqualTo true
             hasAllModifiers(PROTECTED) shouldBeEqualTo false
             hasAllModifiers(PRIVATE, DATA) shouldBeEqualTo false
+            hasAllModifiers(listOf(PRIVATE)) shouldBeEqualTo true
+            hasAllModifiers(listOf(PROTECTED)) shouldBeEqualTo false
+            hasAllModifiers(listOf(PRIVATE, DATA)) shouldBeEqualTo false
+            hasAllModifiers(setOf(PRIVATE)) shouldBeEqualTo true
+            hasAllModifiers(setOf(PROTECTED)) shouldBeEqualTo false
+            hasAllModifiers(setOf(PRIVATE, DATA)) shouldBeEqualTo false
         }
     }
 

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koenumconstant/KoEnumConstantDeclarationForKoAnnotationProviderTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koenumconstant/KoEnumConstantDeclarationForKoAnnotationProviderTest.kt
@@ -9,6 +9,7 @@ import org.amshove.kluent.assertSoftly
 import org.amshove.kluent.shouldBeEqualTo
 import org.junit.jupiter.api.Test
 
+@Suppress("detekt.LongMethod")
 class KoEnumConstantDeclarationForKoAnnotationProviderTest {
     @Test
     fun `enum-const-has-no-annotation`() {
@@ -86,19 +87,23 @@ class KoEnumConstantDeclarationForKoAnnotationProviderTest {
             hasAnnotationWithName(listOf("SampleAnnotation", "OtherAnnotation")) shouldBeEqualTo true
             hasAnnotationWithName(listOf("com.lemonappdev.konsist.testdata.SampleAnnotation")) shouldBeEqualTo true
             hasAnnotationWithName(listOf("com.lemonappdev.konsist.testdata.NonExistingAnnotation")) shouldBeEqualTo false
-            hasAnnotationWithName(listOf(
-                "com.lemonappdev.konsist.testdata.SampleAnnotation",
-                "com.lemonappdev.konsist.testdata.NonExistingAnnotation",
-            )).shouldBeEqualTo(true)
+            hasAnnotationWithName(
+                listOf(
+                    "com.lemonappdev.konsist.testdata.SampleAnnotation",
+                    "com.lemonappdev.konsist.testdata.NonExistingAnnotation",
+                ),
+            ).shouldBeEqualTo(true)
             hasAnnotationWithName(setOf("SampleAnnotation")) shouldBeEqualTo true
             hasAnnotationWithName(setOf("OtherAnnotation")) shouldBeEqualTo false
             hasAnnotationWithName(setOf("SampleAnnotation", "OtherAnnotation")) shouldBeEqualTo true
             hasAnnotationWithName(setOf("com.lemonappdev.konsist.testdata.SampleAnnotation")) shouldBeEqualTo true
             hasAnnotationWithName(setOf("com.lemonappdev.konsist.testdata.NonExistingAnnotation")) shouldBeEqualTo false
-            hasAnnotationWithName(setOf(
-                "com.lemonappdev.konsist.testdata.SampleAnnotation",
-                "com.lemonappdev.konsist.testdata.NonExistingAnnotation",
-            )).shouldBeEqualTo(true)
+            hasAnnotationWithName(
+                setOf(
+                    "com.lemonappdev.konsist.testdata.SampleAnnotation",
+                    "com.lemonappdev.konsist.testdata.NonExistingAnnotation",
+                ),
+            ).shouldBeEqualTo(true)
             hasAnnotationsWithAllNames("SampleAnnotation") shouldBeEqualTo true
             hasAnnotationsWithAllNames("SampleAnnotation", "OtherAnnotation") shouldBeEqualTo false
             hasAnnotationsWithAllNames("com.lemonappdev.konsist.testdata.SampleAnnotation") shouldBeEqualTo true
@@ -109,10 +114,12 @@ class KoEnumConstantDeclarationForKoAnnotationProviderTest {
             hasAnnotationsWithAllNames(listOf("SampleAnnotation")) shouldBeEqualTo true
             hasAnnotationsWithAllNames(listOf("SampleAnnotation", "OtherAnnotation")) shouldBeEqualTo false
             hasAnnotationsWithAllNames(listOf("com.lemonappdev.konsist.testdata.SampleAnnotation")) shouldBeEqualTo true
-            hasAnnotationsWithAllNames(listOf(
-                "com.lemonappdev.konsist.testdata.SampleAnnotation",
-                "com.lemonappdev.konsist.testdata.NonExistingAnnotation",
-            )).shouldBeEqualTo(false)
+            hasAnnotationsWithAllNames(
+                listOf(
+                    "com.lemonappdev.konsist.testdata.SampleAnnotation",
+                    "com.lemonappdev.konsist.testdata.NonExistingAnnotation",
+                ),
+            ).shouldBeEqualTo(false)
             hasAnnotation { it.hasNameStartingWith("Sample") } shouldBeEqualTo true
             hasAnnotation { it.hasNameStartingWith("Other") } shouldBeEqualTo false
             hasAllAnnotations { it.hasNameStartingWith("Sample") } shouldBeEqualTo true
@@ -178,19 +185,23 @@ class KoEnumConstantDeclarationForKoAnnotationProviderTest {
             hasAnnotationWithName(listOf("SampleAnnotation1", "OtherAnnotation")) shouldBeEqualTo true
             hasAnnotationWithName(listOf("com.lemonappdev.konsist.testdata.SampleAnnotation1")) shouldBeEqualTo true
             hasAnnotationWithName(listOf("com.lemonappdev.konsist.testdata.NonExistingAnnotation")) shouldBeEqualTo false
-            hasAnnotationWithName(listOf(
-                "com.lemonappdev.konsist.testdata.SampleAnnotation1",
-                "com.lemonappdev.konsist.testdata.NonExistingAnnotation",
-            )).shouldBeEqualTo(true)
+            hasAnnotationWithName(
+                listOf(
+                    "com.lemonappdev.konsist.testdata.SampleAnnotation1",
+                    "com.lemonappdev.konsist.testdata.NonExistingAnnotation",
+                ),
+            ).shouldBeEqualTo(true)
             hasAnnotationWithName(setOf("SampleAnnotation1")) shouldBeEqualTo true
             hasAnnotationWithName(setOf("OtherAnnotation")) shouldBeEqualTo false
             hasAnnotationWithName(setOf("SampleAnnotation1", "OtherAnnotation")) shouldBeEqualTo true
             hasAnnotationWithName(setOf("com.lemonappdev.konsist.testdata.SampleAnnotation1")) shouldBeEqualTo true
             hasAnnotationWithName(setOf("com.lemonappdev.konsist.testdata.NonExistingAnnotation")) shouldBeEqualTo false
-            hasAnnotationWithName(setOf(
-                "com.lemonappdev.konsist.testdata.SampleAnnotation1",
-                "com.lemonappdev.konsist.testdata.NonExistingAnnotation",
-            )).shouldBeEqualTo(true)
+            hasAnnotationWithName(
+                setOf(
+                    "com.lemonappdev.konsist.testdata.SampleAnnotation1",
+                    "com.lemonappdev.konsist.testdata.NonExistingAnnotation",
+                ),
+            ).shouldBeEqualTo(true)
             hasAnnotationsWithAllNames("SampleAnnotation1") shouldBeEqualTo true
             hasAnnotationsWithAllNames("SampleAnnotation1", "SampleAnnotation2") shouldBeEqualTo true
             hasAnnotationsWithAllNames("SampleAnnotation1", "OtherAnnotation") shouldBeEqualTo false
@@ -208,14 +219,18 @@ class KoEnumConstantDeclarationForKoAnnotationProviderTest {
             hasAnnotationsWithAllNames(listOf("SampleAnnotation1", "SampleAnnotation2")) shouldBeEqualTo true
             hasAnnotationsWithAllNames(listOf("SampleAnnotation1", "OtherAnnotation")) shouldBeEqualTo false
             hasAnnotationsWithAllNames(listOf("com.lemonappdev.konsist.testdata.SampleAnnotation1")) shouldBeEqualTo true
-            hasAnnotationsWithAllNames(listOf(
-                "com.lemonappdev.konsist.testdata.SampleAnnotation1",
-                "com.lemonappdev.konsist.testdata.NonExistingAnnotation",
-            )).shouldBeEqualTo(false)
-            hasAnnotationsWithAllNames(listOf(
-                "com.lemonappdev.konsist.testdata.SampleAnnotation1",
-                "com.lemonappdev.konsist.testdata.SampleAnnotation2",
-            )).shouldBeEqualTo(true)
+            hasAnnotationsWithAllNames(
+                listOf(
+                    "com.lemonappdev.konsist.testdata.SampleAnnotation1",
+                    "com.lemonappdev.konsist.testdata.NonExistingAnnotation",
+                ),
+            ).shouldBeEqualTo(false)
+            hasAnnotationsWithAllNames(
+                listOf(
+                    "com.lemonappdev.konsist.testdata.SampleAnnotation1",
+                    "com.lemonappdev.konsist.testdata.SampleAnnotation2",
+                ),
+            ).shouldBeEqualTo(true)
             hasAnnotation { it.name == "SampleAnnotation1" } shouldBeEqualTo true
             hasAnnotation { it.name == "OtherAnnotation1" } shouldBeEqualTo false
             hasAllAnnotations { !it.hasArguments() } shouldBeEqualTo true

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koenumconstant/KoEnumConstantDeclarationForKoAnnotationProviderTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koenumconstant/KoEnumConstantDeclarationForKoAnnotationProviderTest.kt
@@ -26,12 +26,28 @@ class KoEnumConstantDeclarationForKoAnnotationProviderTest {
             numAnnotations shouldBeEqualTo 0
             countAnnotations { it.name == "NonExistingAnnotation" } shouldBeEqualTo 0
             hasAnnotations() shouldBeEqualTo false
+            hasAnnotationWithName(emptyList()) shouldBeEqualTo false
+            hasAnnotationWithName(emptySet()) shouldBeEqualTo false
+            hasAnnotationsWithAllNames(emptyList()) shouldBeEqualTo false
+            hasAnnotationsWithAllNames(emptySet()) shouldBeEqualTo false
             hasAnnotationWithName("SampleAnnotation") shouldBeEqualTo false
+            hasAnnotationWithName(listOf("SampleAnnotation")) shouldBeEqualTo false
+            hasAnnotationWithName(setOf("SampleAnnotation")) shouldBeEqualTo false
             hasAnnotationsWithAllNames("SampleAnnotation1", "SampleAnnotation2") shouldBeEqualTo false
+            hasAnnotationsWithAllNames(listOf("SampleAnnotation1", "SampleAnnotation2")) shouldBeEqualTo false
+            hasAnnotationsWithAllNames(setOf("SampleAnnotation1", "SampleAnnotation2")) shouldBeEqualTo false
             hasAnnotation { it.hasArguments() } shouldBeEqualTo false
             hasAllAnnotations { it.hasArguments() } shouldBeEqualTo true
+            hasAnnotationOf(emptyList()) shouldBeEqualTo false
+            hasAnnotationOf(emptySet()) shouldBeEqualTo false
+            hasAllAnnotationsOf(emptyList()) shouldBeEqualTo false
+            hasAllAnnotationsOf(emptySet()) shouldBeEqualTo false
             hasAnnotationOf(SampleAnnotation::class) shouldBeEqualTo false
+            hasAnnotationOf(listOf(SampleAnnotation::class)) shouldBeEqualTo false
+            hasAnnotationOf(setOf(SampleAnnotation::class)) shouldBeEqualTo false
             hasAllAnnotationsOf(SampleAnnotation1::class, SampleAnnotation2::class) shouldBeEqualTo false
+            hasAllAnnotationsOf(listOf(SampleAnnotation1::class, SampleAnnotation2::class)) shouldBeEqualTo false
+            hasAllAnnotationsOf(setOf(SampleAnnotation1::class, SampleAnnotation2::class)) shouldBeEqualTo false
             hasAnnotations("SampleAnnotation") shouldBeEqualTo false
         }
     }
@@ -52,6 +68,10 @@ class KoEnumConstantDeclarationForKoAnnotationProviderTest {
             countAnnotations { it.name == "SampleAnnotation" } shouldBeEqualTo 1
             countAnnotations { it.name == "NonExistingAnnotation" } shouldBeEqualTo 0
             hasAnnotations() shouldBeEqualTo true
+            hasAnnotationWithName(emptyList()) shouldBeEqualTo true
+            hasAnnotationWithName(emptySet()) shouldBeEqualTo true
+            hasAnnotationsWithAllNames(emptyList()) shouldBeEqualTo true
+            hasAnnotationsWithAllNames(emptySet()) shouldBeEqualTo true
             hasAnnotationWithName("SampleAnnotation") shouldBeEqualTo true
             hasAnnotationWithName("OtherAnnotation") shouldBeEqualTo false
             hasAnnotationWithName("SampleAnnotation", "OtherAnnotation") shouldBeEqualTo true
@@ -61,6 +81,24 @@ class KoEnumConstantDeclarationForKoAnnotationProviderTest {
                 "com.lemonappdev.konsist.testdata.SampleAnnotation",
                 "com.lemonappdev.konsist.testdata.NonExistingAnnotation",
             ).shouldBeEqualTo(true)
+            hasAnnotationWithName(listOf("SampleAnnotation")) shouldBeEqualTo true
+            hasAnnotationWithName(listOf("OtherAnnotation")) shouldBeEqualTo false
+            hasAnnotationWithName(listOf("SampleAnnotation", "OtherAnnotation")) shouldBeEqualTo true
+            hasAnnotationWithName(listOf("com.lemonappdev.konsist.testdata.SampleAnnotation")) shouldBeEqualTo true
+            hasAnnotationWithName(listOf("com.lemonappdev.konsist.testdata.NonExistingAnnotation")) shouldBeEqualTo false
+            hasAnnotationWithName(listOf(
+                "com.lemonappdev.konsist.testdata.SampleAnnotation",
+                "com.lemonappdev.konsist.testdata.NonExistingAnnotation",
+            )).shouldBeEqualTo(true)
+            hasAnnotationWithName(setOf("SampleAnnotation")) shouldBeEqualTo true
+            hasAnnotationWithName(setOf("OtherAnnotation")) shouldBeEqualTo false
+            hasAnnotationWithName(setOf("SampleAnnotation", "OtherAnnotation")) shouldBeEqualTo true
+            hasAnnotationWithName(setOf("com.lemonappdev.konsist.testdata.SampleAnnotation")) shouldBeEqualTo true
+            hasAnnotationWithName(setOf("com.lemonappdev.konsist.testdata.NonExistingAnnotation")) shouldBeEqualTo false
+            hasAnnotationWithName(setOf(
+                "com.lemonappdev.konsist.testdata.SampleAnnotation",
+                "com.lemonappdev.konsist.testdata.NonExistingAnnotation",
+            )).shouldBeEqualTo(true)
             hasAnnotationsWithAllNames("SampleAnnotation") shouldBeEqualTo true
             hasAnnotationsWithAllNames("SampleAnnotation", "OtherAnnotation") shouldBeEqualTo false
             hasAnnotationsWithAllNames("com.lemonappdev.konsist.testdata.SampleAnnotation") shouldBeEqualTo true
@@ -68,15 +106,35 @@ class KoEnumConstantDeclarationForKoAnnotationProviderTest {
                 "com.lemonappdev.konsist.testdata.SampleAnnotation",
                 "com.lemonappdev.konsist.testdata.NonExistingAnnotation",
             ).shouldBeEqualTo(false)
+            hasAnnotationsWithAllNames(listOf("SampleAnnotation")) shouldBeEqualTo true
+            hasAnnotationsWithAllNames(listOf("SampleAnnotation", "OtherAnnotation")) shouldBeEqualTo false
+            hasAnnotationsWithAllNames(listOf("com.lemonappdev.konsist.testdata.SampleAnnotation")) shouldBeEqualTo true
+            hasAnnotationsWithAllNames(listOf(
+                "com.lemonappdev.konsist.testdata.SampleAnnotation",
+                "com.lemonappdev.konsist.testdata.NonExistingAnnotation",
+            )).shouldBeEqualTo(false)
             hasAnnotation { it.hasNameStartingWith("Sample") } shouldBeEqualTo true
             hasAnnotation { it.hasNameStartingWith("Other") } shouldBeEqualTo false
             hasAllAnnotations { it.hasNameStartingWith("Sample") } shouldBeEqualTo true
-            hasAnnotationOf(SampleAnnotation::class) shouldBeEqualTo true
-            hasAnnotationOf(NonExistingAnnotation::class) shouldBeEqualTo false
-            hasAnnotationOf(SampleAnnotation::class, NonExistingAnnotation::class) shouldBeEqualTo true
+            hasAnnotationOf(emptyList()) shouldBeEqualTo true
+            hasAnnotationOf(emptySet()) shouldBeEqualTo true
+            hasAllAnnotationsOf(emptyList()) shouldBeEqualTo true
+            hasAllAnnotationsOf(emptySet()) shouldBeEqualTo true
+            hasAnnotationOf(listOf(SampleAnnotation::class)) shouldBeEqualTo true
+            hasAnnotationOf(listOf(NonExistingAnnotation::class)) shouldBeEqualTo false
+            hasAnnotationOf(listOf(SampleAnnotation::class, NonExistingAnnotation::class)) shouldBeEqualTo true
+            hasAnnotationOf(setOf(SampleAnnotation::class)) shouldBeEqualTo true
+            hasAnnotationOf(setOf(NonExistingAnnotation::class)) shouldBeEqualTo false
+            hasAnnotationOf(setOf(SampleAnnotation::class, NonExistingAnnotation::class)) shouldBeEqualTo true
             hasAllAnnotationsOf(SampleAnnotation::class) shouldBeEqualTo true
             hasAllAnnotationsOf(NonExistingAnnotation::class) shouldBeEqualTo false
             hasAllAnnotationsOf(SampleAnnotation::class, NonExistingAnnotation::class) shouldBeEqualTo false
+            hasAllAnnotationsOf(listOf(SampleAnnotation::class)) shouldBeEqualTo true
+            hasAllAnnotationsOf(listOf(NonExistingAnnotation::class)) shouldBeEqualTo false
+            hasAllAnnotationsOf(listOf(SampleAnnotation::class, NonExistingAnnotation::class)) shouldBeEqualTo false
+            hasAllAnnotationsOf(setOf(SampleAnnotation::class)) shouldBeEqualTo true
+            hasAllAnnotationsOf(setOf(NonExistingAnnotation::class)) shouldBeEqualTo false
+            hasAllAnnotationsOf(setOf(SampleAnnotation::class, NonExistingAnnotation::class)) shouldBeEqualTo false
             hasAnnotations("SampleAnnotation") shouldBeEqualTo true
             hasAnnotations("NonExistingAnnotation") shouldBeEqualTo false
             hasAnnotations("com.lemonappdev.konsist.testdata.SampleAnnotation") shouldBeEqualTo true
@@ -102,6 +160,10 @@ class KoEnumConstantDeclarationForKoAnnotationProviderTest {
             countAnnotations { it.hasNameStartingWith("Sample") } shouldBeEqualTo 2
             countAnnotations { it.name == "SampleAnnotation1" } shouldBeEqualTo 1
             hasAnnotations() shouldBeEqualTo true
+            hasAnnotationOf(emptyList()) shouldBeEqualTo true
+            hasAnnotationOf(emptySet()) shouldBeEqualTo true
+            hasAllAnnotationsOf(emptyList()) shouldBeEqualTo true
+            hasAllAnnotationsOf(emptySet()) shouldBeEqualTo true
             hasAnnotationWithName("SampleAnnotation1") shouldBeEqualTo true
             hasAnnotationWithName("OtherAnnotation") shouldBeEqualTo false
             hasAnnotationWithName("SampleAnnotation1", "OtherAnnotation") shouldBeEqualTo true
@@ -111,6 +173,24 @@ class KoEnumConstantDeclarationForKoAnnotationProviderTest {
                 "com.lemonappdev.konsist.testdata.SampleAnnotation1",
                 "com.lemonappdev.konsist.testdata.NonExistingAnnotation",
             ).shouldBeEqualTo(true)
+            hasAnnotationWithName(listOf("SampleAnnotation1")) shouldBeEqualTo true
+            hasAnnotationWithName(listOf("OtherAnnotation")) shouldBeEqualTo false
+            hasAnnotationWithName(listOf("SampleAnnotation1", "OtherAnnotation")) shouldBeEqualTo true
+            hasAnnotationWithName(listOf("com.lemonappdev.konsist.testdata.SampleAnnotation1")) shouldBeEqualTo true
+            hasAnnotationWithName(listOf("com.lemonappdev.konsist.testdata.NonExistingAnnotation")) shouldBeEqualTo false
+            hasAnnotationWithName(listOf(
+                "com.lemonappdev.konsist.testdata.SampleAnnotation1",
+                "com.lemonappdev.konsist.testdata.NonExistingAnnotation",
+            )).shouldBeEqualTo(true)
+            hasAnnotationWithName(setOf("SampleAnnotation1")) shouldBeEqualTo true
+            hasAnnotationWithName(setOf("OtherAnnotation")) shouldBeEqualTo false
+            hasAnnotationWithName(setOf("SampleAnnotation1", "OtherAnnotation")) shouldBeEqualTo true
+            hasAnnotationWithName(setOf("com.lemonappdev.konsist.testdata.SampleAnnotation1")) shouldBeEqualTo true
+            hasAnnotationWithName(setOf("com.lemonappdev.konsist.testdata.NonExistingAnnotation")) shouldBeEqualTo false
+            hasAnnotationWithName(setOf(
+                "com.lemonappdev.konsist.testdata.SampleAnnotation1",
+                "com.lemonappdev.konsist.testdata.NonExistingAnnotation",
+            )).shouldBeEqualTo(true)
             hasAnnotationsWithAllNames("SampleAnnotation1") shouldBeEqualTo true
             hasAnnotationsWithAllNames("SampleAnnotation1", "SampleAnnotation2") shouldBeEqualTo true
             hasAnnotationsWithAllNames("SampleAnnotation1", "OtherAnnotation") shouldBeEqualTo false
@@ -123,17 +203,48 @@ class KoEnumConstantDeclarationForKoAnnotationProviderTest {
                 "com.lemonappdev.konsist.testdata.SampleAnnotation1",
                 "com.lemonappdev.konsist.testdata.SampleAnnotation2",
             ).shouldBeEqualTo(true)
+
+            hasAnnotationsWithAllNames(listOf("SampleAnnotation1")) shouldBeEqualTo true
+            hasAnnotationsWithAllNames(listOf("SampleAnnotation1", "SampleAnnotation2")) shouldBeEqualTo true
+            hasAnnotationsWithAllNames(listOf("SampleAnnotation1", "OtherAnnotation")) shouldBeEqualTo false
+            hasAnnotationsWithAllNames(listOf("com.lemonappdev.konsist.testdata.SampleAnnotation1")) shouldBeEqualTo true
+            hasAnnotationsWithAllNames(listOf(
+                "com.lemonappdev.konsist.testdata.SampleAnnotation1",
+                "com.lemonappdev.konsist.testdata.NonExistingAnnotation",
+            )).shouldBeEqualTo(false)
+            hasAnnotationsWithAllNames(listOf(
+                "com.lemonappdev.konsist.testdata.SampleAnnotation1",
+                "com.lemonappdev.konsist.testdata.SampleAnnotation2",
+            )).shouldBeEqualTo(true)
             hasAnnotation { it.name == "SampleAnnotation1" } shouldBeEqualTo true
             hasAnnotation { it.name == "OtherAnnotation1" } shouldBeEqualTo false
             hasAllAnnotations { !it.hasArguments() } shouldBeEqualTo true
             hasAllAnnotations { it.hasNameEndingWith("tion1") } shouldBeEqualTo false
+            hasAnnotationOf(emptyList()) shouldBeEqualTo true
+            hasAnnotationOf(emptySet()) shouldBeEqualTo true
+            hasAllAnnotationsOf(emptyList()) shouldBeEqualTo true
+            hasAllAnnotationsOf(emptySet()) shouldBeEqualTo true
             hasAnnotationOf(SampleAnnotation1::class) shouldBeEqualTo true
             hasAnnotationOf(NonExistingAnnotation::class) shouldBeEqualTo false
             hasAnnotationOf(SampleAnnotation1::class, NonExistingAnnotation::class) shouldBeEqualTo true
+            hasAnnotationOf(listOf(SampleAnnotation1::class)) shouldBeEqualTo true
+            hasAnnotationOf(listOf(NonExistingAnnotation::class)) shouldBeEqualTo false
+            hasAnnotationOf(listOf(SampleAnnotation1::class, NonExistingAnnotation::class)) shouldBeEqualTo true
+            hasAnnotationOf(setOf(SampleAnnotation1::class)) shouldBeEqualTo true
+            hasAnnotationOf(setOf(NonExistingAnnotation::class)) shouldBeEqualTo false
+            hasAnnotationOf(setOf(SampleAnnotation1::class, NonExistingAnnotation::class)) shouldBeEqualTo true
             hasAllAnnotationsOf(SampleAnnotation1::class) shouldBeEqualTo true
             hasAllAnnotationsOf(NonExistingAnnotation::class) shouldBeEqualTo false
             hasAllAnnotationsOf(SampleAnnotation1::class, SampleAnnotation2::class) shouldBeEqualTo true
             hasAllAnnotationsOf(SampleAnnotation1::class, NonExistingAnnotation::class) shouldBeEqualTo false
+            hasAllAnnotationsOf(listOf(SampleAnnotation1::class)) shouldBeEqualTo true
+            hasAllAnnotationsOf(listOf(NonExistingAnnotation::class)) shouldBeEqualTo false
+            hasAllAnnotationsOf(listOf(SampleAnnotation1::class, SampleAnnotation2::class)) shouldBeEqualTo true
+            hasAllAnnotationsOf(listOf(SampleAnnotation1::class, NonExistingAnnotation::class)) shouldBeEqualTo false
+            hasAllAnnotationsOf(setOf(SampleAnnotation1::class)) shouldBeEqualTo true
+            hasAllAnnotationsOf(setOf(NonExistingAnnotation::class)) shouldBeEqualTo false
+            hasAllAnnotationsOf(setOf(SampleAnnotation1::class, SampleAnnotation2::class)) shouldBeEqualTo true
+            hasAllAnnotationsOf(setOf(SampleAnnotation1::class, NonExistingAnnotation::class)) shouldBeEqualTo false
             hasAnnotations("SampleAnnotation1") shouldBeEqualTo true
             hasAnnotations("SampleAnnotation2") shouldBeEqualTo true
             hasAnnotations("NonExistingAnnotation") shouldBeEqualTo false

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koenumconstant/KoEnumConstantDeclarationForKoArgumentProviderTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koenumconstant/KoEnumConstantDeclarationForKoArgumentProviderTest.kt
@@ -22,8 +22,16 @@ class KoEnumConstantDeclarationForKoArgumentProviderTest {
             numArguments shouldBeEqualTo 0
             countArguments { it.value == "text" } shouldBeEqualTo 0
             hasArguments() shouldBeEqualTo false
+            hasArgumentWithName(emptyList()) shouldBeEqualTo false
+            hasArgumentWithName(emptySet()) shouldBeEqualTo false
+            hasArgumentsWithAllNames(emptyList()) shouldBeEqualTo false
+            hasArgumentsWithAllNames(emptySet()) shouldBeEqualTo false
             hasArgumentWithName("sampleArgument") shouldBeEqualTo false
+            hasArgumentWithName(listOf("sampleArgument")) shouldBeEqualTo false
+            hasArgumentWithName(setOf("sampleArgument")) shouldBeEqualTo false
             hasArgumentsWithAllNames("sampleArgument1", "sampleArgument2") shouldBeEqualTo false
+            hasArgumentsWithAllNames(listOf("sampleArgument1", "sampleArgument2")) shouldBeEqualTo false
+            hasArgumentsWithAllNames(setOf("sampleArgument1", "sampleArgument2")) shouldBeEqualTo false
             hasArgument { it.value == "text" } shouldBeEqualTo false
             hasAllArguments { it.value == "text" } shouldBeEqualTo true
         }
@@ -44,8 +52,16 @@ class KoEnumConstantDeclarationForKoArgumentProviderTest {
             numArguments shouldBeEqualTo 0
             countArguments { it.value == "text" } shouldBeEqualTo 0
             hasArguments() shouldBeEqualTo false
+            hasArgumentWithName(emptyList()) shouldBeEqualTo false
+            hasArgumentWithName(emptySet()) shouldBeEqualTo false
+            hasArgumentsWithAllNames(emptyList()) shouldBeEqualTo false
+            hasArgumentsWithAllNames(emptySet()) shouldBeEqualTo false
             hasArgumentWithName("sampleArgument") shouldBeEqualTo false
+            hasArgumentWithName(listOf("sampleArgument")) shouldBeEqualTo false
+            hasArgumentWithName(setOf("sampleArgument")) shouldBeEqualTo false
             hasArgumentsWithAllNames("sampleArgument1", "sampleArgument2") shouldBeEqualTo false
+            hasArgumentsWithAllNames(listOf("sampleArgument1", "sampleArgument2")) shouldBeEqualTo false
+            hasArgumentsWithAllNames(setOf("sampleArgument1", "sampleArgument2")) shouldBeEqualTo false
             hasArgument { it.value == "text" } shouldBeEqualTo false
             hasAllArguments { it.value == "text" } shouldBeEqualTo true
         }
@@ -67,11 +83,25 @@ class KoEnumConstantDeclarationForKoArgumentProviderTest {
             countArguments { it.value == "0" } shouldBeEqualTo 1
             countArguments { it.value == "1" } shouldBeEqualTo 0
             hasArguments() shouldBeEqualTo true
+            hasArgumentWithName(emptyList()) shouldBeEqualTo true
+            hasArgumentWithName(emptySet()) shouldBeEqualTo true
+            hasArgumentsWithAllNames(emptyList()) shouldBeEqualTo true
+            hasArgumentsWithAllNames(emptySet()) shouldBeEqualTo true
             hasArgumentWithName("sampleParameter") shouldBeEqualTo true
             hasArgumentWithName("otherParameter") shouldBeEqualTo false
             hasArgumentWithName("sampleParameter", "otherParameter") shouldBeEqualTo true
+            hasArgumentWithName(listOf("sampleParameter")) shouldBeEqualTo true
+            hasArgumentWithName(listOf("otherParameter")) shouldBeEqualTo false
+            hasArgumentWithName(listOf("sampleParameter", "otherParameter")) shouldBeEqualTo true
+            hasArgumentWithName(setOf("sampleParameter")) shouldBeEqualTo true
+            hasArgumentWithName(setOf("otherParameter")) shouldBeEqualTo false
+            hasArgumentWithName(setOf("sampleParameter", "otherParameter")) shouldBeEqualTo true
             hasArgumentsWithAllNames("sampleParameter") shouldBeEqualTo true
             hasArgumentsWithAllNames("sampleParameter", "otherParameter") shouldBeEqualTo false
+            hasArgumentsWithAllNames(listOf("sampleParameter")) shouldBeEqualTo true
+            hasArgumentsWithAllNames(listOf("sampleParameter", "otherParameter")) shouldBeEqualTo false
+            hasArgumentsWithAllNames(setOf("sampleParameter")) shouldBeEqualTo true
+            hasArgumentsWithAllNames(setOf("sampleParameter", "otherParameter")) shouldBeEqualTo false
             hasArgument { it.value == "0" } shouldBeEqualTo true
             hasArgument { it.value == "1" } shouldBeEqualTo false
             hasAllArguments { it.value == "0" } shouldBeEqualTo true
@@ -95,12 +125,28 @@ class KoEnumConstantDeclarationForKoArgumentProviderTest {
             countArguments { it.value?.startsWith("fal") ?: false || it.value == "0" } shouldBeEqualTo 2
             countArguments { it.value == "0" } shouldBeEqualTo 1
             hasArguments() shouldBeEqualTo true
+            hasArgumentWithName(emptyList()) shouldBeEqualTo true
+            hasArgumentWithName(emptySet()) shouldBeEqualTo true
+            hasArgumentsWithAllNames(emptyList()) shouldBeEqualTo true
+            hasArgumentsWithAllNames(emptySet()) shouldBeEqualTo true
             hasArgumentWithName("sampleParameter1") shouldBeEqualTo true
             hasArgumentWithName("otherParameter") shouldBeEqualTo false
             hasArgumentWithName("sampleParameter1", "otherName") shouldBeEqualTo true
+            hasArgumentWithName(listOf("sampleParameter1")) shouldBeEqualTo true
+            hasArgumentWithName(listOf("otherParameter")) shouldBeEqualTo false
+            hasArgumentWithName(listOf("sampleParameter1", "otherName")) shouldBeEqualTo true
+            hasArgumentWithName(setOf("sampleParameter1")) shouldBeEqualTo true
+            hasArgumentWithName(setOf("otherParameter")) shouldBeEqualTo false
+            hasArgumentWithName(setOf("sampleParameter1", "otherName")) shouldBeEqualTo true
             hasArgumentsWithAllNames("sampleParameter1") shouldBeEqualTo true
             hasArgumentsWithAllNames("sampleParameter1", "sampleParameter2") shouldBeEqualTo false
             hasArgumentsWithAllNames("sampleParameter1", "otherParameter") shouldBeEqualTo false
+            hasArgumentsWithAllNames(listOf("sampleParameter1")) shouldBeEqualTo true
+            hasArgumentsWithAllNames(listOf("sampleParameter1", "sampleParameter2")) shouldBeEqualTo false
+            hasArgumentsWithAllNames(listOf("sampleParameter1", "otherParameter")) shouldBeEqualTo false
+            hasArgumentsWithAllNames(setOf("sampleParameter1")) shouldBeEqualTo true
+            hasArgumentsWithAllNames(setOf("sampleParameter1", "sampleParameter2")) shouldBeEqualTo false
+            hasArgumentsWithAllNames(setOf("sampleParameter1", "otherParameter")) shouldBeEqualTo false
             hasArgument { it.value == "0" } shouldBeEqualTo true
             hasArgument { it.value == "1" } shouldBeEqualTo false
             hasAllArguments { it.value?.startsWith("fal") ?: false || it.value == "0" } shouldBeEqualTo true

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koenumconstant/KoEnumConstantDeclarationForKoLocalClassProviderTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koenumconstant/KoEnumConstantDeclarationForKoLocalClassProviderTest.kt
@@ -22,8 +22,16 @@ class KoEnumConstantDeclarationForKoLocalClassProviderTest {
             numLocalClasses shouldBeEqualTo 0
             countLocalClasses { it.name == "SampleLocalClass" } shouldBeEqualTo 0
             hasLocalClasses() shouldBeEqualTo false
+            hasLocalClassWithName(emptyList()) shouldBeEqualTo false
+            hasLocalClassWithName(emptySet()) shouldBeEqualTo false
+            hasLocalClassesWithAllNames(emptyList()) shouldBeEqualTo false
+            hasLocalClassesWithAllNames(emptySet()) shouldBeEqualTo false
             hasLocalClassWithName("SampleLocalClass") shouldBeEqualTo false
+            hasLocalClassWithName(listOf("SampleLocalClass")) shouldBeEqualTo false
+            hasLocalClassWithName(setOf("SampleLocalClass")) shouldBeEqualTo false
             hasLocalClassesWithAllNames("SampleLocalClass1", "SampleLocalClass2") shouldBeEqualTo false
+            hasLocalClassesWithAllNames(listOf("SampleLocalClass1", "SampleLocalClass2")) shouldBeEqualTo false
+            hasLocalClassesWithAllNames(setOf("SampleLocalClass1", "SampleLocalClass2")) shouldBeEqualTo false
             hasLocalClass { it.name == "SampleLocalClass" } shouldBeEqualTo false
             hasAllLocalClasses { it.name == "SampleLocalClass" } shouldBeEqualTo true
             containsLocalClass { it.name == "SampleLocalClass" } shouldBeEqualTo false
@@ -45,12 +53,28 @@ class KoEnumConstantDeclarationForKoLocalClassProviderTest {
             numLocalClasses shouldBeEqualTo 2
             countLocalClasses { it.name == "SampleLocalClass1" } shouldBeEqualTo 1
             hasLocalClasses() shouldBeEqualTo true
+            hasLocalClassWithName(emptyList()) shouldBeEqualTo true
+            hasLocalClassWithName(emptySet()) shouldBeEqualTo true
+            hasLocalClassesWithAllNames(emptyList()) shouldBeEqualTo true
+            hasLocalClassesWithAllNames(emptySet()) shouldBeEqualTo true
             hasLocalClassWithName("SampleLocalClass1") shouldBeEqualTo true
             hasLocalClassWithName("OtherLocalClass") shouldBeEqualTo false
             hasLocalClassWithName("SampleLocalClass1", "OtherLocalClass") shouldBeEqualTo true
+            hasLocalClassWithName(listOf("SampleLocalClass1")) shouldBeEqualTo true
+            hasLocalClassWithName(listOf("OtherLocalClass")) shouldBeEqualTo false
+            hasLocalClassWithName(listOf("SampleLocalClass1", "OtherLocalClass")) shouldBeEqualTo true
+            hasLocalClassWithName(setOf("SampleLocalClass1")) shouldBeEqualTo true
+            hasLocalClassWithName(setOf("OtherLocalClass")) shouldBeEqualTo false
+            hasLocalClassWithName(setOf("SampleLocalClass1", "OtherLocalClass")) shouldBeEqualTo true
             hasLocalClassesWithAllNames("SampleLocalClass1") shouldBeEqualTo true
             hasLocalClassesWithAllNames("SampleLocalClass1", "SampleLocalClass2") shouldBeEqualTo true
             hasLocalClassesWithAllNames("SampleLocalClass1", "OtherLocalClass") shouldBeEqualTo false
+            hasLocalClassesWithAllNames(listOf("SampleLocalClass1")) shouldBeEqualTo true
+            hasLocalClassesWithAllNames(listOf("SampleLocalClass1", "SampleLocalClass2")) shouldBeEqualTo true
+            hasLocalClassesWithAllNames(listOf("SampleLocalClass1", "OtherLocalClass")) shouldBeEqualTo false
+            hasLocalClassesWithAllNames(setOf("SampleLocalClass1")) shouldBeEqualTo true
+            hasLocalClassesWithAllNames(setOf("SampleLocalClass1", "SampleLocalClass2")) shouldBeEqualTo true
+            hasLocalClassesWithAllNames(setOf("SampleLocalClass1", "OtherLocalClass")) shouldBeEqualTo false
             hasLocalClass { it.name == "SampleLocalClass1" } shouldBeEqualTo true
             hasLocalClass { it.name == "OtherLocalClass" } shouldBeEqualTo false
             hasAllLocalClasses { it.name.endsWith("2") || it.name == "SampleLocalClass1" } shouldBeEqualTo true

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koenumconstant/KoEnumConstantDeclarationForKoLocalFunctionProviderTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koenumconstant/KoEnumConstantDeclarationForKoLocalFunctionProviderTest.kt
@@ -22,8 +22,16 @@ class KoEnumConstantDeclarationForKoLocalFunctionProviderTest {
             numLocalFunctions shouldBeEqualTo 0
             countLocalFunctions { it.name == "sampleLocalFunction" } shouldBeEqualTo 0
             hasLocalFunctions() shouldBeEqualTo false
+            hasLocalFunctionWithName(emptyList()) shouldBeEqualTo false
+            hasLocalFunctionWithName(emptySet()) shouldBeEqualTo false
+            hasLocalFunctionsWithAllNames(emptyList()) shouldBeEqualTo false
+            hasLocalFunctionsWithAllNames(emptySet()) shouldBeEqualTo false
             hasLocalFunctionWithName("sampleLocalFunction") shouldBeEqualTo false
+            hasLocalFunctionWithName(listOf("sampleLocalFunction")) shouldBeEqualTo false
+            hasLocalFunctionWithName(setOf("sampleLocalFunction")) shouldBeEqualTo false
             hasLocalFunctionsWithAllNames("sampleLocalFunction1", "sampleLocalFunction2") shouldBeEqualTo false
+            hasLocalFunctionsWithAllNames(listOf("sampleLocalFunction1", "sampleLocalFunction2")) shouldBeEqualTo false
+            hasLocalFunctionsWithAllNames(setOf("sampleLocalFunction1", "sampleLocalFunction2")) shouldBeEqualTo false
             hasLocalFunction { it.name == "sampleLocalFunction" } shouldBeEqualTo false
             hasAllLocalFunctions { it.name == "sampleLocalFunction" } shouldBeEqualTo true
             containsLocalFunction { it.name == "sampleLocalFunction" } shouldBeEqualTo false
@@ -44,12 +52,28 @@ class KoEnumConstantDeclarationForKoLocalFunctionProviderTest {
             numLocalFunctions shouldBeEqualTo 2
             countLocalFunctions { it.name == "sampleLocalFunction1" } shouldBeEqualTo 1
             hasLocalFunctions() shouldBeEqualTo true
+            hasLocalFunctionWithName(emptyList()) shouldBeEqualTo true
+            hasLocalFunctionWithName(emptySet()) shouldBeEqualTo true
+            hasLocalFunctionsWithAllNames(emptyList()) shouldBeEqualTo true
+            hasLocalFunctionsWithAllNames(emptySet()) shouldBeEqualTo true
             hasLocalFunctionWithName("sampleLocalFunction1") shouldBeEqualTo true
             hasLocalFunctionWithName("otherLocalFunction") shouldBeEqualTo false
             hasLocalFunctionWithName("sampleLocalFunction1", "otherLocalFunction") shouldBeEqualTo true
+            hasLocalFunctionWithName(listOf("sampleLocalFunction1")) shouldBeEqualTo true
+            hasLocalFunctionWithName(listOf("otherLocalFunction")) shouldBeEqualTo false
+            hasLocalFunctionWithName(listOf("sampleLocalFunction1", "otherLocalFunction")) shouldBeEqualTo true
+            hasLocalFunctionWithName(setOf("sampleLocalFunction1")) shouldBeEqualTo true
+            hasLocalFunctionWithName(setOf("otherLocalFunction")) shouldBeEqualTo false
+            hasLocalFunctionWithName(setOf("sampleLocalFunction1", "otherLocalFunction")) shouldBeEqualTo true
             hasLocalFunctionsWithAllNames("sampleLocalFunction1") shouldBeEqualTo true
             hasLocalFunctionsWithAllNames("sampleLocalFunction1", "sampleLocalFunction2") shouldBeEqualTo true
             hasLocalFunctionsWithAllNames("sampleLocalFunction1", "otherLocalFunction") shouldBeEqualTo false
+            hasLocalFunctionsWithAllNames(listOf("sampleLocalFunction1")) shouldBeEqualTo true
+            hasLocalFunctionsWithAllNames(listOf("sampleLocalFunction1", "sampleLocalFunction2")) shouldBeEqualTo true
+            hasLocalFunctionsWithAllNames(listOf("sampleLocalFunction1", "otherLocalFunction")) shouldBeEqualTo false
+            hasLocalFunctionsWithAllNames(setOf("sampleLocalFunction1")) shouldBeEqualTo true
+            hasLocalFunctionsWithAllNames(setOf("sampleLocalFunction1", "sampleLocalFunction2")) shouldBeEqualTo true
+            hasLocalFunctionsWithAllNames(setOf("sampleLocalFunction1", "otherLocalFunction")) shouldBeEqualTo false
             hasLocalFunction { it.name == "sampleLocalFunction1" } shouldBeEqualTo true
             hasLocalFunction { it.name == "otherLocalFunction" } shouldBeEqualTo false
             hasAllLocalFunctions { it.name.endsWith("2") || it.name == "sampleLocalFunction1" } shouldBeEqualTo true

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koenumconstant/KoEnumConstantDeclarationForKoVariableProviderTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koenumconstant/KoEnumConstantDeclarationForKoVariableProviderTest.kt
@@ -22,8 +22,16 @@ class KoEnumConstantDeclarationForKoVariableProviderTest {
             numVariables shouldBeEqualTo 0
             countVariables { it.name == "sampleVariable" } shouldBeEqualTo 0
             hasVariables() shouldBeEqualTo false
+            hasVariableWithName(emptyList()) shouldBeEqualTo false
+            hasVariableWithName(emptySet()) shouldBeEqualTo false
+            hasVariablesWithAllNames(emptyList()) shouldBeEqualTo false
+            hasVariablesWithAllNames(emptySet()) shouldBeEqualTo false
             hasVariableWithName("sampleVariable") shouldBeEqualTo false
+            hasVariableWithName(listOf("sampleVariable")) shouldBeEqualTo false
+            hasVariableWithName(setOf("sampleVariable")) shouldBeEqualTo false
             hasVariablesWithAllNames("sampleVariable1", "sampleVariable2") shouldBeEqualTo false
+            hasVariablesWithAllNames(listOf("sampleVariable1", "sampleVariable2")) shouldBeEqualTo false
+            hasVariablesWithAllNames(setOf("sampleVariable1", "sampleVariable2")) shouldBeEqualTo false
             hasVariable { it.name == "sampleVariable" } shouldBeEqualTo false
             hasAllVariables { it.name == "sampleVariable" } shouldBeEqualTo true
         }
@@ -43,12 +51,28 @@ class KoEnumConstantDeclarationForKoVariableProviderTest {
             numVariables shouldBeEqualTo 2
             countVariables { it.name == "sampleVariable1" } shouldBeEqualTo 1
             hasVariables() shouldBeEqualTo true
+            hasVariableWithName(emptyList()) shouldBeEqualTo true
+            hasVariableWithName(emptySet()) shouldBeEqualTo true
+            hasVariablesWithAllNames(emptyList()) shouldBeEqualTo true
+            hasVariablesWithAllNames(emptySet()) shouldBeEqualTo true
             hasVariableWithName("sampleVariable1") shouldBeEqualTo true
             hasVariableWithName("otherVariable") shouldBeEqualTo false
             hasVariableWithName("sampleVariable1", "otherVariable") shouldBeEqualTo true
+            hasVariableWithName(listOf("sampleVariable1")) shouldBeEqualTo true
+            hasVariableWithName(listOf("otherVariable")) shouldBeEqualTo false
+            hasVariableWithName(listOf("sampleVariable1", "otherVariable")) shouldBeEqualTo true
+            hasVariableWithName(setOf("sampleVariable1")) shouldBeEqualTo true
+            hasVariableWithName(setOf("otherVariable")) shouldBeEqualTo false
+            hasVariableWithName(setOf("sampleVariable1", "otherVariable")) shouldBeEqualTo true
             hasVariablesWithAllNames("sampleVariable1") shouldBeEqualTo true
             hasVariablesWithAllNames("sampleVariable1", "sampleVariable2") shouldBeEqualTo true
             hasVariablesWithAllNames("sampleVariable1", "otherVariable") shouldBeEqualTo false
+            hasVariablesWithAllNames(listOf("sampleVariable1")) shouldBeEqualTo true
+            hasVariablesWithAllNames(listOf("sampleVariable1", "sampleVariable2")) shouldBeEqualTo true
+            hasVariablesWithAllNames(listOf("sampleVariable1", "otherVariable")) shouldBeEqualTo false
+            hasVariablesWithAllNames(setOf("sampleVariable1")) shouldBeEqualTo true
+            hasVariablesWithAllNames(setOf("sampleVariable1", "sampleVariable2")) shouldBeEqualTo true
+            hasVariablesWithAllNames(setOf("sampleVariable1", "otherVariable")) shouldBeEqualTo false
             hasVariable { it.name == "sampleVariable1" } shouldBeEqualTo true
             hasVariable { it.name == "otherVariable" } shouldBeEqualTo false
             hasAllVariables { it.name.endsWith("2") || it.name == "sampleVariable1" } shouldBeEqualTo true

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/kofile/KoFileDeclarationForKoAnnotationProviderTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/kofile/KoFileDeclarationForKoAnnotationProviderTest.kt
@@ -24,14 +24,29 @@ class KoFileDeclarationForKoAnnotationProviderTest {
             numAnnotations shouldBeEqualTo 0
             countAnnotations { it.name == "NonExistingAnnotation" } shouldBeEqualTo 0
             hasAnnotations() shouldBeEqualTo false
+            hasAnnotationWithName(emptyList()) shouldBeEqualTo false
+            hasAnnotationWithName(emptySet()) shouldBeEqualTo false
+            hasAnnotationsWithAllNames(emptyList()) shouldBeEqualTo false
+            hasAnnotationsWithAllNames(emptySet()) shouldBeEqualTo false
             hasAnnotationWithName("SampleAnnotation") shouldBeEqualTo false
+            hasAnnotationWithName(listOf("SampleAnnotation")) shouldBeEqualTo false
+            hasAnnotationWithName(setOf("SampleAnnotation")) shouldBeEqualTo false
             hasAnnotationsWithAllNames("SampleAnnotation1", "SampleAnnotation2") shouldBeEqualTo false
+            hasAnnotationsWithAllNames(listOf("SampleAnnotation1", "SampleAnnotation2")) shouldBeEqualTo false
+            hasAnnotationsWithAllNames(setOf("SampleAnnotation1", "SampleAnnotation2")) shouldBeEqualTo false
             hasAnnotation { it.hasArguments() } shouldBeEqualTo false
             hasAllAnnotations { it.hasArguments() } shouldBeEqualTo true
+            hasAnnotationOf(emptyList()) shouldBeEqualTo false
+            hasAnnotationOf(emptySet()) shouldBeEqualTo false
+            hasAllAnnotationsOf(emptyList()) shouldBeEqualTo false
+            hasAllAnnotationsOf(emptySet()) shouldBeEqualTo false
             hasAnnotationOf(SampleAnnotation::class) shouldBeEqualTo false
+            hasAnnotationOf(listOf(SampleAnnotation::class)) shouldBeEqualTo false
+            hasAnnotationOf(setOf(SampleAnnotation::class)) shouldBeEqualTo false
             hasAllAnnotationsOf(SampleAnnotation1::class, SampleAnnotation2::class) shouldBeEqualTo false
+            hasAllAnnotationsOf(listOf(SampleAnnotation1::class, SampleAnnotation2::class)) shouldBeEqualTo false
+            hasAllAnnotationsOf(setOf(SampleAnnotation1::class, SampleAnnotation2::class)) shouldBeEqualTo false
             hasAnnotations("SampleAnnotation") shouldBeEqualTo false
-            hasAnnotations("com.lemonappdev.konsist.testdata.SampleAnnotation") shouldBeEqualTo false
         }
     }
 
@@ -49,6 +64,10 @@ class KoFileDeclarationForKoAnnotationProviderTest {
             countAnnotations { it.hasNameStartingWith("Sample") } shouldBeEqualTo 2
             countAnnotations { it.name == "SampleAnnotation1" } shouldBeEqualTo 1
             hasAnnotations() shouldBeEqualTo true
+            hasAnnotationOf(emptyList()) shouldBeEqualTo true
+            hasAnnotationOf(emptySet()) shouldBeEqualTo true
+            hasAllAnnotationsOf(emptyList()) shouldBeEqualTo true
+            hasAllAnnotationsOf(emptySet()) shouldBeEqualTo true
             hasAnnotationWithName("SampleAnnotation1") shouldBeEqualTo true
             hasAnnotationWithName("OtherAnnotation") shouldBeEqualTo false
             hasAnnotationWithName("SampleAnnotation1", "OtherAnnotation") shouldBeEqualTo true
@@ -58,6 +77,24 @@ class KoFileDeclarationForKoAnnotationProviderTest {
                 "com.lemonappdev.konsist.testdata.SampleAnnotation1",
                 "com.lemonappdev.konsist.testdata.NonExistingAnnotation",
             ).shouldBeEqualTo(true)
+            hasAnnotationWithName(listOf("SampleAnnotation1")) shouldBeEqualTo true
+            hasAnnotationWithName(listOf("OtherAnnotation")) shouldBeEqualTo false
+            hasAnnotationWithName(listOf("SampleAnnotation1", "OtherAnnotation")) shouldBeEqualTo true
+            hasAnnotationWithName(listOf("com.lemonappdev.konsist.testdata.SampleAnnotation1")) shouldBeEqualTo true
+            hasAnnotationWithName(listOf("com.lemonappdev.konsist.testdata.NonExistingAnnotation")) shouldBeEqualTo false
+            hasAnnotationWithName(listOf(
+                "com.lemonappdev.konsist.testdata.SampleAnnotation1",
+                "com.lemonappdev.konsist.testdata.NonExistingAnnotation",
+            )).shouldBeEqualTo(true)
+            hasAnnotationWithName(setOf("SampleAnnotation1")) shouldBeEqualTo true
+            hasAnnotationWithName(setOf("OtherAnnotation")) shouldBeEqualTo false
+            hasAnnotationWithName(setOf("SampleAnnotation1", "OtherAnnotation")) shouldBeEqualTo true
+            hasAnnotationWithName(setOf("com.lemonappdev.konsist.testdata.SampleAnnotation1")) shouldBeEqualTo true
+            hasAnnotationWithName(setOf("com.lemonappdev.konsist.testdata.NonExistingAnnotation")) shouldBeEqualTo false
+            hasAnnotationWithName(setOf(
+                "com.lemonappdev.konsist.testdata.SampleAnnotation1",
+                "com.lemonappdev.konsist.testdata.NonExistingAnnotation",
+            )).shouldBeEqualTo(true)
             hasAnnotationsWithAllNames("SampleAnnotation1") shouldBeEqualTo true
             hasAnnotationsWithAllNames("SampleAnnotation1", "SampleAnnotation2") shouldBeEqualTo true
             hasAnnotationsWithAllNames("SampleAnnotation1", "OtherAnnotation") shouldBeEqualTo false
@@ -70,17 +107,58 @@ class KoFileDeclarationForKoAnnotationProviderTest {
                 "com.lemonappdev.konsist.testdata.SampleAnnotation1",
                 "com.lemonappdev.konsist.testdata.SampleAnnotation2",
             ).shouldBeEqualTo(true)
+
+            hasAnnotationsWithAllNames(listOf("SampleAnnotation1")) shouldBeEqualTo true
+            hasAnnotationsWithAllNames(listOf("SampleAnnotation1", "SampleAnnotation2")) shouldBeEqualTo true
+            hasAnnotationsWithAllNames(listOf("SampleAnnotation1", "OtherAnnotation")) shouldBeEqualTo false
+            hasAnnotationsWithAllNames(listOf("com.lemonappdev.konsist.testdata.SampleAnnotation1")) shouldBeEqualTo true
+            hasAnnotationsWithAllNames(listOf(
+                "com.lemonappdev.konsist.testdata.SampleAnnotation1",
+                "com.lemonappdev.konsist.testdata.NonExistingAnnotation",
+            )).shouldBeEqualTo(false)
+            hasAnnotationsWithAllNames(listOf(
+                "com.lemonappdev.konsist.testdata.SampleAnnotation1",
+                "com.lemonappdev.konsist.testdata.SampleAnnotation2",
+            )).shouldBeEqualTo(true)
             hasAnnotation { it.name == "SampleAnnotation1" } shouldBeEqualTo true
             hasAnnotation { it.name == "OtherAnnotation1" } shouldBeEqualTo false
             hasAllAnnotations { !it.hasArguments() } shouldBeEqualTo true
             hasAllAnnotations { it.hasNameEndingWith("tion1") } shouldBeEqualTo false
+            hasAnnotationOf(emptyList()) shouldBeEqualTo true
+            hasAnnotationOf(emptySet()) shouldBeEqualTo true
+            hasAllAnnotationsOf(emptyList()) shouldBeEqualTo true
+            hasAllAnnotationsOf(emptySet()) shouldBeEqualTo true
+            hasAnnotationOf(SampleAnnotation1::class) shouldBeEqualTo true
+            hasAnnotationOf(NonExistingAnnotation::class) shouldBeEqualTo false
+            hasAnnotationOf(SampleAnnotation1::class, NonExistingAnnotation::class) shouldBeEqualTo true
+            hasAnnotationOf(listOf(SampleAnnotation1::class)) shouldBeEqualTo true
+            hasAnnotationOf(listOf(NonExistingAnnotation::class)) shouldBeEqualTo false
+            hasAnnotationOf(listOf(SampleAnnotation1::class, NonExistingAnnotation::class)) shouldBeEqualTo true
+            hasAnnotationOf(setOf(SampleAnnotation1::class)) shouldBeEqualTo true
+            hasAnnotationOf(setOf(NonExistingAnnotation::class)) shouldBeEqualTo false
+            hasAnnotationOf(setOf(SampleAnnotation1::class, NonExistingAnnotation::class)) shouldBeEqualTo true
+            hasAllAnnotationsOf(SampleAnnotation1::class) shouldBeEqualTo true
+            hasAllAnnotationsOf(NonExistingAnnotation::class) shouldBeEqualTo false
+            hasAllAnnotationsOf(SampleAnnotation1::class, SampleAnnotation2::class) shouldBeEqualTo true
+            hasAllAnnotationsOf(SampleAnnotation1::class, NonExistingAnnotation::class) shouldBeEqualTo false
+            hasAllAnnotationsOf(listOf(SampleAnnotation1::class)) shouldBeEqualTo true
+            hasAllAnnotationsOf(listOf(NonExistingAnnotation::class)) shouldBeEqualTo false
+            hasAllAnnotationsOf(listOf(SampleAnnotation1::class, SampleAnnotation2::class)) shouldBeEqualTo true
+            hasAllAnnotationsOf(listOf(SampleAnnotation1::class, NonExistingAnnotation::class)) shouldBeEqualTo false
+            hasAllAnnotationsOf(setOf(SampleAnnotation1::class)) shouldBeEqualTo true
+            hasAllAnnotationsOf(setOf(NonExistingAnnotation::class)) shouldBeEqualTo false
+            hasAllAnnotationsOf(setOf(SampleAnnotation1::class, SampleAnnotation2::class)) shouldBeEqualTo true
+            hasAllAnnotationsOf(setOf(SampleAnnotation1::class, NonExistingAnnotation::class)) shouldBeEqualTo false
             hasAnnotations("SampleAnnotation1") shouldBeEqualTo true
             hasAnnotations("SampleAnnotation2") shouldBeEqualTo true
             hasAnnotations("NonExistingAnnotation") shouldBeEqualTo false
             hasAnnotations("SampleAnnotation1", "SampleAnnotation2") shouldBeEqualTo true
             hasAnnotations("SampleAnnotation1", "NonExistingAnnotation") shouldBeEqualTo false
-            hasAnnotations("com.lemonappdev.konsist.testdata.SampleAnnotation1") shouldBeEqualTo true
-            hasAnnotations("com.lemonappdev.konsist.testdata.OtherAnnotation") shouldBeEqualTo false
+            hasAnnotationsOf(SampleAnnotation1::class) shouldBeEqualTo true
+            hasAnnotationsOf(SampleAnnotation1::class) shouldBeEqualTo true
+            hasAnnotationsOf(NonExistingAnnotation::class) shouldBeEqualTo false
+            hasAnnotationsOf(SampleAnnotation1::class, SampleAnnotation1::class) shouldBeEqualTo true
+            hasAnnotationsOf(SampleAnnotation1::class, NonExistingAnnotation::class) shouldBeEqualTo false
         }
     }
 

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/kofile/KoFileDeclarationForKoAnnotationProviderTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/kofile/KoFileDeclarationForKoAnnotationProviderTest.kt
@@ -9,6 +9,7 @@ import org.amshove.kluent.assertSoftly
 import org.amshove.kluent.shouldBeEqualTo
 import org.junit.jupiter.api.Test
 
+@Suppress("detekt.LongMethod")
 class KoFileDeclarationForKoAnnotationProviderTest {
     @Test
     fun `file-contains-no-annotation`() {
@@ -82,19 +83,23 @@ class KoFileDeclarationForKoAnnotationProviderTest {
             hasAnnotationWithName(listOf("SampleAnnotation1", "OtherAnnotation")) shouldBeEqualTo true
             hasAnnotationWithName(listOf("com.lemonappdev.konsist.testdata.SampleAnnotation1")) shouldBeEqualTo true
             hasAnnotationWithName(listOf("com.lemonappdev.konsist.testdata.NonExistingAnnotation")) shouldBeEqualTo false
-            hasAnnotationWithName(listOf(
-                "com.lemonappdev.konsist.testdata.SampleAnnotation1",
-                "com.lemonappdev.konsist.testdata.NonExistingAnnotation",
-            )).shouldBeEqualTo(true)
+            hasAnnotationWithName(
+                listOf(
+                    "com.lemonappdev.konsist.testdata.SampleAnnotation1",
+                    "com.lemonappdev.konsist.testdata.NonExistingAnnotation",
+                ),
+            ).shouldBeEqualTo(true)
             hasAnnotationWithName(setOf("SampleAnnotation1")) shouldBeEqualTo true
             hasAnnotationWithName(setOf("OtherAnnotation")) shouldBeEqualTo false
             hasAnnotationWithName(setOf("SampleAnnotation1", "OtherAnnotation")) shouldBeEqualTo true
             hasAnnotationWithName(setOf("com.lemonappdev.konsist.testdata.SampleAnnotation1")) shouldBeEqualTo true
             hasAnnotationWithName(setOf("com.lemonappdev.konsist.testdata.NonExistingAnnotation")) shouldBeEqualTo false
-            hasAnnotationWithName(setOf(
-                "com.lemonappdev.konsist.testdata.SampleAnnotation1",
-                "com.lemonappdev.konsist.testdata.NonExistingAnnotation",
-            )).shouldBeEqualTo(true)
+            hasAnnotationWithName(
+                setOf(
+                    "com.lemonappdev.konsist.testdata.SampleAnnotation1",
+                    "com.lemonappdev.konsist.testdata.NonExistingAnnotation",
+                ),
+            ).shouldBeEqualTo(true)
             hasAnnotationsWithAllNames("SampleAnnotation1") shouldBeEqualTo true
             hasAnnotationsWithAllNames("SampleAnnotation1", "SampleAnnotation2") shouldBeEqualTo true
             hasAnnotationsWithAllNames("SampleAnnotation1", "OtherAnnotation") shouldBeEqualTo false
@@ -112,14 +117,18 @@ class KoFileDeclarationForKoAnnotationProviderTest {
             hasAnnotationsWithAllNames(listOf("SampleAnnotation1", "SampleAnnotation2")) shouldBeEqualTo true
             hasAnnotationsWithAllNames(listOf("SampleAnnotation1", "OtherAnnotation")) shouldBeEqualTo false
             hasAnnotationsWithAllNames(listOf("com.lemonappdev.konsist.testdata.SampleAnnotation1")) shouldBeEqualTo true
-            hasAnnotationsWithAllNames(listOf(
-                "com.lemonappdev.konsist.testdata.SampleAnnotation1",
-                "com.lemonappdev.konsist.testdata.NonExistingAnnotation",
-            )).shouldBeEqualTo(false)
-            hasAnnotationsWithAllNames(listOf(
-                "com.lemonappdev.konsist.testdata.SampleAnnotation1",
-                "com.lemonappdev.konsist.testdata.SampleAnnotation2",
-            )).shouldBeEqualTo(true)
+            hasAnnotationsWithAllNames(
+                listOf(
+                    "com.lemonappdev.konsist.testdata.SampleAnnotation1",
+                    "com.lemonappdev.konsist.testdata.NonExistingAnnotation",
+                ),
+            ).shouldBeEqualTo(false)
+            hasAnnotationsWithAllNames(
+                listOf(
+                    "com.lemonappdev.konsist.testdata.SampleAnnotation1",
+                    "com.lemonappdev.konsist.testdata.SampleAnnotation2",
+                ),
+            ).shouldBeEqualTo(true)
             hasAnnotation { it.name == "SampleAnnotation1" } shouldBeEqualTo true
             hasAnnotation { it.name == "OtherAnnotation1" } shouldBeEqualTo false
             hasAllAnnotations { !it.hasArguments() } shouldBeEqualTo true

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/kofile/KoFileDeclarationForKoClassProviderTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/kofile/KoFileDeclarationForKoClassProviderTest.kt
@@ -22,8 +22,16 @@ class KoFileDeclarationForKoClassProviderTest {
         assertSoftly(sut) {
             classes() shouldBeEqualTo emptyList()
             hasClasses() shouldBeEqualTo false
+            hasClassWithName(emptyList()) shouldBeEqualTo false
+            hasClassWithName(emptySet()) shouldBeEqualTo false
+            hasClassesWithAllNames(emptyList()) shouldBeEqualTo false
+            hasClassesWithAllNames(emptySet()) shouldBeEqualTo false
             hasClassWithName("SampleClass") shouldBeEqualTo false
+            hasClassWithName(listOf("SampleClass")) shouldBeEqualTo false
+            hasClassWithName(setOf("SampleClass")) shouldBeEqualTo false
             hasClassesWithAllNames("SampleClass1", "SampleClass2") shouldBeEqualTo false
+            hasClassesWithAllNames(listOf("SampleClass1", "SampleClass2")) shouldBeEqualTo false
+            hasClassesWithAllNames(setOf("SampleClass1", "SampleClass2")) shouldBeEqualTo false
             hasClass { it.name == "SampleClass" } shouldBeEqualTo false
             hasAllClasses { it.hasNameStartingWith("Sample") } shouldBeEqualTo true
         }
@@ -40,11 +48,25 @@ class KoFileDeclarationForKoClassProviderTest {
         // then
         assertSoftly(sut) {
             hasClasses() shouldBeEqualTo true
+            hasClassWithName(emptyList()) shouldBeEqualTo true
+            hasClassWithName(emptySet()) shouldBeEqualTo true
+            hasClassesWithAllNames(emptyList()) shouldBeEqualTo true
+            hasClassesWithAllNames(emptySet()) shouldBeEqualTo true
             hasClassWithName("SampleClass1") shouldBeEqualTo true
             hasClassWithName("SampleClass1", "OtherClass") shouldBeEqualTo true
+            hasClassWithName(listOf("SampleClass1")) shouldBeEqualTo true
+            hasClassWithName(listOf("SampleClass1", "OtherClass")) shouldBeEqualTo true
+            hasClassWithName(setOf("SampleClass1")) shouldBeEqualTo true
+            hasClassWithName(setOf("SampleClass1", "OtherClass")) shouldBeEqualTo true
             hasClassesWithAllNames("SampleClass1") shouldBeEqualTo true
             hasClassesWithAllNames("SampleClass1", "SampleClass2") shouldBeEqualTo true
             hasClassesWithAllNames("SampleClass1", "OtherClass") shouldBeEqualTo false
+            hasClassesWithAllNames(listOf("SampleClass1")) shouldBeEqualTo true
+            hasClassesWithAllNames(listOf("SampleClass1", "SampleClass2")) shouldBeEqualTo true
+            hasClassesWithAllNames(listOf("SampleClass1", "OtherClass")) shouldBeEqualTo false
+            hasClassesWithAllNames(setOf("SampleClass1")) shouldBeEqualTo true
+            hasClassesWithAllNames(setOf("SampleClass1", "SampleClass2")) shouldBeEqualTo true
+            hasClassesWithAllNames(setOf("SampleClass1", "OtherClass")) shouldBeEqualTo false
             hasClass { it.name == "SampleClass1" } shouldBeEqualTo true
             hasClass { it.hasNameEndingWith("Class1") } shouldBeEqualTo true
             hasAllClasses { it.hasNameStartingWith("Sample") } shouldBeEqualTo true

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/kofile/KoFileDeclarationForKoFunctionProviderTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/kofile/KoFileDeclarationForKoFunctionProviderTest.kt
@@ -21,8 +21,16 @@ class KoFileDeclarationForKoFunctionProviderTest {
         assertSoftly(sut) {
             functions() shouldBeEqualTo emptyList()
             hasFunctions() shouldBeEqualTo false
+            hasFunctionWithName(emptyList()) shouldBeEqualTo false
+            hasFunctionWithName(emptySet()) shouldBeEqualTo false
+            hasFunctionsWithAllNames(emptyList()) shouldBeEqualTo false
+            hasFunctionsWithAllNames(emptySet()) shouldBeEqualTo false
             hasFunctionWithName("sampleFunction") shouldBeEqualTo false
+            hasFunctionWithName(listOf("sampleFunction")) shouldBeEqualTo false
+            hasFunctionWithName(setOf("sampleFunction")) shouldBeEqualTo false
             hasFunctionsWithAllNames("sampleFunction1", "sampleFunction2") shouldBeEqualTo false
+            hasFunctionsWithAllNames(listOf("sampleFunction1", "sampleFunction2")) shouldBeEqualTo false
+            hasFunctionsWithAllNames(setOf("sampleFunction1", "sampleFunction2")) shouldBeEqualTo false
             hasFunction { it.name == "sampleFunction" } shouldBeEqualTo false
             hasAllFunctions { it.hasNameStartingWith("sample") } shouldBeEqualTo true
         }
@@ -39,11 +47,25 @@ class KoFileDeclarationForKoFunctionProviderTest {
         // then
         assertSoftly(sut) {
             hasFunctions() shouldBeEqualTo true
+            hasFunctionWithName(emptyList()) shouldBeEqualTo true
+            hasFunctionWithName(emptySet()) shouldBeEqualTo true
+            hasFunctionsWithAllNames(emptyList()) shouldBeEqualTo true
+            hasFunctionsWithAllNames(emptySet()) shouldBeEqualTo true
             hasFunctionWithName("sampleFunction1") shouldBeEqualTo true
             hasFunctionWithName("sampleFunction1", "otherFunction") shouldBeEqualTo true
+            hasFunctionWithName(listOf("sampleFunction1")) shouldBeEqualTo true
+            hasFunctionWithName(listOf("sampleFunction1", "otherFunction")) shouldBeEqualTo true
+            hasFunctionWithName(setOf("sampleFunction1")) shouldBeEqualTo true
+            hasFunctionWithName(setOf("sampleFunction1", "otherFunction")) shouldBeEqualTo true
             hasFunctionsWithAllNames("sampleFunction1") shouldBeEqualTo true
             hasFunctionsWithAllNames("sampleFunction1", "sampleFunction2") shouldBeEqualTo true
             hasFunctionsWithAllNames("sampleFunction1", "otherFunction") shouldBeEqualTo false
+            hasFunctionsWithAllNames(listOf("sampleFunction1")) shouldBeEqualTo true
+            hasFunctionsWithAllNames(listOf("sampleFunction1", "sampleFunction2")) shouldBeEqualTo true
+            hasFunctionsWithAllNames(listOf("sampleFunction1", "otherFunction")) shouldBeEqualTo false
+            hasFunctionsWithAllNames(setOf("sampleFunction1")) shouldBeEqualTo true
+            hasFunctionsWithAllNames(setOf("sampleFunction1", "sampleFunction2")) shouldBeEqualTo true
+            hasFunctionsWithAllNames(setOf("sampleFunction1", "otherFunction")) shouldBeEqualTo false
             hasFunction { it.name == "sampleFunction1" } shouldBeEqualTo true
             hasFunction { it.hasNameEndingWith("Function1") } shouldBeEqualTo true
             hasAllFunctions { it.hasNameStartingWith("sample") } shouldBeEqualTo true

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/kofile/KoFileDeclarationForKoImportAliasProviderTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/kofile/KoFileDeclarationForKoImportAliasProviderTest.kt
@@ -20,10 +20,28 @@ class KoFileDeclarationForKoImportAliasProviderTest {
             numImportAliases shouldBeEqualTo 0
             countImportAliases { it.name == "SampleImportAlias" } shouldBeEqualTo 0
             hasImportAliases() shouldBeEqualTo false
+            hasImportAliasWithName(emptyList()) shouldBeEqualTo false
+            hasImportAliasWithName(emptySet()) shouldBeEqualTo false
+            hasImportAliasesWithAllNames(emptyList()) shouldBeEqualTo false
+            hasImportAliasesWithAllNames(emptySet()) shouldBeEqualTo false
             hasImportAliasWithName("SampleImportAlias") shouldBeEqualTo false
+            hasImportAliasWithName(listOf("SampleImportAlias")) shouldBeEqualTo false
+            hasImportAliasWithName(setOf("SampleImportAlias")) shouldBeEqualTo false
             hasImportAliasesWithAllNames(
                 "SampleImportAlias1",
                 "SampleImportAlias2",
+            ).shouldBeEqualTo(false)
+            hasImportAliasesWithAllNames(
+                listOf(
+                    "SampleImportAlias1",
+                    "SampleImportAlias2"
+                ),
+            ).shouldBeEqualTo(false)
+            hasImportAliasesWithAllNames(
+                setOf(
+                    "SampleImportAlias1",
+                    "SampleImportAlias2"
+                ),
             ).shouldBeEqualTo(false)
             hasImportAlias { it.name == "SampleImportAlias" } shouldBeEqualTo false
             hasAllImportAliases { it.hasNameStartingWith("SampleImport") } shouldBeEqualTo true
@@ -44,16 +62,42 @@ class KoFileDeclarationForKoImportAliasProviderTest {
             numImportAliases shouldBeEqualTo 1
             countImportAliases { it.hasNameStartingWith("SampleImport") } shouldBeEqualTo 1
             hasImportAliases() shouldBeEqualTo true
+            hasImportAliasWithName(emptyList()) shouldBeEqualTo true
+            hasImportAliasWithName(emptySet()) shouldBeEqualTo true
+            hasImportAliasesWithAllNames(emptyList()) shouldBeEqualTo true
+            hasImportAliasesWithAllNames(emptySet()) shouldBeEqualTo true
             hasImportAliasWithName("SampleImportAlias") shouldBeEqualTo true
             hasImportAliasWithName("SampleOtherImportAlias") shouldBeEqualTo false
             hasImportAliasWithName(
                 "SampleOtherImportAlias",
                 "SampleImportAlias",
             ).shouldBeEqualTo(true)
+            hasImportAliasWithName(listOf("SampleImportAlias")) shouldBeEqualTo true
+            hasImportAliasWithName(listOf("SampleOtherImportAlias")) shouldBeEqualTo false
+            hasImportAliasWithName(listOf(
+                "SampleOtherImportAlias",
+                "SampleImportAlias",
+            )).shouldBeEqualTo(true)
+            hasImportAliasWithName(setOf("SampleImportAlias")) shouldBeEqualTo true
+            hasImportAliasWithName(setOf("SampleOtherImportAlias")) shouldBeEqualTo false
+            hasImportAliasWithName(setOf(
+                "SampleOtherImportAlias",
+                "SampleImportAlias",
+            )).shouldBeEqualTo(true)
             hasImportAliasesWithAllNames("SampleImportAlias") shouldBeEqualTo true
             hasImportAliasesWithAllNames(
                 "SampleOtherImportAlias",
                 "SampleImportAlias",
+            ).shouldBeEqualTo(false)
+            hasImportAliasesWithAllNames(listOf("SampleImportAlias")) shouldBeEqualTo true
+            hasImportAliasesWithAllNames(listOf(
+                "SampleOtherImportAlias",
+                "SampleImportAlias"),
+            ).shouldBeEqualTo(false)
+            hasImportAliasesWithAllNames(setOf("SampleImportAlias")) shouldBeEqualTo true
+            hasImportAliasesWithAllNames(setOf(
+                "SampleOtherImportAlias",
+                "SampleImportAlias"),
             ).shouldBeEqualTo(false)
             hasImportAlias { it.hasNameStartingWith("SampleImport") } shouldBeEqualTo true
             hasImportAlias { it.name == "SampleOtherImportAlias" } shouldBeEqualTo false
@@ -75,9 +119,19 @@ class KoFileDeclarationForKoImportAliasProviderTest {
             countImportAliases { it.hasNameStartingWith("SampleImport") } shouldBeEqualTo 2
             countImportAliases { it.name == "SampleImportAlias1" } shouldBeEqualTo 1
             hasImportAliases() shouldBeEqualTo true
+            hasImportAliasWithName(emptyList()) shouldBeEqualTo true
+            hasImportAliasWithName(emptySet()) shouldBeEqualTo true
+            hasImportAliasesWithAllNames(emptyList()) shouldBeEqualTo true
+            hasImportAliasesWithAllNames(emptySet()) shouldBeEqualTo true
             hasImportAliasWithName("SampleImportAlias1") shouldBeEqualTo true
             hasImportAliasWithName("SampleOtherImportAlias") shouldBeEqualTo false
             hasImportAliasWithName("SampleImportAlias1", "otherName") shouldBeEqualTo true
+            hasImportAliasWithName(listOf("SampleImportAlias1")) shouldBeEqualTo true
+            hasImportAliasWithName(listOf("SampleOtherImportAlias")) shouldBeEqualTo false
+            hasImportAliasWithName(listOf("SampleImportAlias1", "otherName")) shouldBeEqualTo true
+            hasImportAliasWithName(setOf("SampleImportAlias1")) shouldBeEqualTo true
+            hasImportAliasWithName(setOf("SampleOtherImportAlias")) shouldBeEqualTo false
+            hasImportAliasWithName(setOf("SampleImportAlias1", "otherName")) shouldBeEqualTo true
             hasImportAliasesWithAllNames("SampleImportAlias1") shouldBeEqualTo true
             hasImportAliasesWithAllNames(
                 "SampleImportAlias1",
@@ -86,6 +140,24 @@ class KoFileDeclarationForKoImportAliasProviderTest {
             hasImportAliasesWithAllNames(
                 "SampleImportAlias1",
                 "SampleOtherImportAlias",
+            ).shouldBeEqualTo(false)
+            hasImportAliasesWithAllNames(listOf("SampleImportAlias1")) shouldBeEqualTo true
+            hasImportAliasesWithAllNames(listOf(
+                "SampleImportAlias1",
+                "SampleImportAlias2"),
+            ).shouldBeEqualTo(true)
+            hasImportAliasesWithAllNames(listOf(
+                "SampleImportAlias1",
+                "SampleOtherImportAlias"),
+            ).shouldBeEqualTo(false)
+            hasImportAliasesWithAllNames(setOf("SampleImportAlias1")) shouldBeEqualTo true
+            hasImportAliasesWithAllNames(setOf(
+                "SampleImportAlias1",
+                "SampleImportAlias2"),
+            ).shouldBeEqualTo(true)
+            hasImportAliasesWithAllNames(setOf(
+                "SampleImportAlias1",
+                "SampleOtherImportAlias"),
             ).shouldBeEqualTo(false)
             hasImportAlias { it.name == "SampleImportAlias1" } shouldBeEqualTo true
             hasImportAlias { it.name == "SampleOtherImportAlias" } shouldBeEqualTo false

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/kofile/KoFileDeclarationForKoImportAliasProviderTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/kofile/KoFileDeclarationForKoImportAliasProviderTest.kt
@@ -5,6 +5,7 @@ import org.amshove.kluent.assertSoftly
 import org.amshove.kluent.shouldBeEqualTo
 import org.junit.jupiter.api.Test
 
+@Suppress("detekt.LongMethod")
 class KoFileDeclarationForKoImportAliasProviderTest {
     @Test
     fun `file-has-no-import-alias`() {
@@ -34,13 +35,13 @@ class KoFileDeclarationForKoImportAliasProviderTest {
             hasImportAliasesWithAllNames(
                 listOf(
                     "SampleImportAlias1",
-                    "SampleImportAlias2"
+                    "SampleImportAlias2",
                 ),
             ).shouldBeEqualTo(false)
             hasImportAliasesWithAllNames(
                 setOf(
                     "SampleImportAlias1",
-                    "SampleImportAlias2"
+                    "SampleImportAlias2",
                 ),
             ).shouldBeEqualTo(false)
             hasImportAlias { it.name == "SampleImportAlias" } shouldBeEqualTo false
@@ -74,30 +75,38 @@ class KoFileDeclarationForKoImportAliasProviderTest {
             ).shouldBeEqualTo(true)
             hasImportAliasWithName(listOf("SampleImportAlias")) shouldBeEqualTo true
             hasImportAliasWithName(listOf("SampleOtherImportAlias")) shouldBeEqualTo false
-            hasImportAliasWithName(listOf(
-                "SampleOtherImportAlias",
-                "SampleImportAlias",
-            )).shouldBeEqualTo(true)
+            hasImportAliasWithName(
+                listOf(
+                    "SampleOtherImportAlias",
+                    "SampleImportAlias",
+                ),
+            ).shouldBeEqualTo(true)
             hasImportAliasWithName(setOf("SampleImportAlias")) shouldBeEqualTo true
             hasImportAliasWithName(setOf("SampleOtherImportAlias")) shouldBeEqualTo false
-            hasImportAliasWithName(setOf(
-                "SampleOtherImportAlias",
-                "SampleImportAlias",
-            )).shouldBeEqualTo(true)
+            hasImportAliasWithName(
+                setOf(
+                    "SampleOtherImportAlias",
+                    "SampleImportAlias",
+                ),
+            ).shouldBeEqualTo(true)
             hasImportAliasesWithAllNames("SampleImportAlias") shouldBeEqualTo true
             hasImportAliasesWithAllNames(
                 "SampleOtherImportAlias",
                 "SampleImportAlias",
             ).shouldBeEqualTo(false)
             hasImportAliasesWithAllNames(listOf("SampleImportAlias")) shouldBeEqualTo true
-            hasImportAliasesWithAllNames(listOf(
-                "SampleOtherImportAlias",
-                "SampleImportAlias"),
+            hasImportAliasesWithAllNames(
+                listOf(
+                    "SampleOtherImportAlias",
+                    "SampleImportAlias",
+                ),
             ).shouldBeEqualTo(false)
             hasImportAliasesWithAllNames(setOf("SampleImportAlias")) shouldBeEqualTo true
-            hasImportAliasesWithAllNames(setOf(
-                "SampleOtherImportAlias",
-                "SampleImportAlias"),
+            hasImportAliasesWithAllNames(
+                setOf(
+                    "SampleOtherImportAlias",
+                    "SampleImportAlias",
+                ),
             ).shouldBeEqualTo(false)
             hasImportAlias { it.hasNameStartingWith("SampleImport") } shouldBeEqualTo true
             hasImportAlias { it.name == "SampleOtherImportAlias" } shouldBeEqualTo false
@@ -142,22 +151,30 @@ class KoFileDeclarationForKoImportAliasProviderTest {
                 "SampleOtherImportAlias",
             ).shouldBeEqualTo(false)
             hasImportAliasesWithAllNames(listOf("SampleImportAlias1")) shouldBeEqualTo true
-            hasImportAliasesWithAllNames(listOf(
-                "SampleImportAlias1",
-                "SampleImportAlias2"),
+            hasImportAliasesWithAllNames(
+                listOf(
+                    "SampleImportAlias1",
+                    "SampleImportAlias2",
+                ),
             ).shouldBeEqualTo(true)
-            hasImportAliasesWithAllNames(listOf(
-                "SampleImportAlias1",
-                "SampleOtherImportAlias"),
+            hasImportAliasesWithAllNames(
+                listOf(
+                    "SampleImportAlias1",
+                    "SampleOtherImportAlias",
+                ),
             ).shouldBeEqualTo(false)
             hasImportAliasesWithAllNames(setOf("SampleImportAlias1")) shouldBeEqualTo true
-            hasImportAliasesWithAllNames(setOf(
-                "SampleImportAlias1",
-                "SampleImportAlias2"),
+            hasImportAliasesWithAllNames(
+                setOf(
+                    "SampleImportAlias1",
+                    "SampleImportAlias2",
+                ),
             ).shouldBeEqualTo(true)
-            hasImportAliasesWithAllNames(setOf(
-                "SampleImportAlias1",
-                "SampleOtherImportAlias"),
+            hasImportAliasesWithAllNames(
+                setOf(
+                    "SampleImportAlias1",
+                    "SampleOtherImportAlias",
+                ),
             ).shouldBeEqualTo(false)
             hasImportAlias { it.name == "SampleImportAlias1" } shouldBeEqualTo true
             hasImportAlias { it.name == "SampleOtherImportAlias" } shouldBeEqualTo false

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/kofile/KoFileDeclarationForKoImportProviderTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/kofile/KoFileDeclarationForKoImportProviderTest.kt
@@ -5,6 +5,7 @@ import org.amshove.kluent.assertSoftly
 import org.amshove.kluent.shouldBeEqualTo
 import org.junit.jupiter.api.Test
 
+@Suppress("detekt.LongMethod")
 class KoFileDeclarationForKoImportProviderTest {
     @Test
     fun `file-has-no-import`() {
@@ -33,13 +34,15 @@ class KoFileDeclarationForKoImportProviderTest {
             ).shouldBeEqualTo(false)
             hasImportsWithAllNames(
                 listOf(
-                "com.lemonappdev.konsist.testdata.SampleClass",
-                "com.lemonappdev.konsist.testdata.SampleType"),
+                    "com.lemonappdev.konsist.testdata.SampleClass",
+                    "com.lemonappdev.konsist.testdata.SampleType",
+                ),
             ).shouldBeEqualTo(false)
             hasImportsWithAllNames(
                 setOf(
                     "com.lemonappdev.konsist.testdata.SampleClass",
-                    "com.lemonappdev.konsist.testdata.SampleType"),
+                    "com.lemonappdev.konsist.testdata.SampleType",
+                ),
             ).shouldBeEqualTo(false)
             hasImport { it.name == "com.lemonappdev.konsist.testdata.OtherImport" } shouldBeEqualTo false
             hasAllImports { it.hasNameStartingWith("com.lemonappdev.") } shouldBeEqualTo true
@@ -73,15 +76,19 @@ class KoFileDeclarationForKoImportProviderTest {
             ).shouldBeEqualTo(true)
             hasImportWithName(listOf("com.lemonappdev.konsist.testdata.SampleType")) shouldBeEqualTo true
             hasImportWithName(listOf("com.lemonappdev.konsist.testdata.SampleClass")) shouldBeEqualTo false
-            hasImportWithName(listOf(
-                "com.lemonappdev.konsist.testdata.SampleClass",
-                "com.lemonappdev.konsist.testdata.SampleType"),
+            hasImportWithName(
+                listOf(
+                    "com.lemonappdev.konsist.testdata.SampleClass",
+                    "com.lemonappdev.konsist.testdata.SampleType",
+                ),
             ).shouldBeEqualTo(true)
             hasImportWithName(setOf("com.lemonappdev.konsist.testdata.SampleType")) shouldBeEqualTo true
             hasImportWithName(setOf("com.lemonappdev.konsist.testdata.SampleClass")) shouldBeEqualTo false
-            hasImportWithName(setOf(
-                "com.lemonappdev.konsist.testdata.SampleClass",
-                "com.lemonappdev.konsist.testdata.SampleType"),
+            hasImportWithName(
+                setOf(
+                    "com.lemonappdev.konsist.testdata.SampleClass",
+                    "com.lemonappdev.konsist.testdata.SampleType",
+                ),
             ).shouldBeEqualTo(true)
             hasImportsWithAllNames("com.lemonappdev.konsist.testdata.SampleType") shouldBeEqualTo true
             hasImportsWithAllNames(
@@ -89,14 +96,18 @@ class KoFileDeclarationForKoImportProviderTest {
                 "com.lemonappdev.konsist.testdata.SampleType",
             ).shouldBeEqualTo(false)
             hasImportsWithAllNames(listOf("com.lemonappdev.konsist.testdata.SampleType")) shouldBeEqualTo true
-            hasImportsWithAllNames(listOf(
-                "com.lemonappdev.konsist.testdata.SampleClass",
-                "com.lemonappdev.konsist.testdata.SampleType"),
+            hasImportsWithAllNames(
+                listOf(
+                    "com.lemonappdev.konsist.testdata.SampleClass",
+                    "com.lemonappdev.konsist.testdata.SampleType",
+                ),
             ).shouldBeEqualTo(false)
             hasImportsWithAllNames(setOf("com.lemonappdev.konsist.testdata.SampleType")) shouldBeEqualTo true
-            hasImportsWithAllNames(setOf(
-                "com.lemonappdev.konsist.testdata.SampleClass",
-                "com.lemonappdev.konsist.testdata.SampleType"),
+            hasImportsWithAllNames(
+                setOf(
+                    "com.lemonappdev.konsist.testdata.SampleClass",
+                    "com.lemonappdev.konsist.testdata.SampleType",
+                ),
             ).shouldBeEqualTo(false)
             hasImport { it.hasNameStartingWith("com.lemonappdev.") } shouldBeEqualTo true
             hasImport { it.name == "com.lemonappdev.konsist.testdata.SampleClass" } shouldBeEqualTo false
@@ -143,24 +154,28 @@ class KoFileDeclarationForKoImportProviderTest {
             hasImportsWithAllNames(listOf("com.lemonappdev.konsist.testdata.SampleType")) shouldBeEqualTo true
             hasImportsWithAllNames(
                 listOf(
-                "com.lemonappdev.konsist.testdata.SampleType",
-                "com.lemonappdev.konsist.testdata.SampleAnnotation"),
+                    "com.lemonappdev.konsist.testdata.SampleType",
+                    "com.lemonappdev.konsist.testdata.SampleAnnotation",
+                ),
             ).shouldBeEqualTo(true)
             hasImportsWithAllNames(
                 listOf(
-                "com.lemonappdev.konsist.testdata.SampleType",
-                "com.lemonappdev.konsist.testdata.SampleClass"),
+                    "com.lemonappdev.konsist.testdata.SampleType",
+                    "com.lemonappdev.konsist.testdata.SampleClass",
+                ),
             ).shouldBeEqualTo(false)
             hasImportsWithAllNames(setOf("com.lemonappdev.konsist.testdata.SampleType")) shouldBeEqualTo true
             hasImportsWithAllNames(
                 setOf(
                     "com.lemonappdev.konsist.testdata.SampleType",
-                    "com.lemonappdev.konsist.testdata.SampleAnnotation"),
+                    "com.lemonappdev.konsist.testdata.SampleAnnotation",
+                ),
             ).shouldBeEqualTo(true)
             hasImportsWithAllNames(
                 setOf(
                     "com.lemonappdev.konsist.testdata.SampleType",
-                    "com.lemonappdev.konsist.testdata.SampleClass"),
+                    "com.lemonappdev.konsist.testdata.SampleClass",
+                ),
             ).shouldBeEqualTo(false)
             hasImport { it.name == "com.lemonappdev.konsist.testdata.SampleType" } shouldBeEqualTo true
             hasImport { it.name == "com.lemonappdev.konsist.testdata.OtherType" } shouldBeEqualTo false

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/kofile/KoFileDeclarationForKoImportProviderTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/kofile/KoFileDeclarationForKoImportProviderTest.kt
@@ -20,10 +20,26 @@ class KoFileDeclarationForKoImportProviderTest {
             numImports shouldBeEqualTo 0
             countImports { it.name == "com.lemonappdev.konsist.testdata.OtherImport" } shouldBeEqualTo 0
             hasImports() shouldBeEqualTo false
+            hasImportWithName(emptyList()) shouldBeEqualTo false
+            hasImportWithName(emptySet()) shouldBeEqualTo false
+            hasImportsWithAllNames(emptyList()) shouldBeEqualTo false
+            hasImportsWithAllNames(emptySet()) shouldBeEqualTo false
             hasImportWithName("com.lemonappdev.konsist.testdata.OtherImport") shouldBeEqualTo false
+            hasImportWithName(listOf("com.lemonappdev.konsist.testdata.OtherImport")) shouldBeEqualTo false
+            hasImportWithName(setOf("com.lemonappdev.konsist.testdata.OtherImport")) shouldBeEqualTo false
             hasImportsWithAllNames(
                 "com.lemonappdev.konsist.testdata.SampleClass",
                 "com.lemonappdev.konsist.testdata.SampleType",
+            ).shouldBeEqualTo(false)
+            hasImportsWithAllNames(
+                listOf(
+                "com.lemonappdev.konsist.testdata.SampleClass",
+                "com.lemonappdev.konsist.testdata.SampleType"),
+            ).shouldBeEqualTo(false)
+            hasImportsWithAllNames(
+                setOf(
+                    "com.lemonappdev.konsist.testdata.SampleClass",
+                    "com.lemonappdev.konsist.testdata.SampleType"),
             ).shouldBeEqualTo(false)
             hasImport { it.name == "com.lemonappdev.konsist.testdata.OtherImport" } shouldBeEqualTo false
             hasAllImports { it.hasNameStartingWith("com.lemonappdev.") } shouldBeEqualTo true
@@ -45,16 +61,42 @@ class KoFileDeclarationForKoImportProviderTest {
             numImports shouldBeEqualTo 1
             countImports { it.hasNameStartingWith("com.lemonappdev.") } shouldBeEqualTo 1
             hasImports() shouldBeEqualTo true
+            hasImportWithName(emptyList()) shouldBeEqualTo true
+            hasImportWithName(emptySet()) shouldBeEqualTo true
+            hasImportsWithAllNames(emptyList()) shouldBeEqualTo true
+            hasImportsWithAllNames(emptySet()) shouldBeEqualTo true
             hasImportWithName("com.lemonappdev.konsist.testdata.SampleType") shouldBeEqualTo true
             hasImportWithName("com.lemonappdev.konsist.testdata.SampleClass") shouldBeEqualTo false
             hasImportWithName(
                 "com.lemonappdev.konsist.testdata.SampleClass",
                 "com.lemonappdev.konsist.testdata.SampleType",
             ).shouldBeEqualTo(true)
+            hasImportWithName(listOf("com.lemonappdev.konsist.testdata.SampleType")) shouldBeEqualTo true
+            hasImportWithName(listOf("com.lemonappdev.konsist.testdata.SampleClass")) shouldBeEqualTo false
+            hasImportWithName(listOf(
+                "com.lemonappdev.konsist.testdata.SampleClass",
+                "com.lemonappdev.konsist.testdata.SampleType"),
+            ).shouldBeEqualTo(true)
+            hasImportWithName(setOf("com.lemonappdev.konsist.testdata.SampleType")) shouldBeEqualTo true
+            hasImportWithName(setOf("com.lemonappdev.konsist.testdata.SampleClass")) shouldBeEqualTo false
+            hasImportWithName(setOf(
+                "com.lemonappdev.konsist.testdata.SampleClass",
+                "com.lemonappdev.konsist.testdata.SampleType"),
+            ).shouldBeEqualTo(true)
             hasImportsWithAllNames("com.lemonappdev.konsist.testdata.SampleType") shouldBeEqualTo true
             hasImportsWithAllNames(
                 "com.lemonappdev.konsist.testdata.SampleClass",
                 "com.lemonappdev.konsist.testdata.SampleType",
+            ).shouldBeEqualTo(false)
+            hasImportsWithAllNames(listOf("com.lemonappdev.konsist.testdata.SampleType")) shouldBeEqualTo true
+            hasImportsWithAllNames(listOf(
+                "com.lemonappdev.konsist.testdata.SampleClass",
+                "com.lemonappdev.konsist.testdata.SampleType"),
+            ).shouldBeEqualTo(false)
+            hasImportsWithAllNames(setOf("com.lemonappdev.konsist.testdata.SampleType")) shouldBeEqualTo true
+            hasImportsWithAllNames(setOf(
+                "com.lemonappdev.konsist.testdata.SampleClass",
+                "com.lemonappdev.konsist.testdata.SampleType"),
             ).shouldBeEqualTo(false)
             hasImport { it.hasNameStartingWith("com.lemonappdev.") } shouldBeEqualTo true
             hasImport { it.name == "com.lemonappdev.konsist.testdata.SampleClass" } shouldBeEqualTo false
@@ -76,9 +118,19 @@ class KoFileDeclarationForKoImportProviderTest {
             countImports { it.hasNameStartingWith("com.lemonappdev") } shouldBeEqualTo 2
             countImports { it.name == "com.lemonappdev.konsist.testdata.SampleType" } shouldBeEqualTo 1
             hasImports() shouldBeEqualTo true
+            hasImportWithName(emptyList()) shouldBeEqualTo true
+            hasImportWithName(emptySet()) shouldBeEqualTo true
+            hasImportsWithAllNames(emptyList()) shouldBeEqualTo true
+            hasImportsWithAllNames(emptySet()) shouldBeEqualTo true
             hasImportWithName("com.lemonappdev.konsist.testdata.SampleType") shouldBeEqualTo true
             hasImportWithName("com.lemonappdev.konsist.testdata.SampleClass") shouldBeEqualTo false
             hasImportWithName("com.lemonappdev.konsist.testdata.SampleType", "otherName") shouldBeEqualTo true
+            hasImportWithName(listOf("com.lemonappdev.konsist.testdata.SampleType")) shouldBeEqualTo true
+            hasImportWithName(listOf("com.lemonappdev.konsist.testdata.SampleClass")) shouldBeEqualTo false
+            hasImportWithName(listOf("com.lemonappdev.konsist.testdata.SampleType", "otherName")) shouldBeEqualTo true
+            hasImportWithName(setOf("com.lemonappdev.konsist.testdata.SampleType")) shouldBeEqualTo true
+            hasImportWithName(setOf("com.lemonappdev.konsist.testdata.SampleClass")) shouldBeEqualTo false
+            hasImportWithName(setOf("com.lemonappdev.konsist.testdata.SampleType", "otherName")) shouldBeEqualTo true
             hasImportsWithAllNames("com.lemonappdev.konsist.testdata.SampleType") shouldBeEqualTo true
             hasImportsWithAllNames(
                 "com.lemonappdev.konsist.testdata.SampleType",
@@ -87,6 +139,28 @@ class KoFileDeclarationForKoImportProviderTest {
             hasImportsWithAllNames(
                 "com.lemonappdev.konsist.testdata.SampleType",
                 "com.lemonappdev.konsist.testdata.SampleClass",
+            ).shouldBeEqualTo(false)
+            hasImportsWithAllNames(listOf("com.lemonappdev.konsist.testdata.SampleType")) shouldBeEqualTo true
+            hasImportsWithAllNames(
+                listOf(
+                "com.lemonappdev.konsist.testdata.SampleType",
+                "com.lemonappdev.konsist.testdata.SampleAnnotation"),
+            ).shouldBeEqualTo(true)
+            hasImportsWithAllNames(
+                listOf(
+                "com.lemonappdev.konsist.testdata.SampleType",
+                "com.lemonappdev.konsist.testdata.SampleClass"),
+            ).shouldBeEqualTo(false)
+            hasImportsWithAllNames(setOf("com.lemonappdev.konsist.testdata.SampleType")) shouldBeEqualTo true
+            hasImportsWithAllNames(
+                setOf(
+                    "com.lemonappdev.konsist.testdata.SampleType",
+                    "com.lemonappdev.konsist.testdata.SampleAnnotation"),
+            ).shouldBeEqualTo(true)
+            hasImportsWithAllNames(
+                setOf(
+                    "com.lemonappdev.konsist.testdata.SampleType",
+                    "com.lemonappdev.konsist.testdata.SampleClass"),
             ).shouldBeEqualTo(false)
             hasImport { it.name == "com.lemonappdev.konsist.testdata.SampleType" } shouldBeEqualTo true
             hasImport { it.name == "com.lemonappdev.konsist.testdata.OtherType" } shouldBeEqualTo false

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/kofile/KoFileDeclarationForKoInterfaceProviderTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/kofile/KoFileDeclarationForKoInterfaceProviderTest.kt
@@ -19,10 +19,17 @@ class KoFileDeclarationForKoInterfaceProviderTest {
 
         // then
         assertSoftly(sut) {
-            interfaces() shouldBeEqualTo emptyList()
             hasInterfaces() shouldBeEqualTo false
+            hasInterfaceWithName(emptyList()) shouldBeEqualTo false
+            hasInterfaceWithName(emptySet()) shouldBeEqualTo false
+            hasInterfacesWithAllNames(emptyList()) shouldBeEqualTo false
+            hasInterfacesWithAllNames(emptySet()) shouldBeEqualTo false
             hasInterfaceWithName("SampleInterface") shouldBeEqualTo false
+            hasInterfaceWithName(listOf("SampleInterface")) shouldBeEqualTo false
+            hasInterfaceWithName(setOf("SampleInterface")) shouldBeEqualTo false
             hasInterfacesWithAllNames("SampleInterface1", "SampleInterface2") shouldBeEqualTo false
+            hasInterfacesWithAllNames(listOf("SampleInterface1", "SampleInterface2")) shouldBeEqualTo false
+            hasInterfacesWithAllNames(setOf("SampleInterface1", "SampleInterface2")) shouldBeEqualTo false
             hasInterface { it.name == "SampleInterface" } shouldBeEqualTo false
             hasAllInterfaces { it.hasNameStartingWith("Sample") } shouldBeEqualTo true
         }
@@ -39,11 +46,25 @@ class KoFileDeclarationForKoInterfaceProviderTest {
         // then
         assertSoftly(sut) {
             hasInterfaces() shouldBeEqualTo true
+            hasInterfaceWithName(emptyList()) shouldBeEqualTo true
+            hasInterfaceWithName(emptySet()) shouldBeEqualTo true
+            hasInterfacesWithAllNames(emptyList()) shouldBeEqualTo true
+            hasInterfacesWithAllNames(emptySet()) shouldBeEqualTo true
             hasInterfaceWithName("SampleInterface1") shouldBeEqualTo true
             hasInterfaceWithName("SampleInterface1", "OtherInterface") shouldBeEqualTo true
+            hasInterfaceWithName(listOf("SampleInterface1")) shouldBeEqualTo true
+            hasInterfaceWithName(listOf("SampleInterface1", "OtherInterface")) shouldBeEqualTo true
+            hasInterfaceWithName(setOf("SampleInterface1")) shouldBeEqualTo true
+            hasInterfaceWithName(setOf("SampleInterface1", "OtherInterface")) shouldBeEqualTo true
             hasInterfacesWithAllNames("SampleInterface1") shouldBeEqualTo true
             hasInterfacesWithAllNames("SampleInterface1", "SampleInterface2") shouldBeEqualTo true
             hasInterfacesWithAllNames("SampleInterface1", "OtherInterface") shouldBeEqualTo false
+            hasInterfacesWithAllNames(listOf("SampleInterface1")) shouldBeEqualTo true
+            hasInterfacesWithAllNames(listOf("SampleInterface1", "SampleInterface2")) shouldBeEqualTo true
+            hasInterfacesWithAllNames(listOf("SampleInterface1", "OtherInterface")) shouldBeEqualTo false
+            hasInterfacesWithAllNames(setOf("SampleInterface1")) shouldBeEqualTo true
+            hasInterfacesWithAllNames(setOf("SampleInterface1", "SampleInterface2")) shouldBeEqualTo true
+            hasInterfacesWithAllNames(setOf("SampleInterface1", "OtherInterface")) shouldBeEqualTo false
             hasInterface { it.name == "SampleInterface1" } shouldBeEqualTo true
             hasInterface { it.hasNameEndingWith("Interface1") } shouldBeEqualTo true
             hasAllInterfaces { it.hasNameStartingWith("Sample") } shouldBeEqualTo true

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/kofile/KoFileDeclarationForKoObjectProviderTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/kofile/KoFileDeclarationForKoObjectProviderTest.kt
@@ -21,8 +21,16 @@ class KoFileDeclarationForKoObjectProviderTest {
         assertSoftly(sut) {
             objects() shouldBeEqualTo emptyList()
             hasObjects() shouldBeEqualTo false
+            hasObjectWithName(emptyList()) shouldBeEqualTo false
+            hasObjectWithName(emptySet()) shouldBeEqualTo false
+            hasObjectsWithAllNames(emptyList()) shouldBeEqualTo false
+            hasObjectsWithAllNames(emptySet()) shouldBeEqualTo false
             hasObjectWithName("SampleObject") shouldBeEqualTo false
+            hasObjectWithName(listOf("SampleObject")) shouldBeEqualTo false
+            hasObjectWithName(setOf("SampleObject")) shouldBeEqualTo false
             hasObjectsWithAllNames("SampleObject1", "SampleObject2") shouldBeEqualTo false
+            hasObjectsWithAllNames(listOf("SampleObject1", "SampleObject2")) shouldBeEqualTo false
+            hasObjectsWithAllNames(setOf("SampleObject1", "SampleObject2")) shouldBeEqualTo false
             hasObject { it.name == "SampleObject" } shouldBeEqualTo false
             hasAllObjects { it.hasNameStartingWith("Sample") } shouldBeEqualTo true
         }
@@ -39,11 +47,25 @@ class KoFileDeclarationForKoObjectProviderTest {
         // then
         assertSoftly(sut) {
             hasObjects() shouldBeEqualTo true
+            hasObjectWithName(emptyList()) shouldBeEqualTo true
+            hasObjectWithName(emptySet()) shouldBeEqualTo true
+            hasObjectsWithAllNames(emptyList()) shouldBeEqualTo true
+            hasObjectsWithAllNames(emptySet()) shouldBeEqualTo true
             hasObjectWithName("SampleObject1") shouldBeEqualTo true
             hasObjectWithName("SampleObject1", "OtherObject") shouldBeEqualTo true
+            hasObjectWithName(listOf("SampleObject1")) shouldBeEqualTo true
+            hasObjectWithName(listOf("SampleObject1", "OtherObject")) shouldBeEqualTo true
+            hasObjectWithName(setOf("SampleObject1")) shouldBeEqualTo true
+            hasObjectWithName(setOf("SampleObject1", "OtherObject")) shouldBeEqualTo true
             hasObjectsWithAllNames("SampleObject1") shouldBeEqualTo true
             hasObjectsWithAllNames("SampleObject1", "SampleObject2") shouldBeEqualTo true
             hasObjectsWithAllNames("SampleObject1", "OtherObject") shouldBeEqualTo false
+            hasObjectsWithAllNames(listOf("SampleObject1")) shouldBeEqualTo true
+            hasObjectsWithAllNames(listOf("SampleObject1", "SampleObject2")) shouldBeEqualTo true
+            hasObjectsWithAllNames(listOf("SampleObject1", "OtherObject")) shouldBeEqualTo false
+            hasObjectsWithAllNames(setOf("SampleObject1")) shouldBeEqualTo true
+            hasObjectsWithAllNames(setOf("SampleObject1", "SampleObject2")) shouldBeEqualTo true
+            hasObjectsWithAllNames(setOf("SampleObject1", "OtherObject")) shouldBeEqualTo false
             hasObject { it.name == "SampleObject1" } shouldBeEqualTo true
             hasObject { it.hasNameEndingWith("Object1") } shouldBeEqualTo true
             hasAllObjects { it.hasNameStartingWith("Sample") } shouldBeEqualTo true

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/kofile/KoFileDeclarationForKoPropertyProviderTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/kofile/KoFileDeclarationForKoPropertyProviderTest.kt
@@ -21,8 +21,16 @@ class KoFileDeclarationForKoPropertyProviderTest {
         assertSoftly(sut) {
             properties() shouldBeEqualTo emptyList()
             hasProperties() shouldBeEqualTo false
+            hasPropertyWithName(emptyList()) shouldBeEqualTo false
+            hasPropertyWithName(emptySet()) shouldBeEqualTo false
+            hasPropertiesWithAllNames(emptyList()) shouldBeEqualTo false
+            hasPropertiesWithAllNames(emptySet()) shouldBeEqualTo false
             hasPropertyWithName("sampleProperty") shouldBeEqualTo false
+            hasPropertyWithName(listOf("sampleProperty")) shouldBeEqualTo false
+            hasPropertyWithName(setOf("sampleProperty")) shouldBeEqualTo false
             hasPropertiesWithAllNames("sampleProperty1", "sampleProperty2") shouldBeEqualTo false
+            hasPropertiesWithAllNames(listOf("sampleProperty1", "sampleProperty2")) shouldBeEqualTo false
+            hasPropertiesWithAllNames(setOf("sampleProperty1", "sampleProperty2")) shouldBeEqualTo false
             hasProperty { it.name == "sampleProperty" } shouldBeEqualTo false
             hasAllProperties { it.hasNameStartingWith("sample") } shouldBeEqualTo true
         }
@@ -39,11 +47,25 @@ class KoFileDeclarationForKoPropertyProviderTest {
         // then
         assertSoftly(sut) {
             hasProperties() shouldBeEqualTo true
+            hasPropertyWithName(emptyList()) shouldBeEqualTo true
+            hasPropertyWithName(emptySet()) shouldBeEqualTo true
+            hasPropertiesWithAllNames(emptyList()) shouldBeEqualTo true
+            hasPropertiesWithAllNames(emptySet()) shouldBeEqualTo true
             hasPropertyWithName("sampleProperty1") shouldBeEqualTo true
             hasPropertyWithName("sampleProperty1", "otherProperty") shouldBeEqualTo true
+            hasPropertyWithName(listOf("sampleProperty1")) shouldBeEqualTo true
+            hasPropertyWithName(listOf("sampleProperty1", "otherProperty")) shouldBeEqualTo true
+            hasPropertyWithName(setOf("sampleProperty1")) shouldBeEqualTo true
+            hasPropertyWithName(setOf("sampleProperty1", "otherProperty")) shouldBeEqualTo true
             hasPropertiesWithAllNames("sampleProperty1") shouldBeEqualTo true
             hasPropertiesWithAllNames("sampleProperty1", "sampleProperty2") shouldBeEqualTo true
             hasPropertiesWithAllNames("sampleProperty1", "otherProperty") shouldBeEqualTo false
+            hasPropertiesWithAllNames(listOf("sampleProperty1")) shouldBeEqualTo true
+            hasPropertiesWithAllNames(listOf("sampleProperty1", "sampleProperty2")) shouldBeEqualTo true
+            hasPropertiesWithAllNames(listOf("sampleProperty1", "otherProperty")) shouldBeEqualTo false
+            hasPropertiesWithAllNames(setOf("sampleProperty1")) shouldBeEqualTo true
+            hasPropertiesWithAllNames(setOf("sampleProperty1", "sampleProperty2")) shouldBeEqualTo true
+            hasPropertiesWithAllNames(setOf("sampleProperty1", "otherProperty")) shouldBeEqualTo false
             hasProperty { it.name == "sampleProperty1" } shouldBeEqualTo true
             hasProperty { it.hasNameEndingWith("Property1") } shouldBeEqualTo true
             hasAllProperties { it.hasNameStartingWith("sample") } shouldBeEqualTo true

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/kofile/KoFileDeclarationForKoTypeAliasProviderTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/kofile/KoFileDeclarationForKoTypeAliasProviderTest.kt
@@ -20,8 +20,16 @@ class KoFileDeclarationForKoTypeAliasProviderTest {
             numTypeAliases shouldBeEqualTo 0
             countTypeAliases { it.hasPrivateModifier } shouldBeEqualTo 0
             hasTypeAliases() shouldBeEqualTo false
+            hasTypeAliasWithName(emptyList()) shouldBeEqualTo false
+            hasTypeAliasWithName(emptySet()) shouldBeEqualTo false
+            hasTypeAliasesWithAllNames(emptyList()) shouldBeEqualTo false
+            hasTypeAliasesWithAllNames(emptySet()) shouldBeEqualTo false
             hasTypeAliasWithName("SampleTypeAlias") shouldBeEqualTo false
+            hasTypeAliasWithName(listOf("SampleTypeAlias")) shouldBeEqualTo false
+            hasTypeAliasWithName(setOf("SampleTypeAlias")) shouldBeEqualTo false
             hasTypeAliasesWithAllNames("SampleTypeAlias1", "SampleTypeAlias2") shouldBeEqualTo false
+            hasTypeAliasesWithAllNames(listOf("SampleTypeAlias1", "SampleTypeAlias2")) shouldBeEqualTo false
+            hasTypeAliasesWithAllNames(setOf("SampleTypeAlias1", "SampleTypeAlias2")) shouldBeEqualTo false
             hasTypeAlias { it.hasPublicModifier } shouldBeEqualTo false
             hasAllTypeAliases { it.hasPublicOrDefaultModifier } shouldBeEqualTo true
             hasTypeAliases("SampleTypeAlias") shouldBeEqualTo false
@@ -42,11 +50,25 @@ class KoFileDeclarationForKoTypeAliasProviderTest {
             numTypeAliases shouldBeEqualTo 1
             countTypeAliases { it.hasPublicOrDefaultModifier } shouldBeEqualTo 1
             hasTypeAliases() shouldBeEqualTo true
+            hasTypeAliasWithName(emptyList()) shouldBeEqualTo true
+            hasTypeAliasWithName(emptySet()) shouldBeEqualTo true
+            hasTypeAliasesWithAllNames(emptyList()) shouldBeEqualTo true
+            hasTypeAliasesWithAllNames(emptySet()) shouldBeEqualTo true
             hasTypeAliasWithName("SampleTypeAlias") shouldBeEqualTo true
             hasTypeAliasWithName("otherTypeAlias") shouldBeEqualTo false
             hasTypeAliasWithName("SampleTypeAlias", "otherTypeAlias") shouldBeEqualTo true
+            hasTypeAliasWithName(listOf("SampleTypeAlias")) shouldBeEqualTo true
+            hasTypeAliasWithName(listOf("otherTypeAlias")) shouldBeEqualTo false
+            hasTypeAliasWithName(listOf("SampleTypeAlias", "otherTypeAlias")) shouldBeEqualTo true
+            hasTypeAliasWithName(setOf("SampleTypeAlias")) shouldBeEqualTo true
+            hasTypeAliasWithName(setOf("otherTypeAlias")) shouldBeEqualTo false
+            hasTypeAliasWithName(setOf("SampleTypeAlias", "otherTypeAlias")) shouldBeEqualTo true
             hasTypeAliasesWithAllNames("SampleTypeAlias") shouldBeEqualTo true
             hasTypeAliasesWithAllNames("SampleTypeAlias", "otherTypeAlias") shouldBeEqualTo false
+            hasTypeAliasesWithAllNames(listOf("SampleTypeAlias")) shouldBeEqualTo true
+            hasTypeAliasesWithAllNames(listOf("SampleTypeAlias", "otherTypeAlias")) shouldBeEqualTo false
+            hasTypeAliasesWithAllNames(setOf("SampleTypeAlias")) shouldBeEqualTo true
+            hasTypeAliasesWithAllNames(setOf("SampleTypeAlias", "otherTypeAlias")) shouldBeEqualTo false
             hasTypeAlias { it.hasPublicOrDefaultModifier } shouldBeEqualTo true
             hasTypeAlias { it.hasPublicModifier } shouldBeEqualTo false
             hasAllTypeAliases { it.hasPublicOrDefaultModifier } shouldBeEqualTo true
@@ -67,12 +89,28 @@ class KoFileDeclarationForKoTypeAliasProviderTest {
             countTypeAliases { it.hasNameStartingWith("Sample") } shouldBeEqualTo 2
             countTypeAliases { it.name == "SampleTypeAlias1" } shouldBeEqualTo 1
             hasTypeAliases() shouldBeEqualTo true
+            hasTypeAliasWithName(emptyList()) shouldBeEqualTo true
+            hasTypeAliasWithName(emptySet()) shouldBeEqualTo true
+            hasTypeAliasesWithAllNames(emptyList()) shouldBeEqualTo true
+            hasTypeAliasesWithAllNames(emptySet()) shouldBeEqualTo true
             hasTypeAliasWithName("SampleTypeAlias1") shouldBeEqualTo true
             hasTypeAliasWithName("otherTypeAlias") shouldBeEqualTo false
             hasTypeAliasWithName("SampleTypeAlias1", "otherName") shouldBeEqualTo true
+            hasTypeAliasWithName(listOf("SampleTypeAlias1")) shouldBeEqualTo true
+            hasTypeAliasWithName(listOf("otherTypeAlias")) shouldBeEqualTo false
+            hasTypeAliasWithName(listOf("SampleTypeAlias1", "otherName")) shouldBeEqualTo true
+            hasTypeAliasWithName(setOf("SampleTypeAlias1")) shouldBeEqualTo true
+            hasTypeAliasWithName(setOf("otherTypeAlias")) shouldBeEqualTo false
+            hasTypeAliasWithName(setOf("SampleTypeAlias1", "otherName")) shouldBeEqualTo true
             hasTypeAliasesWithAllNames("SampleTypeAlias1") shouldBeEqualTo true
             hasTypeAliasesWithAllNames("SampleTypeAlias1", "SampleTypeAlias2") shouldBeEqualTo true
             hasTypeAliasesWithAllNames("SampleTypeAlias1", "otherTypeAlias") shouldBeEqualTo false
+            hasTypeAliasesWithAllNames(listOf("SampleTypeAlias1")) shouldBeEqualTo true
+            hasTypeAliasesWithAllNames(listOf("SampleTypeAlias1", "SampleTypeAlias2")) shouldBeEqualTo true
+            hasTypeAliasesWithAllNames(listOf("SampleTypeAlias1", "otherTypeAlias")) shouldBeEqualTo false
+            hasTypeAliasesWithAllNames(setOf("SampleTypeAlias1")) shouldBeEqualTo true
+            hasTypeAliasesWithAllNames(setOf("SampleTypeAlias1", "SampleTypeAlias2")) shouldBeEqualTo true
+            hasTypeAliasesWithAllNames(setOf("SampleTypeAlias1", "otherTypeAlias")) shouldBeEqualTo false
             hasTypeAlias { it.hasPublicOrDefaultModifier } shouldBeEqualTo true
             hasTypeAlias { it.hasPublicModifier } shouldBeEqualTo true
             hasAllTypeAliases { it.hasPublicOrDefaultModifier } shouldBeEqualTo true

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/kofunction/KoFunctionDeclarationForKoAnnotationProviderTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/kofunction/KoFunctionDeclarationForKoAnnotationProviderTest.kt
@@ -24,12 +24,28 @@ class KoFunctionDeclarationForKoAnnotationProviderTest {
             numAnnotations shouldBeEqualTo 0
             countAnnotations { it.name == "NonExistingAnnotation" } shouldBeEqualTo 0
             hasAnnotations() shouldBeEqualTo false
+            hasAnnotationWithName(emptyList()) shouldBeEqualTo false
+            hasAnnotationWithName(emptySet()) shouldBeEqualTo false
+            hasAnnotationsWithAllNames(emptyList()) shouldBeEqualTo false
+            hasAnnotationsWithAllNames(emptySet()) shouldBeEqualTo false
             hasAnnotationWithName("SampleAnnotation") shouldBeEqualTo false
+            hasAnnotationWithName(listOf("SampleAnnotation")) shouldBeEqualTo false
+            hasAnnotationWithName(setOf("SampleAnnotation")) shouldBeEqualTo false
             hasAnnotationsWithAllNames("SampleAnnotation1", "SampleAnnotation2") shouldBeEqualTo false
+            hasAnnotationsWithAllNames(listOf("SampleAnnotation1", "SampleAnnotation2")) shouldBeEqualTo false
+            hasAnnotationsWithAllNames(setOf("SampleAnnotation1", "SampleAnnotation2")) shouldBeEqualTo false
             hasAnnotation { it.hasArguments() } shouldBeEqualTo false
             hasAllAnnotations { it.hasArguments() } shouldBeEqualTo true
+            hasAnnotationOf(emptyList()) shouldBeEqualTo false
+            hasAnnotationOf(emptySet()) shouldBeEqualTo false
+            hasAllAnnotationsOf(emptyList()) shouldBeEqualTo false
+            hasAllAnnotationsOf(emptySet()) shouldBeEqualTo false
             hasAnnotationOf(SampleAnnotation::class) shouldBeEqualTo false
+            hasAnnotationOf(listOf(SampleAnnotation::class)) shouldBeEqualTo false
+            hasAnnotationOf(setOf(SampleAnnotation::class)) shouldBeEqualTo false
             hasAllAnnotationsOf(SampleAnnotation1::class, SampleAnnotation2::class) shouldBeEqualTo false
+            hasAllAnnotationsOf(listOf(SampleAnnotation1::class, SampleAnnotation2::class)) shouldBeEqualTo false
+            hasAllAnnotationsOf(setOf(SampleAnnotation1::class, SampleAnnotation2::class)) shouldBeEqualTo false
             hasAnnotations("SampleAnnotation") shouldBeEqualTo false
         }
     }
@@ -48,6 +64,10 @@ class KoFunctionDeclarationForKoAnnotationProviderTest {
             countAnnotations { it.name == "SampleAnnotation" } shouldBeEqualTo 1
             countAnnotations { it.name == "NonExistingAnnotation" } shouldBeEqualTo 0
             hasAnnotations() shouldBeEqualTo true
+            hasAnnotationWithName(emptyList()) shouldBeEqualTo true
+            hasAnnotationWithName(emptySet()) shouldBeEqualTo true
+            hasAnnotationsWithAllNames(emptyList()) shouldBeEqualTo true
+            hasAnnotationsWithAllNames(emptySet()) shouldBeEqualTo true
             hasAnnotationWithName("SampleAnnotation") shouldBeEqualTo true
             hasAnnotationWithName("OtherAnnotation") shouldBeEqualTo false
             hasAnnotationWithName("SampleAnnotation", "OtherAnnotation") shouldBeEqualTo true
@@ -57,6 +77,24 @@ class KoFunctionDeclarationForKoAnnotationProviderTest {
                 "com.lemonappdev.konsist.testdata.SampleAnnotation",
                 "com.lemonappdev.konsist.testdata.NonExistingAnnotation",
             ).shouldBeEqualTo(true)
+            hasAnnotationWithName(listOf("SampleAnnotation")) shouldBeEqualTo true
+            hasAnnotationWithName(listOf("OtherAnnotation")) shouldBeEqualTo false
+            hasAnnotationWithName(listOf("SampleAnnotation", "OtherAnnotation")) shouldBeEqualTo true
+            hasAnnotationWithName(listOf("com.lemonappdev.konsist.testdata.SampleAnnotation")) shouldBeEqualTo true
+            hasAnnotationWithName(listOf("com.lemonappdev.konsist.testdata.NonExistingAnnotation")) shouldBeEqualTo false
+            hasAnnotationWithName(listOf(
+                "com.lemonappdev.konsist.testdata.SampleAnnotation",
+                "com.lemonappdev.konsist.testdata.NonExistingAnnotation",
+            )).shouldBeEqualTo(true)
+            hasAnnotationWithName(setOf("SampleAnnotation")) shouldBeEqualTo true
+            hasAnnotationWithName(setOf("OtherAnnotation")) shouldBeEqualTo false
+            hasAnnotationWithName(setOf("SampleAnnotation", "OtherAnnotation")) shouldBeEqualTo true
+            hasAnnotationWithName(setOf("com.lemonappdev.konsist.testdata.SampleAnnotation")) shouldBeEqualTo true
+            hasAnnotationWithName(setOf("com.lemonappdev.konsist.testdata.NonExistingAnnotation")) shouldBeEqualTo false
+            hasAnnotationWithName(setOf(
+                "com.lemonappdev.konsist.testdata.SampleAnnotation",
+                "com.lemonappdev.konsist.testdata.NonExistingAnnotation",
+            )).shouldBeEqualTo(true)
             hasAnnotationsWithAllNames("SampleAnnotation") shouldBeEqualTo true
             hasAnnotationsWithAllNames("SampleAnnotation", "OtherAnnotation") shouldBeEqualTo false
             hasAnnotationsWithAllNames("com.lemonappdev.konsist.testdata.SampleAnnotation") shouldBeEqualTo true
@@ -64,15 +102,35 @@ class KoFunctionDeclarationForKoAnnotationProviderTest {
                 "com.lemonappdev.konsist.testdata.SampleAnnotation",
                 "com.lemonappdev.konsist.testdata.NonExistingAnnotation",
             ).shouldBeEqualTo(false)
+            hasAnnotationsWithAllNames(listOf("SampleAnnotation")) shouldBeEqualTo true
+            hasAnnotationsWithAllNames(listOf("SampleAnnotation", "OtherAnnotation")) shouldBeEqualTo false
+            hasAnnotationsWithAllNames(listOf("com.lemonappdev.konsist.testdata.SampleAnnotation")) shouldBeEqualTo true
+            hasAnnotationsWithAllNames(listOf(
+                "com.lemonappdev.konsist.testdata.SampleAnnotation",
+                "com.lemonappdev.konsist.testdata.NonExistingAnnotation",
+            )).shouldBeEqualTo(false)
             hasAnnotation { it.hasNameStartingWith("Sample") } shouldBeEqualTo true
             hasAnnotation { it.hasNameStartingWith("Other") } shouldBeEqualTo false
             hasAllAnnotations { it.hasNameStartingWith("Sample") } shouldBeEqualTo true
-            hasAnnotationOf(SampleAnnotation::class) shouldBeEqualTo true
-            hasAnnotationOf(NonExistingAnnotation::class) shouldBeEqualTo false
-            hasAnnotationOf(SampleAnnotation::class, NonExistingAnnotation::class) shouldBeEqualTo true
+            hasAnnotationOf(emptyList()) shouldBeEqualTo true
+            hasAnnotationOf(emptySet()) shouldBeEqualTo true
+            hasAllAnnotationsOf(emptyList()) shouldBeEqualTo true
+            hasAllAnnotationsOf(emptySet()) shouldBeEqualTo true
+            hasAnnotationOf(listOf(SampleAnnotation::class)) shouldBeEqualTo true
+            hasAnnotationOf(listOf(NonExistingAnnotation::class)) shouldBeEqualTo false
+            hasAnnotationOf(listOf(SampleAnnotation::class, NonExistingAnnotation::class)) shouldBeEqualTo true
+            hasAnnotationOf(setOf(SampleAnnotation::class)) shouldBeEqualTo true
+            hasAnnotationOf(setOf(NonExistingAnnotation::class)) shouldBeEqualTo false
+            hasAnnotationOf(setOf(SampleAnnotation::class, NonExistingAnnotation::class)) shouldBeEqualTo true
             hasAllAnnotationsOf(SampleAnnotation::class) shouldBeEqualTo true
             hasAllAnnotationsOf(NonExistingAnnotation::class) shouldBeEqualTo false
             hasAllAnnotationsOf(SampleAnnotation::class, NonExistingAnnotation::class) shouldBeEqualTo false
+            hasAllAnnotationsOf(listOf(SampleAnnotation::class)) shouldBeEqualTo true
+            hasAllAnnotationsOf(listOf(NonExistingAnnotation::class)) shouldBeEqualTo false
+            hasAllAnnotationsOf(listOf(SampleAnnotation::class, NonExistingAnnotation::class)) shouldBeEqualTo false
+            hasAllAnnotationsOf(setOf(SampleAnnotation::class)) shouldBeEqualTo true
+            hasAllAnnotationsOf(setOf(NonExistingAnnotation::class)) shouldBeEqualTo false
+            hasAllAnnotationsOf(setOf(SampleAnnotation::class, NonExistingAnnotation::class)) shouldBeEqualTo false
             hasAnnotations("SampleAnnotation") shouldBeEqualTo true
             hasAnnotations("NonExistingAnnotation") shouldBeEqualTo false
             hasAnnotations("com.lemonappdev.konsist.testdata.SampleAnnotation") shouldBeEqualTo true
@@ -96,6 +154,10 @@ class KoFunctionDeclarationForKoAnnotationProviderTest {
             countAnnotations { it.hasNameStartingWith("Sample") } shouldBeEqualTo 2
             countAnnotations { it.name == "SampleAnnotation1" } shouldBeEqualTo 1
             hasAnnotations() shouldBeEqualTo true
+            hasAnnotationOf(emptyList()) shouldBeEqualTo true
+            hasAnnotationOf(emptySet()) shouldBeEqualTo true
+            hasAllAnnotationsOf(emptyList()) shouldBeEqualTo true
+            hasAllAnnotationsOf(emptySet()) shouldBeEqualTo true
             hasAnnotationWithName("SampleAnnotation1") shouldBeEqualTo true
             hasAnnotationWithName("OtherAnnotation") shouldBeEqualTo false
             hasAnnotationWithName("SampleAnnotation1", "OtherAnnotation") shouldBeEqualTo true
@@ -105,6 +167,24 @@ class KoFunctionDeclarationForKoAnnotationProviderTest {
                 "com.lemonappdev.konsist.testdata.SampleAnnotation1",
                 "com.lemonappdev.konsist.testdata.NonExistingAnnotation",
             ).shouldBeEqualTo(true)
+            hasAnnotationWithName(listOf("SampleAnnotation1")) shouldBeEqualTo true
+            hasAnnotationWithName(listOf("OtherAnnotation")) shouldBeEqualTo false
+            hasAnnotationWithName(listOf("SampleAnnotation1", "OtherAnnotation")) shouldBeEqualTo true
+            hasAnnotationWithName(listOf("com.lemonappdev.konsist.testdata.SampleAnnotation1")) shouldBeEqualTo true
+            hasAnnotationWithName(listOf("com.lemonappdev.konsist.testdata.NonExistingAnnotation")) shouldBeEqualTo false
+            hasAnnotationWithName(listOf(
+                "com.lemonappdev.konsist.testdata.SampleAnnotation1",
+                "com.lemonappdev.konsist.testdata.NonExistingAnnotation",
+            )).shouldBeEqualTo(true)
+            hasAnnotationWithName(setOf("SampleAnnotation1")) shouldBeEqualTo true
+            hasAnnotationWithName(setOf("OtherAnnotation")) shouldBeEqualTo false
+            hasAnnotationWithName(setOf("SampleAnnotation1", "OtherAnnotation")) shouldBeEqualTo true
+            hasAnnotationWithName(setOf("com.lemonappdev.konsist.testdata.SampleAnnotation1")) shouldBeEqualTo true
+            hasAnnotationWithName(setOf("com.lemonappdev.konsist.testdata.NonExistingAnnotation")) shouldBeEqualTo false
+            hasAnnotationWithName(setOf(
+                "com.lemonappdev.konsist.testdata.SampleAnnotation1",
+                "com.lemonappdev.konsist.testdata.NonExistingAnnotation",
+            )).shouldBeEqualTo(true)
             hasAnnotationsWithAllNames("SampleAnnotation1") shouldBeEqualTo true
             hasAnnotationsWithAllNames("SampleAnnotation1", "SampleAnnotation2") shouldBeEqualTo true
             hasAnnotationsWithAllNames("SampleAnnotation1", "OtherAnnotation") shouldBeEqualTo false
@@ -117,17 +197,48 @@ class KoFunctionDeclarationForKoAnnotationProviderTest {
                 "com.lemonappdev.konsist.testdata.SampleAnnotation1",
                 "com.lemonappdev.konsist.testdata.SampleAnnotation2",
             ).shouldBeEqualTo(true)
+
+            hasAnnotationsWithAllNames(listOf("SampleAnnotation1")) shouldBeEqualTo true
+            hasAnnotationsWithAllNames(listOf("SampleAnnotation1", "SampleAnnotation2")) shouldBeEqualTo true
+            hasAnnotationsWithAllNames(listOf("SampleAnnotation1", "OtherAnnotation")) shouldBeEqualTo false
+            hasAnnotationsWithAllNames(listOf("com.lemonappdev.konsist.testdata.SampleAnnotation1")) shouldBeEqualTo true
+            hasAnnotationsWithAllNames(listOf(
+                "com.lemonappdev.konsist.testdata.SampleAnnotation1",
+                "com.lemonappdev.konsist.testdata.NonExistingAnnotation",
+            )).shouldBeEqualTo(false)
+            hasAnnotationsWithAllNames(listOf(
+                "com.lemonappdev.konsist.testdata.SampleAnnotation1",
+                "com.lemonappdev.konsist.testdata.SampleAnnotation2",
+            )).shouldBeEqualTo(true)
             hasAnnotation { it.name == "SampleAnnotation1" } shouldBeEqualTo true
             hasAnnotation { it.name == "OtherAnnotation1" } shouldBeEqualTo false
             hasAllAnnotations { !it.hasArguments() } shouldBeEqualTo true
             hasAllAnnotations { it.hasNameEndingWith("tion1") } shouldBeEqualTo false
+            hasAnnotationOf(emptyList()) shouldBeEqualTo true
+            hasAnnotationOf(emptySet()) shouldBeEqualTo true
+            hasAllAnnotationsOf(emptyList()) shouldBeEqualTo true
+            hasAllAnnotationsOf(emptySet()) shouldBeEqualTo true
             hasAnnotationOf(SampleAnnotation1::class) shouldBeEqualTo true
             hasAnnotationOf(NonExistingAnnotation::class) shouldBeEqualTo false
             hasAnnotationOf(SampleAnnotation1::class, NonExistingAnnotation::class) shouldBeEqualTo true
+            hasAnnotationOf(listOf(SampleAnnotation1::class)) shouldBeEqualTo true
+            hasAnnotationOf(listOf(NonExistingAnnotation::class)) shouldBeEqualTo false
+            hasAnnotationOf(listOf(SampleAnnotation1::class, NonExistingAnnotation::class)) shouldBeEqualTo true
+            hasAnnotationOf(setOf(SampleAnnotation1::class)) shouldBeEqualTo true
+            hasAnnotationOf(setOf(NonExistingAnnotation::class)) shouldBeEqualTo false
+            hasAnnotationOf(setOf(SampleAnnotation1::class, NonExistingAnnotation::class)) shouldBeEqualTo true
             hasAllAnnotationsOf(SampleAnnotation1::class) shouldBeEqualTo true
             hasAllAnnotationsOf(NonExistingAnnotation::class) shouldBeEqualTo false
             hasAllAnnotationsOf(SampleAnnotation1::class, SampleAnnotation2::class) shouldBeEqualTo true
             hasAllAnnotationsOf(SampleAnnotation1::class, NonExistingAnnotation::class) shouldBeEqualTo false
+            hasAllAnnotationsOf(listOf(SampleAnnotation1::class)) shouldBeEqualTo true
+            hasAllAnnotationsOf(listOf(NonExistingAnnotation::class)) shouldBeEqualTo false
+            hasAllAnnotationsOf(listOf(SampleAnnotation1::class, SampleAnnotation2::class)) shouldBeEqualTo true
+            hasAllAnnotationsOf(listOf(SampleAnnotation1::class, NonExistingAnnotation::class)) shouldBeEqualTo false
+            hasAllAnnotationsOf(setOf(SampleAnnotation1::class)) shouldBeEqualTo true
+            hasAllAnnotationsOf(setOf(NonExistingAnnotation::class)) shouldBeEqualTo false
+            hasAllAnnotationsOf(setOf(SampleAnnotation1::class, SampleAnnotation2::class)) shouldBeEqualTo true
+            hasAllAnnotationsOf(setOf(SampleAnnotation1::class, NonExistingAnnotation::class)) shouldBeEqualTo false
             hasAnnotations("SampleAnnotation1") shouldBeEqualTo true
             hasAnnotations("SampleAnnotation2") shouldBeEqualTo true
             hasAnnotations("NonExistingAnnotation") shouldBeEqualTo false

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/kofunction/KoFunctionDeclarationForKoAnnotationProviderTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/kofunction/KoFunctionDeclarationForKoAnnotationProviderTest.kt
@@ -9,6 +9,7 @@ import org.amshove.kluent.assertSoftly
 import org.amshove.kluent.shouldBeEqualTo
 import org.junit.jupiter.api.Test
 
+@Suppress("detekt.LongMethod")
 class KoFunctionDeclarationForKoAnnotationProviderTest {
     @Test
     fun `function-has-no-annotation`() {
@@ -82,19 +83,23 @@ class KoFunctionDeclarationForKoAnnotationProviderTest {
             hasAnnotationWithName(listOf("SampleAnnotation", "OtherAnnotation")) shouldBeEqualTo true
             hasAnnotationWithName(listOf("com.lemonappdev.konsist.testdata.SampleAnnotation")) shouldBeEqualTo true
             hasAnnotationWithName(listOf("com.lemonappdev.konsist.testdata.NonExistingAnnotation")) shouldBeEqualTo false
-            hasAnnotationWithName(listOf(
-                "com.lemonappdev.konsist.testdata.SampleAnnotation",
-                "com.lemonappdev.konsist.testdata.NonExistingAnnotation",
-            )).shouldBeEqualTo(true)
+            hasAnnotationWithName(
+                listOf(
+                    "com.lemonappdev.konsist.testdata.SampleAnnotation",
+                    "com.lemonappdev.konsist.testdata.NonExistingAnnotation",
+                ),
+            ).shouldBeEqualTo(true)
             hasAnnotationWithName(setOf("SampleAnnotation")) shouldBeEqualTo true
             hasAnnotationWithName(setOf("OtherAnnotation")) shouldBeEqualTo false
             hasAnnotationWithName(setOf("SampleAnnotation", "OtherAnnotation")) shouldBeEqualTo true
             hasAnnotationWithName(setOf("com.lemonappdev.konsist.testdata.SampleAnnotation")) shouldBeEqualTo true
             hasAnnotationWithName(setOf("com.lemonappdev.konsist.testdata.NonExistingAnnotation")) shouldBeEqualTo false
-            hasAnnotationWithName(setOf(
-                "com.lemonappdev.konsist.testdata.SampleAnnotation",
-                "com.lemonappdev.konsist.testdata.NonExistingAnnotation",
-            )).shouldBeEqualTo(true)
+            hasAnnotationWithName(
+                setOf(
+                    "com.lemonappdev.konsist.testdata.SampleAnnotation",
+                    "com.lemonappdev.konsist.testdata.NonExistingAnnotation",
+                ),
+            ).shouldBeEqualTo(true)
             hasAnnotationsWithAllNames("SampleAnnotation") shouldBeEqualTo true
             hasAnnotationsWithAllNames("SampleAnnotation", "OtherAnnotation") shouldBeEqualTo false
             hasAnnotationsWithAllNames("com.lemonappdev.konsist.testdata.SampleAnnotation") shouldBeEqualTo true
@@ -105,10 +110,12 @@ class KoFunctionDeclarationForKoAnnotationProviderTest {
             hasAnnotationsWithAllNames(listOf("SampleAnnotation")) shouldBeEqualTo true
             hasAnnotationsWithAllNames(listOf("SampleAnnotation", "OtherAnnotation")) shouldBeEqualTo false
             hasAnnotationsWithAllNames(listOf("com.lemonappdev.konsist.testdata.SampleAnnotation")) shouldBeEqualTo true
-            hasAnnotationsWithAllNames(listOf(
-                "com.lemonappdev.konsist.testdata.SampleAnnotation",
-                "com.lemonappdev.konsist.testdata.NonExistingAnnotation",
-            )).shouldBeEqualTo(false)
+            hasAnnotationsWithAllNames(
+                listOf(
+                    "com.lemonappdev.konsist.testdata.SampleAnnotation",
+                    "com.lemonappdev.konsist.testdata.NonExistingAnnotation",
+                ),
+            ).shouldBeEqualTo(false)
             hasAnnotation { it.hasNameStartingWith("Sample") } shouldBeEqualTo true
             hasAnnotation { it.hasNameStartingWith("Other") } shouldBeEqualTo false
             hasAllAnnotations { it.hasNameStartingWith("Sample") } shouldBeEqualTo true
@@ -172,19 +179,23 @@ class KoFunctionDeclarationForKoAnnotationProviderTest {
             hasAnnotationWithName(listOf("SampleAnnotation1", "OtherAnnotation")) shouldBeEqualTo true
             hasAnnotationWithName(listOf("com.lemonappdev.konsist.testdata.SampleAnnotation1")) shouldBeEqualTo true
             hasAnnotationWithName(listOf("com.lemonappdev.konsist.testdata.NonExistingAnnotation")) shouldBeEqualTo false
-            hasAnnotationWithName(listOf(
-                "com.lemonappdev.konsist.testdata.SampleAnnotation1",
-                "com.lemonappdev.konsist.testdata.NonExistingAnnotation",
-            )).shouldBeEqualTo(true)
+            hasAnnotationWithName(
+                listOf(
+                    "com.lemonappdev.konsist.testdata.SampleAnnotation1",
+                    "com.lemonappdev.konsist.testdata.NonExistingAnnotation",
+                ),
+            ).shouldBeEqualTo(true)
             hasAnnotationWithName(setOf("SampleAnnotation1")) shouldBeEqualTo true
             hasAnnotationWithName(setOf("OtherAnnotation")) shouldBeEqualTo false
             hasAnnotationWithName(setOf("SampleAnnotation1", "OtherAnnotation")) shouldBeEqualTo true
             hasAnnotationWithName(setOf("com.lemonappdev.konsist.testdata.SampleAnnotation1")) shouldBeEqualTo true
             hasAnnotationWithName(setOf("com.lemonappdev.konsist.testdata.NonExistingAnnotation")) shouldBeEqualTo false
-            hasAnnotationWithName(setOf(
-                "com.lemonappdev.konsist.testdata.SampleAnnotation1",
-                "com.lemonappdev.konsist.testdata.NonExistingAnnotation",
-            )).shouldBeEqualTo(true)
+            hasAnnotationWithName(
+                setOf(
+                    "com.lemonappdev.konsist.testdata.SampleAnnotation1",
+                    "com.lemonappdev.konsist.testdata.NonExistingAnnotation",
+                ),
+            ).shouldBeEqualTo(true)
             hasAnnotationsWithAllNames("SampleAnnotation1") shouldBeEqualTo true
             hasAnnotationsWithAllNames("SampleAnnotation1", "SampleAnnotation2") shouldBeEqualTo true
             hasAnnotationsWithAllNames("SampleAnnotation1", "OtherAnnotation") shouldBeEqualTo false
@@ -202,14 +213,18 @@ class KoFunctionDeclarationForKoAnnotationProviderTest {
             hasAnnotationsWithAllNames(listOf("SampleAnnotation1", "SampleAnnotation2")) shouldBeEqualTo true
             hasAnnotationsWithAllNames(listOf("SampleAnnotation1", "OtherAnnotation")) shouldBeEqualTo false
             hasAnnotationsWithAllNames(listOf("com.lemonappdev.konsist.testdata.SampleAnnotation1")) shouldBeEqualTo true
-            hasAnnotationsWithAllNames(listOf(
-                "com.lemonappdev.konsist.testdata.SampleAnnotation1",
-                "com.lemonappdev.konsist.testdata.NonExistingAnnotation",
-            )).shouldBeEqualTo(false)
-            hasAnnotationsWithAllNames(listOf(
-                "com.lemonappdev.konsist.testdata.SampleAnnotation1",
-                "com.lemonappdev.konsist.testdata.SampleAnnotation2",
-            )).shouldBeEqualTo(true)
+            hasAnnotationsWithAllNames(
+                listOf(
+                    "com.lemonappdev.konsist.testdata.SampleAnnotation1",
+                    "com.lemonappdev.konsist.testdata.NonExistingAnnotation",
+                ),
+            ).shouldBeEqualTo(false)
+            hasAnnotationsWithAllNames(
+                listOf(
+                    "com.lemonappdev.konsist.testdata.SampleAnnotation1",
+                    "com.lemonappdev.konsist.testdata.SampleAnnotation2",
+                ),
+            ).shouldBeEqualTo(true)
             hasAnnotation { it.name == "SampleAnnotation1" } shouldBeEqualTo true
             hasAnnotation { it.name == "OtherAnnotation1" } shouldBeEqualTo false
             hasAllAnnotations { !it.hasArguments() } shouldBeEqualTo true

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/kofunction/KoFunctionDeclarationForKoLocalClassProviderTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/kofunction/KoFunctionDeclarationForKoLocalClassProviderTest.kt
@@ -20,8 +20,16 @@ class KoFunctionDeclarationForKoLocalClassProviderTest {
             numLocalClasses shouldBeEqualTo 0
             countLocalClasses { it.name == "SampleClass" } shouldBeEqualTo 0
             hasLocalClasses() shouldBeEqualTo false
+            hasLocalClassWithName(emptyList()) shouldBeEqualTo false
+            hasLocalClassWithName(emptySet()) shouldBeEqualTo false
+            hasLocalClassesWithAllNames(emptyList()) shouldBeEqualTo false
+            hasLocalClassesWithAllNames(emptySet()) shouldBeEqualTo false
             hasLocalClassWithName("SampleClass") shouldBeEqualTo false
+            hasLocalClassWithName(listOf("SampleClass")) shouldBeEqualTo false
+            hasLocalClassWithName(setOf("SampleClass")) shouldBeEqualTo false
             hasLocalClassesWithAllNames("SampleClass1", "SampleClass2") shouldBeEqualTo false
+            hasLocalClassesWithAllNames(listOf("SampleClass1", "SampleClass2")) shouldBeEqualTo false
+            hasLocalClassesWithAllNames(setOf("SampleClass1", "SampleClass2")) shouldBeEqualTo false
             hasLocalClass { it.name == "SampleClass" } shouldBeEqualTo false
             hasAllLocalClasses { it.name == "SampleClass" } shouldBeEqualTo true
             containsLocalClass { it.name == "SampleClass" } shouldBeEqualTo false
@@ -42,18 +50,34 @@ class KoFunctionDeclarationForKoLocalClassProviderTest {
             numLocalClasses shouldBeEqualTo 2
             countLocalClasses { it.name == "SampleClass1" } shouldBeEqualTo 1
             hasLocalClasses() shouldBeEqualTo true
+            hasLocalClassWithName(emptyList()) shouldBeEqualTo true
+            hasLocalClassWithName(emptySet()) shouldBeEqualTo true
+            hasLocalClassesWithAllNames(emptyList()) shouldBeEqualTo true
+            hasLocalClassesWithAllNames(emptySet()) shouldBeEqualTo true
             hasLocalClassWithName("SampleClass1") shouldBeEqualTo true
-            hasLocalClassWithName("OtherClass") shouldBeEqualTo false
-            hasLocalClassWithName("SampleClass1", "OtherClass") shouldBeEqualTo true
+            hasLocalClassWithName("OtherLocalClass") shouldBeEqualTo false
+            hasLocalClassWithName("SampleClass1", "OtherLocalClass") shouldBeEqualTo true
+            hasLocalClassWithName(listOf("SampleClass1")) shouldBeEqualTo true
+            hasLocalClassWithName(listOf("OtherLocalClass")) shouldBeEqualTo false
+            hasLocalClassWithName(listOf("SampleClass1", "OtherLocalClass")) shouldBeEqualTo true
+            hasLocalClassWithName(setOf("SampleClass1")) shouldBeEqualTo true
+            hasLocalClassWithName(setOf("OtherLocalClass")) shouldBeEqualTo false
+            hasLocalClassWithName(setOf("SampleClass1", "OtherLocalClass")) shouldBeEqualTo true
             hasLocalClassesWithAllNames("SampleClass1") shouldBeEqualTo true
             hasLocalClassesWithAllNames("SampleClass1", "SampleClass2") shouldBeEqualTo true
-            hasLocalClassesWithAllNames("SampleClass1", "OtherClass") shouldBeEqualTo false
+            hasLocalClassesWithAllNames("SampleClass1", "OtherLocalClass") shouldBeEqualTo false
+            hasLocalClassesWithAllNames(listOf("SampleClass1")) shouldBeEqualTo true
+            hasLocalClassesWithAllNames(listOf("SampleClass1", "SampleClass2")) shouldBeEqualTo true
+            hasLocalClassesWithAllNames(listOf("SampleClass1", "OtherLocalClass")) shouldBeEqualTo false
+            hasLocalClassesWithAllNames(setOf("SampleClass1")) shouldBeEqualTo true
+            hasLocalClassesWithAllNames(setOf("SampleClass1", "SampleClass2")) shouldBeEqualTo true
+            hasLocalClassesWithAllNames(setOf("SampleClass1", "OtherLocalClass")) shouldBeEqualTo false
             hasLocalClass { it.name == "SampleClass1" } shouldBeEqualTo true
-            hasLocalClass { it.name == "OtherClass" } shouldBeEqualTo false
+            hasLocalClass { it.name == "OtherLocalClass" } shouldBeEqualTo false
             hasAllLocalClasses { it.name.endsWith("2") || it.name == "SampleClass1" } shouldBeEqualTo true
             hasAllLocalClasses { it.name.endsWith("2") } shouldBeEqualTo false
             containsLocalClass { it.name == "SampleClass1" } shouldBeEqualTo true
-            containsLocalClass { it.name == "OtherClass" } shouldBeEqualTo false
+            containsLocalClass { it.name == "OtherLocalClass" } shouldBeEqualTo false
         }
     }
 

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/kofunction/KoFunctionDeclarationForKoLocalFunctionProviderTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/kofunction/KoFunctionDeclarationForKoLocalFunctionProviderTest.kt
@@ -20,8 +20,16 @@ class KoFunctionDeclarationForKoLocalFunctionProviderTest {
             numLocalFunctions shouldBeEqualTo 0
             countLocalFunctions { it.name == "sampleLocalFunction" } shouldBeEqualTo 0
             hasLocalFunctions() shouldBeEqualTo false
+            hasLocalFunctionWithName(emptyList()) shouldBeEqualTo false
+            hasLocalFunctionWithName(emptySet()) shouldBeEqualTo false
+            hasLocalFunctionsWithAllNames(emptyList()) shouldBeEqualTo false
+            hasLocalFunctionsWithAllNames(emptySet()) shouldBeEqualTo false
             hasLocalFunctionWithName("sampleLocalFunction") shouldBeEqualTo false
+            hasLocalFunctionWithName(listOf("sampleLocalFunction")) shouldBeEqualTo false
+            hasLocalFunctionWithName(setOf("sampleLocalFunction")) shouldBeEqualTo false
             hasLocalFunctionsWithAllNames("sampleLocalFunction1", "sampleLocalFunction2") shouldBeEqualTo false
+            hasLocalFunctionsWithAllNames(listOf("sampleLocalFunction1", "sampleLocalFunction2")) shouldBeEqualTo false
+            hasLocalFunctionsWithAllNames(setOf("sampleLocalFunction1", "sampleLocalFunction2")) shouldBeEqualTo false
             hasLocalFunction { it.name == "sampleLocalFunction" } shouldBeEqualTo false
             hasAllLocalFunctions { it.name == "sampleLocalFunction" } shouldBeEqualTo true
             containsLocalFunction { it.name == "sampleLocalFunction" } shouldBeEqualTo false
@@ -41,12 +49,28 @@ class KoFunctionDeclarationForKoLocalFunctionProviderTest {
             numLocalFunctions shouldBeEqualTo 2
             countLocalFunctions { it.name == "sampleLocalFunction1" } shouldBeEqualTo 1
             hasLocalFunctions() shouldBeEqualTo true
+            hasLocalFunctionWithName(emptyList()) shouldBeEqualTo true
+            hasLocalFunctionWithName(emptySet()) shouldBeEqualTo true
+            hasLocalFunctionsWithAllNames(emptyList()) shouldBeEqualTo true
+            hasLocalFunctionsWithAllNames(emptySet()) shouldBeEqualTo true
             hasLocalFunctionWithName("sampleLocalFunction1") shouldBeEqualTo true
             hasLocalFunctionWithName("otherLocalFunction") shouldBeEqualTo false
             hasLocalFunctionWithName("sampleLocalFunction1", "otherLocalFunction") shouldBeEqualTo true
+            hasLocalFunctionWithName(listOf("sampleLocalFunction1")) shouldBeEqualTo true
+            hasLocalFunctionWithName(listOf("otherLocalFunction")) shouldBeEqualTo false
+            hasLocalFunctionWithName(listOf("sampleLocalFunction1", "otherLocalFunction")) shouldBeEqualTo true
+            hasLocalFunctionWithName(setOf("sampleLocalFunction1")) shouldBeEqualTo true
+            hasLocalFunctionWithName(setOf("otherLocalFunction")) shouldBeEqualTo false
+            hasLocalFunctionWithName(setOf("sampleLocalFunction1", "otherLocalFunction")) shouldBeEqualTo true
             hasLocalFunctionsWithAllNames("sampleLocalFunction1") shouldBeEqualTo true
             hasLocalFunctionsWithAllNames("sampleLocalFunction1", "sampleLocalFunction2") shouldBeEqualTo true
             hasLocalFunctionsWithAllNames("sampleLocalFunction1", "otherLocalFunction") shouldBeEqualTo false
+            hasLocalFunctionsWithAllNames(listOf("sampleLocalFunction1")) shouldBeEqualTo true
+            hasLocalFunctionsWithAllNames(listOf("sampleLocalFunction1", "sampleLocalFunction2")) shouldBeEqualTo true
+            hasLocalFunctionsWithAllNames(listOf("sampleLocalFunction1", "otherLocalFunction")) shouldBeEqualTo false
+            hasLocalFunctionsWithAllNames(setOf("sampleLocalFunction1")) shouldBeEqualTo true
+            hasLocalFunctionsWithAllNames(setOf("sampleLocalFunction1", "sampleLocalFunction2")) shouldBeEqualTo true
+            hasLocalFunctionsWithAllNames(setOf("sampleLocalFunction1", "otherLocalFunction")) shouldBeEqualTo false
             hasLocalFunction { it.name == "sampleLocalFunction1" } shouldBeEqualTo true
             hasLocalFunction { it.name == "otherLocalFunction" } shouldBeEqualTo false
             hasAllLocalFunctions { it.name.endsWith("2") || it.name == "sampleLocalFunction1" } shouldBeEqualTo true

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/kofunction/KoFunctionDeclarationForKoParametersProviderTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/kofunction/KoFunctionDeclarationForKoParametersProviderTest.kt
@@ -20,8 +20,16 @@ class KoFunctionDeclarationForKoParametersProviderTest {
             numParameters shouldBeEqualTo 0
             countParameters { it.hasNameStartingWith("sample") } shouldBeEqualTo 0
             hasParameters() shouldBeEqualTo false
+            hasParameterWithName(emptyList()) shouldBeEqualTo false
+            hasParameterWithName(emptySet()) shouldBeEqualTo false
+            hasParametersWithAllNames(emptyList()) shouldBeEqualTo false
+            hasParametersWithAllNames(emptySet()) shouldBeEqualTo false
             hasParameterWithName("sampleParameter") shouldBeEqualTo false
+            hasParameterWithName(listOf("sampleParameter")) shouldBeEqualTo false
+            hasParameterWithName(setOf("sampleParameter")) shouldBeEqualTo false
             hasParametersWithAllNames("sampleParameter1", "sampleParameter2") shouldBeEqualTo false
+            hasParametersWithAllNames(listOf("sampleParameter1", "sampleParameter2")) shouldBeEqualTo false
+            hasParametersWithAllNames(setOf("sampleParameter1", "sampleParameter2")) shouldBeEqualTo false
             hasParameter { it.hasNameStartingWith("other") } shouldBeEqualTo false
             hasAllParameters { it.hasNameStartingWith("sample") } shouldBeEqualTo true
         }
@@ -41,11 +49,25 @@ class KoFunctionDeclarationForKoParametersProviderTest {
             numParameters shouldBeEqualTo 1
             countParameters { it.hasNameStartingWith("sample") } shouldBeEqualTo 1
             hasParameters() shouldBeEqualTo true
+            hasParameterWithName(emptyList()) shouldBeEqualTo true
+            hasParameterWithName(emptySet()) shouldBeEqualTo true
+            hasParametersWithAllNames(emptyList()) shouldBeEqualTo true
+            hasParametersWithAllNames(emptySet()) shouldBeEqualTo true
             hasParameterWithName("sampleParameter") shouldBeEqualTo true
             hasParameterWithName("otherParameter") shouldBeEqualTo false
             hasParameterWithName("sampleParameter", "otherParameter") shouldBeEqualTo true
+            hasParameterWithName(listOf("sampleParameter")) shouldBeEqualTo true
+            hasParameterWithName(listOf("otherParameter")) shouldBeEqualTo false
+            hasParameterWithName(listOf("sampleParameter", "otherParameter")) shouldBeEqualTo true
+            hasParameterWithName(setOf("sampleParameter")) shouldBeEqualTo true
+            hasParameterWithName(setOf("otherParameter")) shouldBeEqualTo false
+            hasParameterWithName(setOf("sampleParameter", "otherParameter")) shouldBeEqualTo true
             hasParametersWithAllNames("sampleParameter") shouldBeEqualTo true
             hasParametersWithAllNames("sampleParameter", "otherParameter") shouldBeEqualTo false
+            hasParametersWithAllNames(listOf("sampleParameter")) shouldBeEqualTo true
+            hasParametersWithAllNames(listOf("sampleParameter", "otherParameter")) shouldBeEqualTo false
+            hasParametersWithAllNames(setOf("sampleParameter")) shouldBeEqualTo true
+            hasParametersWithAllNames(setOf("sampleParameter", "otherParameter")) shouldBeEqualTo false
             hasParameter { it.hasNameStartingWith("sample") } shouldBeEqualTo true
             hasParameter { it.hasNameStartingWith("other") } shouldBeEqualTo false
             hasAllParameters { it.hasNameStartingWith("sample") } shouldBeEqualTo true
@@ -67,12 +89,28 @@ class KoFunctionDeclarationForKoParametersProviderTest {
             countParameters { it.hasNameStartingWith("sample") } shouldBeEqualTo 2
             countParameters { param -> param.hasType { it.name == "Int" } } shouldBeEqualTo 1
             hasParameters() shouldBeEqualTo true
+            hasParameterWithName(emptyList()) shouldBeEqualTo true
+            hasParameterWithName(emptySet()) shouldBeEqualTo true
+            hasParametersWithAllNames(emptyList()) shouldBeEqualTo true
+            hasParametersWithAllNames(emptySet()) shouldBeEqualTo true
             hasParameterWithName("sampleParameter1") shouldBeEqualTo true
             hasParameterWithName("otherParameter") shouldBeEqualTo false
             hasParameterWithName("sampleParameter1", "otherName") shouldBeEqualTo true
+            hasParameterWithName(listOf("sampleParameter1")) shouldBeEqualTo true
+            hasParameterWithName(listOf("otherParameter")) shouldBeEqualTo false
+            hasParameterWithName(listOf("sampleParameter1", "otherName")) shouldBeEqualTo true
+            hasParameterWithName(setOf("sampleParameter1")) shouldBeEqualTo true
+            hasParameterWithName(setOf("otherParameter")) shouldBeEqualTo false
+            hasParameterWithName(setOf("sampleParameter1", "otherName")) shouldBeEqualTo true
             hasParametersWithAllNames("sampleParameter1") shouldBeEqualTo true
             hasParametersWithAllNames("sampleParameter1", "sampleParameter2") shouldBeEqualTo true
             hasParametersWithAllNames("sampleParameter1", "otherParameter") shouldBeEqualTo false
+            hasParametersWithAllNames(listOf("sampleParameter1")) shouldBeEqualTo true
+            hasParametersWithAllNames(listOf("sampleParameter1", "sampleParameter2")) shouldBeEqualTo true
+            hasParametersWithAllNames(listOf("sampleParameter1", "otherParameter")) shouldBeEqualTo false
+            hasParametersWithAllNames(setOf("sampleParameter1")) shouldBeEqualTo true
+            hasParametersWithAllNames(setOf("sampleParameter1", "sampleParameter2")) shouldBeEqualTo true
+            hasParametersWithAllNames(setOf("sampleParameter1", "otherParameter")) shouldBeEqualTo false
             hasParameter { it.hasNameStartingWith("sample") } shouldBeEqualTo true
             hasParameter { param -> param.hasType { it.name == "Int" } } shouldBeEqualTo true
             hasAllParameters { it.hasNameStartingWith("sample") } shouldBeEqualTo true

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/kofunction/KoFunctionDeclarationForKoVariableProviderTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/kofunction/KoFunctionDeclarationForKoVariableProviderTest.kt
@@ -20,8 +20,16 @@ class KoFunctionDeclarationForKoVariableProviderTest {
             numVariables shouldBeEqualTo 0
             countVariables { it.name == "sampleVariable" } shouldBeEqualTo 0
             hasVariables() shouldBeEqualTo false
+            hasVariableWithName(emptyList()) shouldBeEqualTo false
+            hasVariableWithName(emptySet()) shouldBeEqualTo false
+            hasVariablesWithAllNames(emptyList()) shouldBeEqualTo false
+            hasVariablesWithAllNames(emptySet()) shouldBeEqualTo false
             hasVariableWithName("sampleVariable") shouldBeEqualTo false
+            hasVariableWithName(listOf("sampleVariable")) shouldBeEqualTo false
+            hasVariableWithName(setOf("sampleVariable")) shouldBeEqualTo false
             hasVariablesWithAllNames("sampleVariable1", "sampleVariable2") shouldBeEqualTo false
+            hasVariablesWithAllNames(listOf("sampleVariable1", "sampleVariable2")) shouldBeEqualTo false
+            hasVariablesWithAllNames(setOf("sampleVariable1", "sampleVariable2")) shouldBeEqualTo false
             hasVariable { it.name == "sampleVariable" } shouldBeEqualTo false
             hasAllVariables { it.name == "sampleVariable" } shouldBeEqualTo true
         }
@@ -40,12 +48,28 @@ class KoFunctionDeclarationForKoVariableProviderTest {
             numVariables shouldBeEqualTo 2
             countVariables { it.name == "sampleVariable1" } shouldBeEqualTo 1
             hasVariables() shouldBeEqualTo true
+            hasVariableWithName(emptyList()) shouldBeEqualTo true
+            hasVariableWithName(emptySet()) shouldBeEqualTo true
+            hasVariablesWithAllNames(emptyList()) shouldBeEqualTo true
+            hasVariablesWithAllNames(emptySet()) shouldBeEqualTo true
             hasVariableWithName("sampleVariable1") shouldBeEqualTo true
             hasVariableWithName("otherVariable") shouldBeEqualTo false
             hasVariableWithName("sampleVariable1", "otherVariable") shouldBeEqualTo true
+            hasVariableWithName(listOf("sampleVariable1")) shouldBeEqualTo true
+            hasVariableWithName(listOf("otherVariable")) shouldBeEqualTo false
+            hasVariableWithName(listOf("sampleVariable1", "otherVariable")) shouldBeEqualTo true
+            hasVariableWithName(setOf("sampleVariable1")) shouldBeEqualTo true
+            hasVariableWithName(setOf("otherVariable")) shouldBeEqualTo false
+            hasVariableWithName(setOf("sampleVariable1", "otherVariable")) shouldBeEqualTo true
             hasVariablesWithAllNames("sampleVariable1") shouldBeEqualTo true
             hasVariablesWithAllNames("sampleVariable1", "sampleVariable2") shouldBeEqualTo true
             hasVariablesWithAllNames("sampleVariable1", "otherVariable") shouldBeEqualTo false
+            hasVariablesWithAllNames(listOf("sampleVariable1")) shouldBeEqualTo true
+            hasVariablesWithAllNames(listOf("sampleVariable1", "sampleVariable2")) shouldBeEqualTo true
+            hasVariablesWithAllNames(listOf("sampleVariable1", "otherVariable")) shouldBeEqualTo false
+            hasVariablesWithAllNames(setOf("sampleVariable1")) shouldBeEqualTo true
+            hasVariablesWithAllNames(setOf("sampleVariable1", "sampleVariable2")) shouldBeEqualTo true
+            hasVariablesWithAllNames(setOf("sampleVariable1", "otherVariable")) shouldBeEqualTo false
             hasVariable { it.name == "sampleVariable1" } shouldBeEqualTo true
             hasVariable { it.name == "otherVariable" } shouldBeEqualTo false
             hasAllVariables { it.name.endsWith("2") || it.name == "sampleVariable1" } shouldBeEqualTo true

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/kofunction/forkomodifier/KoFunctionDeclarationForKoModifierProviderTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/kofunction/forkomodifier/KoFunctionDeclarationForKoModifierProviderTest.kt
@@ -28,10 +28,22 @@ class KoFunctionDeclarationForKoModifierProviderTest {
             modifiers shouldBeEqualTo emptyList()
             numModifiers shouldBeEqualTo 0
             hasModifiers() shouldBeEqualTo false
+            hasModifier(emptyList()) shouldBeEqualTo false
+            hasModifier(emptySet()) shouldBeEqualTo false
+            hasAllModifiers(emptyList()) shouldBeEqualTo false
+            hasAllModifiers(emptySet()) shouldBeEqualTo false
             hasModifier(OPEN) shouldBeEqualTo false
             hasModifier(OPEN, DATA) shouldBeEqualTo false
+            hasModifier(listOf(OPEN)) shouldBeEqualTo false
+            hasModifier(listOf(OPEN, DATA)) shouldBeEqualTo false
+            hasModifier(setOf(OPEN)) shouldBeEqualTo false
+            hasModifier(setOf(OPEN, DATA)) shouldBeEqualTo false
             hasAllModifiers(OPEN) shouldBeEqualTo false
             hasAllModifiers(OPEN, DATA) shouldBeEqualTo false
+            hasAllModifiers(listOf(OPEN)) shouldBeEqualTo false
+            hasAllModifiers(listOf(OPEN, DATA)) shouldBeEqualTo false
+            hasAllModifiers(setOf(OPEN)) shouldBeEqualTo false
+            hasAllModifiers(setOf(OPEN, DATA)) shouldBeEqualTo false
             hasModifiers(OPEN) shouldBeEqualTo false
             hasModifiers(OPEN, DATA) shouldBeEqualTo false
         }
@@ -49,13 +61,31 @@ class KoFunctionDeclarationForKoModifierProviderTest {
         assertSoftly(sut) {
             numModifiers shouldBeEqualTo 2
             hasModifiers() shouldBeEqualTo true
+            hasModifier(emptyList()) shouldBeEqualTo true
+            hasModifier(emptySet()) shouldBeEqualTo true
+            hasAllModifiers(emptyList()) shouldBeEqualTo true
+            hasAllModifiers(emptySet()) shouldBeEqualTo true
             hasModifier(PROTECTED) shouldBeEqualTo true
             hasModifier(PUBLIC) shouldBeEqualTo false
             hasModifier(PROTECTED, SUSPEND) shouldBeEqualTo true
+            hasModifier(listOf(PROTECTED)) shouldBeEqualTo true
+            hasModifier(listOf(PUBLIC)) shouldBeEqualTo false
+            hasModifier(listOf(PROTECTED, SUSPEND)) shouldBeEqualTo true
+            hasModifier(setOf(PROTECTED)) shouldBeEqualTo true
+            hasModifier(setOf(PUBLIC)) shouldBeEqualTo false
+            hasModifier(setOf(PROTECTED, SUSPEND)) shouldBeEqualTo true
             hasAllModifiers(PROTECTED) shouldBeEqualTo true
             hasAllModifiers(PUBLIC) shouldBeEqualTo false
             hasAllModifiers(PROTECTED, OPEN) shouldBeEqualTo false
             hasAllModifiers(PROTECTED, SUSPEND) shouldBeEqualTo true
+            hasAllModifiers(listOf(PROTECTED)) shouldBeEqualTo true
+            hasAllModifiers(listOf(PUBLIC)) shouldBeEqualTo false
+            hasAllModifiers(listOf(PROTECTED, OPEN)) shouldBeEqualTo false
+            hasAllModifiers(listOf(PROTECTED, SUSPEND)) shouldBeEqualTo true
+            hasAllModifiers(setOf(PROTECTED)) shouldBeEqualTo true
+            hasAllModifiers(setOf(PUBLIC)) shouldBeEqualTo false
+            hasAllModifiers(setOf(PROTECTED, OPEN)) shouldBeEqualTo false
+            hasAllModifiers(setOf(PROTECTED, SUSPEND)) shouldBeEqualTo true
             hasModifiers(PROTECTED) shouldBeEqualTo true
             hasModifiers(SUSPEND) shouldBeEqualTo true
             hasModifiers(OPEN) shouldBeEqualTo false

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/kogetter/KoGetterDeclarationForKoLocalClassProviderTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/kogetter/KoGetterDeclarationForKoLocalClassProviderTest.kt
@@ -19,12 +19,21 @@ class KoGetterDeclarationForKoLocalClassProviderTest {
         assertSoftly(sut) {
             it?.localClasses shouldBeEqualTo emptyList()
             it?.numLocalClasses shouldBeEqualTo 0
-            it?.countLocalClasses { localClass -> localClass.name == "SampleClass" } shouldBeEqualTo 0
+            it?.countLocalClasses { it.name == "SampleClass" } shouldBeEqualTo 0
             it?.hasLocalClasses() shouldBeEqualTo false
+            it?.hasLocalClassWithName(emptyList()) shouldBeEqualTo false
+            it?.hasLocalClassWithName(emptySet()) shouldBeEqualTo false
+            it?.hasLocalClassesWithAllNames(emptyList()) shouldBeEqualTo false
+            it?.hasLocalClassesWithAllNames(emptySet()) shouldBeEqualTo false
             it?.hasLocalClassWithName("SampleClass") shouldBeEqualTo false
+            it?.hasLocalClassWithName(listOf("SampleClass")) shouldBeEqualTo false
+            it?.hasLocalClassWithName(setOf("SampleClass")) shouldBeEqualTo false
             it?.hasLocalClassesWithAllNames("SampleClass1", "SampleClass2") shouldBeEqualTo false
-            it?.hasLocalClass { localClass -> localClass.name == "SampleClass" } shouldBeEqualTo false
-            it?.hasAllLocalClasses { localClass -> localClass.name == "SampleClass" } shouldBeEqualTo true
+            it?.hasLocalClassesWithAllNames(listOf("SampleClass1", "SampleClass2")) shouldBeEqualTo false
+            it?.hasLocalClassesWithAllNames(setOf("SampleClass1", "SampleClass2")) shouldBeEqualTo false
+            it?.hasLocalClass { it.name == "SampleClass" } shouldBeEqualTo false
+            it?.hasAllLocalClasses { it.name == "SampleClass" } shouldBeEqualTo true
+            it?.containsLocalClass { it.name == "SampleClass" } shouldBeEqualTo false
         }
     }
 
@@ -39,26 +48,38 @@ class KoGetterDeclarationForKoLocalClassProviderTest {
 
         // then
         assertSoftly(sut) {
-            it?.localClasses?.map { localClass -> localClass.name } shouldBeEqualTo
-                listOf(
-                    "SampleClass1",
-                    "SampleClass2",
-                )
+            it?.localClasses?.map { it.name } shouldBeEqualTo listOf("SampleClass1", "SampleClass2")
             it?.numLocalClasses shouldBeEqualTo 2
-            it?.countLocalClasses { localClass -> localClass.name == "SampleClass1" } shouldBeEqualTo 1
+            it?.countLocalClasses { it.name == "SampleClass1" } shouldBeEqualTo 1
             it?.hasLocalClasses() shouldBeEqualTo true
+            it?.hasLocalClassWithName(emptyList()) shouldBeEqualTo true
+            it?.hasLocalClassWithName(emptySet()) shouldBeEqualTo true
+            it?.hasLocalClassesWithAllNames(emptyList()) shouldBeEqualTo true
+            it?.hasLocalClassesWithAllNames(emptySet()) shouldBeEqualTo true
             it?.hasLocalClassWithName("SampleClass1") shouldBeEqualTo true
-            it?.hasLocalClassWithName("OtherClass") shouldBeEqualTo false
-            it?.hasLocalClassWithName("SampleClass1", "OtherClass") shouldBeEqualTo true
+            it?.hasLocalClassWithName("OtherLocalClass") shouldBeEqualTo false
+            it?.hasLocalClassWithName("SampleClass1", "OtherLocalClass") shouldBeEqualTo true
+            it?.hasLocalClassWithName(listOf("SampleClass1")) shouldBeEqualTo true
+            it?.hasLocalClassWithName(listOf("OtherLocalClass")) shouldBeEqualTo false
+            it?.hasLocalClassWithName(listOf("SampleClass1", "OtherLocalClass")) shouldBeEqualTo true
+            it?.hasLocalClassWithName(setOf("SampleClass1")) shouldBeEqualTo true
+            it?.hasLocalClassWithName(setOf("OtherLocalClass")) shouldBeEqualTo false
+            it?.hasLocalClassWithName(setOf("SampleClass1", "OtherLocalClass")) shouldBeEqualTo true
             it?.hasLocalClassesWithAllNames("SampleClass1") shouldBeEqualTo true
             it?.hasLocalClassesWithAllNames("SampleClass1", "SampleClass2") shouldBeEqualTo true
-            it?.hasLocalClassesWithAllNames("SampleClass1", "OtherClass") shouldBeEqualTo false
-            it?.hasLocalClass { localClass -> localClass.name == "SampleClass1" } shouldBeEqualTo true
-            it?.hasLocalClass { localClass -> localClass.name == "OtherClass" } shouldBeEqualTo false
-            it?.hasAllLocalClasses { localClass ->
-                localClass.name.endsWith("2") || localClass.name == "SampleClass1"
-            }.shouldBeEqualTo(true)
-            it?.hasAllLocalClasses { localClass -> localClass.name.endsWith("2") } shouldBeEqualTo false
+            it?.hasLocalClassesWithAllNames("SampleClass1", "OtherLocalClass") shouldBeEqualTo false
+            it?.hasLocalClassesWithAllNames(listOf("SampleClass1")) shouldBeEqualTo true
+            it?.hasLocalClassesWithAllNames(listOf("SampleClass1", "SampleClass2")) shouldBeEqualTo true
+            it?.hasLocalClassesWithAllNames(listOf("SampleClass1", "OtherLocalClass")) shouldBeEqualTo false
+            it?.hasLocalClassesWithAllNames(setOf("SampleClass1")) shouldBeEqualTo true
+            it?.hasLocalClassesWithAllNames(setOf("SampleClass1", "SampleClass2")) shouldBeEqualTo true
+            it?.hasLocalClassesWithAllNames(setOf("SampleClass1", "OtherLocalClass")) shouldBeEqualTo false
+            it?.hasLocalClass { it.name == "SampleClass1" } shouldBeEqualTo true
+            it?.hasLocalClass { it.name == "OtherLocalClass" } shouldBeEqualTo false
+            it?.hasAllLocalClasses { it.name.endsWith("2") || it.name == "SampleClass1" } shouldBeEqualTo true
+            it?.hasAllLocalClasses { it.name.endsWith("2") } shouldBeEqualTo false
+            it?.containsLocalClass { it.name == "SampleClass1" } shouldBeEqualTo true
+            it?.containsLocalClass { it.name == "OtherLocalClass" } shouldBeEqualTo false
         }
     }
 

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/kogetter/KoGetterDeclarationForKoLocalFunctionProviderTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/kogetter/KoGetterDeclarationForKoLocalFunctionProviderTest.kt
@@ -19,12 +19,21 @@ class KoGetterDeclarationForKoLocalFunctionProviderTest {
         assertSoftly(sut) {
             it?.localFunctions shouldBeEqualTo emptyList()
             it?.numLocalFunctions shouldBeEqualTo 0
-            it?.countLocalFunctions { function -> function.name == "sampleLocalFunction" } shouldBeEqualTo 0
+            it?.countLocalFunctions { it.name == "sampleLocalFunction" } shouldBeEqualTo 0
             it?.hasLocalFunctions() shouldBeEqualTo false
+            it?.hasLocalFunctionWithName(emptyList()) shouldBeEqualTo false
+            it?.hasLocalFunctionWithName(emptySet()) shouldBeEqualTo false
+            it?.hasLocalFunctionsWithAllNames(emptyList()) shouldBeEqualTo false
+            it?.hasLocalFunctionsWithAllNames(emptySet()) shouldBeEqualTo false
             it?.hasLocalFunctionWithName("sampleLocalFunction") shouldBeEqualTo false
+            it?.hasLocalFunctionWithName(listOf("sampleLocalFunction")) shouldBeEqualTo false
+            it?.hasLocalFunctionWithName(setOf("sampleLocalFunction")) shouldBeEqualTo false
             it?.hasLocalFunctionsWithAllNames("sampleLocalFunction1", "sampleLocalFunction2") shouldBeEqualTo false
-            it?.hasLocalFunction { function -> function.name == "sampleLocalFunction" } shouldBeEqualTo false
-            it?.hasAllLocalFunctions { function -> function.name == "sampleLocalFunction" } shouldBeEqualTo true
+            it?.hasLocalFunctionsWithAllNames(listOf("sampleLocalFunction1", "sampleLocalFunction2")) shouldBeEqualTo false
+            it?.hasLocalFunctionsWithAllNames(setOf("sampleLocalFunction1", "sampleLocalFunction2")) shouldBeEqualTo false
+            it?.hasLocalFunction { it.name == "sampleLocalFunction" } shouldBeEqualTo false
+            it?.hasAllLocalFunctions { it.name == "sampleLocalFunction" } shouldBeEqualTo true
+            it?.containsLocalFunction { it.name == "sampleLocalFunction" } shouldBeEqualTo false
         }
     }
 
@@ -40,21 +49,39 @@ class KoGetterDeclarationForKoLocalFunctionProviderTest {
         // then
         assertSoftly(sut) {
             it?.numLocalFunctions shouldBeEqualTo 2
-            it?.countLocalFunctions { function -> function.name == "sampleLocalFunction1" } shouldBeEqualTo 1
+            it?.countLocalFunctions { it.name == "sampleLocalFunction1" } shouldBeEqualTo 1
             it?.hasLocalFunctions() shouldBeEqualTo true
+            it?.hasLocalFunctionWithName(emptyList()) shouldBeEqualTo true
+            it?.hasLocalFunctionWithName(emptySet()) shouldBeEqualTo true
+            it?.hasLocalFunctionsWithAllNames(emptyList()) shouldBeEqualTo true
+            it?.hasLocalFunctionsWithAllNames(emptySet()) shouldBeEqualTo true
             it?.hasLocalFunctionWithName("sampleLocalFunction1") shouldBeEqualTo true
             it?.hasLocalFunctionWithName("otherLocalFunction") shouldBeEqualTo false
             it?.hasLocalFunctionWithName("sampleLocalFunction1", "otherLocalFunction") shouldBeEqualTo true
+            it?.hasLocalFunctionWithName(listOf("sampleLocalFunction1")) shouldBeEqualTo true
+            it?.hasLocalFunctionWithName(listOf("otherLocalFunction")) shouldBeEqualTo false
+            it?.hasLocalFunctionWithName(listOf("sampleLocalFunction1", "otherLocalFunction")) shouldBeEqualTo true
+            it?.hasLocalFunctionWithName(setOf("sampleLocalFunction1")) shouldBeEqualTo true
+            it?.hasLocalFunctionWithName(setOf("otherLocalFunction")) shouldBeEqualTo false
+            it?.hasLocalFunctionWithName(setOf("sampleLocalFunction1", "otherLocalFunction")) shouldBeEqualTo true
             it?.hasLocalFunctionsWithAllNames("sampleLocalFunction1") shouldBeEqualTo true
             it?.hasLocalFunctionsWithAllNames("sampleLocalFunction1", "sampleLocalFunction2") shouldBeEqualTo true
             it?.hasLocalFunctionsWithAllNames("sampleLocalFunction1", "otherLocalFunction") shouldBeEqualTo false
-            it?.hasLocalFunction { function -> function.name == "sampleLocalFunction1" } shouldBeEqualTo true
-            it?.hasLocalFunction { function -> function.name == "otherLocalFunction" } shouldBeEqualTo false
-            it?.hasAllLocalFunctions { function,
-                ->
-                function.name.endsWith("2") || function.name == "sampleLocalFunction1"
-            }.shouldBeEqualTo(true)
-            it?.hasAllLocalFunctions { function -> function.name.endsWith("2") } shouldBeEqualTo false
+            it?.hasLocalFunctionsWithAllNames(listOf("sampleLocalFunction1")) shouldBeEqualTo true
+            it?.hasLocalFunctionsWithAllNames(listOf("sampleLocalFunction1", "sampleLocalFunction2")) shouldBeEqualTo true
+            it?.hasLocalFunctionsWithAllNames(listOf("sampleLocalFunction1", "otherLocalFunction")) shouldBeEqualTo false
+            it?.hasLocalFunctionsWithAllNames(setOf("sampleLocalFunction1")) shouldBeEqualTo true
+            it?.hasLocalFunctionsWithAllNames(setOf("sampleLocalFunction1", "sampleLocalFunction2")) shouldBeEqualTo true
+            it?.hasLocalFunctionsWithAllNames(setOf("sampleLocalFunction1", "otherLocalFunction")) shouldBeEqualTo false
+            it?.hasLocalFunction { it.name == "sampleLocalFunction1" } shouldBeEqualTo true
+            it?.hasLocalFunction { it.name == "otherLocalFunction" } shouldBeEqualTo false
+            it?.hasAllLocalFunctions { it.name.endsWith("2") || it.name == "sampleLocalFunction1" } shouldBeEqualTo true
+            it?.hasAllLocalFunctions { it.name.endsWith("2") } shouldBeEqualTo false
+            it?.containsLocalFunction { it.name == "sampleLocalFunction1" } shouldBeEqualTo true
+            it?.containsLocalFunction { it.name == "otherLocalFunction1" } shouldBeEqualTo false
+            it?.localFunctions
+                ?.map { it.name }
+                .shouldBeEqualTo(listOf("sampleLocalFunction1", "sampleLocalFunction2"))
         }
     }
 

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/kogetter/KoGetterDeclarationForKoVariableProviderTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/kogetter/KoGetterDeclarationForKoVariableProviderTest.kt
@@ -22,8 +22,16 @@ class KoGetterDeclarationForKoVariableProviderTest {
             numVariables shouldBeEqualTo 0
             countVariables { it.name == "sampleVariable" } shouldBeEqualTo 0
             hasVariables() shouldBeEqualTo false
+            hasVariableWithName(emptyList()) shouldBeEqualTo false
+            hasVariableWithName(emptySet()) shouldBeEqualTo false
+            hasVariablesWithAllNames(emptyList()) shouldBeEqualTo false
+            hasVariablesWithAllNames(emptySet()) shouldBeEqualTo false
             hasVariableWithName("sampleVariable") shouldBeEqualTo false
+            hasVariableWithName(listOf("sampleVariable")) shouldBeEqualTo false
+            hasVariableWithName(setOf("sampleVariable")) shouldBeEqualTo false
             hasVariablesWithAllNames("sampleVariable1", "sampleVariable2") shouldBeEqualTo false
+            hasVariablesWithAllNames(listOf("sampleVariable1", "sampleVariable2")) shouldBeEqualTo false
+            hasVariablesWithAllNames(setOf("sampleVariable1", "sampleVariable2")) shouldBeEqualTo false
             hasVariable { it.name == "sampleVariable" } shouldBeEqualTo false
             hasAllVariables { it.name == "sampleVariable" } shouldBeEqualTo true
         }
@@ -43,12 +51,28 @@ class KoGetterDeclarationForKoVariableProviderTest {
             numVariables shouldBeEqualTo 2
             countVariables { it.name == "sampleVariable1" } shouldBeEqualTo 1
             hasVariables() shouldBeEqualTo true
+            hasVariableWithName(emptyList()) shouldBeEqualTo true
+            hasVariableWithName(emptySet()) shouldBeEqualTo true
+            hasVariablesWithAllNames(emptyList()) shouldBeEqualTo true
+            hasVariablesWithAllNames(emptySet()) shouldBeEqualTo true
             hasVariableWithName("sampleVariable1") shouldBeEqualTo true
             hasVariableWithName("otherVariable") shouldBeEqualTo false
             hasVariableWithName("sampleVariable1", "otherVariable") shouldBeEqualTo true
+            hasVariableWithName(listOf("sampleVariable1")) shouldBeEqualTo true
+            hasVariableWithName(listOf("otherVariable")) shouldBeEqualTo false
+            hasVariableWithName(listOf("sampleVariable1", "otherVariable")) shouldBeEqualTo true
+            hasVariableWithName(setOf("sampleVariable1")) shouldBeEqualTo true
+            hasVariableWithName(setOf("otherVariable")) shouldBeEqualTo false
+            hasVariableWithName(setOf("sampleVariable1", "otherVariable")) shouldBeEqualTo true
             hasVariablesWithAllNames("sampleVariable1") shouldBeEqualTo true
             hasVariablesWithAllNames("sampleVariable1", "sampleVariable2") shouldBeEqualTo true
             hasVariablesWithAllNames("sampleVariable1", "otherVariable") shouldBeEqualTo false
+            hasVariablesWithAllNames(listOf("sampleVariable1")) shouldBeEqualTo true
+            hasVariablesWithAllNames(listOf("sampleVariable1", "sampleVariable2")) shouldBeEqualTo true
+            hasVariablesWithAllNames(listOf("sampleVariable1", "otherVariable")) shouldBeEqualTo false
+            hasVariablesWithAllNames(setOf("sampleVariable1")) shouldBeEqualTo true
+            hasVariablesWithAllNames(setOf("sampleVariable1", "sampleVariable2")) shouldBeEqualTo true
+            hasVariablesWithAllNames(setOf("sampleVariable1", "otherVariable")) shouldBeEqualTo false
             hasVariable { it.name == "sampleVariable1" } shouldBeEqualTo true
             hasVariable { it.name == "otherVariable" } shouldBeEqualTo false
             hasAllVariables { it.name.endsWith("2") || it.name == "sampleVariable1" } shouldBeEqualTo true

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/kogetter/forkomodifier/KoGetterDeclarationForKoModifierProviderTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/kogetter/forkomodifier/KoGetterDeclarationForKoModifierProviderTest.kt
@@ -1,8 +1,10 @@
 package com.lemonappdev.konsist.core.declaration.kogetter.forkomodifier
 
 import com.lemonappdev.konsist.TestSnippetProvider
+import com.lemonappdev.konsist.api.KoModifier
 import com.lemonappdev.konsist.api.KoModifier.DATA
 import com.lemonappdev.konsist.api.KoModifier.PRIVATE
+import com.lemonappdev.konsist.api.KoModifier.PROTECTED
 import org.amshove.kluent.assertSoftly
 import org.amshove.kluent.shouldBeEqualTo
 import org.amshove.kluent.shouldNotBeEqualTo
@@ -23,9 +25,24 @@ class KoGetterDeclarationForKoModifierProviderTest {
             it?.modifiers shouldBeEqualTo emptyList()
             it?.numModifiers shouldBeEqualTo 0
             it?.hasModifiers() shouldBeEqualTo false
-            it?.hasModifier(PRIVATE) shouldBeEqualTo false
-            it?.hasAllModifiers(PRIVATE) shouldBeEqualTo false
-            it?.hasAllModifiers(PRIVATE, DATA) shouldBeEqualTo false
+            it?.hasModifier(emptyList()) shouldBeEqualTo false
+            it?.hasModifier(emptySet()) shouldBeEqualTo false
+            it?.hasAllModifiers(emptyList()) shouldBeEqualTo false
+            it?.hasAllModifiers(emptySet()) shouldBeEqualTo false
+            it?.hasModifier(KoModifier.OPEN) shouldBeEqualTo false
+            it?.hasModifier(KoModifier.OPEN, DATA) shouldBeEqualTo false
+            it?.hasModifier(listOf(KoModifier.OPEN)) shouldBeEqualTo false
+            it?.hasModifier(listOf(KoModifier.OPEN, DATA)) shouldBeEqualTo false
+            it?.hasModifier(setOf(KoModifier.OPEN)) shouldBeEqualTo false
+            it?.hasModifier(setOf(KoModifier.OPEN, DATA)) shouldBeEqualTo false
+            it?.hasAllModifiers(KoModifier.OPEN) shouldBeEqualTo false
+            it?.hasAllModifiers(KoModifier.OPEN, DATA) shouldBeEqualTo false
+            it?.hasAllModifiers(listOf(KoModifier.OPEN)) shouldBeEqualTo false
+            it?.hasAllModifiers(listOf(KoModifier.OPEN, DATA)) shouldBeEqualTo false
+            it?.hasAllModifiers(setOf(KoModifier.OPEN)) shouldBeEqualTo false
+            it?.hasAllModifiers(setOf(KoModifier.OPEN, DATA)) shouldBeEqualTo false
+            it?.hasModifiers(KoModifier.OPEN) shouldBeEqualTo false
+            it?.hasModifiers(KoModifier.OPEN, DATA) shouldBeEqualTo false
         }
     }
 
@@ -40,15 +57,31 @@ class KoGetterDeclarationForKoModifierProviderTest {
 
         // then
         assertSoftly(sut) {
-            it?.modifiers shouldNotBeEqualTo emptyList()
+            it?.modifiers shouldBeEqualTo listOf(PRIVATE)
             it?.numModifiers shouldBeEqualTo 1
             it?.hasModifiers() shouldBeEqualTo true
+            it?.hasModifier(emptyList()) shouldBeEqualTo true
+            it?.hasModifier(emptySet()) shouldBeEqualTo true
+            it?.hasAllModifiers(emptyList()) shouldBeEqualTo true
+            it?.hasAllModifiers(emptySet()) shouldBeEqualTo true
             it?.hasModifier(PRIVATE) shouldBeEqualTo true
-            it?.hasModifier(DATA) shouldBeEqualTo false
+            it?.hasModifier(PROTECTED) shouldBeEqualTo false
             it?.hasModifier(PRIVATE, DATA) shouldBeEqualTo true
+            it?.hasModifier(listOf(PRIVATE)) shouldBeEqualTo true
+            it?.hasModifier(listOf(PROTECTED)) shouldBeEqualTo false
+            it?.hasModifier(listOf(PRIVATE, DATA)) shouldBeEqualTo true
+            it?.hasModifier(setOf(PRIVATE)) shouldBeEqualTo true
+            it?.hasModifier(setOf(PROTECTED)) shouldBeEqualTo false
+            it?.hasModifier(setOf(PRIVATE, DATA)) shouldBeEqualTo true
             it?.hasAllModifiers(PRIVATE) shouldBeEqualTo true
-            it?.hasAllModifiers(DATA) shouldBeEqualTo false
+            it?.hasAllModifiers(PROTECTED) shouldBeEqualTo false
             it?.hasAllModifiers(PRIVATE, DATA) shouldBeEqualTo false
+            it?.hasAllModifiers(listOf(PRIVATE)) shouldBeEqualTo true
+            it?.hasAllModifiers(listOf(PROTECTED)) shouldBeEqualTo false
+            it?.hasAllModifiers(listOf(PRIVATE, DATA)) shouldBeEqualTo false
+            it?.hasAllModifiers(setOf(PRIVATE)) shouldBeEqualTo true
+            it?.hasAllModifiers(setOf(PROTECTED)) shouldBeEqualTo false
+            it?.hasAllModifiers(setOf(PRIVATE, DATA)) shouldBeEqualTo false
         }
     }
 

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/kogetter/forkomodifier/KoGetterDeclarationForKoModifierProviderTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/kogetter/forkomodifier/KoGetterDeclarationForKoModifierProviderTest.kt
@@ -7,7 +7,6 @@ import com.lemonappdev.konsist.api.KoModifier.PRIVATE
 import com.lemonappdev.konsist.api.KoModifier.PROTECTED
 import org.amshove.kluent.assertSoftly
 import org.amshove.kluent.shouldBeEqualTo
-import org.amshove.kluent.shouldNotBeEqualTo
 import org.junit.jupiter.api.Test
 
 class KoGetterDeclarationForKoModifierProviderTest {

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koinitblock/KoInitBlockDeclarationForKoLocalClassProviderTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koinitblock/KoInitBlockDeclarationForKoLocalClassProviderTest.kt
@@ -22,8 +22,16 @@ class KoInitBlockDeclarationForKoLocalClassProviderTest {
             numLocalClasses shouldBeEqualTo 0
             countLocalClasses { it.name == "SampleLocalClass" } shouldBeEqualTo 0
             hasLocalClasses() shouldBeEqualTo false
+            hasLocalClassWithName(emptyList()) shouldBeEqualTo false
+            hasLocalClassWithName(emptySet()) shouldBeEqualTo false
+            hasLocalClassesWithAllNames(emptyList()) shouldBeEqualTo false
+            hasLocalClassesWithAllNames(emptySet()) shouldBeEqualTo false
             hasLocalClassWithName("SampleLocalClass") shouldBeEqualTo false
+            hasLocalClassWithName(listOf("SampleLocalClass")) shouldBeEqualTo false
+            hasLocalClassWithName(setOf("SampleLocalClass")) shouldBeEqualTo false
             hasLocalClassesWithAllNames("SampleLocalClass1", "SampleLocalClass2") shouldBeEqualTo false
+            hasLocalClassesWithAllNames(listOf("SampleLocalClass1", "SampleLocalClass2")) shouldBeEqualTo false
+            hasLocalClassesWithAllNames(setOf("SampleLocalClass1", "SampleLocalClass2")) shouldBeEqualTo false
             hasLocalClass { it.name == "SampleLocalClass" } shouldBeEqualTo false
             hasAllLocalClasses { it.name == "SampleLocalClass" } shouldBeEqualTo true
             containsLocalClass { it.name == "SampleLocalClass" } shouldBeEqualTo false
@@ -45,12 +53,28 @@ class KoInitBlockDeclarationForKoLocalClassProviderTest {
             numLocalClasses shouldBeEqualTo 2
             countLocalClasses { it.name == "SampleLocalClass1" } shouldBeEqualTo 1
             hasLocalClasses() shouldBeEqualTo true
+            hasLocalClassWithName(emptyList()) shouldBeEqualTo true
+            hasLocalClassWithName(emptySet()) shouldBeEqualTo true
+            hasLocalClassesWithAllNames(emptyList()) shouldBeEqualTo true
+            hasLocalClassesWithAllNames(emptySet()) shouldBeEqualTo true
             hasLocalClassWithName("SampleLocalClass1") shouldBeEqualTo true
             hasLocalClassWithName("OtherLocalClass") shouldBeEqualTo false
             hasLocalClassWithName("SampleLocalClass1", "OtherLocalClass") shouldBeEqualTo true
+            hasLocalClassWithName(listOf("SampleLocalClass1")) shouldBeEqualTo true
+            hasLocalClassWithName(listOf("OtherLocalClass")) shouldBeEqualTo false
+            hasLocalClassWithName(listOf("SampleLocalClass1", "OtherLocalClass")) shouldBeEqualTo true
+            hasLocalClassWithName(setOf("SampleLocalClass1")) shouldBeEqualTo true
+            hasLocalClassWithName(setOf("OtherLocalClass")) shouldBeEqualTo false
+            hasLocalClassWithName(setOf("SampleLocalClass1", "OtherLocalClass")) shouldBeEqualTo true
             hasLocalClassesWithAllNames("SampleLocalClass1") shouldBeEqualTo true
             hasLocalClassesWithAllNames("SampleLocalClass1", "SampleLocalClass2") shouldBeEqualTo true
             hasLocalClassesWithAllNames("SampleLocalClass1", "OtherLocalClass") shouldBeEqualTo false
+            hasLocalClassesWithAllNames(listOf("SampleLocalClass1")) shouldBeEqualTo true
+            hasLocalClassesWithAllNames(listOf("SampleLocalClass1", "SampleLocalClass2")) shouldBeEqualTo true
+            hasLocalClassesWithAllNames(listOf("SampleLocalClass1", "OtherLocalClass")) shouldBeEqualTo false
+            hasLocalClassesWithAllNames(setOf("SampleLocalClass1")) shouldBeEqualTo true
+            hasLocalClassesWithAllNames(setOf("SampleLocalClass1", "SampleLocalClass2")) shouldBeEqualTo true
+            hasLocalClassesWithAllNames(setOf("SampleLocalClass1", "OtherLocalClass")) shouldBeEqualTo false
             hasLocalClass { it.name == "SampleLocalClass1" } shouldBeEqualTo true
             hasLocalClass { it.name == "OtherLocalClass" } shouldBeEqualTo false
             hasAllLocalClasses { it.name.endsWith("2") || it.name == "SampleLocalClass1" } shouldBeEqualTo true

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koinitblock/KoInitBlockDeclarationForKoLocalFunctionProviderTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koinitblock/KoInitBlockDeclarationForKoLocalFunctionProviderTest.kt
@@ -22,8 +22,16 @@ class KoInitBlockDeclarationForKoLocalFunctionProviderTest {
             numLocalFunctions shouldBeEqualTo 0
             countLocalFunctions { it.name == "sampleLocalFunction" } shouldBeEqualTo 0
             hasLocalFunctions() shouldBeEqualTo false
+            hasLocalFunctionWithName(emptyList()) shouldBeEqualTo false
+            hasLocalFunctionWithName(emptySet()) shouldBeEqualTo false
+            hasLocalFunctionsWithAllNames(emptyList()) shouldBeEqualTo false
+            hasLocalFunctionsWithAllNames(emptySet()) shouldBeEqualTo false
             hasLocalFunctionWithName("sampleLocalFunction") shouldBeEqualTo false
+            hasLocalFunctionWithName(listOf("sampleLocalFunction")) shouldBeEqualTo false
+            hasLocalFunctionWithName(setOf("sampleLocalFunction")) shouldBeEqualTo false
             hasLocalFunctionsWithAllNames("sampleLocalFunction1", "sampleLocalFunction2") shouldBeEqualTo false
+            hasLocalFunctionsWithAllNames(listOf("sampleLocalFunction1", "sampleLocalFunction2")) shouldBeEqualTo false
+            hasLocalFunctionsWithAllNames(setOf("sampleLocalFunction1", "sampleLocalFunction2")) shouldBeEqualTo false
             hasLocalFunction { it.name == "sampleLocalFunction" } shouldBeEqualTo false
             hasAllLocalFunctions { it.name == "sampleLocalFunction" } shouldBeEqualTo true
             containsLocalFunction { it.name == "sampleLocalFunction" } shouldBeEqualTo false
@@ -44,12 +52,28 @@ class KoInitBlockDeclarationForKoLocalFunctionProviderTest {
             numLocalFunctions shouldBeEqualTo 2
             countLocalFunctions { it.name == "sampleLocalFunction1" } shouldBeEqualTo 1
             hasLocalFunctions() shouldBeEqualTo true
+            hasLocalFunctionWithName(emptyList()) shouldBeEqualTo true
+            hasLocalFunctionWithName(emptySet()) shouldBeEqualTo true
+            hasLocalFunctionsWithAllNames(emptyList()) shouldBeEqualTo true
+            hasLocalFunctionsWithAllNames(emptySet()) shouldBeEqualTo true
             hasLocalFunctionWithName("sampleLocalFunction1") shouldBeEqualTo true
             hasLocalFunctionWithName("otherLocalFunction") shouldBeEqualTo false
             hasLocalFunctionWithName("sampleLocalFunction1", "otherLocalFunction") shouldBeEqualTo true
+            hasLocalFunctionWithName(listOf("sampleLocalFunction1")) shouldBeEqualTo true
+            hasLocalFunctionWithName(listOf("otherLocalFunction")) shouldBeEqualTo false
+            hasLocalFunctionWithName(listOf("sampleLocalFunction1", "otherLocalFunction")) shouldBeEqualTo true
+            hasLocalFunctionWithName(setOf("sampleLocalFunction1")) shouldBeEqualTo true
+            hasLocalFunctionWithName(setOf("otherLocalFunction")) shouldBeEqualTo false
+            hasLocalFunctionWithName(setOf("sampleLocalFunction1", "otherLocalFunction")) shouldBeEqualTo true
             hasLocalFunctionsWithAllNames("sampleLocalFunction1") shouldBeEqualTo true
             hasLocalFunctionsWithAllNames("sampleLocalFunction1", "sampleLocalFunction2") shouldBeEqualTo true
             hasLocalFunctionsWithAllNames("sampleLocalFunction1", "otherLocalFunction") shouldBeEqualTo false
+            hasLocalFunctionsWithAllNames(listOf("sampleLocalFunction1")) shouldBeEqualTo true
+            hasLocalFunctionsWithAllNames(listOf("sampleLocalFunction1", "sampleLocalFunction2")) shouldBeEqualTo true
+            hasLocalFunctionsWithAllNames(listOf("sampleLocalFunction1", "otherLocalFunction")) shouldBeEqualTo false
+            hasLocalFunctionsWithAllNames(setOf("sampleLocalFunction1")) shouldBeEqualTo true
+            hasLocalFunctionsWithAllNames(setOf("sampleLocalFunction1", "sampleLocalFunction2")) shouldBeEqualTo true
+            hasLocalFunctionsWithAllNames(setOf("sampleLocalFunction1", "otherLocalFunction")) shouldBeEqualTo false
             hasLocalFunction { it.name == "sampleLocalFunction1" } shouldBeEqualTo true
             hasLocalFunction { it.name == "otherLocalFunction" } shouldBeEqualTo false
             hasAllLocalFunctions { it.name.endsWith("2") || it.name == "sampleLocalFunction1" } shouldBeEqualTo true

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koinitblock/KoInitBlockDeclarationForKoVariableProviderTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koinitblock/KoInitBlockDeclarationForKoVariableProviderTest.kt
@@ -22,8 +22,16 @@ class KoInitBlockDeclarationForKoVariableProviderTest {
             numVariables shouldBeEqualTo 0
             countVariables { it.name == "sampleVariable" } shouldBeEqualTo 0
             hasVariables() shouldBeEqualTo false
+            hasVariableWithName(emptyList()) shouldBeEqualTo false
+            hasVariableWithName(emptySet()) shouldBeEqualTo false
+            hasVariablesWithAllNames(emptyList()) shouldBeEqualTo false
+            hasVariablesWithAllNames(emptySet()) shouldBeEqualTo false
             hasVariableWithName("sampleVariable") shouldBeEqualTo false
+            hasVariableWithName(listOf("sampleVariable")) shouldBeEqualTo false
+            hasVariableWithName(setOf("sampleVariable")) shouldBeEqualTo false
             hasVariablesWithAllNames("sampleVariable1", "sampleVariable2") shouldBeEqualTo false
+            hasVariablesWithAllNames(listOf("sampleVariable1", "sampleVariable2")) shouldBeEqualTo false
+            hasVariablesWithAllNames(setOf("sampleVariable1", "sampleVariable2")) shouldBeEqualTo false
             hasVariable { it.name == "sampleVariable" } shouldBeEqualTo false
             hasAllVariables { it.name == "sampleVariable" } shouldBeEqualTo true
         }
@@ -43,12 +51,28 @@ class KoInitBlockDeclarationForKoVariableProviderTest {
             numVariables shouldBeEqualTo 2
             countVariables { it.name == "sampleVariable1" } shouldBeEqualTo 1
             hasVariables() shouldBeEqualTo true
+            hasVariableWithName(emptyList()) shouldBeEqualTo true
+            hasVariableWithName(emptySet()) shouldBeEqualTo true
+            hasVariablesWithAllNames(emptyList()) shouldBeEqualTo true
+            hasVariablesWithAllNames(emptySet()) shouldBeEqualTo true
             hasVariableWithName("sampleVariable1") shouldBeEqualTo true
             hasVariableWithName("otherVariable") shouldBeEqualTo false
             hasVariableWithName("sampleVariable1", "otherVariable") shouldBeEqualTo true
+            hasVariableWithName(listOf("sampleVariable1")) shouldBeEqualTo true
+            hasVariableWithName(listOf("otherVariable")) shouldBeEqualTo false
+            hasVariableWithName(listOf("sampleVariable1", "otherVariable")) shouldBeEqualTo true
+            hasVariableWithName(setOf("sampleVariable1")) shouldBeEqualTo true
+            hasVariableWithName(setOf("otherVariable")) shouldBeEqualTo false
+            hasVariableWithName(setOf("sampleVariable1", "otherVariable")) shouldBeEqualTo true
             hasVariablesWithAllNames("sampleVariable1") shouldBeEqualTo true
             hasVariablesWithAllNames("sampleVariable1", "sampleVariable2") shouldBeEqualTo true
             hasVariablesWithAllNames("sampleVariable1", "otherVariable") shouldBeEqualTo false
+            hasVariablesWithAllNames(listOf("sampleVariable1")) shouldBeEqualTo true
+            hasVariablesWithAllNames(listOf("sampleVariable1", "sampleVariable2")) shouldBeEqualTo true
+            hasVariablesWithAllNames(listOf("sampleVariable1", "otherVariable")) shouldBeEqualTo false
+            hasVariablesWithAllNames(setOf("sampleVariable1")) shouldBeEqualTo true
+            hasVariablesWithAllNames(setOf("sampleVariable1", "sampleVariable2")) shouldBeEqualTo true
+            hasVariablesWithAllNames(setOf("sampleVariable1", "otherVariable")) shouldBeEqualTo false
             hasVariable { it.name == "sampleVariable1" } shouldBeEqualTo true
             hasVariable { it.name == "otherVariable" } shouldBeEqualTo false
             hasAllVariables { it.name.endsWith("2") || it.name == "sampleVariable1" } shouldBeEqualTo true

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/kointerface/KoInterfaceDeclarationForKoAnnotationProviderTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/kointerface/KoInterfaceDeclarationForKoAnnotationProviderTest.kt
@@ -9,6 +9,7 @@ import org.amshove.kluent.assertSoftly
 import org.amshove.kluent.shouldBeEqualTo
 import org.junit.jupiter.api.Test
 
+@Suppress("detekt.LongMethod")
 class KoInterfaceDeclarationForKoAnnotationProviderTest {
     @Test
     fun `interface-has-no-annotation`() {
@@ -82,19 +83,23 @@ class KoInterfaceDeclarationForKoAnnotationProviderTest {
             hasAnnotationWithName(listOf("SampleAnnotation", "OtherAnnotation")) shouldBeEqualTo true
             hasAnnotationWithName(listOf("com.lemonappdev.konsist.testdata.SampleAnnotation")) shouldBeEqualTo true
             hasAnnotationWithName(listOf("com.lemonappdev.konsist.testdata.NonExistingAnnotation")) shouldBeEqualTo false
-            hasAnnotationWithName(listOf(
-                "com.lemonappdev.konsist.testdata.SampleAnnotation",
-                "com.lemonappdev.konsist.testdata.NonExistingAnnotation",
-            )).shouldBeEqualTo(true)
+            hasAnnotationWithName(
+                listOf(
+                    "com.lemonappdev.konsist.testdata.SampleAnnotation",
+                    "com.lemonappdev.konsist.testdata.NonExistingAnnotation",
+                ),
+            ).shouldBeEqualTo(true)
             hasAnnotationWithName(setOf("SampleAnnotation")) shouldBeEqualTo true
             hasAnnotationWithName(setOf("OtherAnnotation")) shouldBeEqualTo false
             hasAnnotationWithName(setOf("SampleAnnotation", "OtherAnnotation")) shouldBeEqualTo true
             hasAnnotationWithName(setOf("com.lemonappdev.konsist.testdata.SampleAnnotation")) shouldBeEqualTo true
             hasAnnotationWithName(setOf("com.lemonappdev.konsist.testdata.NonExistingAnnotation")) shouldBeEqualTo false
-            hasAnnotationWithName(setOf(
-                "com.lemonappdev.konsist.testdata.SampleAnnotation",
-                "com.lemonappdev.konsist.testdata.NonExistingAnnotation",
-            )).shouldBeEqualTo(true)
+            hasAnnotationWithName(
+                setOf(
+                    "com.lemonappdev.konsist.testdata.SampleAnnotation",
+                    "com.lemonappdev.konsist.testdata.NonExistingAnnotation",
+                ),
+            ).shouldBeEqualTo(true)
             hasAnnotationsWithAllNames("SampleAnnotation") shouldBeEqualTo true
             hasAnnotationsWithAllNames("SampleAnnotation", "OtherAnnotation") shouldBeEqualTo false
             hasAnnotationsWithAllNames("com.lemonappdev.konsist.testdata.SampleAnnotation") shouldBeEqualTo true
@@ -105,10 +110,12 @@ class KoInterfaceDeclarationForKoAnnotationProviderTest {
             hasAnnotationsWithAllNames(listOf("SampleAnnotation")) shouldBeEqualTo true
             hasAnnotationsWithAllNames(listOf("SampleAnnotation", "OtherAnnotation")) shouldBeEqualTo false
             hasAnnotationsWithAllNames(listOf("com.lemonappdev.konsist.testdata.SampleAnnotation")) shouldBeEqualTo true
-            hasAnnotationsWithAllNames(listOf(
-                "com.lemonappdev.konsist.testdata.SampleAnnotation",
-                "com.lemonappdev.konsist.testdata.NonExistingAnnotation",
-            )).shouldBeEqualTo(false)
+            hasAnnotationsWithAllNames(
+                listOf(
+                    "com.lemonappdev.konsist.testdata.SampleAnnotation",
+                    "com.lemonappdev.konsist.testdata.NonExistingAnnotation",
+                ),
+            ).shouldBeEqualTo(false)
             hasAnnotation { it.hasNameStartingWith("Sample") } shouldBeEqualTo true
             hasAnnotation { it.hasNameStartingWith("Other") } shouldBeEqualTo false
             hasAllAnnotations { it.hasNameStartingWith("Sample") } shouldBeEqualTo true
@@ -172,19 +179,23 @@ class KoInterfaceDeclarationForKoAnnotationProviderTest {
             hasAnnotationWithName(listOf("SampleAnnotation1", "OtherAnnotation")) shouldBeEqualTo true
             hasAnnotationWithName(listOf("com.lemonappdev.konsist.testdata.SampleAnnotation1")) shouldBeEqualTo true
             hasAnnotationWithName(listOf("com.lemonappdev.konsist.testdata.NonExistingAnnotation")) shouldBeEqualTo false
-            hasAnnotationWithName(listOf(
-                "com.lemonappdev.konsist.testdata.SampleAnnotation1",
-                "com.lemonappdev.konsist.testdata.NonExistingAnnotation",
-            )).shouldBeEqualTo(true)
+            hasAnnotationWithName(
+                listOf(
+                    "com.lemonappdev.konsist.testdata.SampleAnnotation1",
+                    "com.lemonappdev.konsist.testdata.NonExistingAnnotation",
+                ),
+            ).shouldBeEqualTo(true)
             hasAnnotationWithName(setOf("SampleAnnotation1")) shouldBeEqualTo true
             hasAnnotationWithName(setOf("OtherAnnotation")) shouldBeEqualTo false
             hasAnnotationWithName(setOf("SampleAnnotation1", "OtherAnnotation")) shouldBeEqualTo true
             hasAnnotationWithName(setOf("com.lemonappdev.konsist.testdata.SampleAnnotation1")) shouldBeEqualTo true
             hasAnnotationWithName(setOf("com.lemonappdev.konsist.testdata.NonExistingAnnotation")) shouldBeEqualTo false
-            hasAnnotationWithName(setOf(
-                "com.lemonappdev.konsist.testdata.SampleAnnotation1",
-                "com.lemonappdev.konsist.testdata.NonExistingAnnotation",
-            )).shouldBeEqualTo(true)
+            hasAnnotationWithName(
+                setOf(
+                    "com.lemonappdev.konsist.testdata.SampleAnnotation1",
+                    "com.lemonappdev.konsist.testdata.NonExistingAnnotation",
+                ),
+            ).shouldBeEqualTo(true)
             hasAnnotationsWithAllNames("SampleAnnotation1") shouldBeEqualTo true
             hasAnnotationsWithAllNames("SampleAnnotation1", "SampleAnnotation2") shouldBeEqualTo true
             hasAnnotationsWithAllNames("SampleAnnotation1", "OtherAnnotation") shouldBeEqualTo false
@@ -202,14 +213,18 @@ class KoInterfaceDeclarationForKoAnnotationProviderTest {
             hasAnnotationsWithAllNames(listOf("SampleAnnotation1", "SampleAnnotation2")) shouldBeEqualTo true
             hasAnnotationsWithAllNames(listOf("SampleAnnotation1", "OtherAnnotation")) shouldBeEqualTo false
             hasAnnotationsWithAllNames(listOf("com.lemonappdev.konsist.testdata.SampleAnnotation1")) shouldBeEqualTo true
-            hasAnnotationsWithAllNames(listOf(
-                "com.lemonappdev.konsist.testdata.SampleAnnotation1",
-                "com.lemonappdev.konsist.testdata.NonExistingAnnotation",
-            )).shouldBeEqualTo(false)
-            hasAnnotationsWithAllNames(listOf(
-                "com.lemonappdev.konsist.testdata.SampleAnnotation1",
-                "com.lemonappdev.konsist.testdata.SampleAnnotation2",
-            )).shouldBeEqualTo(true)
+            hasAnnotationsWithAllNames(
+                listOf(
+                    "com.lemonappdev.konsist.testdata.SampleAnnotation1",
+                    "com.lemonappdev.konsist.testdata.NonExistingAnnotation",
+                ),
+            ).shouldBeEqualTo(false)
+            hasAnnotationsWithAllNames(
+                listOf(
+                    "com.lemonappdev.konsist.testdata.SampleAnnotation1",
+                    "com.lemonappdev.konsist.testdata.SampleAnnotation2",
+                ),
+            ).shouldBeEqualTo(true)
             hasAnnotation { it.name == "SampleAnnotation1" } shouldBeEqualTo true
             hasAnnotation { it.name == "OtherAnnotation1" } shouldBeEqualTo false
             hasAllAnnotations { !it.hasArguments() } shouldBeEqualTo true

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/kointerface/KoInterfaceDeclarationForKoAnnotationProviderTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/kointerface/KoInterfaceDeclarationForKoAnnotationProviderTest.kt
@@ -24,12 +24,28 @@ class KoInterfaceDeclarationForKoAnnotationProviderTest {
             numAnnotations shouldBeEqualTo 0
             countAnnotations { it.name == "NonExistingAnnotation" } shouldBeEqualTo 0
             hasAnnotations() shouldBeEqualTo false
+            hasAnnotationWithName(emptyList()) shouldBeEqualTo false
+            hasAnnotationWithName(emptySet()) shouldBeEqualTo false
+            hasAnnotationsWithAllNames(emptyList()) shouldBeEqualTo false
+            hasAnnotationsWithAllNames(emptySet()) shouldBeEqualTo false
             hasAnnotationWithName("SampleAnnotation") shouldBeEqualTo false
+            hasAnnotationWithName(listOf("SampleAnnotation")) shouldBeEqualTo false
+            hasAnnotationWithName(setOf("SampleAnnotation")) shouldBeEqualTo false
             hasAnnotationsWithAllNames("SampleAnnotation1", "SampleAnnotation2") shouldBeEqualTo false
+            hasAnnotationsWithAllNames(listOf("SampleAnnotation1", "SampleAnnotation2")) shouldBeEqualTo false
+            hasAnnotationsWithAllNames(setOf("SampleAnnotation1", "SampleAnnotation2")) shouldBeEqualTo false
             hasAnnotation { it.hasArguments() } shouldBeEqualTo false
             hasAllAnnotations { it.hasArguments() } shouldBeEqualTo true
+            hasAnnotationOf(emptyList()) shouldBeEqualTo false
+            hasAnnotationOf(emptySet()) shouldBeEqualTo false
+            hasAllAnnotationsOf(emptyList()) shouldBeEqualTo false
+            hasAllAnnotationsOf(emptySet()) shouldBeEqualTo false
             hasAnnotationOf(SampleAnnotation::class) shouldBeEqualTo false
+            hasAnnotationOf(listOf(SampleAnnotation::class)) shouldBeEqualTo false
+            hasAnnotationOf(setOf(SampleAnnotation::class)) shouldBeEqualTo false
             hasAllAnnotationsOf(SampleAnnotation1::class, SampleAnnotation2::class) shouldBeEqualTo false
+            hasAllAnnotationsOf(listOf(SampleAnnotation1::class, SampleAnnotation2::class)) shouldBeEqualTo false
+            hasAllAnnotationsOf(setOf(SampleAnnotation1::class, SampleAnnotation2::class)) shouldBeEqualTo false
             hasAnnotations("SampleAnnotation") shouldBeEqualTo false
         }
     }
@@ -48,6 +64,10 @@ class KoInterfaceDeclarationForKoAnnotationProviderTest {
             countAnnotations { it.name == "SampleAnnotation" } shouldBeEqualTo 1
             countAnnotations { it.name == "NonExistingAnnotation" } shouldBeEqualTo 0
             hasAnnotations() shouldBeEqualTo true
+            hasAnnotationWithName(emptyList()) shouldBeEqualTo true
+            hasAnnotationWithName(emptySet()) shouldBeEqualTo true
+            hasAnnotationsWithAllNames(emptyList()) shouldBeEqualTo true
+            hasAnnotationsWithAllNames(emptySet()) shouldBeEqualTo true
             hasAnnotationWithName("SampleAnnotation") shouldBeEqualTo true
             hasAnnotationWithName("OtherAnnotation") shouldBeEqualTo false
             hasAnnotationWithName("SampleAnnotation", "OtherAnnotation") shouldBeEqualTo true
@@ -57,6 +77,24 @@ class KoInterfaceDeclarationForKoAnnotationProviderTest {
                 "com.lemonappdev.konsist.testdata.SampleAnnotation",
                 "com.lemonappdev.konsist.testdata.NonExistingAnnotation",
             ).shouldBeEqualTo(true)
+            hasAnnotationWithName(listOf("SampleAnnotation")) shouldBeEqualTo true
+            hasAnnotationWithName(listOf("OtherAnnotation")) shouldBeEqualTo false
+            hasAnnotationWithName(listOf("SampleAnnotation", "OtherAnnotation")) shouldBeEqualTo true
+            hasAnnotationWithName(listOf("com.lemonappdev.konsist.testdata.SampleAnnotation")) shouldBeEqualTo true
+            hasAnnotationWithName(listOf("com.lemonappdev.konsist.testdata.NonExistingAnnotation")) shouldBeEqualTo false
+            hasAnnotationWithName(listOf(
+                "com.lemonappdev.konsist.testdata.SampleAnnotation",
+                "com.lemonappdev.konsist.testdata.NonExistingAnnotation",
+            )).shouldBeEqualTo(true)
+            hasAnnotationWithName(setOf("SampleAnnotation")) shouldBeEqualTo true
+            hasAnnotationWithName(setOf("OtherAnnotation")) shouldBeEqualTo false
+            hasAnnotationWithName(setOf("SampleAnnotation", "OtherAnnotation")) shouldBeEqualTo true
+            hasAnnotationWithName(setOf("com.lemonappdev.konsist.testdata.SampleAnnotation")) shouldBeEqualTo true
+            hasAnnotationWithName(setOf("com.lemonappdev.konsist.testdata.NonExistingAnnotation")) shouldBeEqualTo false
+            hasAnnotationWithName(setOf(
+                "com.lemonappdev.konsist.testdata.SampleAnnotation",
+                "com.lemonappdev.konsist.testdata.NonExistingAnnotation",
+            )).shouldBeEqualTo(true)
             hasAnnotationsWithAllNames("SampleAnnotation") shouldBeEqualTo true
             hasAnnotationsWithAllNames("SampleAnnotation", "OtherAnnotation") shouldBeEqualTo false
             hasAnnotationsWithAllNames("com.lemonappdev.konsist.testdata.SampleAnnotation") shouldBeEqualTo true
@@ -64,15 +102,35 @@ class KoInterfaceDeclarationForKoAnnotationProviderTest {
                 "com.lemonappdev.konsist.testdata.SampleAnnotation",
                 "com.lemonappdev.konsist.testdata.NonExistingAnnotation",
             ).shouldBeEqualTo(false)
+            hasAnnotationsWithAllNames(listOf("SampleAnnotation")) shouldBeEqualTo true
+            hasAnnotationsWithAllNames(listOf("SampleAnnotation", "OtherAnnotation")) shouldBeEqualTo false
+            hasAnnotationsWithAllNames(listOf("com.lemonappdev.konsist.testdata.SampleAnnotation")) shouldBeEqualTo true
+            hasAnnotationsWithAllNames(listOf(
+                "com.lemonappdev.konsist.testdata.SampleAnnotation",
+                "com.lemonappdev.konsist.testdata.NonExistingAnnotation",
+            )).shouldBeEqualTo(false)
             hasAnnotation { it.hasNameStartingWith("Sample") } shouldBeEqualTo true
             hasAnnotation { it.hasNameStartingWith("Other") } shouldBeEqualTo false
             hasAllAnnotations { it.hasNameStartingWith("Sample") } shouldBeEqualTo true
-            hasAnnotationOf(SampleAnnotation::class) shouldBeEqualTo true
-            hasAnnotationOf(NonExistingAnnotation::class) shouldBeEqualTo false
-            hasAnnotationOf(SampleAnnotation::class, NonExistingAnnotation::class) shouldBeEqualTo true
+            hasAnnotationOf(emptyList()) shouldBeEqualTo true
+            hasAnnotationOf(emptySet()) shouldBeEqualTo true
+            hasAllAnnotationsOf(emptyList()) shouldBeEqualTo true
+            hasAllAnnotationsOf(emptySet()) shouldBeEqualTo true
+            hasAnnotationOf(listOf(SampleAnnotation::class)) shouldBeEqualTo true
+            hasAnnotationOf(listOf(NonExistingAnnotation::class)) shouldBeEqualTo false
+            hasAnnotationOf(listOf(SampleAnnotation::class, NonExistingAnnotation::class)) shouldBeEqualTo true
+            hasAnnotationOf(setOf(SampleAnnotation::class)) shouldBeEqualTo true
+            hasAnnotationOf(setOf(NonExistingAnnotation::class)) shouldBeEqualTo false
+            hasAnnotationOf(setOf(SampleAnnotation::class, NonExistingAnnotation::class)) shouldBeEqualTo true
             hasAllAnnotationsOf(SampleAnnotation::class) shouldBeEqualTo true
             hasAllAnnotationsOf(NonExistingAnnotation::class) shouldBeEqualTo false
             hasAllAnnotationsOf(SampleAnnotation::class, NonExistingAnnotation::class) shouldBeEqualTo false
+            hasAllAnnotationsOf(listOf(SampleAnnotation::class)) shouldBeEqualTo true
+            hasAllAnnotationsOf(listOf(NonExistingAnnotation::class)) shouldBeEqualTo false
+            hasAllAnnotationsOf(listOf(SampleAnnotation::class, NonExistingAnnotation::class)) shouldBeEqualTo false
+            hasAllAnnotationsOf(setOf(SampleAnnotation::class)) shouldBeEqualTo true
+            hasAllAnnotationsOf(setOf(NonExistingAnnotation::class)) shouldBeEqualTo false
+            hasAllAnnotationsOf(setOf(SampleAnnotation::class, NonExistingAnnotation::class)) shouldBeEqualTo false
             hasAnnotations("SampleAnnotation") shouldBeEqualTo true
             hasAnnotations("NonExistingAnnotation") shouldBeEqualTo false
             hasAnnotations("com.lemonappdev.konsist.testdata.SampleAnnotation") shouldBeEqualTo true
@@ -96,6 +154,10 @@ class KoInterfaceDeclarationForKoAnnotationProviderTest {
             countAnnotations { it.hasNameStartingWith("Sample") } shouldBeEqualTo 2
             countAnnotations { it.name == "SampleAnnotation1" } shouldBeEqualTo 1
             hasAnnotations() shouldBeEqualTo true
+            hasAnnotationOf(emptyList()) shouldBeEqualTo true
+            hasAnnotationOf(emptySet()) shouldBeEqualTo true
+            hasAllAnnotationsOf(emptyList()) shouldBeEqualTo true
+            hasAllAnnotationsOf(emptySet()) shouldBeEqualTo true
             hasAnnotationWithName("SampleAnnotation1") shouldBeEqualTo true
             hasAnnotationWithName("OtherAnnotation") shouldBeEqualTo false
             hasAnnotationWithName("SampleAnnotation1", "OtherAnnotation") shouldBeEqualTo true
@@ -105,6 +167,24 @@ class KoInterfaceDeclarationForKoAnnotationProviderTest {
                 "com.lemonappdev.konsist.testdata.SampleAnnotation1",
                 "com.lemonappdev.konsist.testdata.NonExistingAnnotation",
             ).shouldBeEqualTo(true)
+            hasAnnotationWithName(listOf("SampleAnnotation1")) shouldBeEqualTo true
+            hasAnnotationWithName(listOf("OtherAnnotation")) shouldBeEqualTo false
+            hasAnnotationWithName(listOf("SampleAnnotation1", "OtherAnnotation")) shouldBeEqualTo true
+            hasAnnotationWithName(listOf("com.lemonappdev.konsist.testdata.SampleAnnotation1")) shouldBeEqualTo true
+            hasAnnotationWithName(listOf("com.lemonappdev.konsist.testdata.NonExistingAnnotation")) shouldBeEqualTo false
+            hasAnnotationWithName(listOf(
+                "com.lemonappdev.konsist.testdata.SampleAnnotation1",
+                "com.lemonappdev.konsist.testdata.NonExistingAnnotation",
+            )).shouldBeEqualTo(true)
+            hasAnnotationWithName(setOf("SampleAnnotation1")) shouldBeEqualTo true
+            hasAnnotationWithName(setOf("OtherAnnotation")) shouldBeEqualTo false
+            hasAnnotationWithName(setOf("SampleAnnotation1", "OtherAnnotation")) shouldBeEqualTo true
+            hasAnnotationWithName(setOf("com.lemonappdev.konsist.testdata.SampleAnnotation1")) shouldBeEqualTo true
+            hasAnnotationWithName(setOf("com.lemonappdev.konsist.testdata.NonExistingAnnotation")) shouldBeEqualTo false
+            hasAnnotationWithName(setOf(
+                "com.lemonappdev.konsist.testdata.SampleAnnotation1",
+                "com.lemonappdev.konsist.testdata.NonExistingAnnotation",
+            )).shouldBeEqualTo(true)
             hasAnnotationsWithAllNames("SampleAnnotation1") shouldBeEqualTo true
             hasAnnotationsWithAllNames("SampleAnnotation1", "SampleAnnotation2") shouldBeEqualTo true
             hasAnnotationsWithAllNames("SampleAnnotation1", "OtherAnnotation") shouldBeEqualTo false
@@ -117,17 +197,48 @@ class KoInterfaceDeclarationForKoAnnotationProviderTest {
                 "com.lemonappdev.konsist.testdata.SampleAnnotation1",
                 "com.lemonappdev.konsist.testdata.SampleAnnotation2",
             ).shouldBeEqualTo(true)
+
+            hasAnnotationsWithAllNames(listOf("SampleAnnotation1")) shouldBeEqualTo true
+            hasAnnotationsWithAllNames(listOf("SampleAnnotation1", "SampleAnnotation2")) shouldBeEqualTo true
+            hasAnnotationsWithAllNames(listOf("SampleAnnotation1", "OtherAnnotation")) shouldBeEqualTo false
+            hasAnnotationsWithAllNames(listOf("com.lemonappdev.konsist.testdata.SampleAnnotation1")) shouldBeEqualTo true
+            hasAnnotationsWithAllNames(listOf(
+                "com.lemonappdev.konsist.testdata.SampleAnnotation1",
+                "com.lemonappdev.konsist.testdata.NonExistingAnnotation",
+            )).shouldBeEqualTo(false)
+            hasAnnotationsWithAllNames(listOf(
+                "com.lemonappdev.konsist.testdata.SampleAnnotation1",
+                "com.lemonappdev.konsist.testdata.SampleAnnotation2",
+            )).shouldBeEqualTo(true)
             hasAnnotation { it.name == "SampleAnnotation1" } shouldBeEqualTo true
             hasAnnotation { it.name == "OtherAnnotation1" } shouldBeEqualTo false
             hasAllAnnotations { !it.hasArguments() } shouldBeEqualTo true
             hasAllAnnotations { it.hasNameEndingWith("tion1") } shouldBeEqualTo false
+            hasAnnotationOf(emptyList()) shouldBeEqualTo true
+            hasAnnotationOf(emptySet()) shouldBeEqualTo true
+            hasAllAnnotationsOf(emptyList()) shouldBeEqualTo true
+            hasAllAnnotationsOf(emptySet()) shouldBeEqualTo true
             hasAnnotationOf(SampleAnnotation1::class) shouldBeEqualTo true
             hasAnnotationOf(NonExistingAnnotation::class) shouldBeEqualTo false
             hasAnnotationOf(SampleAnnotation1::class, NonExistingAnnotation::class) shouldBeEqualTo true
+            hasAnnotationOf(listOf(SampleAnnotation1::class)) shouldBeEqualTo true
+            hasAnnotationOf(listOf(NonExistingAnnotation::class)) shouldBeEqualTo false
+            hasAnnotationOf(listOf(SampleAnnotation1::class, NonExistingAnnotation::class)) shouldBeEqualTo true
+            hasAnnotationOf(setOf(SampleAnnotation1::class)) shouldBeEqualTo true
+            hasAnnotationOf(setOf(NonExistingAnnotation::class)) shouldBeEqualTo false
+            hasAnnotationOf(setOf(SampleAnnotation1::class, NonExistingAnnotation::class)) shouldBeEqualTo true
             hasAllAnnotationsOf(SampleAnnotation1::class) shouldBeEqualTo true
             hasAllAnnotationsOf(NonExistingAnnotation::class) shouldBeEqualTo false
             hasAllAnnotationsOf(SampleAnnotation1::class, SampleAnnotation2::class) shouldBeEqualTo true
             hasAllAnnotationsOf(SampleAnnotation1::class, NonExistingAnnotation::class) shouldBeEqualTo false
+            hasAllAnnotationsOf(listOf(SampleAnnotation1::class)) shouldBeEqualTo true
+            hasAllAnnotationsOf(listOf(NonExistingAnnotation::class)) shouldBeEqualTo false
+            hasAllAnnotationsOf(listOf(SampleAnnotation1::class, SampleAnnotation2::class)) shouldBeEqualTo true
+            hasAllAnnotationsOf(listOf(SampleAnnotation1::class, NonExistingAnnotation::class)) shouldBeEqualTo false
+            hasAllAnnotationsOf(setOf(SampleAnnotation1::class)) shouldBeEqualTo true
+            hasAllAnnotationsOf(setOf(NonExistingAnnotation::class)) shouldBeEqualTo false
+            hasAllAnnotationsOf(setOf(SampleAnnotation1::class, SampleAnnotation2::class)) shouldBeEqualTo true
+            hasAllAnnotationsOf(setOf(SampleAnnotation1::class, NonExistingAnnotation::class)) shouldBeEqualTo false
             hasAnnotations("SampleAnnotation1") shouldBeEqualTo true
             hasAnnotations("SampleAnnotation2") shouldBeEqualTo true
             hasAnnotations("NonExistingAnnotation") shouldBeEqualTo false

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/kointerface/KoInterfaceDeclarationForKoClassProviderTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/kointerface/KoInterfaceDeclarationForKoClassProviderTest.kt
@@ -21,8 +21,16 @@ class KoInterfaceDeclarationForKoClassProviderTest {
         assertSoftly(sut) {
             classes() shouldBeEqualTo emptyList()
             hasClasses() shouldBeEqualTo false
+            hasClassWithName(emptyList()) shouldBeEqualTo false
+            hasClassWithName(emptySet()) shouldBeEqualTo false
+            hasClassesWithAllNames(emptyList()) shouldBeEqualTo false
+            hasClassesWithAllNames(emptySet()) shouldBeEqualTo false
             hasClassWithName("SampleClass") shouldBeEqualTo false
+            hasClassWithName(listOf("SampleClass")) shouldBeEqualTo false
+            hasClassWithName(setOf("SampleClass")) shouldBeEqualTo false
             hasClassesWithAllNames("SampleClass1", "SampleClass2") shouldBeEqualTo false
+            hasClassesWithAllNames(listOf("SampleClass1", "SampleClass2")) shouldBeEqualTo false
+            hasClassesWithAllNames(setOf("SampleClass1", "SampleClass2")) shouldBeEqualTo false
             hasClass { it.name == "SampleClass" } shouldBeEqualTo false
             hasAllClasses { it.hasNameStartingWith("Sample") } shouldBeEqualTo true
         }
@@ -39,11 +47,25 @@ class KoInterfaceDeclarationForKoClassProviderTest {
         // then
         assertSoftly(sut) {
             hasClasses() shouldBeEqualTo true
+            hasClassWithName(emptyList()) shouldBeEqualTo true
+            hasClassWithName(emptySet()) shouldBeEqualTo true
+            hasClassesWithAllNames(emptyList()) shouldBeEqualTo true
+            hasClassesWithAllNames(emptySet()) shouldBeEqualTo true
             hasClassWithName("SampleClass1") shouldBeEqualTo true
             hasClassWithName("SampleClass1", "OtherClass") shouldBeEqualTo true
+            hasClassWithName(listOf("SampleClass1")) shouldBeEqualTo true
+            hasClassWithName(listOf("SampleClass1", "OtherClass")) shouldBeEqualTo true
+            hasClassWithName(setOf("SampleClass1")) shouldBeEqualTo true
+            hasClassWithName(setOf("SampleClass1", "OtherClass")) shouldBeEqualTo true
             hasClassesWithAllNames("SampleClass1") shouldBeEqualTo true
             hasClassesWithAllNames("SampleClass1", "SampleClass2") shouldBeEqualTo true
             hasClassesWithAllNames("SampleClass1", "OtherClass") shouldBeEqualTo false
+            hasClassesWithAllNames(listOf("SampleClass1")) shouldBeEqualTo true
+            hasClassesWithAllNames(listOf("SampleClass1", "SampleClass2")) shouldBeEqualTo true
+            hasClassesWithAllNames(listOf("SampleClass1", "OtherClass")) shouldBeEqualTo false
+            hasClassesWithAllNames(setOf("SampleClass1")) shouldBeEqualTo true
+            hasClassesWithAllNames(setOf("SampleClass1", "SampleClass2")) shouldBeEqualTo true
+            hasClassesWithAllNames(setOf("SampleClass1", "OtherClass")) shouldBeEqualTo false
             hasClass { it.name == "SampleClass1" } shouldBeEqualTo true
             hasClass { it.hasNameEndingWith("Class1") } shouldBeEqualTo true
             hasAllClasses { it.hasNameStartingWith("Sample") } shouldBeEqualTo true

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/kointerface/KoInterfaceDeclarationForKoExternalParentProviderTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/kointerface/KoInterfaceDeclarationForKoExternalParentProviderTest.kt
@@ -10,6 +10,7 @@ import org.amshove.kluent.assertSoftly
 import org.amshove.kluent.shouldBeEqualTo
 import org.junit.jupiter.api.Test
 
+@Suppress("detekt.LongMethod")
 class KoInterfaceDeclarationForKoExternalParentProviderTest {
     @Test
     fun `interface-has-no-external-parent`() {
@@ -225,14 +226,18 @@ class KoInterfaceDeclarationForKoExternalParentProviderTest {
             ) shouldBeEqualTo true
             hasExternalParentWithName(listOf("SampleExternalGenericInterface"), indirectParents = true) shouldBeEqualTo true
             hasExternalParentWithName(listOf("OtherInterface"), indirectParents = true) shouldBeEqualTo false
-            hasExternalParentWithName(listOf(
-                "SampleExternalGenericInterface",
-                "SampleExternalInterface"),
+            hasExternalParentWithName(
+                listOf(
+                    "SampleExternalGenericInterface",
+                    "SampleExternalInterface",
+                ),
                 indirectParents = true,
             ) shouldBeEqualTo true
-            hasExternalParentWithName(listOf(
-                "SampleExternalGenericInterface",
-                "OtherInterface"),
+            hasExternalParentWithName(
+                listOf(
+                    "SampleExternalGenericInterface",
+                    "OtherInterface",
+                ),
                 indirectParents = true,
             ) shouldBeEqualTo true
             hasExternalParentsWithAllNames("SampleExternalGenericInterface", indirectParents = true) shouldBeEqualTo true
@@ -250,14 +255,18 @@ class KoInterfaceDeclarationForKoExternalParentProviderTest {
 
             hasExternalParentsWithAllNames(listOf("SampleExternalGenericInterface"), indirectParents = true) shouldBeEqualTo true
             hasExternalParentsWithAllNames(listOf("OtherInterface"), indirectParents = true) shouldBeEqualTo false
-            hasExternalParentsWithAllNames(listOf(
-                "SampleExternalGenericInterface",
-                "SampleExternalInterface"),
+            hasExternalParentsWithAllNames(
+                listOf(
+                    "SampleExternalGenericInterface",
+                    "SampleExternalInterface",
+                ),
                 indirectParents = true,
             ) shouldBeEqualTo true
-            hasExternalParentsWithAllNames(listOf(
-                "SampleExternalGenericInterface",
-                "OtherInterface"),
+            hasExternalParentsWithAllNames(
+                listOf(
+                    "SampleExternalGenericInterface",
+                    "OtherInterface",
+                ),
                 indirectParents = true,
             ) shouldBeEqualTo false
             hasExternalParent(indirectParents = true) { it.name == "SampleExternalGenericInterface" } shouldBeEqualTo true
@@ -272,9 +281,11 @@ class KoInterfaceDeclarationForKoExternalParentProviderTest {
                 indirectParents = true,
             ) shouldBeEqualTo true
             hasExternalParentOf(listOf(SampleExternalGenericInterface::class), indirectParents = true) shouldBeEqualTo true
-            hasExternalParentOf(listOf(
-                SampleExternalGenericInterface::class,
-                SampleParentClass::class),
+            hasExternalParentOf(
+                listOf(
+                    SampleExternalGenericInterface::class,
+                    SampleParentClass::class,
+                ),
                 indirectParents = true,
             ) shouldBeEqualTo true
             hasAllExternalParentsOf(SampleExternalGenericInterface::class, indirectParents = true) shouldBeEqualTo true
@@ -290,14 +301,18 @@ class KoInterfaceDeclarationForKoExternalParentProviderTest {
             ) shouldBeEqualTo true
 
             hasAllExternalParentsOf(listOf(SampleExternalGenericInterface::class), indirectParents = true) shouldBeEqualTo true
-            hasAllExternalParentsOf(listOf(
-                SampleExternalGenericInterface::class,
-                SampleParentClass::class),
+            hasAllExternalParentsOf(
+                listOf(
+                    SampleExternalGenericInterface::class,
+                    SampleParentClass::class,
+                ),
                 indirectParents = true,
             ) shouldBeEqualTo false
-            hasAllExternalParentsOf(listOf(
-                SampleExternalGenericInterface::class,
-                SampleExternalInterface::class),
+            hasAllExternalParentsOf(
+                listOf(
+                    SampleExternalGenericInterface::class,
+                    SampleExternalInterface::class,
+                ),
                 indirectParents = true,
             ) shouldBeEqualTo true
         }

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/kointerface/KoInterfaceDeclarationForKoExternalParentProviderTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/kointerface/KoInterfaceDeclarationForKoExternalParentProviderTest.kt
@@ -25,12 +25,24 @@ class KoInterfaceDeclarationForKoExternalParentProviderTest {
             numExternalParents() shouldBeEqualTo 0
             countExternalParents { it.name == "SampleExternalParent" } shouldBeEqualTo 0
             hasExternalParents() shouldBeEqualTo false
+            hasExternalParentWithName(emptyList()) shouldBeEqualTo false
+            hasExternalParentWithName(emptySet()) shouldBeEqualTo false
+            hasExternalParentsWithAllNames(emptyList()) shouldBeEqualTo false
+            hasExternalParentsWithAllNames(emptySet()) shouldBeEqualTo false
             hasExternalParentWithName("SampleExternalParent1", "SampleExternalParent2") shouldBeEqualTo false
+            hasExternalParentWithName(listOf("SampleExternalParent1", "SampleExternalParent2")) shouldBeEqualTo false
+            hasExternalParentWithName(setOf("SampleExternalParent1", "SampleExternalParent2")) shouldBeEqualTo false
             hasExternalParentsWithAllNames("SampleExternalParent1", "SampleExternalParent2") shouldBeEqualTo false
+            hasExternalParentsWithAllNames(listOf("SampleExternalParent1", "SampleExternalParent2")) shouldBeEqualTo false
+            hasExternalParentsWithAllNames(setOf("SampleExternalParent1", "SampleExternalParent2")) shouldBeEqualTo false
             hasExternalParent { it.name == "SampleExternalParent" } shouldBeEqualTo false
             hasAllExternalParents { it.hasNameStartingWith("Sample") } shouldBeEqualTo true
             hasExternalParentOf(SampleParentInterface1::class) shouldBeEqualTo false
+            hasExternalParentOf(listOf(SampleParentInterface1::class)) shouldBeEqualTo false
+            hasExternalParentOf(setOf(SampleParentInterface1::class)) shouldBeEqualTo false
             hasAllExternalParentsOf(SampleParentInterface1::class, SampleParentInterface2::class) shouldBeEqualTo false
+            hasAllExternalParentsOf(listOf(SampleParentInterface1::class, SampleParentInterface2::class)) shouldBeEqualTo false
+            hasAllExternalParentsOf(setOf(SampleParentInterface1::class, SampleParentInterface2::class)) shouldBeEqualTo false
         }
     }
 
@@ -49,14 +61,34 @@ class KoInterfaceDeclarationForKoExternalParentProviderTest {
             countExternalParents { it.name == "SampleExternalInterface" } shouldBeEqualTo 1
             countExternalParents { it.hasNameStartingWith("SampleExternal") } shouldBeEqualTo 2
             hasExternalParents() shouldBeEqualTo true
+            hasExternalParentWithName(emptyList()) shouldBeEqualTo true
+            hasExternalParentWithName(emptySet()) shouldBeEqualTo true
+            hasExternalParentsWithAllNames(emptyList()) shouldBeEqualTo true
+            hasExternalParentsWithAllNames(emptySet()) shouldBeEqualTo true
             hasExternalParentWithName("SampleExternalInterface") shouldBeEqualTo true
             hasExternalParentWithName("OtherInterface") shouldBeEqualTo false
             hasExternalParentWithName("SampleExternalInterface", "SampleExternalGenericInterface") shouldBeEqualTo true
             hasExternalParentWithName("SampleExternalInterface", "OtherInterface") shouldBeEqualTo true
+            hasExternalParentWithName(listOf("SampleExternalInterface")) shouldBeEqualTo true
+            hasExternalParentWithName(listOf("OtherInterface")) shouldBeEqualTo false
+            hasExternalParentWithName(listOf("SampleExternalInterface", "SampleExternalGenericInterface")) shouldBeEqualTo true
+            hasExternalParentWithName(listOf("SampleExternalInterface", "OtherInterface")) shouldBeEqualTo true
+            hasExternalParentWithName(setOf("SampleExternalInterface")) shouldBeEqualTo true
+            hasExternalParentWithName(setOf("OtherInterface")) shouldBeEqualTo false
+            hasExternalParentWithName(setOf("SampleExternalInterface", "SampleExternalGenericInterface")) shouldBeEqualTo true
+            hasExternalParentWithName(setOf("SampleExternalInterface", "OtherInterface")) shouldBeEqualTo true
             hasExternalParentsWithAllNames("SampleExternalInterface") shouldBeEqualTo true
             hasExternalParentsWithAllNames("OtherInterface") shouldBeEqualTo false
             hasExternalParentsWithAllNames("SampleExternalInterface", "SampleExternalGenericInterface") shouldBeEqualTo true
             hasExternalParentsWithAllNames("SampleExternalInterface", "OtherInterface") shouldBeEqualTo false
+            hasExternalParentsWithAllNames(listOf("SampleExternalInterface")) shouldBeEqualTo true
+            hasExternalParentsWithAllNames(listOf("OtherInterface")) shouldBeEqualTo false
+            hasExternalParentsWithAllNames(listOf("SampleExternalInterface", "SampleExternalGenericInterface")) shouldBeEqualTo true
+            hasExternalParentsWithAllNames(listOf("SampleExternalInterface", "OtherInterface")) shouldBeEqualTo false
+            hasExternalParentsWithAllNames(setOf("SampleExternalInterface")) shouldBeEqualTo true
+            hasExternalParentsWithAllNames(setOf("OtherInterface")) shouldBeEqualTo false
+            hasExternalParentsWithAllNames(setOf("SampleExternalInterface", "SampleExternalGenericInterface")) shouldBeEqualTo true
+            hasExternalParentsWithAllNames(setOf("SampleExternalInterface", "OtherInterface")) shouldBeEqualTo false
             hasExternalParent { it.name == "SampleExternalInterface" } shouldBeEqualTo true
             hasExternalParent { it.name == "OtherInterface" } shouldBeEqualTo false
             hasAllExternalParents { it.name == "SampleExternalInterface" } shouldBeEqualTo false
@@ -64,9 +96,19 @@ class KoInterfaceDeclarationForKoExternalParentProviderTest {
             hasAllExternalParents { it.hasNameStartingWith("Other") } shouldBeEqualTo false
             hasExternalParentOf(SampleExternalInterface::class) shouldBeEqualTo true
             hasExternalParentOf(SampleExternalInterface::class, SampleParentClass::class) shouldBeEqualTo true
+            hasExternalParentOf(listOf(SampleExternalInterface::class)) shouldBeEqualTo true
+            hasExternalParentOf(listOf(SampleExternalInterface::class, SampleParentClass::class)) shouldBeEqualTo true
+            hasExternalParentOf(setOf(SampleExternalInterface::class)) shouldBeEqualTo true
+            hasExternalParentOf(setOf(SampleExternalInterface::class, SampleParentClass::class)) shouldBeEqualTo true
             hasAllExternalParentsOf(SampleExternalInterface::class) shouldBeEqualTo true
             hasAllExternalParentsOf(SampleExternalInterface::class, SampleParentClass::class) shouldBeEqualTo false
             hasAllExternalParentsOf(SampleExternalInterface::class, SampleExternalGenericInterface::class) shouldBeEqualTo true
+            hasAllExternalParentsOf(listOf(SampleExternalInterface::class)) shouldBeEqualTo true
+            hasAllExternalParentsOf(listOf(SampleExternalInterface::class, SampleParentClass::class)) shouldBeEqualTo false
+            hasAllExternalParentsOf(listOf(SampleExternalInterface::class, SampleExternalGenericInterface::class)) shouldBeEqualTo true
+            hasAllExternalParentsOf(setOf(SampleExternalInterface::class)) shouldBeEqualTo true
+            hasAllExternalParentsOf(setOf(SampleExternalInterface::class, SampleParentClass::class)) shouldBeEqualTo false
+            hasAllExternalParentsOf(setOf(SampleExternalInterface::class, SampleExternalGenericInterface::class)) shouldBeEqualTo true
         }
     }
 
@@ -85,14 +127,34 @@ class KoInterfaceDeclarationForKoExternalParentProviderTest {
             countExternalParents { it.name == "SampleExternalInterface" } shouldBeEqualTo 1
             countExternalParents { it.hasNameStartingWith("SampleExternal") } shouldBeEqualTo 2
             hasExternalParents() shouldBeEqualTo true
+            hasExternalParentWithName(emptyList()) shouldBeEqualTo true
+            hasExternalParentWithName(emptySet()) shouldBeEqualTo true
+            hasExternalParentsWithAllNames(emptyList()) shouldBeEqualTo true
+            hasExternalParentsWithAllNames(emptySet()) shouldBeEqualTo true
             hasExternalParentWithName("SampleExternalInterface") shouldBeEqualTo true
             hasExternalParentWithName("OtherInterface") shouldBeEqualTo false
             hasExternalParentWithName("SampleExternalInterface", "SampleExternalGenericInterface") shouldBeEqualTo true
             hasExternalParentWithName("SampleExternalInterface", "OtherInterface") shouldBeEqualTo true
+            hasExternalParentWithName(listOf("SampleExternalInterface")) shouldBeEqualTo true
+            hasExternalParentWithName(listOf("OtherInterface")) shouldBeEqualTo false
+            hasExternalParentWithName(listOf("SampleExternalInterface", "SampleExternalGenericInterface")) shouldBeEqualTo true
+            hasExternalParentWithName(listOf("SampleExternalInterface", "OtherInterface")) shouldBeEqualTo true
+            hasExternalParentWithName(setOf("SampleExternalInterface")) shouldBeEqualTo true
+            hasExternalParentWithName(setOf("OtherInterface")) shouldBeEqualTo false
+            hasExternalParentWithName(setOf("SampleExternalInterface", "SampleExternalGenericInterface")) shouldBeEqualTo true
+            hasExternalParentWithName(setOf("SampleExternalInterface", "OtherInterface")) shouldBeEqualTo true
             hasExternalParentsWithAllNames("SampleExternalInterface") shouldBeEqualTo true
             hasExternalParentsWithAllNames("OtherInterface") shouldBeEqualTo false
             hasExternalParentsWithAllNames("SampleExternalInterface", "SampleExternalGenericInterface") shouldBeEqualTo true
             hasExternalParentsWithAllNames("SampleExternalInterface", "OtherInterface") shouldBeEqualTo false
+            hasExternalParentsWithAllNames(listOf("SampleExternalInterface")) shouldBeEqualTo true
+            hasExternalParentsWithAllNames(listOf("OtherInterface")) shouldBeEqualTo false
+            hasExternalParentsWithAllNames(listOf("SampleExternalInterface", "SampleExternalGenericInterface")) shouldBeEqualTo true
+            hasExternalParentsWithAllNames(listOf("SampleExternalInterface", "OtherInterface")) shouldBeEqualTo false
+            hasExternalParentsWithAllNames(setOf("SampleExternalInterface")) shouldBeEqualTo true
+            hasExternalParentsWithAllNames(setOf("OtherInterface")) shouldBeEqualTo false
+            hasExternalParentsWithAllNames(setOf("SampleExternalInterface", "SampleExternalGenericInterface")) shouldBeEqualTo true
+            hasExternalParentsWithAllNames(setOf("SampleExternalInterface", "OtherInterface")) shouldBeEqualTo false
             hasExternalParent { it.name == "SampleExternalInterface" } shouldBeEqualTo true
             hasExternalParent { it.name == "OtherInterface" } shouldBeEqualTo false
             hasAllExternalParents { it.name == "SampleExternalInterface" } shouldBeEqualTo false
@@ -100,9 +162,19 @@ class KoInterfaceDeclarationForKoExternalParentProviderTest {
             hasAllExternalParents { it.hasNameStartingWith("Other") } shouldBeEqualTo false
             hasExternalParentOf(SampleExternalInterface::class) shouldBeEqualTo true
             hasExternalParentOf(SampleExternalInterface::class, SampleParentClass::class) shouldBeEqualTo true
+            hasExternalParentOf(listOf(SampleExternalInterface::class)) shouldBeEqualTo true
+            hasExternalParentOf(listOf(SampleExternalInterface::class, SampleParentClass::class)) shouldBeEqualTo true
+            hasExternalParentOf(setOf(SampleExternalInterface::class)) shouldBeEqualTo true
+            hasExternalParentOf(setOf(SampleExternalInterface::class, SampleParentClass::class)) shouldBeEqualTo true
             hasAllExternalParentsOf(SampleExternalInterface::class) shouldBeEqualTo true
             hasAllExternalParentsOf(SampleExternalInterface::class, SampleParentClass::class) shouldBeEqualTo false
             hasAllExternalParentsOf(SampleExternalInterface::class, SampleExternalGenericInterface::class) shouldBeEqualTo true
+            hasAllExternalParentsOf(listOf(SampleExternalInterface::class)) shouldBeEqualTo true
+            hasAllExternalParentsOf(listOf(SampleExternalInterface::class, SampleParentClass::class)) shouldBeEqualTo false
+            hasAllExternalParentsOf(listOf(SampleExternalInterface::class, SampleExternalGenericInterface::class)) shouldBeEqualTo true
+            hasAllExternalParentsOf(setOf(SampleExternalInterface::class)) shouldBeEqualTo true
+            hasAllExternalParentsOf(setOf(SampleExternalInterface::class, SampleParentClass::class)) shouldBeEqualTo false
+            hasAllExternalParentsOf(setOf(SampleExternalInterface::class, SampleExternalGenericInterface::class)) shouldBeEqualTo true
         }
     }
 
@@ -131,6 +203,14 @@ class KoInterfaceDeclarationForKoExternalParentProviderTest {
             countExternalParents(indirectParents = true) { it.hasNameStartingWith("SampleExternal") } shouldBeEqualTo 2
             hasExternalParents(indirectParents = false) shouldBeEqualTo false
             hasExternalParents(indirectParents = true) shouldBeEqualTo true
+            hasExternalParentWithName(emptyList(), indirectParents = false) shouldBeEqualTo false
+            hasExternalParentWithName(emptySet(), indirectParents = false) shouldBeEqualTo false
+            hasExternalParentsWithAllNames(emptyList(), indirectParents = false) shouldBeEqualTo false
+            hasExternalParentsWithAllNames(emptySet(), indirectParents = false) shouldBeEqualTo false
+            hasExternalParentWithName(emptyList(), indirectParents = true) shouldBeEqualTo true
+            hasExternalParentWithName(emptySet(), indirectParents = true) shouldBeEqualTo true
+            hasExternalParentsWithAllNames(emptyList(), indirectParents = true) shouldBeEqualTo true
+            hasExternalParentsWithAllNames(emptySet(), indirectParents = true) shouldBeEqualTo true
             hasExternalParentWithName("SampleExternalGenericInterface", indirectParents = true) shouldBeEqualTo true
             hasExternalParentWithName("OtherInterface", indirectParents = true) shouldBeEqualTo false
             hasExternalParentWithName(
@@ -141,6 +221,18 @@ class KoInterfaceDeclarationForKoExternalParentProviderTest {
             hasExternalParentWithName(
                 "SampleExternalGenericInterface",
                 "OtherInterface",
+                indirectParents = true,
+            ) shouldBeEqualTo true
+            hasExternalParentWithName(listOf("SampleExternalGenericInterface"), indirectParents = true) shouldBeEqualTo true
+            hasExternalParentWithName(listOf("OtherInterface"), indirectParents = true) shouldBeEqualTo false
+            hasExternalParentWithName(listOf(
+                "SampleExternalGenericInterface",
+                "SampleExternalInterface"),
+                indirectParents = true,
+            ) shouldBeEqualTo true
+            hasExternalParentWithName(listOf(
+                "SampleExternalGenericInterface",
+                "OtherInterface"),
                 indirectParents = true,
             ) shouldBeEqualTo true
             hasExternalParentsWithAllNames("SampleExternalGenericInterface", indirectParents = true) shouldBeEqualTo true
@@ -155,6 +247,19 @@ class KoInterfaceDeclarationForKoExternalParentProviderTest {
                 "OtherInterface",
                 indirectParents = true,
             ) shouldBeEqualTo false
+
+            hasExternalParentsWithAllNames(listOf("SampleExternalGenericInterface"), indirectParents = true) shouldBeEqualTo true
+            hasExternalParentsWithAllNames(listOf("OtherInterface"), indirectParents = true) shouldBeEqualTo false
+            hasExternalParentsWithAllNames(listOf(
+                "SampleExternalGenericInterface",
+                "SampleExternalInterface"),
+                indirectParents = true,
+            ) shouldBeEqualTo true
+            hasExternalParentsWithAllNames(listOf(
+                "SampleExternalGenericInterface",
+                "OtherInterface"),
+                indirectParents = true,
+            ) shouldBeEqualTo false
             hasExternalParent(indirectParents = true) { it.name == "SampleExternalGenericInterface" } shouldBeEqualTo true
             hasExternalParent(indirectParents = true) { it.name == "OtherInterface" } shouldBeEqualTo false
             hasAllExternalParents(indirectParents = true) { it.name == "SampleExternalGenericInterface" } shouldBeEqualTo false
@@ -166,6 +271,12 @@ class KoInterfaceDeclarationForKoExternalParentProviderTest {
                 SampleParentClass::class,
                 indirectParents = true,
             ) shouldBeEqualTo true
+            hasExternalParentOf(listOf(SampleExternalGenericInterface::class), indirectParents = true) shouldBeEqualTo true
+            hasExternalParentOf(listOf(
+                SampleExternalGenericInterface::class,
+                SampleParentClass::class),
+                indirectParents = true,
+            ) shouldBeEqualTo true
             hasAllExternalParentsOf(SampleExternalGenericInterface::class, indirectParents = true) shouldBeEqualTo true
             hasAllExternalParentsOf(
                 SampleExternalGenericInterface::class,
@@ -175,6 +286,18 @@ class KoInterfaceDeclarationForKoExternalParentProviderTest {
             hasAllExternalParentsOf(
                 SampleExternalGenericInterface::class,
                 SampleExternalInterface::class,
+                indirectParents = true,
+            ) shouldBeEqualTo true
+
+            hasAllExternalParentsOf(listOf(SampleExternalGenericInterface::class), indirectParents = true) shouldBeEqualTo true
+            hasAllExternalParentsOf(listOf(
+                SampleExternalGenericInterface::class,
+                SampleParentClass::class),
+                indirectParents = true,
+            ) shouldBeEqualTo false
+            hasAllExternalParentsOf(listOf(
+                SampleExternalGenericInterface::class,
+                SampleExternalInterface::class),
                 indirectParents = true,
             ) shouldBeEqualTo true
         }

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/kointerface/KoInterfaceDeclarationForKoFunctionProviderTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/kointerface/KoInterfaceDeclarationForKoFunctionProviderTest.kt
@@ -20,8 +20,16 @@ class KoInterfaceDeclarationForKoFunctionProviderTest {
         assertSoftly(sut) {
             functions() shouldBeEqualTo emptyList()
             hasFunctions() shouldBeEqualTo false
+            hasFunctionWithName(emptyList()) shouldBeEqualTo false
+            hasFunctionWithName(emptySet()) shouldBeEqualTo false
+            hasFunctionsWithAllNames(emptyList()) shouldBeEqualTo false
+            hasFunctionsWithAllNames(emptySet()) shouldBeEqualTo false
             hasFunctionWithName("sampleFunction") shouldBeEqualTo false
+            hasFunctionWithName(listOf("sampleFunction")) shouldBeEqualTo false
+            hasFunctionWithName(setOf("sampleFunction")) shouldBeEqualTo false
             hasFunctionsWithAllNames("sampleFunction1", "sampleFunction2") shouldBeEqualTo false
+            hasFunctionsWithAllNames(listOf("sampleFunction1", "sampleFunction2")) shouldBeEqualTo false
+            hasFunctionsWithAllNames(setOf("sampleFunction1", "sampleFunction2")) shouldBeEqualTo false
             hasFunction { it.name == "sampleFunction" } shouldBeEqualTo false
             hasAllFunctions { it.hasNameStartingWith("sample") } shouldBeEqualTo true
         }
@@ -38,11 +46,25 @@ class KoInterfaceDeclarationForKoFunctionProviderTest {
         // then
         assertSoftly(sut) {
             hasFunctions() shouldBeEqualTo true
+            hasFunctionWithName(emptyList()) shouldBeEqualTo true
+            hasFunctionWithName(emptySet()) shouldBeEqualTo true
+            hasFunctionsWithAllNames(emptyList()) shouldBeEqualTo true
+            hasFunctionsWithAllNames(emptySet()) shouldBeEqualTo true
             hasFunctionWithName("sampleFunction1") shouldBeEqualTo true
             hasFunctionWithName("sampleFunction1", "otherFunction") shouldBeEqualTo true
+            hasFunctionWithName(listOf("sampleFunction1")) shouldBeEqualTo true
+            hasFunctionWithName(listOf("sampleFunction1", "otherFunction")) shouldBeEqualTo true
+            hasFunctionWithName(setOf("sampleFunction1")) shouldBeEqualTo true
+            hasFunctionWithName(setOf("sampleFunction1", "otherFunction")) shouldBeEqualTo true
             hasFunctionsWithAllNames("sampleFunction1") shouldBeEqualTo true
             hasFunctionsWithAllNames("sampleFunction1", "sampleFunction2") shouldBeEqualTo true
             hasFunctionsWithAllNames("sampleFunction1", "otherFunction") shouldBeEqualTo false
+            hasFunctionsWithAllNames(listOf("sampleFunction1")) shouldBeEqualTo true
+            hasFunctionsWithAllNames(listOf("sampleFunction1", "sampleFunction2")) shouldBeEqualTo true
+            hasFunctionsWithAllNames(listOf("sampleFunction1", "otherFunction")) shouldBeEqualTo false
+            hasFunctionsWithAllNames(setOf("sampleFunction1")) shouldBeEqualTo true
+            hasFunctionsWithAllNames(setOf("sampleFunction1", "sampleFunction2")) shouldBeEqualTo true
+            hasFunctionsWithAllNames(setOf("sampleFunction1", "otherFunction")) shouldBeEqualTo false
             hasFunction { it.name == "sampleFunction1" } shouldBeEqualTo true
             hasFunction { it.hasNameEndingWith("Function1") } shouldBeEqualTo true
             hasAllFunctions { it.hasNameStartingWith("sample") } shouldBeEqualTo true

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/kointerface/KoInterfaceDeclarationForKoInterfaceProviderTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/kointerface/KoInterfaceDeclarationForKoInterfaceProviderTest.kt
@@ -19,10 +19,17 @@ class KoInterfaceDeclarationForKoInterfaceProviderTest {
 
         // then
         assertSoftly(sut) {
-            interfaces() shouldBeEqualTo emptyList()
             hasInterfaces() shouldBeEqualTo false
+            hasInterfaceWithName(emptyList()) shouldBeEqualTo false
+            hasInterfaceWithName(emptySet()) shouldBeEqualTo false
+            hasInterfacesWithAllNames(emptyList()) shouldBeEqualTo false
+            hasInterfacesWithAllNames(emptySet()) shouldBeEqualTo false
             hasInterfaceWithName("SampleInterface") shouldBeEqualTo false
+            hasInterfaceWithName(listOf("SampleInterface")) shouldBeEqualTo false
+            hasInterfaceWithName(setOf("SampleInterface")) shouldBeEqualTo false
             hasInterfacesWithAllNames("SampleInterface1", "SampleInterface2") shouldBeEqualTo false
+            hasInterfacesWithAllNames(listOf("SampleInterface1", "SampleInterface2")) shouldBeEqualTo false
+            hasInterfacesWithAllNames(setOf("SampleInterface1", "SampleInterface2")) shouldBeEqualTo false
             hasInterface { it.name == "SampleInterface" } shouldBeEqualTo false
             hasAllInterfaces { it.hasNameStartingWith("Sample") } shouldBeEqualTo true
         }
@@ -39,11 +46,25 @@ class KoInterfaceDeclarationForKoInterfaceProviderTest {
         // then
         assertSoftly(sut) {
             hasInterfaces() shouldBeEqualTo true
+            hasInterfaceWithName(emptyList()) shouldBeEqualTo true
+            hasInterfaceWithName(emptySet()) shouldBeEqualTo true
+            hasInterfacesWithAllNames(emptyList()) shouldBeEqualTo true
+            hasInterfacesWithAllNames(emptySet()) shouldBeEqualTo true
             hasInterfaceWithName("SampleInterface1") shouldBeEqualTo true
             hasInterfaceWithName("SampleInterface1", "OtherInterface") shouldBeEqualTo true
+            hasInterfaceWithName(listOf("SampleInterface1")) shouldBeEqualTo true
+            hasInterfaceWithName(listOf("SampleInterface1", "OtherInterface")) shouldBeEqualTo true
+            hasInterfaceWithName(setOf("SampleInterface1")) shouldBeEqualTo true
+            hasInterfaceWithName(setOf("SampleInterface1", "OtherInterface")) shouldBeEqualTo true
             hasInterfacesWithAllNames("SampleInterface1") shouldBeEqualTo true
             hasInterfacesWithAllNames("SampleInterface1", "SampleInterface2") shouldBeEqualTo true
             hasInterfacesWithAllNames("SampleInterface1", "OtherInterface") shouldBeEqualTo false
+            hasInterfacesWithAllNames(listOf("SampleInterface1")) shouldBeEqualTo true
+            hasInterfacesWithAllNames(listOf("SampleInterface1", "SampleInterface2")) shouldBeEqualTo true
+            hasInterfacesWithAllNames(listOf("SampleInterface1", "OtherInterface")) shouldBeEqualTo false
+            hasInterfacesWithAllNames(setOf("SampleInterface1")) shouldBeEqualTo true
+            hasInterfacesWithAllNames(setOf("SampleInterface1", "SampleInterface2")) shouldBeEqualTo true
+            hasInterfacesWithAllNames(setOf("SampleInterface1", "OtherInterface")) shouldBeEqualTo false
             hasInterface { it.name == "SampleInterface1" } shouldBeEqualTo true
             hasInterface { it.hasNameEndingWith("Interface1") } shouldBeEqualTo true
             hasAllInterfaces { it.hasNameStartingWith("Sample") } shouldBeEqualTo true

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/kointerface/KoInterfaceDeclarationForKoObjectProviderTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/kointerface/KoInterfaceDeclarationForKoObjectProviderTest.kt
@@ -21,8 +21,16 @@ class KoInterfaceDeclarationForKoObjectProviderTest {
         assertSoftly(sut) {
             objects() shouldBeEqualTo emptyList()
             hasObjects() shouldBeEqualTo false
+            hasObjectWithName(emptyList()) shouldBeEqualTo false
+            hasObjectWithName(emptySet()) shouldBeEqualTo false
+            hasObjectsWithAllNames(emptyList()) shouldBeEqualTo false
+            hasObjectsWithAllNames(emptySet()) shouldBeEqualTo false
             hasObjectWithName("SampleObject") shouldBeEqualTo false
+            hasObjectWithName(listOf("SampleObject")) shouldBeEqualTo false
+            hasObjectWithName(setOf("SampleObject")) shouldBeEqualTo false
             hasObjectsWithAllNames("SampleObject1", "SampleObject2") shouldBeEqualTo false
+            hasObjectsWithAllNames(listOf("SampleObject1", "SampleObject2")) shouldBeEqualTo false
+            hasObjectsWithAllNames(setOf("SampleObject1", "SampleObject2")) shouldBeEqualTo false
             hasObject { it.name == "SampleObject" } shouldBeEqualTo false
             hasAllObjects { it.hasNameStartingWith("Sample") } shouldBeEqualTo true
         }
@@ -39,11 +47,25 @@ class KoInterfaceDeclarationForKoObjectProviderTest {
         // then
         assertSoftly(sut) {
             hasObjects() shouldBeEqualTo true
+            hasObjectWithName(emptyList()) shouldBeEqualTo true
+            hasObjectWithName(emptySet()) shouldBeEqualTo true
+            hasObjectsWithAllNames(emptyList()) shouldBeEqualTo true
+            hasObjectsWithAllNames(emptySet()) shouldBeEqualTo true
             hasObjectWithName("SampleObject1") shouldBeEqualTo true
             hasObjectWithName("SampleObject1", "OtherObject") shouldBeEqualTo true
+            hasObjectWithName(listOf("SampleObject1")) shouldBeEqualTo true
+            hasObjectWithName(listOf("SampleObject1", "OtherObject")) shouldBeEqualTo true
+            hasObjectWithName(setOf("SampleObject1")) shouldBeEqualTo true
+            hasObjectWithName(setOf("SampleObject1", "OtherObject")) shouldBeEqualTo true
             hasObjectsWithAllNames("SampleObject1") shouldBeEqualTo true
             hasObjectsWithAllNames("SampleObject1", "SampleObject2") shouldBeEqualTo true
             hasObjectsWithAllNames("SampleObject1", "OtherObject") shouldBeEqualTo false
+            hasObjectsWithAllNames(listOf("SampleObject1")) shouldBeEqualTo true
+            hasObjectsWithAllNames(listOf("SampleObject1", "SampleObject2")) shouldBeEqualTo true
+            hasObjectsWithAllNames(listOf("SampleObject1", "OtherObject")) shouldBeEqualTo false
+            hasObjectsWithAllNames(setOf("SampleObject1")) shouldBeEqualTo true
+            hasObjectsWithAllNames(setOf("SampleObject1", "SampleObject2")) shouldBeEqualTo true
+            hasObjectsWithAllNames(setOf("SampleObject1", "OtherObject")) shouldBeEqualTo false
             hasObject { it.name == "SampleObject1" } shouldBeEqualTo true
             hasObject { it.hasNameEndingWith("Object1") } shouldBeEqualTo true
             hasAllObjects { it.hasNameStartingWith("Sample") } shouldBeEqualTo true

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/kointerface/KoInterfaceDeclarationForKoParentInterfaceProviderTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/kointerface/KoInterfaceDeclarationForKoParentInterfaceProviderTest.kt
@@ -230,14 +230,18 @@ class KoInterfaceDeclarationForKoParentInterfaceProviderTest {
             ) shouldBeEqualTo true
             hasParentInterfaceWithName(listOf("SampleParentInterface2"), indirectParents = true) shouldBeEqualTo true
             hasParentInterfaceWithName(listOf("OtherInterface"), indirectParents = true) shouldBeEqualTo false
-            hasParentInterfaceWithName(listOf(
-                "SampleParentInterface1",
-                "SampleParentInterface2"),
+            hasParentInterfaceWithName(
+                listOf(
+                    "SampleParentInterface1",
+                    "SampleParentInterface2",
+                ),
                 indirectParents = true,
             ) shouldBeEqualTo true
-            hasParentInterfaceWithName(listOf(
-                "SampleParentInterface2",
-                "OtherInterface"),
+            hasParentInterfaceWithName(
+                listOf(
+                    "SampleParentInterface2",
+                    "OtherInterface",
+                ),
                 indirectParents = true,
             ) shouldBeEqualTo true
             hasParentInterfacesWithAllNames("SampleParentInterface2", indirectParents = true) shouldBeEqualTo true
@@ -254,14 +258,18 @@ class KoInterfaceDeclarationForKoParentInterfaceProviderTest {
             ) shouldBeEqualTo false
             hasParentInterfacesWithAllNames(listOf("SampleParentInterface2"), indirectParents = true) shouldBeEqualTo true
             hasParentInterfacesWithAllNames(listOf("OtherInterface"), indirectParents = true) shouldBeEqualTo false
-            hasParentInterfacesWithAllNames(listOf(
-                "SampleParentInterface1",
-                "SampleParentInterface2"),
+            hasParentInterfacesWithAllNames(
+                listOf(
+                    "SampleParentInterface1",
+                    "SampleParentInterface2",
+                ),
                 indirectParents = true,
             ) shouldBeEqualTo true
-            hasParentInterfacesWithAllNames(listOf(
-                "SampleParentInterface2",
-                "OtherInterface"),
+            hasParentInterfacesWithAllNames(
+                listOf(
+                    "SampleParentInterface2",
+                    "OtherInterface",
+                ),
                 indirectParents = true,
             ) shouldBeEqualTo false
             hasParentInterface(indirectParents = true) { it.name == "SampleParentInterface2" } shouldBeEqualTo true
@@ -276,9 +284,11 @@ class KoInterfaceDeclarationForKoParentInterfaceProviderTest {
                 indirectParents = true,
             ) shouldBeEqualTo true
             hasParentInterfaceOf(listOf(SampleParentInterface2::class), indirectParents = true) shouldBeEqualTo true
-            hasParentInterfaceOf(listOf(
-                SampleParentInterface1::class,
-                SampleParentInterface2::class),
+            hasParentInterfaceOf(
+                listOf(
+                    SampleParentInterface1::class,
+                    SampleParentInterface2::class,
+                ),
                 indirectParents = true,
             ) shouldBeEqualTo true
             hasAllParentInterfacesOf(SampleParentInterface2::class, indirectParents = true) shouldBeEqualTo true
@@ -288,9 +298,11 @@ class KoInterfaceDeclarationForKoParentInterfaceProviderTest {
                 indirectParents = true,
             ) shouldBeEqualTo false
             hasAllParentInterfacesOf(listOf(SampleParentInterface2::class), indirectParents = true) shouldBeEqualTo true
-            hasAllParentInterfacesOf(listOf(
-                SampleParentInterface2::class,
-                SampleParentInterface::class),
+            hasAllParentInterfacesOf(
+                listOf(
+                    SampleParentInterface2::class,
+                    SampleParentInterface::class,
+                ),
                 indirectParents = true,
             ) shouldBeEqualTo false
         }

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/kointerface/KoInterfaceDeclarationForKoParentInterfaceProviderTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/kointerface/KoInterfaceDeclarationForKoParentInterfaceProviderTest.kt
@@ -9,6 +9,7 @@ import org.amshove.kluent.assertSoftly
 import org.amshove.kluent.shouldBeEqualTo
 import org.junit.jupiter.api.Test
 
+@Suppress("detekt.LongMethod")
 class KoInterfaceDeclarationForKoParentInterfaceProviderTest {
     @Test
     fun `interface-has-no-parent-interface`() {

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/kointerface/KoInterfaceDeclarationForKoParentInterfaceProviderTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/kointerface/KoInterfaceDeclarationForKoParentInterfaceProviderTest.kt
@@ -24,12 +24,24 @@ class KoInterfaceDeclarationForKoParentInterfaceProviderTest {
             numParentInterfaces shouldBeEqualTo 0
             countParentInterfaces { it.name == "SampleParentInterface" } shouldBeEqualTo 0
             hasParentInterfaces() shouldBeEqualTo false
+            hasParentInterfaceWithName(emptyList()) shouldBeEqualTo false
+            hasParentInterfaceWithName(emptySet()) shouldBeEqualTo false
+            hasParentInterfacesWithAllNames(emptyList()) shouldBeEqualTo false
+            hasParentInterfacesWithAllNames(emptySet()) shouldBeEqualTo false
             hasParentInterfaceWithName("SampleParentInterface1", "SampleParentInterface2") shouldBeEqualTo false
+            hasParentInterfaceWithName(listOf("SampleParentInterface1", "SampleParentInterface2")) shouldBeEqualTo false
+            hasParentInterfaceWithName(setOf("SampleParentInterface1", "SampleParentInterface2")) shouldBeEqualTo false
             hasParentInterfacesWithAllNames("SampleParentInterface1", "SampleParentInterface2") shouldBeEqualTo false
+            hasParentInterfacesWithAllNames(listOf("SampleParentInterface1", "SampleParentInterface2")) shouldBeEqualTo false
+            hasParentInterfacesWithAllNames(setOf("SampleParentInterface1", "SampleParentInterface2")) shouldBeEqualTo false
             hasParentInterface { it.name == "SampleParentInterface" } shouldBeEqualTo false
             hasAllParentInterfaces { it.hasNameStartingWith("Sample") } shouldBeEqualTo true
             hasParentInterfaceOf(SampleParentInterface1::class) shouldBeEqualTo false
+            hasParentInterfaceOf(listOf(SampleParentInterface1::class)) shouldBeEqualTo false
+            hasParentInterfaceOf(setOf(SampleParentInterface1::class)) shouldBeEqualTo false
             hasAllParentInterfacesOf(SampleParentInterface1::class, SampleParentInterface2::class) shouldBeEqualTo false
+            hasAllParentInterfacesOf(listOf(SampleParentInterface1::class, SampleParentInterface2::class)) shouldBeEqualTo false
+            hasAllParentInterfacesOf(setOf(SampleParentInterface1::class, SampleParentInterface2::class)) shouldBeEqualTo false
             hasParentInterfaces("SampleParentInterface") shouldBeEqualTo false
         }
     }
@@ -49,14 +61,34 @@ class KoInterfaceDeclarationForKoParentInterfaceProviderTest {
             countParentInterfaces { it.name == "SampleParentInterface1" } shouldBeEqualTo 1
             countParentInterfaces { it.hasNameStartingWith("SampleParentInterface") } shouldBeEqualTo 2
             hasParentInterfaces() shouldBeEqualTo true
+            hasParentInterfaceWithName(emptyList()) shouldBeEqualTo true
+            hasParentInterfaceWithName(emptySet()) shouldBeEqualTo true
+            hasParentInterfacesWithAllNames(emptyList()) shouldBeEqualTo true
+            hasParentInterfacesWithAllNames(emptySet()) shouldBeEqualTo true
             hasParentInterfaceWithName("SampleParentInterface1") shouldBeEqualTo true
             hasParentInterfaceWithName("OtherInterface") shouldBeEqualTo false
             hasParentInterfaceWithName("SampleParentInterface1", "SampleParentInterface2") shouldBeEqualTo true
             hasParentInterfaceWithName("SampleParentInterface1", "OtherInterface") shouldBeEqualTo true
+            hasParentInterfaceWithName(listOf("SampleParentInterface1")) shouldBeEqualTo true
+            hasParentInterfaceWithName(listOf("OtherInterface")) shouldBeEqualTo false
+            hasParentInterfaceWithName(listOf("SampleParentInterface1", "SampleParentInterface2")) shouldBeEqualTo true
+            hasParentInterfaceWithName(listOf("SampleParentInterface1", "OtherInterface")) shouldBeEqualTo true
+            hasParentInterfaceWithName(setOf("SampleParentInterface1")) shouldBeEqualTo true
+            hasParentInterfaceWithName(setOf("OtherInterface")) shouldBeEqualTo false
+            hasParentInterfaceWithName(setOf("SampleParentInterface1", "SampleParentInterface2")) shouldBeEqualTo true
+            hasParentInterfaceWithName(setOf("SampleParentInterface1", "OtherInterface")) shouldBeEqualTo true
             hasParentInterfacesWithAllNames("SampleParentInterface1") shouldBeEqualTo true
             hasParentInterfacesWithAllNames("OtherInterface") shouldBeEqualTo false
             hasParentInterfacesWithAllNames("SampleParentInterface1", "SampleParentInterface2") shouldBeEqualTo true
             hasParentInterfacesWithAllNames("SampleParentInterface1", "OtherInterface") shouldBeEqualTo false
+            hasParentInterfacesWithAllNames(listOf("SampleParentInterface1")) shouldBeEqualTo true
+            hasParentInterfacesWithAllNames(listOf("OtherInterface")) shouldBeEqualTo false
+            hasParentInterfacesWithAllNames(listOf("SampleParentInterface1", "SampleParentInterface2")) shouldBeEqualTo true
+            hasParentInterfacesWithAllNames(listOf("SampleParentInterface1", "OtherInterface")) shouldBeEqualTo false
+            hasParentInterfacesWithAllNames(setOf("SampleParentInterface1")) shouldBeEqualTo true
+            hasParentInterfacesWithAllNames(setOf("OtherInterface")) shouldBeEqualTo false
+            hasParentInterfacesWithAllNames(setOf("SampleParentInterface1", "SampleParentInterface2")) shouldBeEqualTo true
+            hasParentInterfacesWithAllNames(setOf("SampleParentInterface1", "OtherInterface")) shouldBeEqualTo false
             hasParentInterface { it.name == "SampleParentInterface1" } shouldBeEqualTo true
             hasParentInterface { it.name == "OtherInterface" } shouldBeEqualTo false
             hasAllParentInterfaces { it.name == "SampleParentInterface1" } shouldBeEqualTo false
@@ -64,9 +96,19 @@ class KoInterfaceDeclarationForKoParentInterfaceProviderTest {
             hasAllParentInterfaces { it.hasNameStartingWith("Other") } shouldBeEqualTo false
             hasParentInterfaceOf(SampleParentInterface1::class) shouldBeEqualTo true
             hasParentInterfaceOf(SampleParentInterface1::class, SampleParentClass::class) shouldBeEqualTo true
+            hasParentInterfaceOf(listOf(SampleParentInterface1::class)) shouldBeEqualTo true
+            hasParentInterfaceOf(listOf(SampleParentInterface1::class, SampleParentClass::class)) shouldBeEqualTo true
+            hasParentInterfaceOf(setOf(SampleParentInterface1::class)) shouldBeEqualTo true
+            hasParentInterfaceOf(setOf(SampleParentInterface1::class, SampleParentClass::class)) shouldBeEqualTo true
             hasAllParentInterfacesOf(SampleParentInterface1::class) shouldBeEqualTo true
             hasAllParentInterfacesOf(SampleParentInterface1::class, SampleParentClass::class) shouldBeEqualTo false
             hasAllParentInterfacesOf(SampleParentInterface1::class, SampleParentInterface2::class) shouldBeEqualTo true
+            hasAllParentInterfacesOf(listOf(SampleParentInterface1::class)) shouldBeEqualTo true
+            hasAllParentInterfacesOf(listOf(SampleParentInterface1::class, SampleParentClass::class)) shouldBeEqualTo false
+            hasAllParentInterfacesOf(listOf(SampleParentInterface1::class, SampleParentInterface2::class)) shouldBeEqualTo true
+            hasAllParentInterfacesOf(setOf(SampleParentInterface1::class)) shouldBeEqualTo true
+            hasAllParentInterfacesOf(setOf(SampleParentInterface1::class, SampleParentClass::class)) shouldBeEqualTo false
+            hasAllParentInterfacesOf(setOf(SampleParentInterface1::class, SampleParentInterface2::class)) shouldBeEqualTo true
             hasParentInterfaces("SampleParentInterface1") shouldBeEqualTo true
             hasParentInterfaces("OtherInterface") shouldBeEqualTo false
             hasParentInterfaces("SampleParentInterface1", "SampleParentInterface2") shouldBeEqualTo true
@@ -89,14 +131,34 @@ class KoInterfaceDeclarationForKoParentInterfaceProviderTest {
             countParentInterfaces { it.name == "SampleParentInterface1" } shouldBeEqualTo 1
             countParentInterfaces { it.hasNameStartingWith("SampleParentInterface") } shouldBeEqualTo 2
             hasParentInterfaces() shouldBeEqualTo true
+            hasParentInterfaceWithName(emptyList()) shouldBeEqualTo true
+            hasParentInterfaceWithName(emptySet()) shouldBeEqualTo true
+            hasParentInterfacesWithAllNames(emptyList()) shouldBeEqualTo true
+            hasParentInterfacesWithAllNames(emptySet()) shouldBeEqualTo true
             hasParentInterfaceWithName("SampleParentInterface1") shouldBeEqualTo true
             hasParentInterfaceWithName("OtherInterface") shouldBeEqualTo false
             hasParentInterfaceWithName("SampleParentInterface1", "SampleParentInterface2") shouldBeEqualTo true
             hasParentInterfaceWithName("SampleParentInterface1", "OtherInterface") shouldBeEqualTo true
+            hasParentInterfaceWithName(listOf("SampleParentInterface1")) shouldBeEqualTo true
+            hasParentInterfaceWithName(listOf("OtherInterface")) shouldBeEqualTo false
+            hasParentInterfaceWithName(listOf("SampleParentInterface1", "SampleParentInterface2")) shouldBeEqualTo true
+            hasParentInterfaceWithName(listOf("SampleParentInterface1", "OtherInterface")) shouldBeEqualTo true
+            hasParentInterfaceWithName(setOf("SampleParentInterface1")) shouldBeEqualTo true
+            hasParentInterfaceWithName(setOf("OtherInterface")) shouldBeEqualTo false
+            hasParentInterfaceWithName(setOf("SampleParentInterface1", "SampleParentInterface2")) shouldBeEqualTo true
+            hasParentInterfaceWithName(setOf("SampleParentInterface1", "OtherInterface")) shouldBeEqualTo true
             hasParentInterfacesWithAllNames("SampleParentInterface1") shouldBeEqualTo true
             hasParentInterfacesWithAllNames("OtherInterface") shouldBeEqualTo false
             hasParentInterfacesWithAllNames("SampleParentInterface1", "SampleParentInterface2") shouldBeEqualTo true
             hasParentInterfacesWithAllNames("SampleParentInterface1", "OtherInterface") shouldBeEqualTo false
+            hasParentInterfacesWithAllNames(listOf("SampleParentInterface1")) shouldBeEqualTo true
+            hasParentInterfacesWithAllNames(listOf("OtherInterface")) shouldBeEqualTo false
+            hasParentInterfacesWithAllNames(listOf("SampleParentInterface1", "SampleParentInterface2")) shouldBeEqualTo true
+            hasParentInterfacesWithAllNames(listOf("SampleParentInterface1", "OtherInterface")) shouldBeEqualTo false
+            hasParentInterfacesWithAllNames(setOf("SampleParentInterface1")) shouldBeEqualTo true
+            hasParentInterfacesWithAllNames(setOf("OtherInterface")) shouldBeEqualTo false
+            hasParentInterfacesWithAllNames(setOf("SampleParentInterface1", "SampleParentInterface2")) shouldBeEqualTo true
+            hasParentInterfacesWithAllNames(setOf("SampleParentInterface1", "OtherInterface")) shouldBeEqualTo false
             hasParentInterface { it.name == "SampleParentInterface1" } shouldBeEqualTo true
             hasParentInterface { it.name == "OtherInterface" } shouldBeEqualTo false
             hasAllParentInterfaces { it.name == "SampleParentInterface1" } shouldBeEqualTo false
@@ -104,9 +166,19 @@ class KoInterfaceDeclarationForKoParentInterfaceProviderTest {
             hasAllParentInterfaces { it.hasNameStartingWith("Other") } shouldBeEqualTo false
             hasParentInterfaceOf(SampleParentInterface1::class) shouldBeEqualTo true
             hasParentInterfaceOf(SampleParentInterface1::class, SampleParentClass::class) shouldBeEqualTo true
+            hasParentInterfaceOf(listOf(SampleParentInterface1::class)) shouldBeEqualTo true
+            hasParentInterfaceOf(listOf(SampleParentInterface1::class, SampleParentClass::class)) shouldBeEqualTo true
+            hasParentInterfaceOf(setOf(SampleParentInterface1::class)) shouldBeEqualTo true
+            hasParentInterfaceOf(setOf(SampleParentInterface1::class, SampleParentClass::class)) shouldBeEqualTo true
             hasAllParentInterfacesOf(SampleParentInterface1::class) shouldBeEqualTo true
             hasAllParentInterfacesOf(SampleParentInterface1::class, SampleParentClass::class) shouldBeEqualTo false
             hasAllParentInterfacesOf(SampleParentInterface1::class, SampleParentInterface2::class) shouldBeEqualTo true
+            hasAllParentInterfacesOf(listOf(SampleParentInterface1::class)) shouldBeEqualTo true
+            hasAllParentInterfacesOf(listOf(SampleParentInterface1::class, SampleParentClass::class)) shouldBeEqualTo false
+            hasAllParentInterfacesOf(listOf(SampleParentInterface1::class, SampleParentInterface2::class)) shouldBeEqualTo true
+            hasAllParentInterfacesOf(setOf(SampleParentInterface1::class)) shouldBeEqualTo true
+            hasAllParentInterfacesOf(setOf(SampleParentInterface1::class, SampleParentClass::class)) shouldBeEqualTo false
+            hasAllParentInterfacesOf(setOf(SampleParentInterface1::class, SampleParentInterface2::class)) shouldBeEqualTo true
             hasParentInterfaces("SampleParentInterface1") shouldBeEqualTo true
             hasParentInterfaces("OtherInterface") shouldBeEqualTo false
             hasParentInterfaces("SampleParentInterface1", "SampleParentInterface2") shouldBeEqualTo true
@@ -140,6 +212,10 @@ class KoInterfaceDeclarationForKoParentInterfaceProviderTest {
             countParentInterfaces(indirectParents = true) { it.hasNameStartingWith("SampleParent") } shouldBeEqualTo 3
             hasParentInterfaces(indirectParents = false) shouldBeEqualTo true
             hasParentInterfaces(indirectParents = true) shouldBeEqualTo true
+            hasParentInterfaceWithName(emptyList(), indirectParents = true) shouldBeEqualTo true
+            hasParentInterfaceWithName(emptySet(), indirectParents = true) shouldBeEqualTo true
+            hasParentInterfacesWithAllNames(emptyList(), indirectParents = true) shouldBeEqualTo true
+            hasParentInterfacesWithAllNames(emptySet(), indirectParents = true) shouldBeEqualTo true
             hasParentInterfaceWithName("SampleParentInterface2", indirectParents = true) shouldBeEqualTo true
             hasParentInterfaceWithName("OtherInterface", indirectParents = true) shouldBeEqualTo false
             hasParentInterfaceWithName(
@@ -150,6 +226,18 @@ class KoInterfaceDeclarationForKoParentInterfaceProviderTest {
             hasParentInterfaceWithName(
                 "SampleParentInterface2",
                 "OtherInterface",
+                indirectParents = true,
+            ) shouldBeEqualTo true
+            hasParentInterfaceWithName(listOf("SampleParentInterface2"), indirectParents = true) shouldBeEqualTo true
+            hasParentInterfaceWithName(listOf("OtherInterface"), indirectParents = true) shouldBeEqualTo false
+            hasParentInterfaceWithName(listOf(
+                "SampleParentInterface1",
+                "SampleParentInterface2"),
+                indirectParents = true,
+            ) shouldBeEqualTo true
+            hasParentInterfaceWithName(listOf(
+                "SampleParentInterface2",
+                "OtherInterface"),
                 indirectParents = true,
             ) shouldBeEqualTo true
             hasParentInterfacesWithAllNames("SampleParentInterface2", indirectParents = true) shouldBeEqualTo true
@@ -164,6 +252,18 @@ class KoInterfaceDeclarationForKoParentInterfaceProviderTest {
                 "OtherInterface",
                 indirectParents = true,
             ) shouldBeEqualTo false
+            hasParentInterfacesWithAllNames(listOf("SampleParentInterface2"), indirectParents = true) shouldBeEqualTo true
+            hasParentInterfacesWithAllNames(listOf("OtherInterface"), indirectParents = true) shouldBeEqualTo false
+            hasParentInterfacesWithAllNames(listOf(
+                "SampleParentInterface1",
+                "SampleParentInterface2"),
+                indirectParents = true,
+            ) shouldBeEqualTo true
+            hasParentInterfacesWithAllNames(listOf(
+                "SampleParentInterface2",
+                "OtherInterface"),
+                indirectParents = true,
+            ) shouldBeEqualTo false
             hasParentInterface(indirectParents = true) { it.name == "SampleParentInterface2" } shouldBeEqualTo true
             hasParentInterface(indirectParents = true) { it.name == "OtherInterface" } shouldBeEqualTo false
             hasAllParentInterfaces(indirectParents = true) { it.name == "SampleParentInterface2" } shouldBeEqualTo false
@@ -175,10 +275,22 @@ class KoInterfaceDeclarationForKoParentInterfaceProviderTest {
                 SampleParentInterface2::class,
                 indirectParents = true,
             ) shouldBeEqualTo true
+            hasParentInterfaceOf(listOf(SampleParentInterface2::class), indirectParents = true) shouldBeEqualTo true
+            hasParentInterfaceOf(listOf(
+                SampleParentInterface1::class,
+                SampleParentInterface2::class),
+                indirectParents = true,
+            ) shouldBeEqualTo true
             hasAllParentInterfacesOf(SampleParentInterface2::class, indirectParents = true) shouldBeEqualTo true
             hasAllParentInterfacesOf(
                 SampleParentInterface2::class,
                 SampleParentInterface::class,
+                indirectParents = true,
+            ) shouldBeEqualTo false
+            hasAllParentInterfacesOf(listOf(SampleParentInterface2::class), indirectParents = true) shouldBeEqualTo true
+            hasAllParentInterfacesOf(listOf(
+                SampleParentInterface2::class,
+                SampleParentInterface::class),
                 indirectParents = true,
             ) shouldBeEqualTo false
         }

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/kointerface/KoInterfaceDeclarationForKoParentProviderTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/kointerface/KoInterfaceDeclarationForKoParentProviderTest.kt
@@ -25,12 +25,24 @@ class KoInterfaceDeclarationForKoParentProviderTest {
             numParents shouldBeEqualTo 0
             countParents { it.name == "SampleParentClass" } shouldBeEqualTo 0
             hasParents() shouldBeEqualTo false
+            hasParentWithName(emptyList()) shouldBeEqualTo false
+            hasParentWithName(emptySet()) shouldBeEqualTo false
+            hasParentsWithAllNames(emptyList()) shouldBeEqualTo false
+            hasParentsWithAllNames(emptySet()) shouldBeEqualTo false
             hasParentWithName("SampleParentClass") shouldBeEqualTo false
+            hasParentWithName(listOf("SampleParentClass")) shouldBeEqualTo false
+            hasParentWithName(setOf("SampleParentClass")) shouldBeEqualTo false
             hasParentsWithAllNames("SampleParentClass", "SampleParentInterface") shouldBeEqualTo false
+            hasParentsWithAllNames(listOf("SampleParentClass", "SampleParentInterface")) shouldBeEqualTo false
+            hasParentsWithAllNames(setOf("SampleParentClass", "SampleParentInterface")) shouldBeEqualTo false
             hasParent { it.name == "SampleParentClass" } shouldBeEqualTo false
             hasAllParents { it.hasNameStartingWith("Sample") } shouldBeEqualTo true
             hasParentOf(SampleParentClass::class) shouldBeEqualTo false
+            hasParentOf(listOf(SampleParentClass::class)) shouldBeEqualTo false
+            hasParentOf(setOf(SampleParentClass::class)) shouldBeEqualTo false
             hasAllParentsOf(SampleParentClass::class, SampleParentInterface::class) shouldBeEqualTo false
+            hasAllParentsOf(listOf(SampleParentClass::class, SampleParentInterface::class)) shouldBeEqualTo false
+            hasAllParentsOf(setOf(SampleParentClass::class, SampleParentInterface::class)) shouldBeEqualTo false
             hasParents("SampleParentClass") shouldBeEqualTo false
         }
     }
@@ -64,13 +76,31 @@ class KoInterfaceDeclarationForKoParentProviderTest {
             countParents { it.name == "SampleParentInterface1" } shouldBeEqualTo 1
             countParents { it.hasNameStartingWith("SampleExternal") } shouldBeEqualTo 2
             hasParents() shouldBeEqualTo true
+            hasParentWithName(emptyList()) shouldBeEqualTo true
+            hasParentWithName(emptySet()) shouldBeEqualTo true
+            hasParentsWithAllNames(emptyList()) shouldBeEqualTo true
+            hasParentsWithAllNames(emptySet()) shouldBeEqualTo true
             hasParentWithName("SampleParentInterface1") shouldBeEqualTo true
             hasParentWithName("OtherInterface") shouldBeEqualTo false
             hasParentWithName("SampleParentInterface1", "OtherInterface") shouldBeEqualTo true
+            hasParentWithName(listOf("SampleParentInterface1")) shouldBeEqualTo true
+            hasParentWithName(listOf("OtherInterface")) shouldBeEqualTo false
+            hasParentWithName(listOf("SampleParentInterface1", "OtherInterface")) shouldBeEqualTo true
+            hasParentWithName(setOf("SampleParentInterface1")) shouldBeEqualTo true
+            hasParentWithName(setOf("OtherInterface")) shouldBeEqualTo false
+            hasParentWithName(setOf("SampleParentInterface1", "OtherInterface")) shouldBeEqualTo true
             hasParentsWithAllNames("SampleParentInterface1") shouldBeEqualTo true
             hasParentsWithAllNames("OtherInterface") shouldBeEqualTo false
             hasParentsWithAllNames("SampleParentInterface1", "SampleExternalInterface") shouldBeEqualTo true
             hasParentsWithAllNames("SampleParentInterface1", "OtherInterface") shouldBeEqualTo false
+            hasParentsWithAllNames(listOf("SampleParentInterface1")) shouldBeEqualTo true
+            hasParentsWithAllNames(listOf("OtherInterface")) shouldBeEqualTo false
+            hasParentsWithAllNames(listOf("SampleParentInterface1", "SampleExternalInterface")) shouldBeEqualTo true
+            hasParentsWithAllNames(listOf("SampleParentInterface1", "OtherInterface")) shouldBeEqualTo false
+            hasParentsWithAllNames(setOf("SampleParentInterface1")) shouldBeEqualTo true
+            hasParentsWithAllNames(setOf("OtherInterface")) shouldBeEqualTo false
+            hasParentsWithAllNames(setOf("SampleParentInterface1", "SampleExternalInterface")) shouldBeEqualTo true
+            hasParentsWithAllNames(setOf("SampleParentInterface1", "OtherInterface")) shouldBeEqualTo false
             hasParent { it.name == "SampleParentInterface1" } shouldBeEqualTo true
             hasParent { it.name == "OtherInterface" } shouldBeEqualTo false
             hasAllParents { it.name == "SampleParentInterface1" } shouldBeEqualTo false
@@ -78,9 +108,19 @@ class KoInterfaceDeclarationForKoParentProviderTest {
             hasAllParents { it.hasNameStartingWith("Other") } shouldBeEqualTo false
             hasParentOf(SampleParentInterface1::class) shouldBeEqualTo true
             hasParentOf(SampleParentInterface1::class, SampleInterface::class) shouldBeEqualTo true
+            hasParentOf(listOf(SampleParentInterface1::class)) shouldBeEqualTo true
+            hasParentOf(listOf(SampleParentInterface1::class, SampleInterface::class)) shouldBeEqualTo true
+            hasParentOf(setOf(SampleParentInterface1::class)) shouldBeEqualTo true
+            hasParentOf(setOf(SampleParentInterface1::class, SampleInterface::class)) shouldBeEqualTo true
             hasAllParentsOf(SampleParentInterface1::class) shouldBeEqualTo true
             hasAllParentsOf(SampleParentInterface1::class, SampleInterface::class) shouldBeEqualTo false
             hasAllParentsOf(SampleParentInterface1::class, SampleParentInterface2::class) shouldBeEqualTo true
+            hasAllParentsOf(listOf(SampleParentInterface1::class)) shouldBeEqualTo true
+            hasAllParentsOf(listOf(SampleParentInterface1::class, SampleInterface::class)) shouldBeEqualTo false
+            hasAllParentsOf(listOf(SampleParentInterface1::class, SampleParentInterface2::class)) shouldBeEqualTo true
+            hasAllParentsOf(setOf(SampleParentInterface1::class)) shouldBeEqualTo true
+            hasAllParentsOf(setOf(SampleParentInterface1::class, SampleInterface::class)) shouldBeEqualTo false
+            hasAllParentsOf(setOf(SampleParentInterface1::class, SampleParentInterface2::class)) shouldBeEqualTo true
             hasParents("SampleParentInterface1") shouldBeEqualTo true
             hasParents("OtherInterface") shouldBeEqualTo false
             hasParents("SampleParentInterface1", "SampleParentInterface2") shouldBeEqualTo true
@@ -115,9 +155,20 @@ class KoInterfaceDeclarationForKoParentProviderTest {
             countParents(indirectParents = true) { it.name == "SampleParentInterface2" } shouldBeEqualTo 1
             countParents(indirectParents = true) { it.hasNameStartingWith("SampleParentInterface") } shouldBeEqualTo 3
             hasParents(indirectParents = true) shouldBeEqualTo true
+            hasParents(indirectParents = true) shouldBeEqualTo true
+            hasParentWithName(emptyList(), indirectParents = true) shouldBeEqualTo true
+            hasParentWithName(emptySet(), indirectParents = true) shouldBeEqualTo true
+            hasParentsWithAllNames(emptyList(), indirectParents = true) shouldBeEqualTo true
+            hasParentsWithAllNames(emptySet(), indirectParents = true) shouldBeEqualTo true
             hasParentWithName("SampleParentInterface2", indirectParents = true) shouldBeEqualTo true
             hasParentWithName("OtherInterface", indirectParents = true) shouldBeEqualTo false
             hasParentWithName("SampleParentInterface2", "OtherInterface", indirectParents = true) shouldBeEqualTo true
+            hasParentWithName(listOf("SampleParentInterface2"), indirectParents = true) shouldBeEqualTo true
+            hasParentWithName(listOf("OtherInterface"), indirectParents = true) shouldBeEqualTo false
+            hasParentWithName(listOf("SampleParentInterface2", "OtherInterface"), indirectParents = true) shouldBeEqualTo true
+            hasParentWithName(setOf("SampleParentInterface2"), indirectParents = true) shouldBeEqualTo true
+            hasParentWithName(setOf("OtherInterface"), indirectParents = true) shouldBeEqualTo false
+            hasParentWithName(setOf("SampleParentInterface2", "OtherInterface"), indirectParents = true) shouldBeEqualTo true
             hasParentsWithAllNames("SampleParentInterface2", indirectParents = true) shouldBeEqualTo true
             hasParentsWithAllNames("OtherInterface", indirectParents = true) shouldBeEqualTo false
             hasParentsWithAllNames(
@@ -126,6 +177,22 @@ class KoInterfaceDeclarationForKoParentProviderTest {
                 indirectParents = true,
             ) shouldBeEqualTo true
             hasParentsWithAllNames("SampleParentInterface2", "OtherInterface", indirectParents = true) shouldBeEqualTo false
+            hasParentsWithAllNames(listOf("SampleParentInterface2"), indirectParents = true) shouldBeEqualTo true
+            hasParentsWithAllNames(listOf("OtherInterface"), indirectParents = true) shouldBeEqualTo false
+            hasParentsWithAllNames(listOf(
+                "SampleParentInterface2",
+                "SampleParentInterface1"),
+                indirectParents = true,
+            ) shouldBeEqualTo true
+            hasParentsWithAllNames(listOf("SampleParentInterface2", "OtherInterface"), indirectParents = true) shouldBeEqualTo false
+            hasParentsWithAllNames(setOf("SampleParentInterface2"), indirectParents = true) shouldBeEqualTo true
+            hasParentsWithAllNames(setOf("OtherInterface"), indirectParents = true) shouldBeEqualTo false
+            hasParentsWithAllNames(setOf(
+                "SampleParentInterface2",
+                "SampleParentInterface1"),
+                indirectParents = true,
+            ) shouldBeEqualTo true
+            hasParentsWithAllNames(setOf("SampleParentInterface2", "OtherInterface"), indirectParents = true) shouldBeEqualTo false
             hasParent(indirectParents = true) { it.name == "SampleParentInterface2" } shouldBeEqualTo true
             hasParent(indirectParents = true) { it.name == "OtherClass" } shouldBeEqualTo false
             hasAllParents(indirectParents = true) { it.name == "SampleParentInterface2" } shouldBeEqualTo false
@@ -133,6 +200,10 @@ class KoInterfaceDeclarationForKoParentProviderTest {
             hasAllParents(indirectParents = true) { it.hasNameStartingWith("Other") } shouldBeEqualTo false
             hasParentOf(SampleParentInterface2::class, indirectParents = true) shouldBeEqualTo true
             hasParentOf(SampleParentInterface2::class, SampleInterface::class, indirectParents = true) shouldBeEqualTo true
+            hasParentOf(listOf(SampleParentInterface2::class), indirectParents = true) shouldBeEqualTo true
+            hasParentOf(listOf(SampleParentInterface2::class, SampleInterface::class), indirectParents = true) shouldBeEqualTo true
+            hasParentOf(setOf(SampleParentInterface2::class), indirectParents = true) shouldBeEqualTo true
+            hasParentOf(setOf(SampleParentInterface2::class, SampleInterface::class), indirectParents = true) shouldBeEqualTo true
             hasAllParentsOf(SampleParentInterface2::class, indirectParents = true) shouldBeEqualTo true
             hasAllParentsOf(
                 SampleParentInterface2::class,
@@ -142,6 +213,17 @@ class KoInterfaceDeclarationForKoParentProviderTest {
             hasAllParentsOf(
                 SampleParentInterface2::class,
                 SampleParentInterface1::class,
+                indirectParents = true,
+            ) shouldBeEqualTo true
+            hasAllParentsOf(listOf(SampleParentInterface2::class), indirectParents = true) shouldBeEqualTo true
+            hasAllParentsOf(listOf(
+                SampleParentInterface2::class,
+                SampleInterface::class),
+                indirectParents = true,
+            ) shouldBeEqualTo false
+            hasAllParentsOf(listOf(
+                SampleParentInterface2::class,
+                SampleParentInterface1::class),
                 indirectParents = true,
             ) shouldBeEqualTo true
         }

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/kointerface/KoInterfaceDeclarationForKoParentProviderTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/kointerface/KoInterfaceDeclarationForKoParentProviderTest.kt
@@ -10,6 +10,7 @@ import org.amshove.kluent.assertSoftly
 import org.amshove.kluent.shouldBeEqualTo
 import org.junit.jupiter.api.Test
 
+@Suppress("detekt.LongMethod")
 class KoInterfaceDeclarationForKoParentProviderTest {
     @Test
     fun `interface-has-no-parents`() {
@@ -179,17 +180,21 @@ class KoInterfaceDeclarationForKoParentProviderTest {
             hasParentsWithAllNames("SampleParentInterface2", "OtherInterface", indirectParents = true) shouldBeEqualTo false
             hasParentsWithAllNames(listOf("SampleParentInterface2"), indirectParents = true) shouldBeEqualTo true
             hasParentsWithAllNames(listOf("OtherInterface"), indirectParents = true) shouldBeEqualTo false
-            hasParentsWithAllNames(listOf(
-                "SampleParentInterface2",
-                "SampleParentInterface1"),
+            hasParentsWithAllNames(
+                listOf(
+                    "SampleParentInterface2",
+                    "SampleParentInterface1",
+                ),
                 indirectParents = true,
             ) shouldBeEqualTo true
             hasParentsWithAllNames(listOf("SampleParentInterface2", "OtherInterface"), indirectParents = true) shouldBeEqualTo false
             hasParentsWithAllNames(setOf("SampleParentInterface2"), indirectParents = true) shouldBeEqualTo true
             hasParentsWithAllNames(setOf("OtherInterface"), indirectParents = true) shouldBeEqualTo false
-            hasParentsWithAllNames(setOf(
-                "SampleParentInterface2",
-                "SampleParentInterface1"),
+            hasParentsWithAllNames(
+                setOf(
+                    "SampleParentInterface2",
+                    "SampleParentInterface1",
+                ),
                 indirectParents = true,
             ) shouldBeEqualTo true
             hasParentsWithAllNames(setOf("SampleParentInterface2", "OtherInterface"), indirectParents = true) shouldBeEqualTo false
@@ -216,14 +221,18 @@ class KoInterfaceDeclarationForKoParentProviderTest {
                 indirectParents = true,
             ) shouldBeEqualTo true
             hasAllParentsOf(listOf(SampleParentInterface2::class), indirectParents = true) shouldBeEqualTo true
-            hasAllParentsOf(listOf(
-                SampleParentInterface2::class,
-                SampleInterface::class),
+            hasAllParentsOf(
+                listOf(
+                    SampleParentInterface2::class,
+                    SampleInterface::class,
+                ),
                 indirectParents = true,
             ) shouldBeEqualTo false
-            hasAllParentsOf(listOf(
-                SampleParentInterface2::class,
-                SampleParentInterface1::class),
+            hasAllParentsOf(
+                listOf(
+                    SampleParentInterface2::class,
+                    SampleParentInterface1::class,
+                ),
                 indirectParents = true,
             ) shouldBeEqualTo true
         }

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/kointerface/KoInterfaceDeclarationForKoPropertyProviderTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/kointerface/KoInterfaceDeclarationForKoPropertyProviderTest.kt
@@ -20,8 +20,16 @@ class KoInterfaceDeclarationForKoPropertyProviderTest {
         assertSoftly(sut) {
             properties() shouldBeEqualTo emptyList()
             hasProperties() shouldBeEqualTo false
+            hasPropertyWithName(emptyList()) shouldBeEqualTo false
+            hasPropertyWithName(emptySet()) shouldBeEqualTo false
+            hasPropertiesWithAllNames(emptyList()) shouldBeEqualTo false
+            hasPropertiesWithAllNames(emptySet()) shouldBeEqualTo false
             hasPropertyWithName("sampleProperty") shouldBeEqualTo false
+            hasPropertyWithName(listOf("sampleProperty")) shouldBeEqualTo false
+            hasPropertyWithName(setOf("sampleProperty")) shouldBeEqualTo false
             hasPropertiesWithAllNames("sampleProperty1", "sampleProperty2") shouldBeEqualTo false
+            hasPropertiesWithAllNames(listOf("sampleProperty1", "sampleProperty2")) shouldBeEqualTo false
+            hasPropertiesWithAllNames(setOf("sampleProperty1", "sampleProperty2")) shouldBeEqualTo false
             hasProperty { it.name == "sampleProperty" } shouldBeEqualTo false
             hasAllProperties { it.hasNameStartingWith("sample") } shouldBeEqualTo true
         }
@@ -38,11 +46,25 @@ class KoInterfaceDeclarationForKoPropertyProviderTest {
         // then
         assertSoftly(sut) {
             hasProperties() shouldBeEqualTo true
+            hasPropertyWithName(emptyList()) shouldBeEqualTo true
+            hasPropertyWithName(emptySet()) shouldBeEqualTo true
+            hasPropertiesWithAllNames(emptyList()) shouldBeEqualTo true
+            hasPropertiesWithAllNames(emptySet()) shouldBeEqualTo true
             hasPropertyWithName("sampleProperty1") shouldBeEqualTo true
             hasPropertyWithName("sampleProperty1", "otherProperty") shouldBeEqualTo true
+            hasPropertyWithName(listOf("sampleProperty1")) shouldBeEqualTo true
+            hasPropertyWithName(listOf("sampleProperty1", "otherProperty")) shouldBeEqualTo true
+            hasPropertyWithName(setOf("sampleProperty1")) shouldBeEqualTo true
+            hasPropertyWithName(setOf("sampleProperty1", "otherProperty")) shouldBeEqualTo true
             hasPropertiesWithAllNames("sampleProperty1") shouldBeEqualTo true
             hasPropertiesWithAllNames("sampleProperty1", "sampleProperty2") shouldBeEqualTo true
             hasPropertiesWithAllNames("sampleProperty1", "otherProperty") shouldBeEqualTo false
+            hasPropertiesWithAllNames(listOf("sampleProperty1")) shouldBeEqualTo true
+            hasPropertiesWithAllNames(listOf("sampleProperty1", "sampleProperty2")) shouldBeEqualTo true
+            hasPropertiesWithAllNames(listOf("sampleProperty1", "otherProperty")) shouldBeEqualTo false
+            hasPropertiesWithAllNames(setOf("sampleProperty1")) shouldBeEqualTo true
+            hasPropertiesWithAllNames(setOf("sampleProperty1", "sampleProperty2")) shouldBeEqualTo true
+            hasPropertiesWithAllNames(setOf("sampleProperty1", "otherProperty")) shouldBeEqualTo false
             hasProperty { it.name == "sampleProperty1" } shouldBeEqualTo true
             hasProperty { it.hasNameEndingWith("Property1") } shouldBeEqualTo true
             hasAllProperties { it.hasNameStartingWith("sample") } shouldBeEqualTo true

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/kointerface/forkomodifier/KoInterfaceDeclarationForKoModifierProviderTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/kointerface/forkomodifier/KoInterfaceDeclarationForKoModifierProviderTest.kt
@@ -28,15 +28,24 @@ class KoInterfaceDeclarationForKoModifierProviderTest {
             modifiers shouldBeEqualTo emptyList()
             numModifiers shouldBeEqualTo 0
             hasModifiers() shouldBeEqualTo false
+            hasModifier(emptyList()) shouldBeEqualTo false
+            hasModifier(emptySet()) shouldBeEqualTo false
+            hasAllModifiers(emptyList()) shouldBeEqualTo false
+            hasAllModifiers(emptySet()) shouldBeEqualTo false
             hasModifier(OPEN) shouldBeEqualTo false
             hasModifier(OPEN, DATA) shouldBeEqualTo false
+            hasModifier(listOf(OPEN)) shouldBeEqualTo false
+            hasModifier(listOf(OPEN, DATA)) shouldBeEqualTo false
+            hasModifier(setOf(OPEN)) shouldBeEqualTo false
+            hasModifier(setOf(OPEN, DATA)) shouldBeEqualTo false
             hasAllModifiers(OPEN) shouldBeEqualTo false
             hasAllModifiers(OPEN, DATA) shouldBeEqualTo false
+            hasAllModifiers(listOf(OPEN)) shouldBeEqualTo false
+            hasAllModifiers(listOf(OPEN, DATA)) shouldBeEqualTo false
+            hasAllModifiers(setOf(OPEN)) shouldBeEqualTo false
+            hasAllModifiers(setOf(OPEN, DATA)) shouldBeEqualTo false
             hasModifiers(OPEN) shouldBeEqualTo false
             hasModifiers(OPEN, DATA) shouldBeEqualTo false
-            hasActualModifier shouldBeEqualTo false
-            hasExpectModifier shouldBeEqualTo false
-            hasFunModifier shouldBeEqualTo false
         }
     }
 
@@ -52,13 +61,31 @@ class KoInterfaceDeclarationForKoModifierProviderTest {
         assertSoftly(sut) {
             numModifiers shouldBeEqualTo 2
             hasModifiers() shouldBeEqualTo true
+            hasModifier(emptyList()) shouldBeEqualTo true
+            hasModifier(emptySet()) shouldBeEqualTo true
+            hasAllModifiers(emptyList()) shouldBeEqualTo true
+            hasAllModifiers(emptySet()) shouldBeEqualTo true
             hasModifier(PUBLIC) shouldBeEqualTo true
             hasModifier(PROTECTED) shouldBeEqualTo false
             hasModifier(PUBLIC, DATA) shouldBeEqualTo true
+            hasModifier(listOf(PUBLIC)) shouldBeEqualTo true
+            hasModifier(listOf(PROTECTED)) shouldBeEqualTo false
+            hasModifier(listOf(PUBLIC, DATA)) shouldBeEqualTo true
+            hasModifier(setOf(PUBLIC)) shouldBeEqualTo true
+            hasModifier(setOf(PROTECTED)) shouldBeEqualTo false
+            hasModifier(setOf(PUBLIC, DATA)) shouldBeEqualTo true
             hasAllModifiers(PUBLIC) shouldBeEqualTo true
             hasAllModifiers(PROTECTED) shouldBeEqualTo false
             hasAllModifiers(PUBLIC, DATA) shouldBeEqualTo false
             hasAllModifiers(PUBLIC, ABSTRACT) shouldBeEqualTo true
+            hasAllModifiers(listOf(PUBLIC)) shouldBeEqualTo true
+            hasAllModifiers(listOf(PROTECTED)) shouldBeEqualTo false
+            hasAllModifiers(listOf(PUBLIC, DATA)) shouldBeEqualTo false
+            hasAllModifiers(listOf(PUBLIC, ABSTRACT)) shouldBeEqualTo true
+            hasAllModifiers(setOf(PUBLIC)) shouldBeEqualTo true
+            hasAllModifiers(setOf(PROTECTED)) shouldBeEqualTo false
+            hasAllModifiers(setOf(PUBLIC, DATA)) shouldBeEqualTo false
+            hasAllModifiers(setOf(PUBLIC, ABSTRACT)) shouldBeEqualTo true
             hasModifiers(PUBLIC) shouldBeEqualTo true
             hasModifiers(ABSTRACT) shouldBeEqualTo true
             hasModifiers(PROTECTED) shouldBeEqualTo false

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/kokdoc/KoKDocDeclarationForKoKDocTagProviderTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/kokdoc/KoKDocDeclarationForKoKDocTagProviderTest.kt
@@ -95,10 +95,28 @@ class KoKDocDeclarationForKoKDocTagProviderTest {
         assertSoftly(sut) {
             it?.numTags shouldBeEqualTo 0
             it?.hasTags() shouldBeEqualTo false
+            it?.hasTag(emptyList()) shouldBeEqualTo false
+            it?.hasTag(emptySet()) shouldBeEqualTo false
+            it?.hasAllTags(emptyList()) shouldBeEqualTo false
+            it?.hasAllTags(emptySet()) shouldBeEqualTo false
             it?.hasTag(KoKDocTag.SINCE) shouldBeEqualTo false
             it?.hasTag(KoKDocTag.SINCE, KoKDocTag.SUPPRESS) shouldBeEqualTo false
+            it?.hasTag(listOf(KoKDocTag.SINCE)) shouldBeEqualTo false
+            it?.hasTag(listOf(KoKDocTag.SINCE, KoKDocTag.SUPPRESS)) shouldBeEqualTo false
+            it?.hasTag(setOf(KoKDocTag.SINCE)) shouldBeEqualTo false
+            it?.hasTag(setOf(KoKDocTag.SINCE, KoKDocTag.SUPPRESS)) shouldBeEqualTo false
             it?.hasAllTags(KoKDocTag.SINCE) shouldBeEqualTo false
             it?.hasAllTags(KoKDocTag.SINCE, KoKDocTag.SUPPRESS) shouldBeEqualTo false
+            it?.hasAllTags(KoKDocTag.SINCE) shouldBeEqualTo false
+            it?.hasAllTags(KoKDocTag.SINCE, KoKDocTag.SUPPRESS) shouldBeEqualTo false
+            it?.hasAllTags(listOf(KoKDocTag.SINCE)) shouldBeEqualTo false
+            it?.hasAllTags(listOf(KoKDocTag.SINCE, KoKDocTag.SUPPRESS)) shouldBeEqualTo false
+            it?.hasAllTags(listOf(KoKDocTag.SINCE)) shouldBeEqualTo false
+            it?.hasAllTags(listOf(KoKDocTag.SINCE, KoKDocTag.SUPPRESS)) shouldBeEqualTo false
+            it?.hasAllTags(setOf(KoKDocTag.SINCE)) shouldBeEqualTo false
+            it?.hasAllTags(setOf(KoKDocTag.SINCE, KoKDocTag.SUPPRESS)) shouldBeEqualTo false
+            it?.hasAllTags(setOf(KoKDocTag.SINCE)) shouldBeEqualTo false
+            it?.hasAllTags(setOf(KoKDocTag.SINCE, KoKDocTag.SUPPRESS)) shouldBeEqualTo false
             it?.hasTags(KoKDocTag.SINCE) shouldBeEqualTo false
         }
     }
@@ -116,12 +134,28 @@ class KoKDocDeclarationForKoKDocTagProviderTest {
         assertSoftly(sut) {
             it?.numTags shouldBeEqualTo 2
             it?.hasTags() shouldBeEqualTo true
+            it?.hasTag(emptyList()) shouldBeEqualTo true
+            it?.hasTag(emptySet()) shouldBeEqualTo true
+            it?.hasAllTags(emptyList()) shouldBeEqualTo true
+            it?.hasAllTags(emptySet()) shouldBeEqualTo true
             it?.hasTag(KoKDocTag.SINCE) shouldBeEqualTo true
             it?.hasTag(KoKDocTag.SINCE, KoKDocTag.SEE) shouldBeEqualTo true
             it?.hasTag(KoKDocTag.SINCE, KoKDocTag.SUPPRESS) shouldBeEqualTo true
+            it?.hasTag(listOf(KoKDocTag.SINCE)) shouldBeEqualTo true
+            it?.hasTag(listOf(KoKDocTag.SINCE, KoKDocTag.SEE)) shouldBeEqualTo true
+            it?.hasTag(listOf(KoKDocTag.SINCE, KoKDocTag.SUPPRESS)) shouldBeEqualTo true
+            it?.hasTag(setOf(KoKDocTag.SINCE)) shouldBeEqualTo true
+            it?.hasTag(setOf(KoKDocTag.SINCE, KoKDocTag.SEE)) shouldBeEqualTo true
+            it?.hasTag(setOf(KoKDocTag.SINCE, KoKDocTag.SUPPRESS)) shouldBeEqualTo true
             it?.hasAllTags(KoKDocTag.SINCE) shouldBeEqualTo true
             it?.hasAllTags(KoKDocTag.SINCE, KoKDocTag.SEE) shouldBeEqualTo true
             it?.hasAllTags(KoKDocTag.SINCE, KoKDocTag.SUPPRESS) shouldBeEqualTo false
+            it?.hasAllTags(listOf(KoKDocTag.SINCE)) shouldBeEqualTo true
+            it?.hasAllTags(listOf(KoKDocTag.SINCE, KoKDocTag.SEE)) shouldBeEqualTo true
+            it?.hasAllTags(listOf(KoKDocTag.SINCE, KoKDocTag.SUPPRESS)) shouldBeEqualTo false
+            it?.hasAllTags(setOf(KoKDocTag.SINCE)) shouldBeEqualTo true
+            it?.hasAllTags(setOf(KoKDocTag.SINCE, KoKDocTag.SEE)) shouldBeEqualTo true
+            it?.hasAllTags(setOf(KoKDocTag.SINCE, KoKDocTag.SUPPRESS)) shouldBeEqualTo false
             it?.hasTags(KoKDocTag.SINCE) shouldBeEqualTo true
             it?.hasTags(KoKDocTag.SINCE, KoKDocTag.SEE) shouldBeEqualTo true
             it?.hasTags(KoKDocTag.SAMPLE) shouldBeEqualTo false

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koobject/KoObjectDeclarationForKoAnnotationProviderTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koobject/KoObjectDeclarationForKoAnnotationProviderTest.kt
@@ -9,6 +9,7 @@ import org.amshove.kluent.assertSoftly
 import org.amshove.kluent.shouldBeEqualTo
 import org.junit.jupiter.api.Test
 
+@Suppress("detekt.LongMethod")
 class KoObjectDeclarationForKoAnnotationProviderTest {
     @Test
     fun `object-has-no-annotation`() {
@@ -81,19 +82,23 @@ class KoObjectDeclarationForKoAnnotationProviderTest {
             hasAnnotationWithName(listOf("SampleAnnotation", "OtherAnnotation")) shouldBeEqualTo true
             hasAnnotationWithName(listOf("com.lemonappdev.konsist.testdata.SampleAnnotation")) shouldBeEqualTo true
             hasAnnotationWithName(listOf("com.lemonappdev.konsist.testdata.NonExistingAnnotation")) shouldBeEqualTo false
-            hasAnnotationWithName(listOf(
-                "com.lemonappdev.konsist.testdata.SampleAnnotation",
-                "com.lemonappdev.konsist.testdata.NonExistingAnnotation",
-            )).shouldBeEqualTo(true)
+            hasAnnotationWithName(
+                listOf(
+                    "com.lemonappdev.konsist.testdata.SampleAnnotation",
+                    "com.lemonappdev.konsist.testdata.NonExistingAnnotation",
+                ),
+            ).shouldBeEqualTo(true)
             hasAnnotationWithName(setOf("SampleAnnotation")) shouldBeEqualTo true
             hasAnnotationWithName(setOf("OtherAnnotation")) shouldBeEqualTo false
             hasAnnotationWithName(setOf("SampleAnnotation", "OtherAnnotation")) shouldBeEqualTo true
             hasAnnotationWithName(setOf("com.lemonappdev.konsist.testdata.SampleAnnotation")) shouldBeEqualTo true
             hasAnnotationWithName(setOf("com.lemonappdev.konsist.testdata.NonExistingAnnotation")) shouldBeEqualTo false
-            hasAnnotationWithName(setOf(
-                "com.lemonappdev.konsist.testdata.SampleAnnotation",
-                "com.lemonappdev.konsist.testdata.NonExistingAnnotation",
-            )).shouldBeEqualTo(true)
+            hasAnnotationWithName(
+                setOf(
+                    "com.lemonappdev.konsist.testdata.SampleAnnotation",
+                    "com.lemonappdev.konsist.testdata.NonExistingAnnotation",
+                ),
+            ).shouldBeEqualTo(true)
             hasAnnotationsWithAllNames("SampleAnnotation") shouldBeEqualTo true
             hasAnnotationsWithAllNames("SampleAnnotation", "OtherAnnotation") shouldBeEqualTo false
             hasAnnotationsWithAllNames("com.lemonappdev.konsist.testdata.SampleAnnotation") shouldBeEqualTo true
@@ -104,10 +109,12 @@ class KoObjectDeclarationForKoAnnotationProviderTest {
             hasAnnotationsWithAllNames(listOf("SampleAnnotation")) shouldBeEqualTo true
             hasAnnotationsWithAllNames(listOf("SampleAnnotation", "OtherAnnotation")) shouldBeEqualTo false
             hasAnnotationsWithAllNames(listOf("com.lemonappdev.konsist.testdata.SampleAnnotation")) shouldBeEqualTo true
-            hasAnnotationsWithAllNames(listOf(
-                "com.lemonappdev.konsist.testdata.SampleAnnotation",
-                "com.lemonappdev.konsist.testdata.NonExistingAnnotation",
-            )).shouldBeEqualTo(false)
+            hasAnnotationsWithAllNames(
+                listOf(
+                    "com.lemonappdev.konsist.testdata.SampleAnnotation",
+                    "com.lemonappdev.konsist.testdata.NonExistingAnnotation",
+                ),
+            ).shouldBeEqualTo(false)
             hasAnnotation { it.hasNameStartingWith("Sample") } shouldBeEqualTo true
             hasAnnotation { it.hasNameStartingWith("Other") } shouldBeEqualTo false
             hasAllAnnotations { it.hasNameStartingWith("Sample") } shouldBeEqualTo true
@@ -171,19 +178,23 @@ class KoObjectDeclarationForKoAnnotationProviderTest {
             hasAnnotationWithName(listOf("SampleAnnotation1", "OtherAnnotation")) shouldBeEqualTo true
             hasAnnotationWithName(listOf("com.lemonappdev.konsist.testdata.SampleAnnotation1")) shouldBeEqualTo true
             hasAnnotationWithName(listOf("com.lemonappdev.konsist.testdata.NonExistingAnnotation")) shouldBeEqualTo false
-            hasAnnotationWithName(listOf(
-                "com.lemonappdev.konsist.testdata.SampleAnnotation1",
-                "com.lemonappdev.konsist.testdata.NonExistingAnnotation",
-            )).shouldBeEqualTo(true)
+            hasAnnotationWithName(
+                listOf(
+                    "com.lemonappdev.konsist.testdata.SampleAnnotation1",
+                    "com.lemonappdev.konsist.testdata.NonExistingAnnotation",
+                ),
+            ).shouldBeEqualTo(true)
             hasAnnotationWithName(setOf("SampleAnnotation1")) shouldBeEqualTo true
             hasAnnotationWithName(setOf("OtherAnnotation")) shouldBeEqualTo false
             hasAnnotationWithName(setOf("SampleAnnotation1", "OtherAnnotation")) shouldBeEqualTo true
             hasAnnotationWithName(setOf("com.lemonappdev.konsist.testdata.SampleAnnotation1")) shouldBeEqualTo true
             hasAnnotationWithName(setOf("com.lemonappdev.konsist.testdata.NonExistingAnnotation")) shouldBeEqualTo false
-            hasAnnotationWithName(setOf(
-                "com.lemonappdev.konsist.testdata.SampleAnnotation1",
-                "com.lemonappdev.konsist.testdata.NonExistingAnnotation",
-            )).shouldBeEqualTo(true)
+            hasAnnotationWithName(
+                setOf(
+                    "com.lemonappdev.konsist.testdata.SampleAnnotation1",
+                    "com.lemonappdev.konsist.testdata.NonExistingAnnotation",
+                ),
+            ).shouldBeEqualTo(true)
             hasAnnotationsWithAllNames("SampleAnnotation1") shouldBeEqualTo true
             hasAnnotationsWithAllNames("SampleAnnotation1", "SampleAnnotation2") shouldBeEqualTo true
             hasAnnotationsWithAllNames("SampleAnnotation1", "OtherAnnotation") shouldBeEqualTo false
@@ -201,14 +212,18 @@ class KoObjectDeclarationForKoAnnotationProviderTest {
             hasAnnotationsWithAllNames(listOf("SampleAnnotation1", "SampleAnnotation2")) shouldBeEqualTo true
             hasAnnotationsWithAllNames(listOf("SampleAnnotation1", "OtherAnnotation")) shouldBeEqualTo false
             hasAnnotationsWithAllNames(listOf("com.lemonappdev.konsist.testdata.SampleAnnotation1")) shouldBeEqualTo true
-            hasAnnotationsWithAllNames(listOf(
-                "com.lemonappdev.konsist.testdata.SampleAnnotation1",
-                "com.lemonappdev.konsist.testdata.NonExistingAnnotation",
-            )).shouldBeEqualTo(false)
-            hasAnnotationsWithAllNames(listOf(
-                "com.lemonappdev.konsist.testdata.SampleAnnotation1",
-                "com.lemonappdev.konsist.testdata.SampleAnnotation2",
-            )).shouldBeEqualTo(true)
+            hasAnnotationsWithAllNames(
+                listOf(
+                    "com.lemonappdev.konsist.testdata.SampleAnnotation1",
+                    "com.lemonappdev.konsist.testdata.NonExistingAnnotation",
+                ),
+            ).shouldBeEqualTo(false)
+            hasAnnotationsWithAllNames(
+                listOf(
+                    "com.lemonappdev.konsist.testdata.SampleAnnotation1",
+                    "com.lemonappdev.konsist.testdata.SampleAnnotation2",
+                ),
+            ).shouldBeEqualTo(true)
             hasAnnotation { it.name == "SampleAnnotation1" } shouldBeEqualTo true
             hasAnnotation { it.name == "OtherAnnotation1" } shouldBeEqualTo false
             hasAllAnnotations { !it.hasArguments() } shouldBeEqualTo true

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koobject/KoObjectDeclarationForKoAnnotationProviderTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koobject/KoObjectDeclarationForKoAnnotationProviderTest.kt
@@ -24,12 +24,28 @@ class KoObjectDeclarationForKoAnnotationProviderTest {
             numAnnotations shouldBeEqualTo 0
             countAnnotations { it.name == "NonExistingAnnotation" } shouldBeEqualTo 0
             hasAnnotations() shouldBeEqualTo false
+            hasAnnotationWithName(emptyList()) shouldBeEqualTo false
+            hasAnnotationWithName(emptySet()) shouldBeEqualTo false
+            hasAnnotationsWithAllNames(emptyList()) shouldBeEqualTo false
+            hasAnnotationsWithAllNames(emptySet()) shouldBeEqualTo false
             hasAnnotationWithName("SampleAnnotation") shouldBeEqualTo false
+            hasAnnotationWithName(listOf("SampleAnnotation")) shouldBeEqualTo false
+            hasAnnotationWithName(setOf("SampleAnnotation")) shouldBeEqualTo false
             hasAnnotationsWithAllNames("SampleAnnotation1", "SampleAnnotation2") shouldBeEqualTo false
+            hasAnnotationsWithAllNames(listOf("SampleAnnotation1", "SampleAnnotation2")) shouldBeEqualTo false
+            hasAnnotationsWithAllNames(setOf("SampleAnnotation1", "SampleAnnotation2")) shouldBeEqualTo false
             hasAnnotation { it.hasArguments() } shouldBeEqualTo false
             hasAllAnnotations { it.hasArguments() } shouldBeEqualTo true
+            hasAnnotationOf(emptyList()) shouldBeEqualTo false
+            hasAnnotationOf(emptySet()) shouldBeEqualTo false
+            hasAllAnnotationsOf(emptyList()) shouldBeEqualTo false
+            hasAllAnnotationsOf(emptySet()) shouldBeEqualTo false
             hasAnnotationOf(SampleAnnotation::class) shouldBeEqualTo false
+            hasAnnotationOf(listOf(SampleAnnotation::class)) shouldBeEqualTo false
+            hasAnnotationOf(setOf(SampleAnnotation::class)) shouldBeEqualTo false
             hasAllAnnotationsOf(SampleAnnotation1::class, SampleAnnotation2::class) shouldBeEqualTo false
+            hasAllAnnotationsOf(listOf(SampleAnnotation1::class, SampleAnnotation2::class)) shouldBeEqualTo false
+            hasAllAnnotationsOf(setOf(SampleAnnotation1::class, SampleAnnotation2::class)) shouldBeEqualTo false
             hasAnnotations("SampleAnnotation") shouldBeEqualTo false
         }
     }
@@ -44,10 +60,13 @@ class KoObjectDeclarationForKoAnnotationProviderTest {
 
         // then
         assertSoftly(sut) {
-            numAnnotations shouldBeEqualTo 1
             countAnnotations { it.name == "SampleAnnotation" } shouldBeEqualTo 1
             countAnnotations { it.name == "NonExistingAnnotation" } shouldBeEqualTo 0
             hasAnnotations() shouldBeEqualTo true
+            hasAnnotationWithName(emptyList()) shouldBeEqualTo true
+            hasAnnotationWithName(emptySet()) shouldBeEqualTo true
+            hasAnnotationsWithAllNames(emptyList()) shouldBeEqualTo true
+            hasAnnotationsWithAllNames(emptySet()) shouldBeEqualTo true
             hasAnnotationWithName("SampleAnnotation") shouldBeEqualTo true
             hasAnnotationWithName("OtherAnnotation") shouldBeEqualTo false
             hasAnnotationWithName("SampleAnnotation", "OtherAnnotation") shouldBeEqualTo true
@@ -57,6 +76,24 @@ class KoObjectDeclarationForKoAnnotationProviderTest {
                 "com.lemonappdev.konsist.testdata.SampleAnnotation",
                 "com.lemonappdev.konsist.testdata.NonExistingAnnotation",
             ).shouldBeEqualTo(true)
+            hasAnnotationWithName(listOf("SampleAnnotation")) shouldBeEqualTo true
+            hasAnnotationWithName(listOf("OtherAnnotation")) shouldBeEqualTo false
+            hasAnnotationWithName(listOf("SampleAnnotation", "OtherAnnotation")) shouldBeEqualTo true
+            hasAnnotationWithName(listOf("com.lemonappdev.konsist.testdata.SampleAnnotation")) shouldBeEqualTo true
+            hasAnnotationWithName(listOf("com.lemonappdev.konsist.testdata.NonExistingAnnotation")) shouldBeEqualTo false
+            hasAnnotationWithName(listOf(
+                "com.lemonappdev.konsist.testdata.SampleAnnotation",
+                "com.lemonappdev.konsist.testdata.NonExistingAnnotation",
+            )).shouldBeEqualTo(true)
+            hasAnnotationWithName(setOf("SampleAnnotation")) shouldBeEqualTo true
+            hasAnnotationWithName(setOf("OtherAnnotation")) shouldBeEqualTo false
+            hasAnnotationWithName(setOf("SampleAnnotation", "OtherAnnotation")) shouldBeEqualTo true
+            hasAnnotationWithName(setOf("com.lemonappdev.konsist.testdata.SampleAnnotation")) shouldBeEqualTo true
+            hasAnnotationWithName(setOf("com.lemonappdev.konsist.testdata.NonExistingAnnotation")) shouldBeEqualTo false
+            hasAnnotationWithName(setOf(
+                "com.lemonappdev.konsist.testdata.SampleAnnotation",
+                "com.lemonappdev.konsist.testdata.NonExistingAnnotation",
+            )).shouldBeEqualTo(true)
             hasAnnotationsWithAllNames("SampleAnnotation") shouldBeEqualTo true
             hasAnnotationsWithAllNames("SampleAnnotation", "OtherAnnotation") shouldBeEqualTo false
             hasAnnotationsWithAllNames("com.lemonappdev.konsist.testdata.SampleAnnotation") shouldBeEqualTo true
@@ -64,15 +101,35 @@ class KoObjectDeclarationForKoAnnotationProviderTest {
                 "com.lemonappdev.konsist.testdata.SampleAnnotation",
                 "com.lemonappdev.konsist.testdata.NonExistingAnnotation",
             ).shouldBeEqualTo(false)
+            hasAnnotationsWithAllNames(listOf("SampleAnnotation")) shouldBeEqualTo true
+            hasAnnotationsWithAllNames(listOf("SampleAnnotation", "OtherAnnotation")) shouldBeEqualTo false
+            hasAnnotationsWithAllNames(listOf("com.lemonappdev.konsist.testdata.SampleAnnotation")) shouldBeEqualTo true
+            hasAnnotationsWithAllNames(listOf(
+                "com.lemonappdev.konsist.testdata.SampleAnnotation",
+                "com.lemonappdev.konsist.testdata.NonExistingAnnotation",
+            )).shouldBeEqualTo(false)
             hasAnnotation { it.hasNameStartingWith("Sample") } shouldBeEqualTo true
             hasAnnotation { it.hasNameStartingWith("Other") } shouldBeEqualTo false
             hasAllAnnotations { it.hasNameStartingWith("Sample") } shouldBeEqualTo true
-            hasAnnotationOf(SampleAnnotation::class) shouldBeEqualTo true
-            hasAnnotationOf(NonExistingAnnotation::class) shouldBeEqualTo false
-            hasAnnotationOf(SampleAnnotation::class, NonExistingAnnotation::class) shouldBeEqualTo true
+            hasAnnotationOf(emptyList()) shouldBeEqualTo true
+            hasAnnotationOf(emptySet()) shouldBeEqualTo true
+            hasAllAnnotationsOf(emptyList()) shouldBeEqualTo true
+            hasAllAnnotationsOf(emptySet()) shouldBeEqualTo true
+            hasAnnotationOf(listOf(SampleAnnotation::class)) shouldBeEqualTo true
+            hasAnnotationOf(listOf(NonExistingAnnotation::class)) shouldBeEqualTo false
+            hasAnnotationOf(listOf(SampleAnnotation::class, NonExistingAnnotation::class)) shouldBeEqualTo true
+            hasAnnotationOf(setOf(SampleAnnotation::class)) shouldBeEqualTo true
+            hasAnnotationOf(setOf(NonExistingAnnotation::class)) shouldBeEqualTo false
+            hasAnnotationOf(setOf(SampleAnnotation::class, NonExistingAnnotation::class)) shouldBeEqualTo true
             hasAllAnnotationsOf(SampleAnnotation::class) shouldBeEqualTo true
             hasAllAnnotationsOf(NonExistingAnnotation::class) shouldBeEqualTo false
             hasAllAnnotationsOf(SampleAnnotation::class, NonExistingAnnotation::class) shouldBeEqualTo false
+            hasAllAnnotationsOf(listOf(SampleAnnotation::class)) shouldBeEqualTo true
+            hasAllAnnotationsOf(listOf(NonExistingAnnotation::class)) shouldBeEqualTo false
+            hasAllAnnotationsOf(listOf(SampleAnnotation::class, NonExistingAnnotation::class)) shouldBeEqualTo false
+            hasAllAnnotationsOf(setOf(SampleAnnotation::class)) shouldBeEqualTo true
+            hasAllAnnotationsOf(setOf(NonExistingAnnotation::class)) shouldBeEqualTo false
+            hasAllAnnotationsOf(setOf(SampleAnnotation::class, NonExistingAnnotation::class)) shouldBeEqualTo false
             hasAnnotations("SampleAnnotation") shouldBeEqualTo true
             hasAnnotations("NonExistingAnnotation") shouldBeEqualTo false
             hasAnnotations("com.lemonappdev.konsist.testdata.SampleAnnotation") shouldBeEqualTo true
@@ -96,6 +153,10 @@ class KoObjectDeclarationForKoAnnotationProviderTest {
             countAnnotations { it.hasNameStartingWith("Sample") } shouldBeEqualTo 2
             countAnnotations { it.name == "SampleAnnotation1" } shouldBeEqualTo 1
             hasAnnotations() shouldBeEqualTo true
+            hasAnnotationOf(emptyList()) shouldBeEqualTo true
+            hasAnnotationOf(emptySet()) shouldBeEqualTo true
+            hasAllAnnotationsOf(emptyList()) shouldBeEqualTo true
+            hasAllAnnotationsOf(emptySet()) shouldBeEqualTo true
             hasAnnotationWithName("SampleAnnotation1") shouldBeEqualTo true
             hasAnnotationWithName("OtherAnnotation") shouldBeEqualTo false
             hasAnnotationWithName("SampleAnnotation1", "OtherAnnotation") shouldBeEqualTo true
@@ -105,6 +166,24 @@ class KoObjectDeclarationForKoAnnotationProviderTest {
                 "com.lemonappdev.konsist.testdata.SampleAnnotation1",
                 "com.lemonappdev.konsist.testdata.NonExistingAnnotation",
             ).shouldBeEqualTo(true)
+            hasAnnotationWithName(listOf("SampleAnnotation1")) shouldBeEqualTo true
+            hasAnnotationWithName(listOf("OtherAnnotation")) shouldBeEqualTo false
+            hasAnnotationWithName(listOf("SampleAnnotation1", "OtherAnnotation")) shouldBeEqualTo true
+            hasAnnotationWithName(listOf("com.lemonappdev.konsist.testdata.SampleAnnotation1")) shouldBeEqualTo true
+            hasAnnotationWithName(listOf("com.lemonappdev.konsist.testdata.NonExistingAnnotation")) shouldBeEqualTo false
+            hasAnnotationWithName(listOf(
+                "com.lemonappdev.konsist.testdata.SampleAnnotation1",
+                "com.lemonappdev.konsist.testdata.NonExistingAnnotation",
+            )).shouldBeEqualTo(true)
+            hasAnnotationWithName(setOf("SampleAnnotation1")) shouldBeEqualTo true
+            hasAnnotationWithName(setOf("OtherAnnotation")) shouldBeEqualTo false
+            hasAnnotationWithName(setOf("SampleAnnotation1", "OtherAnnotation")) shouldBeEqualTo true
+            hasAnnotationWithName(setOf("com.lemonappdev.konsist.testdata.SampleAnnotation1")) shouldBeEqualTo true
+            hasAnnotationWithName(setOf("com.lemonappdev.konsist.testdata.NonExistingAnnotation")) shouldBeEqualTo false
+            hasAnnotationWithName(setOf(
+                "com.lemonappdev.konsist.testdata.SampleAnnotation1",
+                "com.lemonappdev.konsist.testdata.NonExistingAnnotation",
+            )).shouldBeEqualTo(true)
             hasAnnotationsWithAllNames("SampleAnnotation1") shouldBeEqualTo true
             hasAnnotationsWithAllNames("SampleAnnotation1", "SampleAnnotation2") shouldBeEqualTo true
             hasAnnotationsWithAllNames("SampleAnnotation1", "OtherAnnotation") shouldBeEqualTo false
@@ -117,17 +196,48 @@ class KoObjectDeclarationForKoAnnotationProviderTest {
                 "com.lemonappdev.konsist.testdata.SampleAnnotation1",
                 "com.lemonappdev.konsist.testdata.SampleAnnotation2",
             ).shouldBeEqualTo(true)
+
+            hasAnnotationsWithAllNames(listOf("SampleAnnotation1")) shouldBeEqualTo true
+            hasAnnotationsWithAllNames(listOf("SampleAnnotation1", "SampleAnnotation2")) shouldBeEqualTo true
+            hasAnnotationsWithAllNames(listOf("SampleAnnotation1", "OtherAnnotation")) shouldBeEqualTo false
+            hasAnnotationsWithAllNames(listOf("com.lemonappdev.konsist.testdata.SampleAnnotation1")) shouldBeEqualTo true
+            hasAnnotationsWithAllNames(listOf(
+                "com.lemonappdev.konsist.testdata.SampleAnnotation1",
+                "com.lemonappdev.konsist.testdata.NonExistingAnnotation",
+            )).shouldBeEqualTo(false)
+            hasAnnotationsWithAllNames(listOf(
+                "com.lemonappdev.konsist.testdata.SampleAnnotation1",
+                "com.lemonappdev.konsist.testdata.SampleAnnotation2",
+            )).shouldBeEqualTo(true)
             hasAnnotation { it.name == "SampleAnnotation1" } shouldBeEqualTo true
             hasAnnotation { it.name == "OtherAnnotation1" } shouldBeEqualTo false
             hasAllAnnotations { !it.hasArguments() } shouldBeEqualTo true
             hasAllAnnotations { it.hasNameEndingWith("tion1") } shouldBeEqualTo false
+            hasAnnotationOf(emptyList()) shouldBeEqualTo true
+            hasAnnotationOf(emptySet()) shouldBeEqualTo true
+            hasAllAnnotationsOf(emptyList()) shouldBeEqualTo true
+            hasAllAnnotationsOf(emptySet()) shouldBeEqualTo true
             hasAnnotationOf(SampleAnnotation1::class) shouldBeEqualTo true
             hasAnnotationOf(NonExistingAnnotation::class) shouldBeEqualTo false
             hasAnnotationOf(SampleAnnotation1::class, NonExistingAnnotation::class) shouldBeEqualTo true
+            hasAnnotationOf(listOf(SampleAnnotation1::class)) shouldBeEqualTo true
+            hasAnnotationOf(listOf(NonExistingAnnotation::class)) shouldBeEqualTo false
+            hasAnnotationOf(listOf(SampleAnnotation1::class, NonExistingAnnotation::class)) shouldBeEqualTo true
+            hasAnnotationOf(setOf(SampleAnnotation1::class)) shouldBeEqualTo true
+            hasAnnotationOf(setOf(NonExistingAnnotation::class)) shouldBeEqualTo false
+            hasAnnotationOf(setOf(SampleAnnotation1::class, NonExistingAnnotation::class)) shouldBeEqualTo true
             hasAllAnnotationsOf(SampleAnnotation1::class) shouldBeEqualTo true
             hasAllAnnotationsOf(NonExistingAnnotation::class) shouldBeEqualTo false
             hasAllAnnotationsOf(SampleAnnotation1::class, SampleAnnotation2::class) shouldBeEqualTo true
             hasAllAnnotationsOf(SampleAnnotation1::class, NonExistingAnnotation::class) shouldBeEqualTo false
+            hasAllAnnotationsOf(listOf(SampleAnnotation1::class)) shouldBeEqualTo true
+            hasAllAnnotationsOf(listOf(NonExistingAnnotation::class)) shouldBeEqualTo false
+            hasAllAnnotationsOf(listOf(SampleAnnotation1::class, SampleAnnotation2::class)) shouldBeEqualTo true
+            hasAllAnnotationsOf(listOf(SampleAnnotation1::class, NonExistingAnnotation::class)) shouldBeEqualTo false
+            hasAllAnnotationsOf(setOf(SampleAnnotation1::class)) shouldBeEqualTo true
+            hasAllAnnotationsOf(setOf(NonExistingAnnotation::class)) shouldBeEqualTo false
+            hasAllAnnotationsOf(setOf(SampleAnnotation1::class, SampleAnnotation2::class)) shouldBeEqualTo true
+            hasAllAnnotationsOf(setOf(SampleAnnotation1::class, NonExistingAnnotation::class)) shouldBeEqualTo false
             hasAnnotations("SampleAnnotation1") shouldBeEqualTo true
             hasAnnotations("SampleAnnotation2") shouldBeEqualTo true
             hasAnnotations("NonExistingAnnotation") shouldBeEqualTo false

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koobject/KoObjectDeclarationForKoClassProviderTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koobject/KoObjectDeclarationForKoClassProviderTest.kt
@@ -21,8 +21,16 @@ class KoObjectDeclarationForKoClassProviderTest {
         assertSoftly(sut) {
             classes() shouldBeEqualTo emptyList()
             hasClasses() shouldBeEqualTo false
+            hasClassWithName(emptyList()) shouldBeEqualTo false
+            hasClassWithName(emptySet()) shouldBeEqualTo false
+            hasClassesWithAllNames(emptyList()) shouldBeEqualTo false
+            hasClassesWithAllNames(emptySet()) shouldBeEqualTo false
             hasClassWithName("SampleClass") shouldBeEqualTo false
+            hasClassWithName(listOf("SampleClass")) shouldBeEqualTo false
+            hasClassWithName(setOf("SampleClass")) shouldBeEqualTo false
             hasClassesWithAllNames("SampleClass1", "SampleClass2") shouldBeEqualTo false
+            hasClassesWithAllNames(listOf("SampleClass1", "SampleClass2")) shouldBeEqualTo false
+            hasClassesWithAllNames(setOf("SampleClass1", "SampleClass2")) shouldBeEqualTo false
             hasClass { it.name == "SampleClass" } shouldBeEqualTo false
             hasAllClasses { it.hasNameStartingWith("Sample") } shouldBeEqualTo true
         }
@@ -39,11 +47,25 @@ class KoObjectDeclarationForKoClassProviderTest {
         // then
         assertSoftly(sut) {
             hasClasses() shouldBeEqualTo true
+            hasClassWithName(emptyList()) shouldBeEqualTo true
+            hasClassWithName(emptySet()) shouldBeEqualTo true
+            hasClassesWithAllNames(emptyList()) shouldBeEqualTo true
+            hasClassesWithAllNames(emptySet()) shouldBeEqualTo true
             hasClassWithName("SampleClass1") shouldBeEqualTo true
             hasClassWithName("SampleClass1", "OtherClass") shouldBeEqualTo true
+            hasClassWithName(listOf("SampleClass1")) shouldBeEqualTo true
+            hasClassWithName(listOf("SampleClass1", "OtherClass")) shouldBeEqualTo true
+            hasClassWithName(setOf("SampleClass1")) shouldBeEqualTo true
+            hasClassWithName(setOf("SampleClass1", "OtherClass")) shouldBeEqualTo true
             hasClassesWithAllNames("SampleClass1") shouldBeEqualTo true
             hasClassesWithAllNames("SampleClass1", "SampleClass2") shouldBeEqualTo true
             hasClassesWithAllNames("SampleClass1", "OtherClass") shouldBeEqualTo false
+            hasClassesWithAllNames(listOf("SampleClass1")) shouldBeEqualTo true
+            hasClassesWithAllNames(listOf("SampleClass1", "SampleClass2")) shouldBeEqualTo true
+            hasClassesWithAllNames(listOf("SampleClass1", "OtherClass")) shouldBeEqualTo false
+            hasClassesWithAllNames(setOf("SampleClass1")) shouldBeEqualTo true
+            hasClassesWithAllNames(setOf("SampleClass1", "SampleClass2")) shouldBeEqualTo true
+            hasClassesWithAllNames(setOf("SampleClass1", "OtherClass")) shouldBeEqualTo false
             hasClass { it.name == "SampleClass1" } shouldBeEqualTo true
             hasClass { it.hasNameEndingWith("Class1") } shouldBeEqualTo true
             hasAllClasses { it.hasNameStartingWith("Sample") } shouldBeEqualTo true

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koobject/KoObjectDeclarationForKoExternalParentProviderTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koobject/KoObjectDeclarationForKoExternalParentProviderTest.kt
@@ -11,6 +11,7 @@ import org.amshove.kluent.assertSoftly
 import org.amshove.kluent.shouldBeEqualTo
 import org.junit.jupiter.api.Test
 
+@Suppress("detekt.LongMethod")
 class KoObjectDeclarationForKoExternalParentProviderTest {
     @Test
     fun `object-has-no-external-parent`() {
@@ -192,10 +193,10 @@ class KoObjectDeclarationForKoExternalParentProviderTest {
         assertSoftly(sut) {
             externalParents(indirectParents = false) shouldBeEqualTo emptyList()
             externalParents(indirectParents = true).map { it.name } shouldBeEqualTo
-                    listOf(
-                        "SampleExternalClass",
-                        "SampleExternalInterface",
-                    )
+                listOf(
+                    "SampleExternalClass",
+                    "SampleExternalInterface",
+                )
             numExternalParents(indirectParents = false) shouldBeEqualTo 0
             numExternalParents(indirectParents = true) shouldBeEqualTo 2
             countExternalParents(indirectParents = false) { it.name == "SampleExternalInterface" } shouldBeEqualTo 0
@@ -226,14 +227,18 @@ class KoObjectDeclarationForKoExternalParentProviderTest {
             ) shouldBeEqualTo true
             hasExternalParentWithName(listOf("SampleExternalInterface"), indirectParents = true) shouldBeEqualTo true
             hasExternalParentWithName(listOf("OtherInterface"), indirectParents = true) shouldBeEqualTo false
-            hasExternalParentWithName(listOf(
-                "SampleExternalInterface",
-                "SampleExternalClass"),
+            hasExternalParentWithName(
+                listOf(
+                    "SampleExternalInterface",
+                    "SampleExternalClass",
+                ),
                 indirectParents = true,
             ) shouldBeEqualTo true
-            hasExternalParentWithName(listOf(
-                "SampleExternalInterface",
-                "OtherInterface"),
+            hasExternalParentWithName(
+                listOf(
+                    "SampleExternalInterface",
+                    "OtherInterface",
+                ),
                 indirectParents = true,
             ) shouldBeEqualTo true
             hasExternalParentsWithAllNames("SampleExternalInterface", indirectParents = true) shouldBeEqualTo true
@@ -251,14 +256,18 @@ class KoObjectDeclarationForKoExternalParentProviderTest {
 
             hasExternalParentsWithAllNames(listOf("SampleExternalInterface"), indirectParents = true) shouldBeEqualTo true
             hasExternalParentsWithAllNames(listOf("OtherInterface"), indirectParents = true) shouldBeEqualTo false
-            hasExternalParentsWithAllNames(listOf(
-                "SampleExternalInterface",
-                "SampleExternalClass"),
+            hasExternalParentsWithAllNames(
+                listOf(
+                    "SampleExternalInterface",
+                    "SampleExternalClass",
+                ),
                 indirectParents = true,
             ) shouldBeEqualTo true
-            hasExternalParentsWithAllNames(listOf(
-                "SampleExternalInterface",
-                "OtherInterface"),
+            hasExternalParentsWithAllNames(
+                listOf(
+                    "SampleExternalInterface",
+                    "OtherInterface",
+                ),
                 indirectParents = true,
             ) shouldBeEqualTo false
             hasExternalParent(indirectParents = true) { it.name == "SampleExternalInterface" } shouldBeEqualTo true
@@ -273,9 +282,11 @@ class KoObjectDeclarationForKoExternalParentProviderTest {
                 indirectParents = true,
             ) shouldBeEqualTo true
             hasExternalParentOf(listOf(SampleExternalInterface::class), indirectParents = true) shouldBeEqualTo true
-            hasExternalParentOf(listOf(
-                SampleExternalInterface::class,
-                SampleParentClass::class),
+            hasExternalParentOf(
+                listOf(
+                    SampleExternalInterface::class,
+                    SampleParentClass::class,
+                ),
                 indirectParents = true,
             ) shouldBeEqualTo true
             hasAllExternalParentsOf(SampleExternalInterface::class, indirectParents = true) shouldBeEqualTo true
@@ -291,14 +302,18 @@ class KoObjectDeclarationForKoExternalParentProviderTest {
             ) shouldBeEqualTo true
 
             hasAllExternalParentsOf(listOf(SampleExternalInterface::class), indirectParents = true) shouldBeEqualTo true
-            hasAllExternalParentsOf(listOf(
-                SampleExternalInterface::class,
-                SampleParentClass::class),
+            hasAllExternalParentsOf(
+                listOf(
+                    SampleExternalInterface::class,
+                    SampleParentClass::class,
+                ),
                 indirectParents = true,
             ) shouldBeEqualTo false
-            hasAllExternalParentsOf(listOf(
-                SampleExternalInterface::class,
-                SampleExternalClass::class),
+            hasAllExternalParentsOf(
+                listOf(
+                    SampleExternalInterface::class,
+                    SampleExternalClass::class,
+                ),
                 indirectParents = true,
             ) shouldBeEqualTo true
         }

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koobject/KoObjectDeclarationForKoExternalParentProviderTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koobject/KoObjectDeclarationForKoExternalParentProviderTest.kt
@@ -26,12 +26,24 @@ class KoObjectDeclarationForKoExternalParentProviderTest {
             numExternalParents() shouldBeEqualTo 0
             countExternalParents { it.name == "SampleExternalParent" } shouldBeEqualTo 0
             hasExternalParents() shouldBeEqualTo false
-            hasExternalParentWithName("SampleExternalParent1", "SampleExternalParent2") shouldBeEqualTo false
-            hasExternalParentsWithAllNames("SampleExternalParent1", "SampleExternalParent2") shouldBeEqualTo false
+            hasExternalParentWithName(emptyList()) shouldBeEqualTo false
+            hasExternalParentWithName(emptySet()) shouldBeEqualTo false
+            hasExternalParentsWithAllNames(emptyList()) shouldBeEqualTo false
+            hasExternalParentsWithAllNames(emptySet()) shouldBeEqualTo false
+            hasExternalParentWithName("SampleExternalClass", "SampleExternalInterface") shouldBeEqualTo false
+            hasExternalParentWithName(listOf("SampleExternalClass", "SampleExternalInterface")) shouldBeEqualTo false
+            hasExternalParentWithName(setOf("SampleExternalClass", "SampleExternalInterface")) shouldBeEqualTo false
+            hasExternalParentsWithAllNames("SampleExternalClass", "SampleExternalInterface") shouldBeEqualTo false
+            hasExternalParentsWithAllNames(listOf("SampleExternalClass", "SampleExternalInterface")) shouldBeEqualTo false
+            hasExternalParentsWithAllNames(setOf("SampleExternalClass", "SampleExternalInterface")) shouldBeEqualTo false
             hasExternalParent { it.name == "SampleExternalParent" } shouldBeEqualTo false
             hasAllExternalParents { it.hasNameStartingWith("Sample") } shouldBeEqualTo true
             hasExternalParentOf(SampleParentInterface1::class) shouldBeEqualTo false
+            hasExternalParentOf(listOf(SampleParentInterface1::class)) shouldBeEqualTo false
+            hasExternalParentOf(setOf(SampleParentInterface1::class)) shouldBeEqualTo false
             hasAllExternalParentsOf(SampleParentInterface1::class, SampleParentInterface2::class) shouldBeEqualTo false
+            hasAllExternalParentsOf(listOf(SampleParentInterface1::class, SampleParentInterface2::class)) shouldBeEqualTo false
+            hasAllExternalParentsOf(setOf(SampleParentInterface1::class, SampleParentInterface2::class)) shouldBeEqualTo false
         }
     }
 
@@ -50,14 +62,34 @@ class KoObjectDeclarationForKoExternalParentProviderTest {
             countExternalParents { it.name == "SampleExternalClass" } shouldBeEqualTo 1
             countExternalParents { it.hasNameStartingWith("SampleExternal") } shouldBeEqualTo 2
             hasExternalParents() shouldBeEqualTo true
+            hasExternalParentWithName(emptyList()) shouldBeEqualTo true
+            hasExternalParentWithName(emptySet()) shouldBeEqualTo true
+            hasExternalParentsWithAllNames(emptyList()) shouldBeEqualTo true
+            hasExternalParentsWithAllNames(emptySet()) shouldBeEqualTo true
             hasExternalParentWithName("SampleExternalClass") shouldBeEqualTo true
             hasExternalParentWithName("OtherInterface") shouldBeEqualTo false
             hasExternalParentWithName("SampleExternalClass", "SampleExternalInterface") shouldBeEqualTo true
             hasExternalParentWithName("SampleExternalClass", "OtherInterface") shouldBeEqualTo true
+            hasExternalParentWithName(listOf("SampleExternalClass")) shouldBeEqualTo true
+            hasExternalParentWithName(listOf("OtherInterface")) shouldBeEqualTo false
+            hasExternalParentWithName(listOf("SampleExternalClass", "SampleExternalInterface")) shouldBeEqualTo true
+            hasExternalParentWithName(listOf("SampleExternalClass", "OtherInterface")) shouldBeEqualTo true
+            hasExternalParentWithName(setOf("SampleExternalClass")) shouldBeEqualTo true
+            hasExternalParentWithName(setOf("OtherInterface")) shouldBeEqualTo false
+            hasExternalParentWithName(setOf("SampleExternalClass", "SampleExternalInterface")) shouldBeEqualTo true
+            hasExternalParentWithName(setOf("SampleExternalClass", "OtherInterface")) shouldBeEqualTo true
             hasExternalParentsWithAllNames("SampleExternalClass") shouldBeEqualTo true
             hasExternalParentsWithAllNames("OtherInterface") shouldBeEqualTo false
             hasExternalParentsWithAllNames("SampleExternalClass", "SampleExternalInterface") shouldBeEqualTo true
             hasExternalParentsWithAllNames("SampleExternalClass", "OtherInterface") shouldBeEqualTo false
+            hasExternalParentsWithAllNames(listOf("SampleExternalClass")) shouldBeEqualTo true
+            hasExternalParentsWithAllNames(listOf("OtherInterface")) shouldBeEqualTo false
+            hasExternalParentsWithAllNames(listOf("SampleExternalClass", "SampleExternalInterface")) shouldBeEqualTo true
+            hasExternalParentsWithAllNames(listOf("SampleExternalClass", "OtherInterface")) shouldBeEqualTo false
+            hasExternalParentsWithAllNames(setOf("SampleExternalClass")) shouldBeEqualTo true
+            hasExternalParentsWithAllNames(setOf("OtherInterface")) shouldBeEqualTo false
+            hasExternalParentsWithAllNames(setOf("SampleExternalClass", "SampleExternalInterface")) shouldBeEqualTo true
+            hasExternalParentsWithAllNames(setOf("SampleExternalClass", "OtherInterface")) shouldBeEqualTo false
             hasExternalParent { it.name == "SampleExternalClass" } shouldBeEqualTo true
             hasExternalParent { it.name == "OtherInterface" } shouldBeEqualTo false
             hasAllExternalParents { it.name == "SampleExternalClass" } shouldBeEqualTo false
@@ -65,9 +97,19 @@ class KoObjectDeclarationForKoExternalParentProviderTest {
             hasAllExternalParents { it.hasNameStartingWith("Other") } shouldBeEqualTo false
             hasExternalParentOf(SampleExternalClass::class) shouldBeEqualTo true
             hasExternalParentOf(SampleExternalClass::class, SampleParentClass::class) shouldBeEqualTo true
+            hasExternalParentOf(listOf(SampleExternalClass::class)) shouldBeEqualTo true
+            hasExternalParentOf(listOf(SampleExternalClass::class, SampleParentClass::class)) shouldBeEqualTo true
+            hasExternalParentOf(setOf(SampleExternalClass::class)) shouldBeEqualTo true
+            hasExternalParentOf(setOf(SampleExternalClass::class, SampleParentClass::class)) shouldBeEqualTo true
             hasAllExternalParentsOf(SampleExternalClass::class) shouldBeEqualTo true
             hasAllExternalParentsOf(SampleExternalClass::class, SampleParentClass::class) shouldBeEqualTo false
             hasAllExternalParentsOf(SampleExternalClass::class, SampleExternalInterface::class) shouldBeEqualTo true
+            hasAllExternalParentsOf(listOf(SampleExternalClass::class)) shouldBeEqualTo true
+            hasAllExternalParentsOf(listOf(SampleExternalClass::class, SampleParentClass::class)) shouldBeEqualTo false
+            hasAllExternalParentsOf(listOf(SampleExternalClass::class, SampleExternalInterface::class)) shouldBeEqualTo true
+            hasAllExternalParentsOf(setOf(SampleExternalClass::class)) shouldBeEqualTo true
+            hasAllExternalParentsOf(setOf(SampleExternalClass::class, SampleParentClass::class)) shouldBeEqualTo false
+            hasAllExternalParentsOf(setOf(SampleExternalClass::class, SampleExternalInterface::class)) shouldBeEqualTo true
         }
     }
 
@@ -86,14 +128,34 @@ class KoObjectDeclarationForKoExternalParentProviderTest {
             countExternalParents { it.name == "SampleExternalInterface" } shouldBeEqualTo 1
             countExternalParents { it.hasNameStartingWith("SampleExternal") } shouldBeEqualTo 2
             hasExternalParents() shouldBeEqualTo true
+            hasExternalParentWithName(emptyList()) shouldBeEqualTo true
+            hasExternalParentWithName(emptySet()) shouldBeEqualTo true
+            hasExternalParentsWithAllNames(emptyList()) shouldBeEqualTo true
+            hasExternalParentsWithAllNames(emptySet()) shouldBeEqualTo true
             hasExternalParentWithName("SampleExternalInterface") shouldBeEqualTo true
             hasExternalParentWithName("OtherInterface") shouldBeEqualTo false
             hasExternalParentWithName("SampleExternalInterface", "SampleExternalGenericInterface") shouldBeEqualTo true
             hasExternalParentWithName("SampleExternalInterface", "OtherInterface") shouldBeEqualTo true
+            hasExternalParentWithName(listOf("SampleExternalInterface")) shouldBeEqualTo true
+            hasExternalParentWithName(listOf("OtherInterface")) shouldBeEqualTo false
+            hasExternalParentWithName(listOf("SampleExternalInterface", "SampleExternalGenericInterface")) shouldBeEqualTo true
+            hasExternalParentWithName(listOf("SampleExternalInterface", "OtherInterface")) shouldBeEqualTo true
+            hasExternalParentWithName(setOf("SampleExternalInterface")) shouldBeEqualTo true
+            hasExternalParentWithName(setOf("OtherInterface")) shouldBeEqualTo false
+            hasExternalParentWithName(setOf("SampleExternalInterface", "SampleExternalGenericInterface")) shouldBeEqualTo true
+            hasExternalParentWithName(setOf("SampleExternalInterface", "OtherInterface")) shouldBeEqualTo true
             hasExternalParentsWithAllNames("SampleExternalInterface") shouldBeEqualTo true
             hasExternalParentsWithAllNames("OtherInterface") shouldBeEqualTo false
             hasExternalParentsWithAllNames("SampleExternalInterface", "SampleExternalGenericInterface") shouldBeEqualTo true
             hasExternalParentsWithAllNames("SampleExternalInterface", "OtherInterface") shouldBeEqualTo false
+            hasExternalParentsWithAllNames(listOf("SampleExternalInterface")) shouldBeEqualTo true
+            hasExternalParentsWithAllNames(listOf("OtherInterface")) shouldBeEqualTo false
+            hasExternalParentsWithAllNames(listOf("SampleExternalInterface", "SampleExternalGenericInterface")) shouldBeEqualTo true
+            hasExternalParentsWithAllNames(listOf("SampleExternalInterface", "OtherInterface")) shouldBeEqualTo false
+            hasExternalParentsWithAllNames(setOf("SampleExternalInterface")) shouldBeEqualTo true
+            hasExternalParentsWithAllNames(setOf("OtherInterface")) shouldBeEqualTo false
+            hasExternalParentsWithAllNames(setOf("SampleExternalInterface", "SampleExternalGenericInterface")) shouldBeEqualTo true
+            hasExternalParentsWithAllNames(setOf("SampleExternalInterface", "OtherInterface")) shouldBeEqualTo false
             hasExternalParent { it.name == "SampleExternalInterface" } shouldBeEqualTo true
             hasExternalParent { it.name == "OtherInterface" } shouldBeEqualTo false
             hasAllExternalParents { it.name == "SampleExternalInterface" } shouldBeEqualTo false
@@ -101,9 +163,19 @@ class KoObjectDeclarationForKoExternalParentProviderTest {
             hasAllExternalParents { it.hasNameStartingWith("Other") } shouldBeEqualTo false
             hasExternalParentOf(SampleExternalInterface::class) shouldBeEqualTo true
             hasExternalParentOf(SampleExternalInterface::class, SampleParentClass::class) shouldBeEqualTo true
+            hasExternalParentOf(listOf(SampleExternalInterface::class)) shouldBeEqualTo true
+            hasExternalParentOf(listOf(SampleExternalInterface::class, SampleParentClass::class)) shouldBeEqualTo true
+            hasExternalParentOf(setOf(SampleExternalInterface::class)) shouldBeEqualTo true
+            hasExternalParentOf(setOf(SampleExternalInterface::class, SampleParentClass::class)) shouldBeEqualTo true
             hasAllExternalParentsOf(SampleExternalInterface::class) shouldBeEqualTo true
             hasAllExternalParentsOf(SampleExternalInterface::class, SampleParentClass::class) shouldBeEqualTo false
             hasAllExternalParentsOf(SampleExternalInterface::class, SampleExternalGenericInterface::class) shouldBeEqualTo true
+            hasAllExternalParentsOf(listOf(SampleExternalInterface::class)) shouldBeEqualTo true
+            hasAllExternalParentsOf(listOf(SampleExternalInterface::class, SampleParentClass::class)) shouldBeEqualTo false
+            hasAllExternalParentsOf(listOf(SampleExternalInterface::class, SampleExternalGenericInterface::class)) shouldBeEqualTo true
+            hasAllExternalParentsOf(setOf(SampleExternalInterface::class)) shouldBeEqualTo true
+            hasAllExternalParentsOf(setOf(SampleExternalInterface::class, SampleParentClass::class)) shouldBeEqualTo false
+            hasAllExternalParentsOf(setOf(SampleExternalInterface::class, SampleExternalGenericInterface::class)) shouldBeEqualTo true
         }
     }
 
@@ -120,62 +192,113 @@ class KoObjectDeclarationForKoExternalParentProviderTest {
         assertSoftly(sut) {
             externalParents(indirectParents = false) shouldBeEqualTo emptyList()
             externalParents(indirectParents = true).map { it.name } shouldBeEqualTo
-                listOf(
-                    "SampleExternalClass",
-                    "SampleExternalInterface",
-                )
+                    listOf(
+                        "SampleExternalClass",
+                        "SampleExternalInterface",
+                    )
             numExternalParents(indirectParents = false) shouldBeEqualTo 0
             numExternalParents(indirectParents = true) shouldBeEqualTo 2
-            countExternalParents(indirectParents = false) { it.name == "SampleExternalClass" } shouldBeEqualTo 0
-            countExternalParents(indirectParents = true) { it.name == "SampleExternalClass" } shouldBeEqualTo 1
+            countExternalParents(indirectParents = false) { it.name == "SampleExternalInterface" } shouldBeEqualTo 0
+            countExternalParents(indirectParents = true) { it.name == "SampleExternalInterface" } shouldBeEqualTo 1
             countExternalParents(indirectParents = false) { it.hasNameStartingWith("SampleExternal") } shouldBeEqualTo 0
             countExternalParents(indirectParents = true) { it.hasNameStartingWith("SampleExternal") } shouldBeEqualTo 2
             hasExternalParents(indirectParents = false) shouldBeEqualTo false
             hasExternalParents(indirectParents = true) shouldBeEqualTo true
-            hasExternalParentWithName("SampleExternalClass", indirectParents = true) shouldBeEqualTo true
+            hasExternalParentWithName(emptyList(), indirectParents = false) shouldBeEqualTo false
+            hasExternalParentWithName(emptySet(), indirectParents = false) shouldBeEqualTo false
+            hasExternalParentsWithAllNames(emptyList(), indirectParents = false) shouldBeEqualTo false
+            hasExternalParentsWithAllNames(emptySet(), indirectParents = false) shouldBeEqualTo false
+            hasExternalParentWithName(emptyList(), indirectParents = true) shouldBeEqualTo true
+            hasExternalParentWithName(emptySet(), indirectParents = true) shouldBeEqualTo true
+            hasExternalParentsWithAllNames(emptyList(), indirectParents = true) shouldBeEqualTo true
+            hasExternalParentsWithAllNames(emptySet(), indirectParents = true) shouldBeEqualTo true
+            hasExternalParentWithName("SampleExternalInterface", indirectParents = true) shouldBeEqualTo true
             hasExternalParentWithName("OtherInterface", indirectParents = true) shouldBeEqualTo false
             hasExternalParentWithName(
-                "SampleExternalClass",
                 "SampleExternalInterface",
+                "SampleExternalClass",
                 indirectParents = true,
             ) shouldBeEqualTo true
             hasExternalParentWithName(
-                "SampleExternalClass",
+                "SampleExternalInterface",
                 "OtherInterface",
                 indirectParents = true,
             ) shouldBeEqualTo true
-            hasExternalParentsWithAllNames("SampleExternalClass", indirectParents = true) shouldBeEqualTo true
+            hasExternalParentWithName(listOf("SampleExternalInterface"), indirectParents = true) shouldBeEqualTo true
+            hasExternalParentWithName(listOf("OtherInterface"), indirectParents = true) shouldBeEqualTo false
+            hasExternalParentWithName(listOf(
+                "SampleExternalInterface",
+                "SampleExternalClass"),
+                indirectParents = true,
+            ) shouldBeEqualTo true
+            hasExternalParentWithName(listOf(
+                "SampleExternalInterface",
+                "OtherInterface"),
+                indirectParents = true,
+            ) shouldBeEqualTo true
+            hasExternalParentsWithAllNames("SampleExternalInterface", indirectParents = true) shouldBeEqualTo true
             hasExternalParentsWithAllNames("OtherInterface", indirectParents = true) shouldBeEqualTo false
             hasExternalParentsWithAllNames(
-                "SampleExternalClass",
                 "SampleExternalInterface",
+                "SampleExternalClass",
                 indirectParents = true,
             ) shouldBeEqualTo true
             hasExternalParentsWithAllNames(
-                "SampleExternalClass",
+                "SampleExternalInterface",
                 "OtherInterface",
                 indirectParents = true,
             ) shouldBeEqualTo false
-            hasExternalParent(indirectParents = true) { it.name == "SampleExternalClass" } shouldBeEqualTo true
+
+            hasExternalParentsWithAllNames(listOf("SampleExternalInterface"), indirectParents = true) shouldBeEqualTo true
+            hasExternalParentsWithAllNames(listOf("OtherInterface"), indirectParents = true) shouldBeEqualTo false
+            hasExternalParentsWithAllNames(listOf(
+                "SampleExternalInterface",
+                "SampleExternalClass"),
+                indirectParents = true,
+            ) shouldBeEqualTo true
+            hasExternalParentsWithAllNames(listOf(
+                "SampleExternalInterface",
+                "OtherInterface"),
+                indirectParents = true,
+            ) shouldBeEqualTo false
+            hasExternalParent(indirectParents = true) { it.name == "SampleExternalInterface" } shouldBeEqualTo true
             hasExternalParent(indirectParents = true) { it.name == "OtherInterface" } shouldBeEqualTo false
-            hasAllExternalParents(indirectParents = true) { it.name == "SampleExternalClass" } shouldBeEqualTo false
+            hasAllExternalParents(indirectParents = true) { it.name == "SampleExternalInterface" } shouldBeEqualTo false
             hasAllExternalParents(indirectParents = true) { it.hasNameStartingWith("Sample") } shouldBeEqualTo true
             hasAllExternalParents(indirectParents = true) { it.hasNameStartingWith("Other") } shouldBeEqualTo false
-            hasExternalParentOf(SampleExternalClass::class, indirectParents = true) shouldBeEqualTo true
+            hasExternalParentOf(SampleExternalInterface::class, indirectParents = true) shouldBeEqualTo true
             hasExternalParentOf(
-                SampleExternalClass::class,
+                SampleExternalInterface::class,
                 SampleParentClass::class,
                 indirectParents = true,
             ) shouldBeEqualTo true
-            hasAllExternalParentsOf(SampleExternalClass::class, indirectParents = true) shouldBeEqualTo true
+            hasExternalParentOf(listOf(SampleExternalInterface::class), indirectParents = true) shouldBeEqualTo true
+            hasExternalParentOf(listOf(
+                SampleExternalInterface::class,
+                SampleParentClass::class),
+                indirectParents = true,
+            ) shouldBeEqualTo true
+            hasAllExternalParentsOf(SampleExternalInterface::class, indirectParents = true) shouldBeEqualTo true
             hasAllExternalParentsOf(
-                SampleExternalClass::class,
+                SampleExternalInterface::class,
                 SampleParentClass::class,
                 indirectParents = true,
             ) shouldBeEqualTo false
             hasAllExternalParentsOf(
-                SampleExternalClass::class,
                 SampleExternalInterface::class,
+                SampleExternalClass::class,
+                indirectParents = true,
+            ) shouldBeEqualTo true
+
+            hasAllExternalParentsOf(listOf(SampleExternalInterface::class), indirectParents = true) shouldBeEqualTo true
+            hasAllExternalParentsOf(listOf(
+                SampleExternalInterface::class,
+                SampleParentClass::class),
+                indirectParents = true,
+            ) shouldBeEqualTo false
+            hasAllExternalParentsOf(listOf(
+                SampleExternalInterface::class,
+                SampleExternalClass::class),
                 indirectParents = true,
             ) shouldBeEqualTo true
         }

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koobject/KoObjectDeclarationForKoFunctionProviderTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koobject/KoObjectDeclarationForKoFunctionProviderTest.kt
@@ -21,8 +21,16 @@ class KoObjectDeclarationForKoFunctionProviderTest {
         assertSoftly(sut) {
             functions() shouldBeEqualTo emptyList()
             hasFunctions() shouldBeEqualTo false
+            hasFunctionWithName(emptyList()) shouldBeEqualTo false
+            hasFunctionWithName(emptySet()) shouldBeEqualTo false
+            hasFunctionsWithAllNames(emptyList()) shouldBeEqualTo false
+            hasFunctionsWithAllNames(emptySet()) shouldBeEqualTo false
             hasFunctionWithName("sampleFunction") shouldBeEqualTo false
+            hasFunctionWithName(listOf("sampleFunction")) shouldBeEqualTo false
+            hasFunctionWithName(setOf("sampleFunction")) shouldBeEqualTo false
             hasFunctionsWithAllNames("sampleFunction1", "sampleFunction2") shouldBeEqualTo false
+            hasFunctionsWithAllNames(listOf("sampleFunction1", "sampleFunction2")) shouldBeEqualTo false
+            hasFunctionsWithAllNames(setOf("sampleFunction1", "sampleFunction2")) shouldBeEqualTo false
             hasFunction { it.name == "sampleFunction" } shouldBeEqualTo false
             hasAllFunctions { it.hasNameStartingWith("sample") } shouldBeEqualTo true
         }
@@ -39,11 +47,25 @@ class KoObjectDeclarationForKoFunctionProviderTest {
         // then
         assertSoftly(sut) {
             hasFunctions() shouldBeEqualTo true
+            hasFunctionWithName(emptyList()) shouldBeEqualTo true
+            hasFunctionWithName(emptySet()) shouldBeEqualTo true
+            hasFunctionsWithAllNames(emptyList()) shouldBeEqualTo true
+            hasFunctionsWithAllNames(emptySet()) shouldBeEqualTo true
             hasFunctionWithName("sampleFunction1") shouldBeEqualTo true
             hasFunctionWithName("sampleFunction1", "otherFunction") shouldBeEqualTo true
+            hasFunctionWithName(listOf("sampleFunction1")) shouldBeEqualTo true
+            hasFunctionWithName(listOf("sampleFunction1", "otherFunction")) shouldBeEqualTo true
+            hasFunctionWithName(setOf("sampleFunction1")) shouldBeEqualTo true
+            hasFunctionWithName(setOf("sampleFunction1", "otherFunction")) shouldBeEqualTo true
             hasFunctionsWithAllNames("sampleFunction1") shouldBeEqualTo true
             hasFunctionsWithAllNames("sampleFunction1", "sampleFunction2") shouldBeEqualTo true
             hasFunctionsWithAllNames("sampleFunction1", "otherFunction") shouldBeEqualTo false
+            hasFunctionsWithAllNames(listOf("sampleFunction1")) shouldBeEqualTo true
+            hasFunctionsWithAllNames(listOf("sampleFunction1", "sampleFunction2")) shouldBeEqualTo true
+            hasFunctionsWithAllNames(listOf("sampleFunction1", "otherFunction")) shouldBeEqualTo false
+            hasFunctionsWithAllNames(setOf("sampleFunction1")) shouldBeEqualTo true
+            hasFunctionsWithAllNames(setOf("sampleFunction1", "sampleFunction2")) shouldBeEqualTo true
+            hasFunctionsWithAllNames(setOf("sampleFunction1", "otherFunction")) shouldBeEqualTo false
             hasFunction { it.name == "sampleFunction1" } shouldBeEqualTo true
             hasFunction { it.hasNameEndingWith("Function1") } shouldBeEqualTo true
             hasAllFunctions { it.hasNameStartingWith("sample") } shouldBeEqualTo true

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koobject/KoObjectDeclarationForKoInterfaceProviderTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koobject/KoObjectDeclarationForKoInterfaceProviderTest.kt
@@ -19,10 +19,17 @@ class KoObjectDeclarationForKoInterfaceProviderTest {
 
         // then
         assertSoftly(sut) {
-            interfaces() shouldBeEqualTo emptyList()
             hasInterfaces() shouldBeEqualTo false
+            hasInterfaceWithName(emptyList()) shouldBeEqualTo false
+            hasInterfaceWithName(emptySet()) shouldBeEqualTo false
+            hasInterfacesWithAllNames(emptyList()) shouldBeEqualTo false
+            hasInterfacesWithAllNames(emptySet()) shouldBeEqualTo false
             hasInterfaceWithName("SampleInterface") shouldBeEqualTo false
+            hasInterfaceWithName(listOf("SampleInterface")) shouldBeEqualTo false
+            hasInterfaceWithName(setOf("SampleInterface")) shouldBeEqualTo false
             hasInterfacesWithAllNames("SampleInterface1", "SampleInterface2") shouldBeEqualTo false
+            hasInterfacesWithAllNames(listOf("SampleInterface1", "SampleInterface2")) shouldBeEqualTo false
+            hasInterfacesWithAllNames(setOf("SampleInterface1", "SampleInterface2")) shouldBeEqualTo false
             hasInterface { it.name == "SampleInterface" } shouldBeEqualTo false
             hasAllInterfaces { it.hasNameStartingWith("Sample") } shouldBeEqualTo true
         }
@@ -39,11 +46,25 @@ class KoObjectDeclarationForKoInterfaceProviderTest {
         // then
         assertSoftly(sut) {
             hasInterfaces() shouldBeEqualTo true
+            hasInterfaceWithName(emptyList()) shouldBeEqualTo true
+            hasInterfaceWithName(emptySet()) shouldBeEqualTo true
+            hasInterfacesWithAllNames(emptyList()) shouldBeEqualTo true
+            hasInterfacesWithAllNames(emptySet()) shouldBeEqualTo true
             hasInterfaceWithName("SampleInterface1") shouldBeEqualTo true
             hasInterfaceWithName("SampleInterface1", "OtherInterface") shouldBeEqualTo true
+            hasInterfaceWithName(listOf("SampleInterface1")) shouldBeEqualTo true
+            hasInterfaceWithName(listOf("SampleInterface1", "OtherInterface")) shouldBeEqualTo true
+            hasInterfaceWithName(setOf("SampleInterface1")) shouldBeEqualTo true
+            hasInterfaceWithName(setOf("SampleInterface1", "OtherInterface")) shouldBeEqualTo true
             hasInterfacesWithAllNames("SampleInterface1") shouldBeEqualTo true
             hasInterfacesWithAllNames("SampleInterface1", "SampleInterface2") shouldBeEqualTo true
             hasInterfacesWithAllNames("SampleInterface1", "OtherInterface") shouldBeEqualTo false
+            hasInterfacesWithAllNames(listOf("SampleInterface1")) shouldBeEqualTo true
+            hasInterfacesWithAllNames(listOf("SampleInterface1", "SampleInterface2")) shouldBeEqualTo true
+            hasInterfacesWithAllNames(listOf("SampleInterface1", "OtherInterface")) shouldBeEqualTo false
+            hasInterfacesWithAllNames(setOf("SampleInterface1")) shouldBeEqualTo true
+            hasInterfacesWithAllNames(setOf("SampleInterface1", "SampleInterface2")) shouldBeEqualTo true
+            hasInterfacesWithAllNames(setOf("SampleInterface1", "OtherInterface")) shouldBeEqualTo false
             hasInterface { it.name == "SampleInterface1" } shouldBeEqualTo true
             hasInterface { it.hasNameEndingWith("Interface1") } shouldBeEqualTo true
             hasAllInterfaces { it.hasNameStartingWith("Sample") } shouldBeEqualTo true

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koobject/KoObjectDeclarationForKoObjectProviderTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koobject/KoObjectDeclarationForKoObjectProviderTest.kt
@@ -21,8 +21,16 @@ class KoObjectDeclarationForKoObjectProviderTest {
         assertSoftly(sut) {
             objects() shouldBeEqualTo emptyList()
             hasObjects() shouldBeEqualTo false
+            hasObjectWithName(emptyList()) shouldBeEqualTo false
+            hasObjectWithName(emptySet()) shouldBeEqualTo false
+            hasObjectsWithAllNames(emptyList()) shouldBeEqualTo false
+            hasObjectsWithAllNames(emptySet()) shouldBeEqualTo false
             hasObjectWithName("SampleObject") shouldBeEqualTo false
+            hasObjectWithName(listOf("SampleObject")) shouldBeEqualTo false
+            hasObjectWithName(setOf("SampleObject")) shouldBeEqualTo false
             hasObjectsWithAllNames("SampleObject1", "SampleObject2") shouldBeEqualTo false
+            hasObjectsWithAllNames(listOf("SampleObject1", "SampleObject2")) shouldBeEqualTo false
+            hasObjectsWithAllNames(setOf("SampleObject1", "SampleObject2")) shouldBeEqualTo false
             hasObject { it.name == "SampleObject" } shouldBeEqualTo false
             hasAllObjects { it.hasNameStartingWith("Sample") } shouldBeEqualTo true
         }
@@ -39,11 +47,25 @@ class KoObjectDeclarationForKoObjectProviderTest {
         // then
         assertSoftly(sut) {
             hasObjects() shouldBeEqualTo true
+            hasObjectWithName(emptyList()) shouldBeEqualTo true
+            hasObjectWithName(emptySet()) shouldBeEqualTo true
+            hasObjectsWithAllNames(emptyList()) shouldBeEqualTo true
+            hasObjectsWithAllNames(emptySet()) shouldBeEqualTo true
             hasObjectWithName("SampleObject1") shouldBeEqualTo true
             hasObjectWithName("SampleObject1", "OtherObject") shouldBeEqualTo true
+            hasObjectWithName(listOf("SampleObject1")) shouldBeEqualTo true
+            hasObjectWithName(listOf("SampleObject1", "OtherObject")) shouldBeEqualTo true
+            hasObjectWithName(setOf("SampleObject1")) shouldBeEqualTo true
+            hasObjectWithName(setOf("SampleObject1", "OtherObject")) shouldBeEqualTo true
             hasObjectsWithAllNames("SampleObject1") shouldBeEqualTo true
             hasObjectsWithAllNames("SampleObject1", "SampleObject2") shouldBeEqualTo true
             hasObjectsWithAllNames("SampleObject1", "OtherObject") shouldBeEqualTo false
+            hasObjectsWithAllNames(listOf("SampleObject1")) shouldBeEqualTo true
+            hasObjectsWithAllNames(listOf("SampleObject1", "SampleObject2")) shouldBeEqualTo true
+            hasObjectsWithAllNames(listOf("SampleObject1", "OtherObject")) shouldBeEqualTo false
+            hasObjectsWithAllNames(setOf("SampleObject1")) shouldBeEqualTo true
+            hasObjectsWithAllNames(setOf("SampleObject1", "SampleObject2")) shouldBeEqualTo true
+            hasObjectsWithAllNames(setOf("SampleObject1", "OtherObject")) shouldBeEqualTo false
             hasObject { it.name == "SampleObject1" } shouldBeEqualTo true
             hasObject { it.hasNameEndingWith("Object1") } shouldBeEqualTo true
             hasAllObjects { it.hasNameStartingWith("Sample") } shouldBeEqualTo true

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koobject/KoObjectDeclarationForKoParentClassProviderTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koobject/KoObjectDeclarationForKoParentClassProviderTest.kt
@@ -9,6 +9,7 @@ import org.amshove.kluent.assertSoftly
 import org.amshove.kluent.shouldBeEqualTo
 import org.junit.jupiter.api.Test
 
+@Suppress("detekt.LongMethod")
 class KoObjectDeclarationForKoParentClassProviderTest {
     @Test
     fun `object-has-no-parent-class`() {
@@ -21,21 +22,42 @@ class KoObjectDeclarationForKoParentClassProviderTest {
         // then
         assertSoftly(sut) {
             parentClass shouldBeEqualTo null
+            parentClass shouldBeEqualTo null
             parentClasses() shouldBeEqualTo emptyList()
             numParentClasses() shouldBeEqualTo 0
             countParentClasses { it.hasPrivateModifier } shouldBeEqualTo 0
             hasParentClass() shouldBeEqualTo false
             hasParentClass { it.name == "SampleParentClass" } shouldBeEqualTo false
             hasParentClasses() shouldBeEqualTo false
+            hasParentClassWithName(emptyList()) shouldBeEqualTo false
+            hasParentClassWithName(emptySet()) shouldBeEqualTo false
+            hasParentClassesWithAllNames(emptyList()) shouldBeEqualTo false
+            hasParentClassesWithAllNames(emptySet()) shouldBeEqualTo false
             hasAllParentClasses { it.hasPrivateModifier } shouldBeEqualTo true
             hasParentClassWithName("SampleParentClass") shouldBeEqualTo false
             hasParentClassWithName("SampleParentClass", "OtherClass") shouldBeEqualTo false
+            hasParentClassWithName(listOf("SampleParentClass")) shouldBeEqualTo false
+            hasParentClassWithName(listOf("SampleParentClass", "OtherClass")) shouldBeEqualTo false
+            hasParentClassWithName(setOf("SampleParentClass")) shouldBeEqualTo false
+            hasParentClassWithName(setOf("SampleParentClass", "OtherClass")) shouldBeEqualTo false
             hasParentClassesWithAllNames("SampleParentClass") shouldBeEqualTo false
             hasParentClassesWithAllNames("SampleParentClass", "OtherClass") shouldBeEqualTo false
+            hasParentClassesWithAllNames(listOf("SampleParentClass")) shouldBeEqualTo false
+            hasParentClassesWithAllNames(listOf("SampleParentClass", "OtherClass")) shouldBeEqualTo false
+            hasParentClassesWithAllNames(setOf("SampleParentClass")) shouldBeEqualTo false
+            hasParentClassesWithAllNames(setOf("SampleParentClass", "OtherClass")) shouldBeEqualTo false
             hasParentClassOf(SampleParentClass::class) shouldBeEqualTo false
             hasParentClassOf(SampleParentClass::class, SampleClass::class) shouldBeEqualTo false
+            hasParentClassOf(listOf(SampleParentClass::class)) shouldBeEqualTo false
+            hasParentClassOf(listOf(SampleParentClass::class, SampleClass::class)) shouldBeEqualTo false
+            hasParentClassOf(setOf(SampleParentClass::class)) shouldBeEqualTo false
+            hasParentClassOf(setOf(SampleParentClass::class, SampleClass::class)) shouldBeEqualTo false
             hasAllParentClassesOf(SampleParentClass::class) shouldBeEqualTo false
             hasAllParentClassesOf(SampleParentClass::class, SampleClass::class) shouldBeEqualTo false
+            hasAllParentClassesOf(listOf(SampleParentClass::class)) shouldBeEqualTo false
+            hasAllParentClassesOf(listOf(SampleParentClass::class, SampleClass::class)) shouldBeEqualTo false
+            hasAllParentClassesOf(setOf(SampleParentClass::class)) shouldBeEqualTo false
+            hasAllParentClassesOf(setOf(SampleParentClass::class, SampleClass::class)) shouldBeEqualTo false
             hasParentClass("SampleParentClass") shouldBeEqualTo false
         }
     }
@@ -59,20 +81,48 @@ class KoObjectDeclarationForKoParentClassProviderTest {
             hasParentClass { it.name == "SampleParentClass" } shouldBeEqualTo true
             hasParentClass { it.name == "OtherClass" } shouldBeEqualTo false
             hasParentClasses() shouldBeEqualTo true
+            hasParentClassWithName(emptyList()) shouldBeEqualTo true
+            hasParentClassWithName(emptySet()) shouldBeEqualTo true
+            hasParentClassesWithAllNames(emptyList()) shouldBeEqualTo true
+            hasParentClassesWithAllNames(emptySet()) shouldBeEqualTo true
             hasAllParentClasses { it.hasNameStartingWith("Sample") } shouldBeEqualTo true
             hasAllParentClasses { it.hasPrivateModifier } shouldBeEqualTo false
             hasParentClassWithName("SampleParentClass") shouldBeEqualTo true
             hasParentClassWithName("OtherClass") shouldBeEqualTo false
             hasParentClassWithName("SampleParentClass", "OtherClass") shouldBeEqualTo true
+            hasParentClassWithName(listOf("SampleParentClass")) shouldBeEqualTo true
+            hasParentClassWithName(listOf("OtherClass")) shouldBeEqualTo false
+            hasParentClassWithName(listOf("SampleParentClass", "OtherClass")) shouldBeEqualTo true
+            hasParentClassWithName(setOf("SampleParentClass")) shouldBeEqualTo true
+            hasParentClassWithName(setOf("OtherClass")) shouldBeEqualTo false
+            hasParentClassWithName(setOf("SampleParentClass", "OtherClass")) shouldBeEqualTo true
             hasParentClassesWithAllNames("SampleParentClass") shouldBeEqualTo true
             hasParentClassesWithAllNames("OtherClass") shouldBeEqualTo false
             hasParentClassesWithAllNames("SampleParentClass", "OtherClass") shouldBeEqualTo false
+            hasParentClassesWithAllNames(listOf("SampleParentClass")) shouldBeEqualTo true
+            hasParentClassesWithAllNames(listOf("OtherClass")) shouldBeEqualTo false
+            hasParentClassesWithAllNames(listOf("SampleParentClass", "OtherClass")) shouldBeEqualTo false
+            hasParentClassesWithAllNames(setOf("SampleParentClass")) shouldBeEqualTo true
+            hasParentClassesWithAllNames(setOf("OtherClass")) shouldBeEqualTo false
+            hasParentClassesWithAllNames(setOf("SampleParentClass", "OtherClass")) shouldBeEqualTo false
             hasParentClassOf(SampleParentClass::class) shouldBeEqualTo true
             hasParentClassOf(SampleClass::class) shouldBeEqualTo false
             hasParentClassOf(SampleParentClass::class, SampleClass::class) shouldBeEqualTo true
+            hasParentClassOf(listOf(SampleParentClass::class)) shouldBeEqualTo true
+            hasParentClassOf(listOf(SampleClass::class)) shouldBeEqualTo false
+            hasParentClassOf(listOf(SampleParentClass::class, SampleClass::class)) shouldBeEqualTo true
+            hasParentClassOf(setOf(SampleParentClass::class)) shouldBeEqualTo true
+            hasParentClassOf(setOf(SampleClass::class)) shouldBeEqualTo false
+            hasParentClassOf(setOf(SampleParentClass::class, SampleClass::class)) shouldBeEqualTo true
             hasAllParentClassesOf(SampleParentClass::class) shouldBeEqualTo true
             hasAllParentClassesOf(SampleClass::class) shouldBeEqualTo false
             hasAllParentClassesOf(SampleParentClass::class, SampleClass::class) shouldBeEqualTo false
+            hasAllParentClassesOf(listOf(SampleParentClass::class)) shouldBeEqualTo true
+            hasAllParentClassesOf(listOf(SampleClass::class)) shouldBeEqualTo false
+            hasAllParentClassesOf(listOf(SampleParentClass::class, SampleClass::class)) shouldBeEqualTo false
+            hasAllParentClassesOf(setOf(SampleParentClass::class)) shouldBeEqualTo true
+            hasAllParentClassesOf(setOf(SampleClass::class)) shouldBeEqualTo false
+            hasAllParentClassesOf(setOf(SampleParentClass::class, SampleClass::class)) shouldBeEqualTo false
             hasParentClass("SampleParentClass") shouldBeEqualTo true
             hasParentClass("OtherClass") shouldBeEqualTo false
         }
@@ -97,20 +147,48 @@ class KoObjectDeclarationForKoParentClassProviderTest {
             hasParentClass { it.name == "SampleParentClass" } shouldBeEqualTo true
             hasParentClass { it.name == "OtherClass" } shouldBeEqualTo false
             hasParentClasses() shouldBeEqualTo true
+            hasParentClassWithName(emptyList()) shouldBeEqualTo true
+            hasParentClassWithName(emptySet()) shouldBeEqualTo true
+            hasParentClassesWithAllNames(emptyList()) shouldBeEqualTo true
+            hasParentClassesWithAllNames(emptySet()) shouldBeEqualTo true
             hasAllParentClasses { it.hasNameStartingWith("Sample") } shouldBeEqualTo true
             hasAllParentClasses { it.hasPrivateModifier } shouldBeEqualTo false
             hasParentClassWithName("SampleParentClass") shouldBeEqualTo true
             hasParentClassWithName("OtherClass") shouldBeEqualTo false
             hasParentClassWithName("SampleParentClass", "OtherClass") shouldBeEqualTo true
+            hasParentClassWithName(listOf("SampleParentClass")) shouldBeEqualTo true
+            hasParentClassWithName(listOf("OtherClass")) shouldBeEqualTo false
+            hasParentClassWithName(listOf("SampleParentClass", "OtherClass")) shouldBeEqualTo true
+            hasParentClassWithName(setOf("SampleParentClass")) shouldBeEqualTo true
+            hasParentClassWithName(setOf("OtherClass")) shouldBeEqualTo false
+            hasParentClassWithName(setOf("SampleParentClass", "OtherClass")) shouldBeEqualTo true
             hasParentClassesWithAllNames("SampleParentClass") shouldBeEqualTo true
             hasParentClassesWithAllNames("OtherClass") shouldBeEqualTo false
             hasParentClassesWithAllNames("SampleParentClass", "OtherClass") shouldBeEqualTo false
+            hasParentClassesWithAllNames(listOf("SampleParentClass")) shouldBeEqualTo true
+            hasParentClassesWithAllNames(listOf("OtherClass")) shouldBeEqualTo false
+            hasParentClassesWithAllNames(listOf("SampleParentClass", "OtherClass")) shouldBeEqualTo false
+            hasParentClassesWithAllNames(setOf("SampleParentClass")) shouldBeEqualTo true
+            hasParentClassesWithAllNames(setOf("OtherClass")) shouldBeEqualTo false
+            hasParentClassesWithAllNames(setOf("SampleParentClass", "OtherClass")) shouldBeEqualTo false
             hasParentClassOf(SampleParentClass::class) shouldBeEqualTo true
             hasParentClassOf(SampleClass::class) shouldBeEqualTo false
             hasParentClassOf(SampleParentClass::class, SampleClass::class) shouldBeEqualTo true
+            hasParentClassOf(listOf(SampleParentClass::class)) shouldBeEqualTo true
+            hasParentClassOf(listOf(SampleClass::class)) shouldBeEqualTo false
+            hasParentClassOf(listOf(SampleParentClass::class, SampleClass::class)) shouldBeEqualTo true
+            hasParentClassOf(setOf(SampleParentClass::class)) shouldBeEqualTo true
+            hasParentClassOf(setOf(SampleClass::class)) shouldBeEqualTo false
+            hasParentClassOf(setOf(SampleParentClass::class, SampleClass::class)) shouldBeEqualTo true
             hasAllParentClassesOf(SampleParentClass::class) shouldBeEqualTo true
             hasAllParentClassesOf(SampleClass::class) shouldBeEqualTo false
             hasAllParentClassesOf(SampleParentClass::class, SampleClass::class) shouldBeEqualTo false
+            hasAllParentClassesOf(listOf(SampleParentClass::class)) shouldBeEqualTo true
+            hasAllParentClassesOf(listOf(SampleClass::class)) shouldBeEqualTo false
+            hasAllParentClassesOf(listOf(SampleParentClass::class, SampleClass::class)) shouldBeEqualTo false
+            hasAllParentClassesOf(setOf(SampleParentClass::class)) shouldBeEqualTo true
+            hasAllParentClassesOf(setOf(SampleClass::class)) shouldBeEqualTo false
+            hasAllParentClassesOf(setOf(SampleParentClass::class, SampleClass::class)) shouldBeEqualTo false
             hasParentClass("SampleParentClass") shouldBeEqualTo true
             hasParentClass("OtherClass") shouldBeEqualTo false
         }
@@ -138,7 +216,6 @@ class KoObjectDeclarationForKoParentClassProviderTest {
         }
     }
 
-    @Suppress("detekt.LongMethod")
     @Test
     fun `object-has-indirect-parent-classes`() {
         // given
@@ -151,11 +228,11 @@ class KoObjectDeclarationForKoParentClassProviderTest {
         assertSoftly(sut) {
             parentClasses(indirectParents = false).map { it.name } shouldBeEqualTo listOf("SampleParentClass")
             parentClasses(indirectParents = true).map { it.name } shouldBeEqualTo
-                listOf(
-                    "SampleParentClass",
-                    "SampleParentClass1",
-                    "SampleParentClass2",
-                )
+                    listOf(
+                        "SampleParentClass",
+                        "SampleParentClass1",
+                        "SampleParentClass2",
+                    )
             numParentClasses(indirectParents = false) shouldBeEqualTo 1
             numParentClasses(indirectParents = true) shouldBeEqualTo 3
             countParentClasses(indirectParents = false) { it.name == "SampleParentClass1" } shouldBeEqualTo 0
@@ -165,6 +242,10 @@ class KoObjectDeclarationForKoParentClassProviderTest {
             hasParentClass() shouldBeEqualTo true
             hasParentClasses(indirectParents = false) shouldBeEqualTo true
             hasParentClasses(indirectParents = true) shouldBeEqualTo true
+            hasParentClassWithName(emptyList(), indirectParents = false) shouldBeEqualTo true
+            hasParentClassWithName(emptySet(), indirectParents = false) shouldBeEqualTo true
+            hasParentClassesWithAllNames(emptyList(), indirectParents = false) shouldBeEqualTo true
+            hasParentClassesWithAllNames(emptySet(), indirectParents = false) shouldBeEqualTo true
             hasParentClassWithName("SampleParentClass1", indirectParents = true) shouldBeEqualTo true
             hasParentClassWithName("OtherClass", indirectParents = true) shouldBeEqualTo false
             hasParentClassWithName(
@@ -175,6 +256,30 @@ class KoObjectDeclarationForKoParentClassProviderTest {
             hasParentClassWithName(
                 "SampleParentClass1",
                 "OtherClass",
+                indirectParents = true,
+            ) shouldBeEqualTo true
+            hasParentClassWithName(listOf("SampleParentClass1"), indirectParents = true) shouldBeEqualTo true
+            hasParentClassWithName(listOf("OtherClass"), indirectParents = true) shouldBeEqualTo false
+            hasParentClassWithName(listOf(
+                "SampleParentClass1",
+                "SampleParentClass2"),
+                indirectParents = true,
+            ) shouldBeEqualTo true
+            hasParentClassWithName(listOf(
+                "SampleParentClass1",
+                "OtherClass"),
+                indirectParents = true,
+            ) shouldBeEqualTo true
+            hasParentClassWithName(setOf("SampleParentClass1"), indirectParents = true) shouldBeEqualTo true
+            hasParentClassWithName(setOf("OtherClass"), indirectParents = true) shouldBeEqualTo false
+            hasParentClassWithName(setOf(
+                "SampleParentClass1",
+                "SampleParentClass2"),
+                indirectParents = true,
+            ) shouldBeEqualTo true
+            hasParentClassWithName(setOf(
+                "SampleParentClass1",
+                "OtherClass"),
                 indirectParents = true,
             ) shouldBeEqualTo true
             hasParentClassesWithAllNames("SampleParentClass1", indirectParents = true) shouldBeEqualTo true
@@ -189,21 +294,54 @@ class KoObjectDeclarationForKoParentClassProviderTest {
                 "OtherClass",
                 indirectParents = true,
             ) shouldBeEqualTo false
+            hasParentClassesWithAllNames(listOf("SampleParentClass1"), indirectParents = true) shouldBeEqualTo true
+            hasParentClassesWithAllNames(listOf("OtherClass"), indirectParents = true) shouldBeEqualTo false
+            hasParentClassesWithAllNames(listOf(
+                "SampleParentClass1",
+                "SampleParentClass2"),
+                indirectParents = true,
+            ) shouldBeEqualTo true
+            hasParentClassesWithAllNames(listOf(
+                "SampleParentClass1",
+                "OtherClass"),
+                indirectParents = true,
+            ) shouldBeEqualTo false
+            hasParentClassesWithAllNames(setOf("SampleParentClass1"), indirectParents = true) shouldBeEqualTo true
+            hasParentClassesWithAllNames(setOf("OtherClass"), indirectParents = true) shouldBeEqualTo false
+            hasParentClassesWithAllNames(setOf(
+                "SampleParentClass1",
+                "SampleParentClass2"),
+                indirectParents = true,
+            ) shouldBeEqualTo true
+            hasParentClassesWithAllNames(setOf(
+                "SampleParentClass1",
+                "OtherClass"),
+                indirectParents = true,
+            ) shouldBeEqualTo false
             hasParentClass(indirectParents = true) { it.name == "SampleParentClass1" } shouldBeEqualTo true
             hasParentClass(indirectParents = true) { it.name == "OtherClass" } shouldBeEqualTo false
             hasAllParentClasses(indirectParents = true) { it.name == "SampleParentClass1" } shouldBeEqualTo false
             hasAllParentClasses(indirectParents = true) { it.hasNameStartingWith("Sample") } shouldBeEqualTo true
             hasAllParentClasses(indirectParents = true) { it.hasNameStartingWith("Other") } shouldBeEqualTo false
             hasParentClassOf(SampleParentClass2::class, indirectParents = true) shouldBeEqualTo true
-            hasParentClassOf(
-                SampleClass::class,
-                SampleParentClass2::class,
-                indirectParents = true,
-            ) shouldBeEqualTo true
+            hasParentClassOf(listOf(SampleParentClass2::class), indirectParents = true) shouldBeEqualTo true
+            hasParentClassOf(setOf(SampleParentClass2::class), indirectParents = true) shouldBeEqualTo true
             hasAllParentClassesOf(SampleParentClass2::class, indirectParents = true) shouldBeEqualTo true
             hasAllParentClassesOf(
-                SampleParentClass1::class,
+                SampleParentClass2::class,
                 SampleClass::class,
+                indirectParents = true,
+            ) shouldBeEqualTo false
+            hasAllParentClassesOf(listOf(SampleParentClass2::class), indirectParents = true) shouldBeEqualTo true
+            hasAllParentClassesOf(listOf(
+                SampleParentClass2::class,
+                SampleClass::class),
+                indirectParents = true,
+            ) shouldBeEqualTo false
+            hasAllParentClassesOf(setOf(SampleParentClass2::class), indirectParents = true) shouldBeEqualTo true
+            hasAllParentClassesOf(setOf(
+                SampleParentClass2::class,
+                SampleClass::class),
                 indirectParents = true,
             ) shouldBeEqualTo false
         }

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koobject/KoObjectDeclarationForKoParentClassProviderTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koobject/KoObjectDeclarationForKoParentClassProviderTest.kt
@@ -3,7 +3,6 @@ package com.lemonappdev.konsist.core.declaration.koobject
 import com.lemonappdev.konsist.TestSnippetProvider.getSnippetKoScope
 import com.lemonappdev.konsist.testdata.SampleClass
 import com.lemonappdev.konsist.testdata.SampleParentClass
-import com.lemonappdev.konsist.testdata.SampleParentClass1
 import com.lemonappdev.konsist.testdata.SampleParentClass2
 import org.amshove.kluent.assertSoftly
 import org.amshove.kluent.shouldBeEqualTo
@@ -228,11 +227,11 @@ class KoObjectDeclarationForKoParentClassProviderTest {
         assertSoftly(sut) {
             parentClasses(indirectParents = false).map { it.name } shouldBeEqualTo listOf("SampleParentClass")
             parentClasses(indirectParents = true).map { it.name } shouldBeEqualTo
-                    listOf(
-                        "SampleParentClass",
-                        "SampleParentClass1",
-                        "SampleParentClass2",
-                    )
+                listOf(
+                    "SampleParentClass",
+                    "SampleParentClass1",
+                    "SampleParentClass2",
+                )
             numParentClasses(indirectParents = false) shouldBeEqualTo 1
             numParentClasses(indirectParents = true) shouldBeEqualTo 3
             countParentClasses(indirectParents = false) { it.name == "SampleParentClass1" } shouldBeEqualTo 0
@@ -260,26 +259,34 @@ class KoObjectDeclarationForKoParentClassProviderTest {
             ) shouldBeEqualTo true
             hasParentClassWithName(listOf("SampleParentClass1"), indirectParents = true) shouldBeEqualTo true
             hasParentClassWithName(listOf("OtherClass"), indirectParents = true) shouldBeEqualTo false
-            hasParentClassWithName(listOf(
-                "SampleParentClass1",
-                "SampleParentClass2"),
+            hasParentClassWithName(
+                listOf(
+                    "SampleParentClass1",
+                    "SampleParentClass2",
+                ),
                 indirectParents = true,
             ) shouldBeEqualTo true
-            hasParentClassWithName(listOf(
-                "SampleParentClass1",
-                "OtherClass"),
+            hasParentClassWithName(
+                listOf(
+                    "SampleParentClass1",
+                    "OtherClass",
+                ),
                 indirectParents = true,
             ) shouldBeEqualTo true
             hasParentClassWithName(setOf("SampleParentClass1"), indirectParents = true) shouldBeEqualTo true
             hasParentClassWithName(setOf("OtherClass"), indirectParents = true) shouldBeEqualTo false
-            hasParentClassWithName(setOf(
-                "SampleParentClass1",
-                "SampleParentClass2"),
+            hasParentClassWithName(
+                setOf(
+                    "SampleParentClass1",
+                    "SampleParentClass2",
+                ),
                 indirectParents = true,
             ) shouldBeEqualTo true
-            hasParentClassWithName(setOf(
-                "SampleParentClass1",
-                "OtherClass"),
+            hasParentClassWithName(
+                setOf(
+                    "SampleParentClass1",
+                    "OtherClass",
+                ),
                 indirectParents = true,
             ) shouldBeEqualTo true
             hasParentClassesWithAllNames("SampleParentClass1", indirectParents = true) shouldBeEqualTo true
@@ -296,26 +303,34 @@ class KoObjectDeclarationForKoParentClassProviderTest {
             ) shouldBeEqualTo false
             hasParentClassesWithAllNames(listOf("SampleParentClass1"), indirectParents = true) shouldBeEqualTo true
             hasParentClassesWithAllNames(listOf("OtherClass"), indirectParents = true) shouldBeEqualTo false
-            hasParentClassesWithAllNames(listOf(
-                "SampleParentClass1",
-                "SampleParentClass2"),
+            hasParentClassesWithAllNames(
+                listOf(
+                    "SampleParentClass1",
+                    "SampleParentClass2",
+                ),
                 indirectParents = true,
             ) shouldBeEqualTo true
-            hasParentClassesWithAllNames(listOf(
-                "SampleParentClass1",
-                "OtherClass"),
+            hasParentClassesWithAllNames(
+                listOf(
+                    "SampleParentClass1",
+                    "OtherClass",
+                ),
                 indirectParents = true,
             ) shouldBeEqualTo false
             hasParentClassesWithAllNames(setOf("SampleParentClass1"), indirectParents = true) shouldBeEqualTo true
             hasParentClassesWithAllNames(setOf("OtherClass"), indirectParents = true) shouldBeEqualTo false
-            hasParentClassesWithAllNames(setOf(
-                "SampleParentClass1",
-                "SampleParentClass2"),
+            hasParentClassesWithAllNames(
+                setOf(
+                    "SampleParentClass1",
+                    "SampleParentClass2",
+                ),
                 indirectParents = true,
             ) shouldBeEqualTo true
-            hasParentClassesWithAllNames(setOf(
-                "SampleParentClass1",
-                "OtherClass"),
+            hasParentClassesWithAllNames(
+                setOf(
+                    "SampleParentClass1",
+                    "OtherClass",
+                ),
                 indirectParents = true,
             ) shouldBeEqualTo false
             hasParentClass(indirectParents = true) { it.name == "SampleParentClass1" } shouldBeEqualTo true
@@ -333,15 +348,19 @@ class KoObjectDeclarationForKoParentClassProviderTest {
                 indirectParents = true,
             ) shouldBeEqualTo false
             hasAllParentClassesOf(listOf(SampleParentClass2::class), indirectParents = true) shouldBeEqualTo true
-            hasAllParentClassesOf(listOf(
-                SampleParentClass2::class,
-                SampleClass::class),
+            hasAllParentClassesOf(
+                listOf(
+                    SampleParentClass2::class,
+                    SampleClass::class,
+                ),
                 indirectParents = true,
             ) shouldBeEqualTo false
             hasAllParentClassesOf(setOf(SampleParentClass2::class), indirectParents = true) shouldBeEqualTo true
-            hasAllParentClassesOf(setOf(
-                SampleParentClass2::class,
-                SampleClass::class),
+            hasAllParentClassesOf(
+                setOf(
+                    SampleParentClass2::class,
+                    SampleClass::class,
+                ),
                 indirectParents = true,
             ) shouldBeEqualTo false
         }

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koobject/KoObjectDeclarationForKoParentInterfaceProviderTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koobject/KoObjectDeclarationForKoParentInterfaceProviderTest.kt
@@ -1,7 +1,6 @@
 package com.lemonappdev.konsist.core.declaration.koobject
 
 import com.lemonappdev.konsist.TestSnippetProvider.getSnippetKoScope
-import com.lemonappdev.konsist.testdata.SampleInterface
 import com.lemonappdev.konsist.testdata.SampleParentClass
 import com.lemonappdev.konsist.testdata.SampleParentInterface
 import com.lemonappdev.konsist.testdata.SampleParentInterface1
@@ -127,63 +126,63 @@ class KoObjectDeclarationForKoParentInterfaceProviderTest {
 
         // then
         assertSoftly(sut) {
-                parentInterfaces.map { it.name } shouldBeEqualTo listOf("SampleParentInterface1", "SampleParentInterface2")
-                numParentInterfaces shouldBeEqualTo 2
-                countParentInterfaces { it.name == "SampleParentInterface1" } shouldBeEqualTo 1
-                countParentInterfaces { it.hasNameStartingWith("SampleParentInterface") } shouldBeEqualTo 2
-                hasParentInterfaces() shouldBeEqualTo true
-                hasParentInterfaceWithName(emptyList()) shouldBeEqualTo true
-                hasParentInterfaceWithName(emptySet()) shouldBeEqualTo true
-                hasParentInterfacesWithAllNames(emptyList()) shouldBeEqualTo true
-                hasParentInterfacesWithAllNames(emptySet()) shouldBeEqualTo true
-                hasParentInterfaceWithName("SampleParentInterface1") shouldBeEqualTo true
-                hasParentInterfaceWithName("OtherInterface") shouldBeEqualTo false
-                hasParentInterfaceWithName("SampleParentInterface1", "SampleParentInterface2") shouldBeEqualTo true
-                hasParentInterfaceWithName("SampleParentInterface1", "OtherInterface") shouldBeEqualTo true
-                hasParentInterfaceWithName(listOf("SampleParentInterface1")) shouldBeEqualTo true
-                hasParentInterfaceWithName(listOf("OtherInterface")) shouldBeEqualTo false
-                hasParentInterfaceWithName(listOf("SampleParentInterface1", "SampleParentInterface2")) shouldBeEqualTo true
-                hasParentInterfaceWithName(listOf("SampleParentInterface1", "OtherInterface")) shouldBeEqualTo true
-                hasParentInterfaceWithName(setOf("SampleParentInterface1")) shouldBeEqualTo true
-                hasParentInterfaceWithName(setOf("OtherInterface")) shouldBeEqualTo false
-                hasParentInterfaceWithName(setOf("SampleParentInterface1", "SampleParentInterface2")) shouldBeEqualTo true
-                hasParentInterfaceWithName(setOf("SampleParentInterface1", "OtherInterface")) shouldBeEqualTo true
-                hasParentInterfacesWithAllNames("SampleParentInterface1") shouldBeEqualTo true
-                hasParentInterfacesWithAllNames("OtherInterface") shouldBeEqualTo false
-                hasParentInterfacesWithAllNames("SampleParentInterface1", "SampleParentInterface2") shouldBeEqualTo true
-                hasParentInterfacesWithAllNames("SampleParentInterface1", "OtherInterface") shouldBeEqualTo false
-                hasParentInterfacesWithAllNames(listOf("SampleParentInterface1")) shouldBeEqualTo true
-                hasParentInterfacesWithAllNames(listOf("OtherInterface")) shouldBeEqualTo false
-                hasParentInterfacesWithAllNames(listOf("SampleParentInterface1", "SampleParentInterface2")) shouldBeEqualTo true
-                hasParentInterfacesWithAllNames(listOf("SampleParentInterface1", "OtherInterface")) shouldBeEqualTo false
-                hasParentInterfacesWithAllNames(setOf("SampleParentInterface1")) shouldBeEqualTo true
-                hasParentInterfacesWithAllNames(setOf("OtherInterface")) shouldBeEqualTo false
-                hasParentInterfacesWithAllNames(setOf("SampleParentInterface1", "SampleParentInterface2")) shouldBeEqualTo true
-                hasParentInterfacesWithAllNames(setOf("SampleParentInterface1", "OtherInterface")) shouldBeEqualTo false
-                hasParentInterface { it.name == "SampleParentInterface1" } shouldBeEqualTo true
-                hasParentInterface { it.name == "OtherInterface" } shouldBeEqualTo false
-                hasAllParentInterfaces { it.name == "SampleParentInterface1" } shouldBeEqualTo false
-                hasAllParentInterfaces { it.hasNameStartingWith("Sample") } shouldBeEqualTo true
-                hasAllParentInterfaces { it.hasNameStartingWith("Other") } shouldBeEqualTo false
-                hasParentInterfaceOf(SampleParentInterface1::class) shouldBeEqualTo true
-                hasParentInterfaceOf(SampleParentInterface1::class, SampleParentClass::class) shouldBeEqualTo true
-                hasParentInterfaceOf(listOf(SampleParentInterface1::class)) shouldBeEqualTo true
-                hasParentInterfaceOf(listOf(SampleParentInterface1::class, SampleParentClass::class)) shouldBeEqualTo true
-                hasParentInterfaceOf(setOf(SampleParentInterface1::class)) shouldBeEqualTo true
-                hasParentInterfaceOf(setOf(SampleParentInterface1::class, SampleParentClass::class)) shouldBeEqualTo true
-                hasAllParentInterfacesOf(SampleParentInterface1::class) shouldBeEqualTo true
-                hasAllParentInterfacesOf(SampleParentInterface1::class, SampleParentClass::class) shouldBeEqualTo false
-                hasAllParentInterfacesOf(SampleParentInterface1::class, SampleParentInterface2::class) shouldBeEqualTo true
-                hasAllParentInterfacesOf(listOf(SampleParentInterface1::class)) shouldBeEqualTo true
-                hasAllParentInterfacesOf(listOf(SampleParentInterface1::class, SampleParentClass::class)) shouldBeEqualTo false
-                hasAllParentInterfacesOf(listOf(SampleParentInterface1::class, SampleParentInterface2::class)) shouldBeEqualTo true
-                hasAllParentInterfacesOf(setOf(SampleParentInterface1::class)) shouldBeEqualTo true
-                hasAllParentInterfacesOf(setOf(SampleParentInterface1::class, SampleParentClass::class)) shouldBeEqualTo false
-                hasAllParentInterfacesOf(setOf(SampleParentInterface1::class, SampleParentInterface2::class)) shouldBeEqualTo true
-                hasParentInterfaces("SampleParentInterface1") shouldBeEqualTo true
-                hasParentInterfaces("OtherInterface") shouldBeEqualTo false
-                hasParentInterfaces("SampleParentInterface1", "SampleParentInterface2") shouldBeEqualTo true
-                hasParentInterfaces("SampleParentInterface1", "OtherInterface") shouldBeEqualTo false
+            parentInterfaces.map { it.name } shouldBeEqualTo listOf("SampleParentInterface1", "SampleParentInterface2")
+            numParentInterfaces shouldBeEqualTo 2
+            countParentInterfaces { it.name == "SampleParentInterface1" } shouldBeEqualTo 1
+            countParentInterfaces { it.hasNameStartingWith("SampleParentInterface") } shouldBeEqualTo 2
+            hasParentInterfaces() shouldBeEqualTo true
+            hasParentInterfaceWithName(emptyList()) shouldBeEqualTo true
+            hasParentInterfaceWithName(emptySet()) shouldBeEqualTo true
+            hasParentInterfacesWithAllNames(emptyList()) shouldBeEqualTo true
+            hasParentInterfacesWithAllNames(emptySet()) shouldBeEqualTo true
+            hasParentInterfaceWithName("SampleParentInterface1") shouldBeEqualTo true
+            hasParentInterfaceWithName("OtherInterface") shouldBeEqualTo false
+            hasParentInterfaceWithName("SampleParentInterface1", "SampleParentInterface2") shouldBeEqualTo true
+            hasParentInterfaceWithName("SampleParentInterface1", "OtherInterface") shouldBeEqualTo true
+            hasParentInterfaceWithName(listOf("SampleParentInterface1")) shouldBeEqualTo true
+            hasParentInterfaceWithName(listOf("OtherInterface")) shouldBeEqualTo false
+            hasParentInterfaceWithName(listOf("SampleParentInterface1", "SampleParentInterface2")) shouldBeEqualTo true
+            hasParentInterfaceWithName(listOf("SampleParentInterface1", "OtherInterface")) shouldBeEqualTo true
+            hasParentInterfaceWithName(setOf("SampleParentInterface1")) shouldBeEqualTo true
+            hasParentInterfaceWithName(setOf("OtherInterface")) shouldBeEqualTo false
+            hasParentInterfaceWithName(setOf("SampleParentInterface1", "SampleParentInterface2")) shouldBeEqualTo true
+            hasParentInterfaceWithName(setOf("SampleParentInterface1", "OtherInterface")) shouldBeEqualTo true
+            hasParentInterfacesWithAllNames("SampleParentInterface1") shouldBeEqualTo true
+            hasParentInterfacesWithAllNames("OtherInterface") shouldBeEqualTo false
+            hasParentInterfacesWithAllNames("SampleParentInterface1", "SampleParentInterface2") shouldBeEqualTo true
+            hasParentInterfacesWithAllNames("SampleParentInterface1", "OtherInterface") shouldBeEqualTo false
+            hasParentInterfacesWithAllNames(listOf("SampleParentInterface1")) shouldBeEqualTo true
+            hasParentInterfacesWithAllNames(listOf("OtherInterface")) shouldBeEqualTo false
+            hasParentInterfacesWithAllNames(listOf("SampleParentInterface1", "SampleParentInterface2")) shouldBeEqualTo true
+            hasParentInterfacesWithAllNames(listOf("SampleParentInterface1", "OtherInterface")) shouldBeEqualTo false
+            hasParentInterfacesWithAllNames(setOf("SampleParentInterface1")) shouldBeEqualTo true
+            hasParentInterfacesWithAllNames(setOf("OtherInterface")) shouldBeEqualTo false
+            hasParentInterfacesWithAllNames(setOf("SampleParentInterface1", "SampleParentInterface2")) shouldBeEqualTo true
+            hasParentInterfacesWithAllNames(setOf("SampleParentInterface1", "OtherInterface")) shouldBeEqualTo false
+            hasParentInterface { it.name == "SampleParentInterface1" } shouldBeEqualTo true
+            hasParentInterface { it.name == "OtherInterface" } shouldBeEqualTo false
+            hasAllParentInterfaces { it.name == "SampleParentInterface1" } shouldBeEqualTo false
+            hasAllParentInterfaces { it.hasNameStartingWith("Sample") } shouldBeEqualTo true
+            hasAllParentInterfaces { it.hasNameStartingWith("Other") } shouldBeEqualTo false
+            hasParentInterfaceOf(SampleParentInterface1::class) shouldBeEqualTo true
+            hasParentInterfaceOf(SampleParentInterface1::class, SampleParentClass::class) shouldBeEqualTo true
+            hasParentInterfaceOf(listOf(SampleParentInterface1::class)) shouldBeEqualTo true
+            hasParentInterfaceOf(listOf(SampleParentInterface1::class, SampleParentClass::class)) shouldBeEqualTo true
+            hasParentInterfaceOf(setOf(SampleParentInterface1::class)) shouldBeEqualTo true
+            hasParentInterfaceOf(setOf(SampleParentInterface1::class, SampleParentClass::class)) shouldBeEqualTo true
+            hasAllParentInterfacesOf(SampleParentInterface1::class) shouldBeEqualTo true
+            hasAllParentInterfacesOf(SampleParentInterface1::class, SampleParentClass::class) shouldBeEqualTo false
+            hasAllParentInterfacesOf(SampleParentInterface1::class, SampleParentInterface2::class) shouldBeEqualTo true
+            hasAllParentInterfacesOf(listOf(SampleParentInterface1::class)) shouldBeEqualTo true
+            hasAllParentInterfacesOf(listOf(SampleParentInterface1::class, SampleParentClass::class)) shouldBeEqualTo false
+            hasAllParentInterfacesOf(listOf(SampleParentInterface1::class, SampleParentInterface2::class)) shouldBeEqualTo true
+            hasAllParentInterfacesOf(setOf(SampleParentInterface1::class)) shouldBeEqualTo true
+            hasAllParentInterfacesOf(setOf(SampleParentInterface1::class, SampleParentClass::class)) shouldBeEqualTo false
+            hasAllParentInterfacesOf(setOf(SampleParentInterface1::class, SampleParentInterface2::class)) shouldBeEqualTo true
+            hasParentInterfaces("SampleParentInterface1") shouldBeEqualTo true
+            hasParentInterfaces("OtherInterface") shouldBeEqualTo false
+            hasParentInterfaces("SampleParentInterface1", "SampleParentInterface2") shouldBeEqualTo true
+            hasParentInterfaces("SampleParentInterface1", "OtherInterface") shouldBeEqualTo false
         }
     }
 
@@ -200,10 +199,10 @@ class KoObjectDeclarationForKoParentInterfaceProviderTest {
         assertSoftly(sut) {
             parentInterfaces(indirectParents = false) shouldBeEqualTo emptyList()
             parentInterfaces(indirectParents = true).map { it.name } shouldBeEqualTo
-                    listOf(
-                        "SampleParentInterface1",
-                        "SampleParentInterface2",
-                    )
+                listOf(
+                    "SampleParentInterface1",
+                    "SampleParentInterface2",
+                )
             numParentInterfaces(indirectParents = false) shouldBeEqualTo 0
             numParentInterfaces(indirectParents = true) shouldBeEqualTo 2
             countParentInterfaces(indirectParents = false) { it.name == "SampleParentInterface1" } shouldBeEqualTo 0
@@ -234,14 +233,18 @@ class KoObjectDeclarationForKoParentInterfaceProviderTest {
             ) shouldBeEqualTo true
             hasParentInterfaceWithName(listOf("SampleParentInterface1"), indirectParents = true) shouldBeEqualTo true
             hasParentInterfaceWithName(listOf("OtherInterface"), indirectParents = true) shouldBeEqualTo false
-            hasParentInterfaceWithName(listOf(
-                "SampleParentInterface1",
-                "SampleParentInterface2"),
+            hasParentInterfaceWithName(
+                listOf(
+                    "SampleParentInterface1",
+                    "SampleParentInterface2",
+                ),
                 indirectParents = true,
             ) shouldBeEqualTo true
-            hasParentInterfaceWithName(listOf(
-                "SampleParentInterface1",
-                "OtherInterface"),
+            hasParentInterfaceWithName(
+                listOf(
+                    "SampleParentInterface1",
+                    "OtherInterface",
+                ),
                 indirectParents = true,
             ) shouldBeEqualTo true
             hasParentInterfacesWithAllNames("SampleParentInterface1", indirectParents = true) shouldBeEqualTo true
@@ -258,14 +261,18 @@ class KoObjectDeclarationForKoParentInterfaceProviderTest {
             ) shouldBeEqualTo false
             hasParentInterfacesWithAllNames(listOf("SampleParentInterface1"), indirectParents = true) shouldBeEqualTo true
             hasParentInterfacesWithAllNames(listOf("OtherInterface"), indirectParents = true) shouldBeEqualTo false
-            hasParentInterfacesWithAllNames(listOf(
-                "SampleParentInterface1",
-                "SampleParentInterface2"),
+            hasParentInterfacesWithAllNames(
+                listOf(
+                    "SampleParentInterface1",
+                    "SampleParentInterface2",
+                ),
                 indirectParents = true,
             ) shouldBeEqualTo true
-            hasParentInterfacesWithAllNames(listOf(
-                "SampleParentInterface1",
-                "OtherInterface"),
+            hasParentInterfacesWithAllNames(
+                listOf(
+                    "SampleParentInterface1",
+                    "OtherInterface",
+                ),
                 indirectParents = true,
             ) shouldBeEqualTo false
             hasParentInterface(indirectParents = true) { it.name == "SampleParentInterface1" } shouldBeEqualTo true
@@ -282,9 +289,11 @@ class KoObjectDeclarationForKoParentInterfaceProviderTest {
                 indirectParents = true,
             ) shouldBeEqualTo false
             hasAllParentInterfacesOf(listOf(SampleParentInterface2::class), indirectParents = true) shouldBeEqualTo true
-            hasAllParentInterfacesOf(listOf(
-                SampleParentInterface2::class,
-                SampleParentInterface::class),
+            hasAllParentInterfacesOf(
+                listOf(
+                    SampleParentInterface2::class,
+                    SampleParentInterface::class,
+                ),
                 indirectParents = true,
             ) shouldBeEqualTo false
         }

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koobject/KoObjectDeclarationForKoParentInterfaceProviderTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koobject/KoObjectDeclarationForKoParentInterfaceProviderTest.kt
@@ -3,6 +3,7 @@ package com.lemonappdev.konsist.core.declaration.koobject
 import com.lemonappdev.konsist.TestSnippetProvider.getSnippetKoScope
 import com.lemonappdev.konsist.testdata.SampleInterface
 import com.lemonappdev.konsist.testdata.SampleParentClass
+import com.lemonappdev.konsist.testdata.SampleParentInterface
 import com.lemonappdev.konsist.testdata.SampleParentInterface1
 import com.lemonappdev.konsist.testdata.SampleParentInterface2
 import org.amshove.kluent.assertSoftly
@@ -22,16 +23,26 @@ class KoObjectDeclarationForKoParentInterfaceProviderTest {
         assertSoftly(sut) {
             parentInterfaces shouldBeEqualTo emptyList()
             numParentInterfaces shouldBeEqualTo 0
-            parentInterfaces() shouldBeEqualTo emptyList()
-            numParentInterfaces() shouldBeEqualTo 0
             countParentInterfaces { it.name == "SampleParentInterface" } shouldBeEqualTo 0
             hasParentInterfaces() shouldBeEqualTo false
+            hasParentInterfaceWithName(emptyList()) shouldBeEqualTo false
+            hasParentInterfaceWithName(emptySet()) shouldBeEqualTo false
+            hasParentInterfacesWithAllNames(emptyList()) shouldBeEqualTo false
+            hasParentInterfacesWithAllNames(emptySet()) shouldBeEqualTo false
             hasParentInterfaceWithName("SampleParentInterface1", "SampleParentInterface2") shouldBeEqualTo false
+            hasParentInterfaceWithName(listOf("SampleParentInterface1", "SampleParentInterface2")) shouldBeEqualTo false
+            hasParentInterfaceWithName(setOf("SampleParentInterface1", "SampleParentInterface2")) shouldBeEqualTo false
             hasParentInterfacesWithAllNames("SampleParentInterface1", "SampleParentInterface2") shouldBeEqualTo false
+            hasParentInterfacesWithAllNames(listOf("SampleParentInterface1", "SampleParentInterface2")) shouldBeEqualTo false
+            hasParentInterfacesWithAllNames(setOf("SampleParentInterface1", "SampleParentInterface2")) shouldBeEqualTo false
             hasParentInterface { it.name == "SampleParentInterface" } shouldBeEqualTo false
             hasAllParentInterfaces { it.hasNameStartingWith("Sample") } shouldBeEqualTo true
             hasParentInterfaceOf(SampleParentInterface1::class) shouldBeEqualTo false
+            hasParentInterfaceOf(listOf(SampleParentInterface1::class)) shouldBeEqualTo false
+            hasParentInterfaceOf(setOf(SampleParentInterface1::class)) shouldBeEqualTo false
             hasAllParentInterfacesOf(SampleParentInterface1::class, SampleParentInterface2::class) shouldBeEqualTo false
+            hasAllParentInterfacesOf(listOf(SampleParentInterface1::class, SampleParentInterface2::class)) shouldBeEqualTo false
+            hasAllParentInterfacesOf(setOf(SampleParentInterface1::class, SampleParentInterface2::class)) shouldBeEqualTo false
             hasParentInterfaces("SampleParentInterface") shouldBeEqualTo false
         }
     }
@@ -48,19 +59,37 @@ class KoObjectDeclarationForKoParentInterfaceProviderTest {
         assertSoftly(sut) {
             parentInterfaces.map { it.name } shouldBeEqualTo listOf("SampleParentInterface1", "SampleParentInterface2")
             numParentInterfaces shouldBeEqualTo 2
-            parentInterfaces().map { it.name } shouldBeEqualTo listOf("SampleParentInterface1", "SampleParentInterface2")
-            numParentInterfaces() shouldBeEqualTo 2
             countParentInterfaces { it.name == "SampleParentInterface1" } shouldBeEqualTo 1
             countParentInterfaces { it.hasNameStartingWith("SampleParentInterface") } shouldBeEqualTo 2
             hasParentInterfaces() shouldBeEqualTo true
+            hasParentInterfaceWithName(emptyList()) shouldBeEqualTo true
+            hasParentInterfaceWithName(emptySet()) shouldBeEqualTo true
+            hasParentInterfacesWithAllNames(emptyList()) shouldBeEqualTo true
+            hasParentInterfacesWithAllNames(emptySet()) shouldBeEqualTo true
             hasParentInterfaceWithName("SampleParentInterface1") shouldBeEqualTo true
             hasParentInterfaceWithName("OtherInterface") shouldBeEqualTo false
             hasParentInterfaceWithName("SampleParentInterface1", "SampleParentInterface2") shouldBeEqualTo true
             hasParentInterfaceWithName("SampleParentInterface1", "OtherInterface") shouldBeEqualTo true
+            hasParentInterfaceWithName(listOf("SampleParentInterface1")) shouldBeEqualTo true
+            hasParentInterfaceWithName(listOf("OtherInterface")) shouldBeEqualTo false
+            hasParentInterfaceWithName(listOf("SampleParentInterface1", "SampleParentInterface2")) shouldBeEqualTo true
+            hasParentInterfaceWithName(listOf("SampleParentInterface1", "OtherInterface")) shouldBeEqualTo true
+            hasParentInterfaceWithName(setOf("SampleParentInterface1")) shouldBeEqualTo true
+            hasParentInterfaceWithName(setOf("OtherInterface")) shouldBeEqualTo false
+            hasParentInterfaceWithName(setOf("SampleParentInterface1", "SampleParentInterface2")) shouldBeEqualTo true
+            hasParentInterfaceWithName(setOf("SampleParentInterface1", "OtherInterface")) shouldBeEqualTo true
             hasParentInterfacesWithAllNames("SampleParentInterface1") shouldBeEqualTo true
             hasParentInterfacesWithAllNames("OtherInterface") shouldBeEqualTo false
             hasParentInterfacesWithAllNames("SampleParentInterface1", "SampleParentInterface2") shouldBeEqualTo true
             hasParentInterfacesWithAllNames("SampleParentInterface1", "OtherInterface") shouldBeEqualTo false
+            hasParentInterfacesWithAllNames(listOf("SampleParentInterface1")) shouldBeEqualTo true
+            hasParentInterfacesWithAllNames(listOf("OtherInterface")) shouldBeEqualTo false
+            hasParentInterfacesWithAllNames(listOf("SampleParentInterface1", "SampleParentInterface2")) shouldBeEqualTo true
+            hasParentInterfacesWithAllNames(listOf("SampleParentInterface1", "OtherInterface")) shouldBeEqualTo false
+            hasParentInterfacesWithAllNames(setOf("SampleParentInterface1")) shouldBeEqualTo true
+            hasParentInterfacesWithAllNames(setOf("OtherInterface")) shouldBeEqualTo false
+            hasParentInterfacesWithAllNames(setOf("SampleParentInterface1", "SampleParentInterface2")) shouldBeEqualTo true
+            hasParentInterfacesWithAllNames(setOf("SampleParentInterface1", "OtherInterface")) shouldBeEqualTo false
             hasParentInterface { it.name == "SampleParentInterface1" } shouldBeEqualTo true
             hasParentInterface { it.name == "OtherInterface" } shouldBeEqualTo false
             hasAllParentInterfaces { it.name == "SampleParentInterface1" } shouldBeEqualTo false
@@ -68,9 +97,19 @@ class KoObjectDeclarationForKoParentInterfaceProviderTest {
             hasAllParentInterfaces { it.hasNameStartingWith("Other") } shouldBeEqualTo false
             hasParentInterfaceOf(SampleParentInterface1::class) shouldBeEqualTo true
             hasParentInterfaceOf(SampleParentInterface1::class, SampleParentClass::class) shouldBeEqualTo true
+            hasParentInterfaceOf(listOf(SampleParentInterface1::class)) shouldBeEqualTo true
+            hasParentInterfaceOf(listOf(SampleParentInterface1::class, SampleParentClass::class)) shouldBeEqualTo true
+            hasParentInterfaceOf(setOf(SampleParentInterface1::class)) shouldBeEqualTo true
+            hasParentInterfaceOf(setOf(SampleParentInterface1::class, SampleParentClass::class)) shouldBeEqualTo true
             hasAllParentInterfacesOf(SampleParentInterface1::class) shouldBeEqualTo true
             hasAllParentInterfacesOf(SampleParentInterface1::class, SampleParentClass::class) shouldBeEqualTo false
             hasAllParentInterfacesOf(SampleParentInterface1::class, SampleParentInterface2::class) shouldBeEqualTo true
+            hasAllParentInterfacesOf(listOf(SampleParentInterface1::class)) shouldBeEqualTo true
+            hasAllParentInterfacesOf(listOf(SampleParentInterface1::class, SampleParentClass::class)) shouldBeEqualTo false
+            hasAllParentInterfacesOf(listOf(SampleParentInterface1::class, SampleParentInterface2::class)) shouldBeEqualTo true
+            hasAllParentInterfacesOf(setOf(SampleParentInterface1::class)) shouldBeEqualTo true
+            hasAllParentInterfacesOf(setOf(SampleParentInterface1::class, SampleParentClass::class)) shouldBeEqualTo false
+            hasAllParentInterfacesOf(setOf(SampleParentInterface1::class, SampleParentInterface2::class)) shouldBeEqualTo true
             hasParentInterfaces("SampleParentInterface1") shouldBeEqualTo true
             hasParentInterfaces("OtherInterface") shouldBeEqualTo false
             hasParentInterfaces("SampleParentInterface1", "SampleParentInterface2") shouldBeEqualTo true
@@ -88,35 +127,63 @@ class KoObjectDeclarationForKoParentInterfaceProviderTest {
 
         // then
         assertSoftly(sut) {
-            parentInterfaces.map { it.name } shouldBeEqualTo listOf("SampleParentInterface1", "SampleParentInterface2")
-            numParentInterfaces shouldBeEqualTo 2
-            parentInterfaces().map { it.name } shouldBeEqualTo listOf("SampleParentInterface1", "SampleParentInterface2")
-            numParentInterfaces() shouldBeEqualTo 2
-            countParentInterfaces { it.name == "SampleParentInterface1" } shouldBeEqualTo 1
-            countParentInterfaces { it.hasNameStartingWith("SampleParentInterface") } shouldBeEqualTo 2
-            hasParentInterfaces() shouldBeEqualTo true
-            hasParentInterfaceWithName("SampleParentInterface1") shouldBeEqualTo true
-            hasParentInterfaceWithName("OtherInterface") shouldBeEqualTo false
-            hasParentInterfaceWithName("SampleParentInterface1", "SampleParentInterface2") shouldBeEqualTo true
-            hasParentInterfaceWithName("SampleParentInterface1", "OtherInterface") shouldBeEqualTo true
-            hasParentInterfacesWithAllNames("SampleParentInterface1") shouldBeEqualTo true
-            hasParentInterfacesWithAllNames("OtherInterface") shouldBeEqualTo false
-            hasParentInterfacesWithAllNames("SampleParentInterface1", "SampleParentInterface2") shouldBeEqualTo true
-            hasParentInterfacesWithAllNames("SampleParentInterface1", "OtherInterface") shouldBeEqualTo false
-            hasParentInterface { it.name == "SampleParentInterface1" } shouldBeEqualTo true
-            hasParentInterface { it.name == "OtherInterface" } shouldBeEqualTo false
-            hasAllParentInterfaces { it.name == "SampleParentInterface1" } shouldBeEqualTo false
-            hasAllParentInterfaces { it.hasNameStartingWith("Sample") } shouldBeEqualTo true
-            hasAllParentInterfaces { it.hasNameStartingWith("Other") } shouldBeEqualTo false
-            hasParentInterfaceOf(SampleParentInterface1::class) shouldBeEqualTo true
-            hasParentInterfaceOf(SampleParentInterface1::class, SampleParentClass::class) shouldBeEqualTo true
-            hasAllParentInterfacesOf(SampleParentInterface1::class) shouldBeEqualTo true
-            hasAllParentInterfacesOf(SampleParentInterface1::class, SampleParentClass::class) shouldBeEqualTo false
-            hasAllParentInterfacesOf(SampleParentInterface1::class, SampleParentInterface2::class) shouldBeEqualTo true
-            hasParentInterfaces("SampleParentInterface1") shouldBeEqualTo true
-            hasParentInterfaces("OtherInterface") shouldBeEqualTo false
-            hasParentInterfaces("SampleParentInterface1", "SampleParentInterface2") shouldBeEqualTo true
-            hasParentInterfaces("SampleParentInterface1", "OtherInterface") shouldBeEqualTo false
+                parentInterfaces.map { it.name } shouldBeEqualTo listOf("SampleParentInterface1", "SampleParentInterface2")
+                numParentInterfaces shouldBeEqualTo 2
+                countParentInterfaces { it.name == "SampleParentInterface1" } shouldBeEqualTo 1
+                countParentInterfaces { it.hasNameStartingWith("SampleParentInterface") } shouldBeEqualTo 2
+                hasParentInterfaces() shouldBeEqualTo true
+                hasParentInterfaceWithName(emptyList()) shouldBeEqualTo true
+                hasParentInterfaceWithName(emptySet()) shouldBeEqualTo true
+                hasParentInterfacesWithAllNames(emptyList()) shouldBeEqualTo true
+                hasParentInterfacesWithAllNames(emptySet()) shouldBeEqualTo true
+                hasParentInterfaceWithName("SampleParentInterface1") shouldBeEqualTo true
+                hasParentInterfaceWithName("OtherInterface") shouldBeEqualTo false
+                hasParentInterfaceWithName("SampleParentInterface1", "SampleParentInterface2") shouldBeEqualTo true
+                hasParentInterfaceWithName("SampleParentInterface1", "OtherInterface") shouldBeEqualTo true
+                hasParentInterfaceWithName(listOf("SampleParentInterface1")) shouldBeEqualTo true
+                hasParentInterfaceWithName(listOf("OtherInterface")) shouldBeEqualTo false
+                hasParentInterfaceWithName(listOf("SampleParentInterface1", "SampleParentInterface2")) shouldBeEqualTo true
+                hasParentInterfaceWithName(listOf("SampleParentInterface1", "OtherInterface")) shouldBeEqualTo true
+                hasParentInterfaceWithName(setOf("SampleParentInterface1")) shouldBeEqualTo true
+                hasParentInterfaceWithName(setOf("OtherInterface")) shouldBeEqualTo false
+                hasParentInterfaceWithName(setOf("SampleParentInterface1", "SampleParentInterface2")) shouldBeEqualTo true
+                hasParentInterfaceWithName(setOf("SampleParentInterface1", "OtherInterface")) shouldBeEqualTo true
+                hasParentInterfacesWithAllNames("SampleParentInterface1") shouldBeEqualTo true
+                hasParentInterfacesWithAllNames("OtherInterface") shouldBeEqualTo false
+                hasParentInterfacesWithAllNames("SampleParentInterface1", "SampleParentInterface2") shouldBeEqualTo true
+                hasParentInterfacesWithAllNames("SampleParentInterface1", "OtherInterface") shouldBeEqualTo false
+                hasParentInterfacesWithAllNames(listOf("SampleParentInterface1")) shouldBeEqualTo true
+                hasParentInterfacesWithAllNames(listOf("OtherInterface")) shouldBeEqualTo false
+                hasParentInterfacesWithAllNames(listOf("SampleParentInterface1", "SampleParentInterface2")) shouldBeEqualTo true
+                hasParentInterfacesWithAllNames(listOf("SampleParentInterface1", "OtherInterface")) shouldBeEqualTo false
+                hasParentInterfacesWithAllNames(setOf("SampleParentInterface1")) shouldBeEqualTo true
+                hasParentInterfacesWithAllNames(setOf("OtherInterface")) shouldBeEqualTo false
+                hasParentInterfacesWithAllNames(setOf("SampleParentInterface1", "SampleParentInterface2")) shouldBeEqualTo true
+                hasParentInterfacesWithAllNames(setOf("SampleParentInterface1", "OtherInterface")) shouldBeEqualTo false
+                hasParentInterface { it.name == "SampleParentInterface1" } shouldBeEqualTo true
+                hasParentInterface { it.name == "OtherInterface" } shouldBeEqualTo false
+                hasAllParentInterfaces { it.name == "SampleParentInterface1" } shouldBeEqualTo false
+                hasAllParentInterfaces { it.hasNameStartingWith("Sample") } shouldBeEqualTo true
+                hasAllParentInterfaces { it.hasNameStartingWith("Other") } shouldBeEqualTo false
+                hasParentInterfaceOf(SampleParentInterface1::class) shouldBeEqualTo true
+                hasParentInterfaceOf(SampleParentInterface1::class, SampleParentClass::class) shouldBeEqualTo true
+                hasParentInterfaceOf(listOf(SampleParentInterface1::class)) shouldBeEqualTo true
+                hasParentInterfaceOf(listOf(SampleParentInterface1::class, SampleParentClass::class)) shouldBeEqualTo true
+                hasParentInterfaceOf(setOf(SampleParentInterface1::class)) shouldBeEqualTo true
+                hasParentInterfaceOf(setOf(SampleParentInterface1::class, SampleParentClass::class)) shouldBeEqualTo true
+                hasAllParentInterfacesOf(SampleParentInterface1::class) shouldBeEqualTo true
+                hasAllParentInterfacesOf(SampleParentInterface1::class, SampleParentClass::class) shouldBeEqualTo false
+                hasAllParentInterfacesOf(SampleParentInterface1::class, SampleParentInterface2::class) shouldBeEqualTo true
+                hasAllParentInterfacesOf(listOf(SampleParentInterface1::class)) shouldBeEqualTo true
+                hasAllParentInterfacesOf(listOf(SampleParentInterface1::class, SampleParentClass::class)) shouldBeEqualTo false
+                hasAllParentInterfacesOf(listOf(SampleParentInterface1::class, SampleParentInterface2::class)) shouldBeEqualTo true
+                hasAllParentInterfacesOf(setOf(SampleParentInterface1::class)) shouldBeEqualTo true
+                hasAllParentInterfacesOf(setOf(SampleParentInterface1::class, SampleParentClass::class)) shouldBeEqualTo false
+                hasAllParentInterfacesOf(setOf(SampleParentInterface1::class, SampleParentInterface2::class)) shouldBeEqualTo true
+                hasParentInterfaces("SampleParentInterface1") shouldBeEqualTo true
+                hasParentInterfaces("OtherInterface") shouldBeEqualTo false
+                hasParentInterfaces("SampleParentInterface1", "SampleParentInterface2") shouldBeEqualTo true
+                hasParentInterfaces("SampleParentInterface1", "OtherInterface") shouldBeEqualTo false
         }
     }
 
@@ -133,10 +200,10 @@ class KoObjectDeclarationForKoParentInterfaceProviderTest {
         assertSoftly(sut) {
             parentInterfaces(indirectParents = false) shouldBeEqualTo emptyList()
             parentInterfaces(indirectParents = true).map { it.name } shouldBeEqualTo
-                listOf(
-                    "SampleParentInterface1",
-                    "SampleParentInterface2",
-                )
+                    listOf(
+                        "SampleParentInterface1",
+                        "SampleParentInterface2",
+                    )
             numParentInterfaces(indirectParents = false) shouldBeEqualTo 0
             numParentInterfaces(indirectParents = true) shouldBeEqualTo 2
             countParentInterfaces(indirectParents = false) { it.name == "SampleParentInterface1" } shouldBeEqualTo 0
@@ -145,6 +212,14 @@ class KoObjectDeclarationForKoParentInterfaceProviderTest {
             countParentInterfaces(indirectParents = true) { it.hasNameStartingWith("SampleParent") } shouldBeEqualTo 2
             hasParentInterfaces(indirectParents = false) shouldBeEqualTo false
             hasParentInterfaces(indirectParents = true) shouldBeEqualTo true
+            hasParentInterfaceWithName(emptyList(), indirectParents = false) shouldBeEqualTo false
+            hasParentInterfaceWithName(emptySet(), indirectParents = false) shouldBeEqualTo false
+            hasParentInterfacesWithAllNames(emptyList(), indirectParents = false) shouldBeEqualTo false
+            hasParentInterfacesWithAllNames(emptySet(), indirectParents = false) shouldBeEqualTo false
+            hasParentInterfaceWithName(emptyList(), indirectParents = true) shouldBeEqualTo true
+            hasParentInterfaceWithName(emptySet(), indirectParents = true) shouldBeEqualTo true
+            hasParentInterfacesWithAllNames(emptyList(), indirectParents = true) shouldBeEqualTo true
+            hasParentInterfacesWithAllNames(emptySet(), indirectParents = true) shouldBeEqualTo true
             hasParentInterfaceWithName("SampleParentInterface1", indirectParents = true) shouldBeEqualTo true
             hasParentInterfaceWithName("OtherInterface", indirectParents = true) shouldBeEqualTo false
             hasParentInterfaceWithName(
@@ -155,6 +230,18 @@ class KoObjectDeclarationForKoParentInterfaceProviderTest {
             hasParentInterfaceWithName(
                 "SampleParentInterface1",
                 "OtherInterface",
+                indirectParents = true,
+            ) shouldBeEqualTo true
+            hasParentInterfaceWithName(listOf("SampleParentInterface1"), indirectParents = true) shouldBeEqualTo true
+            hasParentInterfaceWithName(listOf("OtherInterface"), indirectParents = true) shouldBeEqualTo false
+            hasParentInterfaceWithName(listOf(
+                "SampleParentInterface1",
+                "SampleParentInterface2"),
+                indirectParents = true,
+            ) shouldBeEqualTo true
+            hasParentInterfaceWithName(listOf(
+                "SampleParentInterface1",
+                "OtherInterface"),
                 indirectParents = true,
             ) shouldBeEqualTo true
             hasParentInterfacesWithAllNames("SampleParentInterface1", indirectParents = true) shouldBeEqualTo true
@@ -169,21 +256,35 @@ class KoObjectDeclarationForKoParentInterfaceProviderTest {
                 "OtherInterface",
                 indirectParents = true,
             ) shouldBeEqualTo false
+            hasParentInterfacesWithAllNames(listOf("SampleParentInterface1"), indirectParents = true) shouldBeEqualTo true
+            hasParentInterfacesWithAllNames(listOf("OtherInterface"), indirectParents = true) shouldBeEqualTo false
+            hasParentInterfacesWithAllNames(listOf(
+                "SampleParentInterface1",
+                "SampleParentInterface2"),
+                indirectParents = true,
+            ) shouldBeEqualTo true
+            hasParentInterfacesWithAllNames(listOf(
+                "SampleParentInterface1",
+                "OtherInterface"),
+                indirectParents = true,
+            ) shouldBeEqualTo false
             hasParentInterface(indirectParents = true) { it.name == "SampleParentInterface1" } shouldBeEqualTo true
             hasParentInterface(indirectParents = true) { it.name == "OtherInterface" } shouldBeEqualTo false
             hasAllParentInterfaces(indirectParents = true) { it.name == "SampleParentInterface1" } shouldBeEqualTo false
             hasAllParentInterfaces(indirectParents = true) { it.hasNameStartingWith("Sample") } shouldBeEqualTo true
             hasAllParentInterfaces(indirectParents = true) { it.hasNameStartingWith("Other") } shouldBeEqualTo false
             hasParentInterfaceOf(SampleParentInterface2::class, indirectParents = true) shouldBeEqualTo true
-            hasParentInterfaceOf(
-                SampleInterface::class,
-                SampleParentInterface2::class,
-                indirectParents = true,
-            ) shouldBeEqualTo true
+            hasParentInterfaceOf(listOf(SampleParentInterface2::class), indirectParents = true) shouldBeEqualTo true
             hasAllParentInterfacesOf(SampleParentInterface2::class, indirectParents = true) shouldBeEqualTo true
             hasAllParentInterfacesOf(
                 SampleParentInterface2::class,
-                SampleInterface::class,
+                SampleParentInterface::class,
+                indirectParents = true,
+            ) shouldBeEqualTo false
+            hasAllParentInterfacesOf(listOf(SampleParentInterface2::class), indirectParents = true) shouldBeEqualTo true
+            hasAllParentInterfacesOf(listOf(
+                SampleParentInterface2::class,
+                SampleParentInterface::class),
                 indirectParents = true,
             ) shouldBeEqualTo false
         }

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koobject/KoObjectDeclarationForKoParentInterfaceProviderTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koobject/KoObjectDeclarationForKoParentInterfaceProviderTest.kt
@@ -9,6 +9,7 @@ import org.amshove.kluent.assertSoftly
 import org.amshove.kluent.shouldBeEqualTo
 import org.junit.jupiter.api.Test
 
+@Suppress("detekt.LongMethod")
 class KoObjectDeclarationForKoParentInterfaceProviderTest {
     @Test
     fun `object-has-no-parent-interface`() {

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koobject/KoObjectDeclarationForKoParentProviderTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koobject/KoObjectDeclarationForKoParentProviderTest.kt
@@ -25,12 +25,24 @@ class KoObjectDeclarationForKoParentProviderTest {
             numParents shouldBeEqualTo 0
             countParents { it.name == "SampleParentClass" } shouldBeEqualTo 0
             hasParents() shouldBeEqualTo false
+            hasParentWithName(emptyList()) shouldBeEqualTo false
+            hasParentWithName(emptySet()) shouldBeEqualTo false
+            hasParentsWithAllNames(emptyList()) shouldBeEqualTo false
+            hasParentsWithAllNames(emptySet()) shouldBeEqualTo false
             hasParentWithName("SampleParentClass") shouldBeEqualTo false
+            hasParentWithName(listOf("SampleParentClass")) shouldBeEqualTo false
+            hasParentWithName(setOf("SampleParentClass")) shouldBeEqualTo false
             hasParentsWithAllNames("SampleParentClass", "SampleParentInterface") shouldBeEqualTo false
+            hasParentsWithAllNames(listOf("SampleParentClass", "SampleParentInterface")) shouldBeEqualTo false
+            hasParentsWithAllNames(setOf("SampleParentClass", "SampleParentInterface")) shouldBeEqualTo false
             hasParent { it.name == "SampleParentClass" } shouldBeEqualTo false
             hasAllParents { it.hasNameStartingWith("Sample") } shouldBeEqualTo true
             hasParentOf(SampleParentClass::class) shouldBeEqualTo false
+            hasParentOf(listOf(SampleParentClass::class)) shouldBeEqualTo false
+            hasParentOf(setOf(SampleParentClass::class)) shouldBeEqualTo false
             hasAllParentsOf(SampleParentClass::class, SampleParentInterface::class) shouldBeEqualTo false
+            hasAllParentsOf(listOf(SampleParentClass::class, SampleParentInterface::class)) shouldBeEqualTo false
+            hasAllParentsOf(setOf(SampleParentClass::class, SampleParentInterface::class)) shouldBeEqualTo false
             hasParents("SampleParentClass") shouldBeEqualTo false
         }
     }
@@ -56,13 +68,31 @@ class KoObjectDeclarationForKoParentProviderTest {
             countParents { it.name == "SampleParentClass" } shouldBeEqualTo 1
             countParents { it.hasNameStartingWith("SampleParentInterface") } shouldBeEqualTo 2
             hasParents() shouldBeEqualTo true
+            hasParentWithName(emptyList()) shouldBeEqualTo true
+            hasParentWithName(emptySet()) shouldBeEqualTo true
+            hasParentsWithAllNames(emptyList()) shouldBeEqualTo true
+            hasParentsWithAllNames(emptySet()) shouldBeEqualTo true
             hasParentWithName("SampleParentClass") shouldBeEqualTo true
             hasParentWithName("OtherInterface") shouldBeEqualTo false
             hasParentWithName("SampleParentClass", "OtherInterface") shouldBeEqualTo true
+            hasParentWithName(listOf("SampleParentClass")) shouldBeEqualTo true
+            hasParentWithName(listOf("OtherInterface")) shouldBeEqualTo false
+            hasParentWithName(listOf("SampleParentClass", "OtherInterface")) shouldBeEqualTo true
+            hasParentWithName(setOf("SampleParentClass")) shouldBeEqualTo true
+            hasParentWithName(setOf("OtherInterface")) shouldBeEqualTo false
+            hasParentWithName(setOf("SampleParentClass", "OtherInterface")) shouldBeEqualTo true
             hasParentsWithAllNames("SampleParentClass") shouldBeEqualTo true
             hasParentsWithAllNames("OtherInterface") shouldBeEqualTo false
             hasParentsWithAllNames("SampleParentClass", "SampleParentInterface1") shouldBeEqualTo true
             hasParentsWithAllNames("SampleParentClass", "OtherInterface") shouldBeEqualTo false
+            hasParentsWithAllNames(listOf("SampleParentClass")) shouldBeEqualTo true
+            hasParentsWithAllNames(listOf("OtherInterface")) shouldBeEqualTo false
+            hasParentsWithAllNames(listOf("SampleParentClass", "SampleParentInterface1")) shouldBeEqualTo true
+            hasParentsWithAllNames(listOf("SampleParentClass", "OtherInterface")) shouldBeEqualTo false
+            hasParentsWithAllNames(setOf("SampleParentClass")) shouldBeEqualTo true
+            hasParentsWithAllNames(setOf("OtherInterface")) shouldBeEqualTo false
+            hasParentsWithAllNames(setOf("SampleParentClass", "SampleParentInterface1")) shouldBeEqualTo true
+            hasParentsWithAllNames(setOf("SampleParentClass", "OtherInterface")) shouldBeEqualTo false
             hasParent { it.name == "SampleParentClass" } shouldBeEqualTo true
             hasParent { it.name == "OtherClass" } shouldBeEqualTo false
             hasAllParents { it.name == "SampleParentClass" } shouldBeEqualTo false
@@ -70,9 +100,19 @@ class KoObjectDeclarationForKoParentProviderTest {
             hasAllParents { it.hasNameStartingWith("Other") } shouldBeEqualTo false
             hasParentOf(SampleParentClass::class) shouldBeEqualTo true
             hasParentOf(SampleParentClass::class, SampleInterface::class) shouldBeEqualTo true
+            hasParentOf(listOf(SampleParentClass::class)) shouldBeEqualTo true
+            hasParentOf(listOf(SampleParentClass::class, SampleInterface::class)) shouldBeEqualTo true
+            hasParentOf(setOf(SampleParentClass::class)) shouldBeEqualTo true
+            hasParentOf(setOf(SampleParentClass::class, SampleInterface::class)) shouldBeEqualTo true
             hasAllParentsOf(SampleParentClass::class) shouldBeEqualTo true
             hasAllParentsOf(SampleParentClass::class, SampleInterface::class) shouldBeEqualTo false
             hasAllParentsOf(SampleParentClass::class, SampleParentInterface1::class) shouldBeEqualTo true
+            hasAllParentsOf(listOf(SampleParentClass::class)) shouldBeEqualTo true
+            hasAllParentsOf(listOf(SampleParentClass::class, SampleInterface::class)) shouldBeEqualTo false
+            hasAllParentsOf(listOf(SampleParentClass::class, SampleParentInterface1::class)) shouldBeEqualTo true
+            hasAllParentsOf(setOf(SampleParentClass::class)) shouldBeEqualTo true
+            hasAllParentsOf(setOf(SampleParentClass::class, SampleInterface::class)) shouldBeEqualTo false
+            hasAllParentsOf(setOf(SampleParentClass::class, SampleParentInterface1::class)) shouldBeEqualTo true
             hasParents("SampleParentClass") shouldBeEqualTo true
             hasParents("OtherInterface") shouldBeEqualTo false
             hasParents("SampleParentClass", "SampleParentInterface1") shouldBeEqualTo true
@@ -108,9 +148,19 @@ class KoObjectDeclarationForKoParentProviderTest {
             countParents(indirectParents = true) { it.name == "SampleParentInterface2" } shouldBeEqualTo 1
             countParents(indirectParents = true) { it.hasNameStartingWith("SampleParentInterface") } shouldBeEqualTo 2
             hasParents(indirectParents = true) shouldBeEqualTo true
+            hasParentWithName(emptyList(), indirectParents = true) shouldBeEqualTo true
+            hasParentWithName(emptySet(), indirectParents = true) shouldBeEqualTo true
+            hasParentsWithAllNames(emptyList(), indirectParents = true) shouldBeEqualTo true
+            hasParentsWithAllNames(emptySet(), indirectParents = true) shouldBeEqualTo true
             hasParentWithName("SampleParentInterface2", indirectParents = true) shouldBeEqualTo true
             hasParentWithName("OtherInterface", indirectParents = true) shouldBeEqualTo false
             hasParentWithName("SampleParentInterface2", "OtherInterface", indirectParents = true) shouldBeEqualTo true
+            hasParentWithName(listOf("SampleParentInterface2"), indirectParents = true) shouldBeEqualTo true
+            hasParentWithName(listOf("OtherInterface"), indirectParents = true) shouldBeEqualTo false
+            hasParentWithName(listOf("SampleParentInterface2", "OtherInterface"), indirectParents = true) shouldBeEqualTo true
+            hasParentWithName(setOf("SampleParentInterface2"), indirectParents = true) shouldBeEqualTo true
+            hasParentWithName(setOf("OtherInterface"), indirectParents = true) shouldBeEqualTo false
+            hasParentWithName(setOf("SampleParentInterface2", "OtherInterface"), indirectParents = true) shouldBeEqualTo true
             hasParentsWithAllNames("SampleParentInterface2", indirectParents = true) shouldBeEqualTo true
             hasParentsWithAllNames("OtherInterface", indirectParents = true) shouldBeEqualTo false
             hasParentsWithAllNames(
@@ -119,6 +169,22 @@ class KoObjectDeclarationForKoParentProviderTest {
                 indirectParents = true,
             ) shouldBeEqualTo true
             hasParentsWithAllNames("SampleParentInterface2", "OtherInterface", indirectParents = true) shouldBeEqualTo false
+            hasParentsWithAllNames(listOf("SampleParentInterface2"), indirectParents = true) shouldBeEqualTo true
+            hasParentsWithAllNames(listOf("OtherInterface"), indirectParents = true) shouldBeEqualTo false
+            hasParentsWithAllNames(listOf(
+                "SampleParentInterface2",
+                "SampleParentInterface1"),
+                indirectParents = true,
+            ) shouldBeEqualTo true
+            hasParentsWithAllNames(listOf("SampleParentInterface2", "OtherInterface"), indirectParents = true) shouldBeEqualTo false
+            hasParentsWithAllNames(setOf("SampleParentInterface2"), indirectParents = true) shouldBeEqualTo true
+            hasParentsWithAllNames(setOf("OtherInterface"), indirectParents = true) shouldBeEqualTo false
+            hasParentsWithAllNames(setOf(
+                "SampleParentInterface2",
+                "SampleParentInterface1"),
+                indirectParents = true,
+            ) shouldBeEqualTo true
+            hasParentsWithAllNames(setOf("SampleParentInterface2", "OtherInterface"), indirectParents = true) shouldBeEqualTo false
             hasParent(indirectParents = true) { it.name == "SampleParentInterface2" } shouldBeEqualTo true
             hasParent(indirectParents = true) { it.name == "OtherClass" } shouldBeEqualTo false
             hasAllParents(indirectParents = true) { it.name == "SampleParentInterface2" } shouldBeEqualTo false
@@ -126,10 +192,26 @@ class KoObjectDeclarationForKoParentProviderTest {
             hasAllParents(indirectParents = true) { it.hasNameStartingWith("Other") } shouldBeEqualTo false
             hasParentOf(SampleParentInterface2::class, indirectParents = true) shouldBeEqualTo true
             hasParentOf(SampleParentInterface2::class, SampleInterface::class, indirectParents = true) shouldBeEqualTo true
+            hasParentOf(listOf(SampleParentInterface2::class), indirectParents = true) shouldBeEqualTo true
+            hasParentOf(listOf(SampleParentInterface2::class, SampleInterface::class), indirectParents = true) shouldBeEqualTo true
+            hasParentOf(setOf(SampleParentInterface2::class), indirectParents = true) shouldBeEqualTo true
+            hasParentOf(setOf(SampleParentInterface2::class, SampleInterface::class), indirectParents = true) shouldBeEqualTo true
             hasAllParentsOf(SampleParentInterface2::class, indirectParents = true) shouldBeEqualTo true
             hasAllParentsOf(
                 SampleParentInterface2::class,
                 SampleInterface::class,
+                indirectParents = true,
+            ) shouldBeEqualTo false
+            hasAllParentsOf(listOf(SampleParentInterface2::class), indirectParents = true) shouldBeEqualTo true
+            hasAllParentsOf(listOf(
+                SampleParentInterface2::class,
+                SampleInterface::class),
+                indirectParents = true,
+            ) shouldBeEqualTo false
+            hasAllParentsOf(setOf(SampleParentInterface2::class), indirectParents = true) shouldBeEqualTo true
+            hasAllParentsOf(setOf(
+                SampleParentInterface2::class,
+                SampleInterface::class),
                 indirectParents = true,
             ) shouldBeEqualTo false
         }

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koobject/KoObjectDeclarationForKoParentProviderTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koobject/KoObjectDeclarationForKoParentProviderTest.kt
@@ -10,6 +10,7 @@ import org.amshove.kluent.assertSoftly
 import org.amshove.kluent.shouldBeEqualTo
 import org.junit.jupiter.api.Test
 
+@Suppress("detekt.LongMethod")
 class KoObjectDeclarationForKoParentProviderTest {
     @Test
     fun `object-has-no-parents`() {
@@ -171,17 +172,21 @@ class KoObjectDeclarationForKoParentProviderTest {
             hasParentsWithAllNames("SampleParentInterface2", "OtherInterface", indirectParents = true) shouldBeEqualTo false
             hasParentsWithAllNames(listOf("SampleParentInterface2"), indirectParents = true) shouldBeEqualTo true
             hasParentsWithAllNames(listOf("OtherInterface"), indirectParents = true) shouldBeEqualTo false
-            hasParentsWithAllNames(listOf(
-                "SampleParentInterface2",
-                "SampleParentInterface1"),
+            hasParentsWithAllNames(
+                listOf(
+                    "SampleParentInterface2",
+                    "SampleParentInterface1",
+                ),
                 indirectParents = true,
             ) shouldBeEqualTo true
             hasParentsWithAllNames(listOf("SampleParentInterface2", "OtherInterface"), indirectParents = true) shouldBeEqualTo false
             hasParentsWithAllNames(setOf("SampleParentInterface2"), indirectParents = true) shouldBeEqualTo true
             hasParentsWithAllNames(setOf("OtherInterface"), indirectParents = true) shouldBeEqualTo false
-            hasParentsWithAllNames(setOf(
-                "SampleParentInterface2",
-                "SampleParentInterface1"),
+            hasParentsWithAllNames(
+                setOf(
+                    "SampleParentInterface2",
+                    "SampleParentInterface1",
+                ),
                 indirectParents = true,
             ) shouldBeEqualTo true
             hasParentsWithAllNames(setOf("SampleParentInterface2", "OtherInterface"), indirectParents = true) shouldBeEqualTo false
@@ -203,15 +208,19 @@ class KoObjectDeclarationForKoParentProviderTest {
                 indirectParents = true,
             ) shouldBeEqualTo false
             hasAllParentsOf(listOf(SampleParentInterface2::class), indirectParents = true) shouldBeEqualTo true
-            hasAllParentsOf(listOf(
-                SampleParentInterface2::class,
-                SampleInterface::class),
+            hasAllParentsOf(
+                listOf(
+                    SampleParentInterface2::class,
+                    SampleInterface::class,
+                ),
                 indirectParents = true,
             ) shouldBeEqualTo false
             hasAllParentsOf(setOf(SampleParentInterface2::class), indirectParents = true) shouldBeEqualTo true
-            hasAllParentsOf(setOf(
-                SampleParentInterface2::class,
-                SampleInterface::class),
+            hasAllParentsOf(
+                setOf(
+                    SampleParentInterface2::class,
+                    SampleInterface::class,
+                ),
                 indirectParents = true,
             ) shouldBeEqualTo false
         }

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koobject/KoObjectDeclarationForKoPropertyProviderTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koobject/KoObjectDeclarationForKoPropertyProviderTest.kt
@@ -20,8 +20,16 @@ class KoObjectDeclarationForKoPropertyProviderTest {
         assertSoftly(sut) {
             properties() shouldBeEqualTo emptyList()
             hasProperties() shouldBeEqualTo false
+            hasPropertyWithName(emptyList()) shouldBeEqualTo false
+            hasPropertyWithName(emptySet()) shouldBeEqualTo false
+            hasPropertiesWithAllNames(emptyList()) shouldBeEqualTo false
+            hasPropertiesWithAllNames(emptySet()) shouldBeEqualTo false
             hasPropertyWithName("sampleProperty") shouldBeEqualTo false
+            hasPropertyWithName(listOf("sampleProperty")) shouldBeEqualTo false
+            hasPropertyWithName(setOf("sampleProperty")) shouldBeEqualTo false
             hasPropertiesWithAllNames("sampleProperty1", "sampleProperty2") shouldBeEqualTo false
+            hasPropertiesWithAllNames(listOf("sampleProperty1", "sampleProperty2")) shouldBeEqualTo false
+            hasPropertiesWithAllNames(setOf("sampleProperty1", "sampleProperty2")) shouldBeEqualTo false
             hasProperty { it.name == "sampleProperty" } shouldBeEqualTo false
             hasAllProperties { it.hasNameStartingWith("sample") } shouldBeEqualTo true
         }
@@ -38,11 +46,25 @@ class KoObjectDeclarationForKoPropertyProviderTest {
         // then
         assertSoftly(sut) {
             hasProperties() shouldBeEqualTo true
+            hasPropertyWithName(emptyList()) shouldBeEqualTo true
+            hasPropertyWithName(emptySet()) shouldBeEqualTo true
+            hasPropertiesWithAllNames(emptyList()) shouldBeEqualTo true
+            hasPropertiesWithAllNames(emptySet()) shouldBeEqualTo true
             hasPropertyWithName("sampleProperty1") shouldBeEqualTo true
             hasPropertyWithName("sampleProperty1", "otherProperty") shouldBeEqualTo true
+            hasPropertyWithName(listOf("sampleProperty1")) shouldBeEqualTo true
+            hasPropertyWithName(listOf("sampleProperty1", "otherProperty")) shouldBeEqualTo true
+            hasPropertyWithName(setOf("sampleProperty1")) shouldBeEqualTo true
+            hasPropertyWithName(setOf("sampleProperty1", "otherProperty")) shouldBeEqualTo true
             hasPropertiesWithAllNames("sampleProperty1") shouldBeEqualTo true
             hasPropertiesWithAllNames("sampleProperty1", "sampleProperty2") shouldBeEqualTo true
             hasPropertiesWithAllNames("sampleProperty1", "otherProperty") shouldBeEqualTo false
+            hasPropertiesWithAllNames(listOf("sampleProperty1")) shouldBeEqualTo true
+            hasPropertiesWithAllNames(listOf("sampleProperty1", "sampleProperty2")) shouldBeEqualTo true
+            hasPropertiesWithAllNames(listOf("sampleProperty1", "otherProperty")) shouldBeEqualTo false
+            hasPropertiesWithAllNames(setOf("sampleProperty1")) shouldBeEqualTo true
+            hasPropertiesWithAllNames(setOf("sampleProperty1", "sampleProperty2")) shouldBeEqualTo true
+            hasPropertiesWithAllNames(setOf("sampleProperty1", "otherProperty")) shouldBeEqualTo false
             hasProperty { it.name == "sampleProperty1" } shouldBeEqualTo true
             hasProperty { it.hasNameEndingWith("Property1") } shouldBeEqualTo true
             hasAllProperties { it.hasNameStartingWith("sample") } shouldBeEqualTo true

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koobject/forkomodifier/KoObjectDeclarationForKoModifierProviderTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koobject/forkomodifier/KoObjectDeclarationForKoModifierProviderTest.kt
@@ -27,14 +27,24 @@ class KoObjectDeclarationForKoModifierProviderTest {
             modifiers shouldBeEqualTo emptyList()
             numModifiers shouldBeEqualTo 0
             hasModifiers() shouldBeEqualTo false
+            hasModifier(emptyList()) shouldBeEqualTo false
+            hasModifier(emptySet()) shouldBeEqualTo false
+            hasAllModifiers(emptyList()) shouldBeEqualTo false
+            hasAllModifiers(emptySet()) shouldBeEqualTo false
             hasModifier(OPEN) shouldBeEqualTo false
             hasModifier(OPEN, DATA) shouldBeEqualTo false
+            hasModifier(listOf(OPEN)) shouldBeEqualTo false
+            hasModifier(listOf(OPEN, DATA)) shouldBeEqualTo false
+            hasModifier(setOf(OPEN)) shouldBeEqualTo false
+            hasModifier(setOf(OPEN, DATA)) shouldBeEqualTo false
             hasAllModifiers(OPEN) shouldBeEqualTo false
             hasAllModifiers(OPEN, DATA) shouldBeEqualTo false
+            hasAllModifiers(listOf(OPEN)) shouldBeEqualTo false
+            hasAllModifiers(listOf(OPEN, DATA)) shouldBeEqualTo false
+            hasAllModifiers(setOf(OPEN)) shouldBeEqualTo false
+            hasAllModifiers(setOf(OPEN, DATA)) shouldBeEqualTo false
             hasModifiers(OPEN) shouldBeEqualTo false
             hasModifiers(OPEN, DATA) shouldBeEqualTo false
-            hasDataModifier shouldBeEqualTo false
-            hasCompanionModifier shouldBeEqualTo false
         }
     }
 
@@ -49,14 +59,32 @@ class KoObjectDeclarationForKoModifierProviderTest {
         // then
         assertSoftly(sut) {
             numModifiers shouldBeEqualTo 2
+            hasModifiers() shouldBeEqualTo true
+            hasModifier(emptyList()) shouldBeEqualTo true
+            hasModifier(emptySet()) shouldBeEqualTo true
+            hasAllModifiers(emptyList()) shouldBeEqualTo true
+            hasAllModifiers(emptySet()) shouldBeEqualTo true
             hasModifier(DATA) shouldBeEqualTo true
             hasModifier(PUBLIC) shouldBeEqualTo false
             hasModifier(DATA, PUBLIC) shouldBeEqualTo true
+            hasModifier(listOf(DATA)) shouldBeEqualTo true
+            hasModifier(listOf(PUBLIC)) shouldBeEqualTo false
+            hasModifier(listOf(DATA, PUBLIC)) shouldBeEqualTo true
+            hasModifier(setOf(DATA)) shouldBeEqualTo true
+            hasModifier(setOf(PUBLIC)) shouldBeEqualTo false
+            hasModifier(setOf(DATA, PUBLIC)) shouldBeEqualTo true
             hasAllModifiers(DATA) shouldBeEqualTo true
             hasAllModifiers(PUBLIC) shouldBeEqualTo false
             hasAllModifiers(DATA, PUBLIC) shouldBeEqualTo false
             hasAllModifiers(DATA, PRIVATE) shouldBeEqualTo true
-            hasModifiers() shouldBeEqualTo true
+            hasAllModifiers(listOf(DATA)) shouldBeEqualTo true
+            hasAllModifiers(listOf(PUBLIC)) shouldBeEqualTo false
+            hasAllModifiers(listOf(DATA, PUBLIC)) shouldBeEqualTo false
+            hasAllModifiers(listOf(DATA, PRIVATE)) shouldBeEqualTo true
+            hasAllModifiers(setOf(DATA)) shouldBeEqualTo true
+            hasAllModifiers(setOf(PUBLIC)) shouldBeEqualTo false
+            hasAllModifiers(setOf(DATA, PUBLIC)) shouldBeEqualTo false
+            hasAllModifiers(setOf(DATA, PRIVATE)) shouldBeEqualTo true
             hasModifiers(PRIVATE) shouldBeEqualTo true
             hasModifiers(DATA) shouldBeEqualTo true
             hasModifiers(OPEN) shouldBeEqualTo false

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koparameter/KoParameterDeclarationForKoAnnotationProviderTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koparameter/KoParameterDeclarationForKoAnnotationProviderTest.kt
@@ -25,14 +25,30 @@ class KoParameterDeclarationForKoAnnotationProviderTest {
         assertSoftly(sut) {
             it?.annotations shouldBeEqualTo emptyList()
             it?.numAnnotations shouldBeEqualTo 0
-            it?.countAnnotations { annotation -> annotation.name == "NonExistingAnnotation" } shouldBeEqualTo 0
+            it?.countAnnotations { it.name == "NonExistingAnnotation" } shouldBeEqualTo 0
             it?.hasAnnotations() shouldBeEqualTo false
+            it?.hasAnnotationWithName(emptyList()) shouldBeEqualTo false
+            it?.hasAnnotationWithName(emptySet()) shouldBeEqualTo false
+            it?.hasAnnotationsWithAllNames(emptyList()) shouldBeEqualTo false
+            it?.hasAnnotationsWithAllNames(emptySet()) shouldBeEqualTo false
             it?.hasAnnotationWithName("SampleAnnotation") shouldBeEqualTo false
+            it?.hasAnnotationWithName(listOf("SampleAnnotation")) shouldBeEqualTo false
+            it?.hasAnnotationWithName(setOf("SampleAnnotation")) shouldBeEqualTo false
             it?.hasAnnotationsWithAllNames("SampleAnnotation1", "SampleAnnotation2") shouldBeEqualTo false
-            it?.hasAnnotation { annotation -> annotation.hasArguments() } shouldBeEqualTo false
-            it?.hasAllAnnotations { annotation -> annotation.hasArguments() } shouldBeEqualTo true
+            it?.hasAnnotationsWithAllNames(listOf("SampleAnnotation1", "SampleAnnotation2")) shouldBeEqualTo false
+            it?.hasAnnotationsWithAllNames(setOf("SampleAnnotation1", "SampleAnnotation2")) shouldBeEqualTo false
+            it?.hasAnnotation { it.hasArguments() } shouldBeEqualTo false
+            it?.hasAllAnnotations { it.hasArguments() } shouldBeEqualTo true
+            it?.hasAnnotationOf(emptyList()) shouldBeEqualTo false
+            it?.hasAnnotationOf(emptySet()) shouldBeEqualTo false
+            it?.hasAllAnnotationsOf(emptyList()) shouldBeEqualTo false
+            it?.hasAllAnnotationsOf(emptySet()) shouldBeEqualTo false
             it?.hasAnnotationOf(SampleAnnotation::class) shouldBeEqualTo false
+            it?.hasAnnotationOf(listOf(SampleAnnotation::class)) shouldBeEqualTo false
+            it?.hasAnnotationOf(setOf(SampleAnnotation::class)) shouldBeEqualTo false
             it?.hasAllAnnotationsOf(SampleAnnotation1::class, SampleAnnotation2::class) shouldBeEqualTo false
+            it?.hasAllAnnotationsOf(listOf(SampleAnnotation1::class, SampleAnnotation2::class)) shouldBeEqualTo false
+            it?.hasAllAnnotationsOf(setOf(SampleAnnotation1::class, SampleAnnotation2::class)) shouldBeEqualTo false
             it?.hasAnnotations("SampleAnnotation") shouldBeEqualTo false
         }
     }
@@ -51,9 +67,13 @@ class KoParameterDeclarationForKoAnnotationProviderTest {
         // then
         assertSoftly(sut) {
             it?.numAnnotations shouldBeEqualTo 1
-            it?.countAnnotations { annotation -> annotation.name == "SampleAnnotation" } shouldBeEqualTo 1
-            it?.countAnnotations { annotation -> annotation.name == "NonExistingAnnotation" } shouldBeEqualTo 0
+            it?.countAnnotations { it.name == "SampleAnnotation" } shouldBeEqualTo 1
+            it?.countAnnotations { it.name == "NonExistingAnnotation" } shouldBeEqualTo 0
             it?.hasAnnotations() shouldBeEqualTo true
+            it?.hasAnnotationWithName(emptyList()) shouldBeEqualTo true
+            it?.hasAnnotationWithName(emptySet()) shouldBeEqualTo true
+            it?.hasAnnotationsWithAllNames(emptyList()) shouldBeEqualTo true
+            it?.hasAnnotationsWithAllNames(emptySet()) shouldBeEqualTo true
             it?.hasAnnotationWithName("SampleAnnotation") shouldBeEqualTo true
             it?.hasAnnotationWithName("OtherAnnotation") shouldBeEqualTo false
             it?.hasAnnotationWithName("SampleAnnotation", "OtherAnnotation") shouldBeEqualTo true
@@ -63,6 +83,28 @@ class KoParameterDeclarationForKoAnnotationProviderTest {
                 "com.lemonappdev.konsist.testdata.SampleAnnotation",
                 "com.lemonappdev.konsist.testdata.NonExistingAnnotation",
             ).shouldBeEqualTo(true)
+            it?.hasAnnotationWithName(listOf("SampleAnnotation")) shouldBeEqualTo true
+            it?.hasAnnotationWithName(listOf("OtherAnnotation")) shouldBeEqualTo false
+            it?.hasAnnotationWithName(listOf("SampleAnnotation", "OtherAnnotation")) shouldBeEqualTo true
+            it?.hasAnnotationWithName(listOf("com.lemonappdev.konsist.testdata.SampleAnnotation")) shouldBeEqualTo true
+            it?.hasAnnotationWithName(listOf("com.lemonappdev.konsist.testdata.NonExistingAnnotation")) shouldBeEqualTo false
+            it?.hasAnnotationWithName(
+                listOf(
+                    "com.lemonappdev.konsist.testdata.SampleAnnotation",
+                    "com.lemonappdev.konsist.testdata.NonExistingAnnotation",
+                )
+            ).shouldBeEqualTo(true)
+            it?.hasAnnotationWithName(setOf("SampleAnnotation")) shouldBeEqualTo true
+            it?.hasAnnotationWithName(setOf("OtherAnnotation")) shouldBeEqualTo false
+            it?.hasAnnotationWithName(setOf("SampleAnnotation", "OtherAnnotation")) shouldBeEqualTo true
+            it?.hasAnnotationWithName(setOf("com.lemonappdev.konsist.testdata.SampleAnnotation")) shouldBeEqualTo true
+            it?.hasAnnotationWithName(setOf("com.lemonappdev.konsist.testdata.NonExistingAnnotation")) shouldBeEqualTo false
+            it?.hasAnnotationWithName(
+                setOf(
+                    "com.lemonappdev.konsist.testdata.SampleAnnotation",
+                    "com.lemonappdev.konsist.testdata.NonExistingAnnotation",
+                )
+            ).shouldBeEqualTo(true)
             it?.hasAnnotationsWithAllNames("SampleAnnotation") shouldBeEqualTo true
             it?.hasAnnotationsWithAllNames("SampleAnnotation", "OtherAnnotation") shouldBeEqualTo false
             it?.hasAnnotationsWithAllNames("com.lemonappdev.konsist.testdata.SampleAnnotation") shouldBeEqualTo true
@@ -70,15 +112,37 @@ class KoParameterDeclarationForKoAnnotationProviderTest {
                 "com.lemonappdev.konsist.testdata.SampleAnnotation",
                 "com.lemonappdev.konsist.testdata.NonExistingAnnotation",
             ).shouldBeEqualTo(false)
-            it?.hasAnnotation { annotation -> annotation.hasNameStartingWith("Sample") } shouldBeEqualTo true
-            it?.hasAnnotation { annotation -> annotation.hasNameStartingWith("Other") } shouldBeEqualTo false
-            it?.hasAllAnnotations { annotation -> annotation.hasNameStartingWith("Sample") } shouldBeEqualTo true
-            it?.hasAnnotationOf(SampleAnnotation::class) shouldBeEqualTo true
-            it?.hasAnnotationOf(NonExistingAnnotation::class) shouldBeEqualTo false
-            it?.hasAnnotationOf(SampleAnnotation::class, NonExistingAnnotation::class) shouldBeEqualTo true
+            it?.hasAnnotationsWithAllNames(listOf("SampleAnnotation")) shouldBeEqualTo true
+            it?.hasAnnotationsWithAllNames(listOf("SampleAnnotation", "OtherAnnotation")) shouldBeEqualTo false
+            it?.hasAnnotationsWithAllNames(listOf("com.lemonappdev.konsist.testdata.SampleAnnotation")) shouldBeEqualTo true
+            it?.hasAnnotationsWithAllNames(
+                listOf(
+                    "com.lemonappdev.konsist.testdata.SampleAnnotation",
+                    "com.lemonappdev.konsist.testdata.NonExistingAnnotation",
+                )
+            ).shouldBeEqualTo(false)
+            it?.hasAnnotation { it.hasNameStartingWith("Sample") } shouldBeEqualTo true
+            it?.hasAnnotation { it.hasNameStartingWith("Other") } shouldBeEqualTo false
+            it?.hasAllAnnotations { it.hasNameStartingWith("Sample") } shouldBeEqualTo true
+            it?.hasAnnotationOf(emptyList()) shouldBeEqualTo true
+            it?.hasAnnotationOf(emptySet()) shouldBeEqualTo true
+            it?.hasAllAnnotationsOf(emptyList()) shouldBeEqualTo true
+            it?.hasAllAnnotationsOf(emptySet()) shouldBeEqualTo true
+            it?.hasAnnotationOf(listOf(SampleAnnotation::class)) shouldBeEqualTo true
+            it?.hasAnnotationOf(listOf(NonExistingAnnotation::class)) shouldBeEqualTo false
+            it?.hasAnnotationOf(listOf(SampleAnnotation::class, NonExistingAnnotation::class)) shouldBeEqualTo true
+            it?.hasAnnotationOf(setOf(SampleAnnotation::class)) shouldBeEqualTo true
+            it?.hasAnnotationOf(setOf(NonExistingAnnotation::class)) shouldBeEqualTo false
+            it?.hasAnnotationOf(setOf(SampleAnnotation::class, NonExistingAnnotation::class)) shouldBeEqualTo true
             it?.hasAllAnnotationsOf(SampleAnnotation::class) shouldBeEqualTo true
             it?.hasAllAnnotationsOf(NonExistingAnnotation::class) shouldBeEqualTo false
             it?.hasAllAnnotationsOf(SampleAnnotation::class, NonExistingAnnotation::class) shouldBeEqualTo false
+            it?.hasAllAnnotationsOf(listOf(SampleAnnotation::class)) shouldBeEqualTo true
+            it?.hasAllAnnotationsOf(listOf(NonExistingAnnotation::class)) shouldBeEqualTo false
+            it?.hasAllAnnotationsOf(listOf(SampleAnnotation::class, NonExistingAnnotation::class)) shouldBeEqualTo false
+            it?.hasAllAnnotationsOf(setOf(SampleAnnotation::class)) shouldBeEqualTo true
+            it?.hasAllAnnotationsOf(setOf(NonExistingAnnotation::class)) shouldBeEqualTo false
+            it?.hasAllAnnotationsOf(setOf(SampleAnnotation::class, NonExistingAnnotation::class)) shouldBeEqualTo false
             it?.hasAnnotations("SampleAnnotation") shouldBeEqualTo true
             it?.hasAnnotations("NonExistingAnnotation") shouldBeEqualTo false
             it?.hasAnnotations("com.lemonappdev.konsist.testdata.SampleAnnotation") shouldBeEqualTo true
@@ -102,9 +166,13 @@ class KoParameterDeclarationForKoAnnotationProviderTest {
         // then
         assertSoftly(sut) {
             it?.numAnnotations shouldBeEqualTo 2
-            it?.countAnnotations { annotation -> annotation.hasNameStartingWith("Sample") } shouldBeEqualTo 2
-            it?.countAnnotations { annotation -> annotation.name == "SampleAnnotation1" } shouldBeEqualTo 1
+            it?.countAnnotations { it.hasNameStartingWith("Sample") } shouldBeEqualTo 2
+            it?.countAnnotations { it.name == "SampleAnnotation1" } shouldBeEqualTo 1
             it?.hasAnnotations() shouldBeEqualTo true
+            it?.hasAnnotationOf(emptyList()) shouldBeEqualTo true
+            it?.hasAnnotationOf(emptySet()) shouldBeEqualTo true
+            it?.hasAllAnnotationsOf(emptyList()) shouldBeEqualTo true
+            it?.hasAllAnnotationsOf(emptySet()) shouldBeEqualTo true
             it?.hasAnnotationWithName("SampleAnnotation1") shouldBeEqualTo true
             it?.hasAnnotationWithName("OtherAnnotation") shouldBeEqualTo false
             it?.hasAnnotationWithName("SampleAnnotation1", "OtherAnnotation") shouldBeEqualTo true
@@ -114,6 +182,24 @@ class KoParameterDeclarationForKoAnnotationProviderTest {
                 "com.lemonappdev.konsist.testdata.SampleAnnotation1",
                 "com.lemonappdev.konsist.testdata.NonExistingAnnotation",
             ).shouldBeEqualTo(true)
+            it?.hasAnnotationWithName(listOf("SampleAnnotation1")) shouldBeEqualTo true
+            it?.hasAnnotationWithName(listOf("OtherAnnotation")) shouldBeEqualTo false
+            it?.hasAnnotationWithName(listOf("SampleAnnotation1", "OtherAnnotation")) shouldBeEqualTo true
+            it?.hasAnnotationWithName(listOf("com.lemonappdev.konsist.testdata.SampleAnnotation1")) shouldBeEqualTo true
+            it?.hasAnnotationWithName(listOf("com.lemonappdev.konsist.testdata.NonExistingAnnotation")) shouldBeEqualTo false
+            it?.hasAnnotationWithName(listOf(
+                "com.lemonappdev.konsist.testdata.SampleAnnotation1",
+                "com.lemonappdev.konsist.testdata.NonExistingAnnotation",
+            )).shouldBeEqualTo(true)
+            it?.hasAnnotationWithName(setOf("SampleAnnotation1")) shouldBeEqualTo true
+            it?.hasAnnotationWithName(setOf("OtherAnnotation")) shouldBeEqualTo false
+            it?.hasAnnotationWithName(setOf("SampleAnnotation1", "OtherAnnotation")) shouldBeEqualTo true
+            it?.hasAnnotationWithName(setOf("com.lemonappdev.konsist.testdata.SampleAnnotation1")) shouldBeEqualTo true
+            it?.hasAnnotationWithName(setOf("com.lemonappdev.konsist.testdata.NonExistingAnnotation")) shouldBeEqualTo false
+            it?.hasAnnotationWithName(setOf(
+                "com.lemonappdev.konsist.testdata.SampleAnnotation1",
+                "com.lemonappdev.konsist.testdata.NonExistingAnnotation",
+            )).shouldBeEqualTo(true)
             it?.hasAnnotationsWithAllNames("SampleAnnotation1") shouldBeEqualTo true
             it?.hasAnnotationsWithAllNames("SampleAnnotation1", "SampleAnnotation2") shouldBeEqualTo true
             it?.hasAnnotationsWithAllNames("SampleAnnotation1", "OtherAnnotation") shouldBeEqualTo false
@@ -126,17 +212,48 @@ class KoParameterDeclarationForKoAnnotationProviderTest {
                 "com.lemonappdev.konsist.testdata.SampleAnnotation1",
                 "com.lemonappdev.konsist.testdata.SampleAnnotation2",
             ).shouldBeEqualTo(true)
-            it?.hasAnnotation { annotation -> annotation.name == "SampleAnnotation1" } shouldBeEqualTo true
-            it?.hasAnnotation { annotation -> annotation.name == "OtherAnnotation1" } shouldBeEqualTo false
+
+            it?.hasAnnotationsWithAllNames(listOf("SampleAnnotation1")) shouldBeEqualTo true
+            it?.hasAnnotationsWithAllNames(listOf("SampleAnnotation1", "SampleAnnotation2")) shouldBeEqualTo true
+            it?.hasAnnotationsWithAllNames(listOf("SampleAnnotation1", "OtherAnnotation")) shouldBeEqualTo false
+            it?.hasAnnotationsWithAllNames(listOf("com.lemonappdev.konsist.testdata.SampleAnnotation1")) shouldBeEqualTo true
+            it?.hasAnnotationsWithAllNames(listOf(
+                "com.lemonappdev.konsist.testdata.SampleAnnotation1",
+                "com.lemonappdev.konsist.testdata.NonExistingAnnotation",
+            )).shouldBeEqualTo(false)
+            it?.hasAnnotationsWithAllNames(listOf(
+                "com.lemonappdev.konsist.testdata.SampleAnnotation1",
+                "com.lemonappdev.konsist.testdata.SampleAnnotation2",
+            )).shouldBeEqualTo(true)
+            it?.hasAnnotation { it.name == "SampleAnnotation1" } shouldBeEqualTo true
+            it?.hasAnnotation { it.name == "OtherAnnotation1" } shouldBeEqualTo false
             it?.hasAllAnnotations { !it.hasArguments() } shouldBeEqualTo true
-            it?.hasAllAnnotations { annotation -> annotation.hasNameEndingWith("tion1") } shouldBeEqualTo false
+            it?.hasAllAnnotations { it.hasNameEndingWith("tion1") } shouldBeEqualTo false
+            it?.hasAnnotationOf(emptyList()) shouldBeEqualTo true
+            it?.hasAnnotationOf(emptySet()) shouldBeEqualTo true
+            it?.hasAllAnnotationsOf(emptyList()) shouldBeEqualTo true
+            it?.hasAllAnnotationsOf(emptySet()) shouldBeEqualTo true
             it?.hasAnnotationOf(SampleAnnotation1::class) shouldBeEqualTo true
             it?.hasAnnotationOf(NonExistingAnnotation::class) shouldBeEqualTo false
             it?.hasAnnotationOf(SampleAnnotation1::class, NonExistingAnnotation::class) shouldBeEqualTo true
+            it?.hasAnnotationOf(listOf(SampleAnnotation1::class)) shouldBeEqualTo true
+            it?.hasAnnotationOf(listOf(NonExistingAnnotation::class)) shouldBeEqualTo false
+            it?.hasAnnotationOf(listOf(SampleAnnotation1::class, NonExistingAnnotation::class)) shouldBeEqualTo true
+            it?.hasAnnotationOf(setOf(SampleAnnotation1::class)) shouldBeEqualTo true
+            it?.hasAnnotationOf(setOf(NonExistingAnnotation::class)) shouldBeEqualTo false
+            it?.hasAnnotationOf(setOf(SampleAnnotation1::class, NonExistingAnnotation::class)) shouldBeEqualTo true
             it?.hasAllAnnotationsOf(SampleAnnotation1::class) shouldBeEqualTo true
             it?.hasAllAnnotationsOf(NonExistingAnnotation::class) shouldBeEqualTo false
             it?.hasAllAnnotationsOf(SampleAnnotation1::class, SampleAnnotation2::class) shouldBeEqualTo true
             it?.hasAllAnnotationsOf(SampleAnnotation1::class, NonExistingAnnotation::class) shouldBeEqualTo false
+            it?.hasAllAnnotationsOf(listOf(SampleAnnotation1::class)) shouldBeEqualTo true
+            it?.hasAllAnnotationsOf(listOf(NonExistingAnnotation::class)) shouldBeEqualTo false
+            it?.hasAllAnnotationsOf(listOf(SampleAnnotation1::class, SampleAnnotation2::class)) shouldBeEqualTo true
+            it?.hasAllAnnotationsOf(listOf(SampleAnnotation1::class, NonExistingAnnotation::class)) shouldBeEqualTo false
+            it?.hasAllAnnotationsOf(setOf(SampleAnnotation1::class)) shouldBeEqualTo true
+            it?.hasAllAnnotationsOf(setOf(NonExistingAnnotation::class)) shouldBeEqualTo false
+            it?.hasAllAnnotationsOf(setOf(SampleAnnotation1::class, SampleAnnotation2::class)) shouldBeEqualTo true
+            it?.hasAllAnnotationsOf(setOf(SampleAnnotation1::class, NonExistingAnnotation::class)) shouldBeEqualTo false
             it?.hasAnnotations("SampleAnnotation1") shouldBeEqualTo true
             it?.hasAnnotations("SampleAnnotation2") shouldBeEqualTo true
             it?.hasAnnotations("NonExistingAnnotation") shouldBeEqualTo false

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koparameter/KoParameterDeclarationForKoAnnotationProviderTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koparameter/KoParameterDeclarationForKoAnnotationProviderTest.kt
@@ -9,6 +9,7 @@ import org.amshove.kluent.assertSoftly
 import org.amshove.kluent.shouldBeEqualTo
 import org.junit.jupiter.api.Test
 
+@Suppress("detekt.LongMethod")
 class KoParameterDeclarationForKoAnnotationProviderTest {
     @Test
     fun `parameter-has-no-annotation`() {
@@ -92,7 +93,7 @@ class KoParameterDeclarationForKoAnnotationProviderTest {
                 listOf(
                     "com.lemonappdev.konsist.testdata.SampleAnnotation",
                     "com.lemonappdev.konsist.testdata.NonExistingAnnotation",
-                )
+                ),
             ).shouldBeEqualTo(true)
             it?.hasAnnotationWithName(setOf("SampleAnnotation")) shouldBeEqualTo true
             it?.hasAnnotationWithName(setOf("OtherAnnotation")) shouldBeEqualTo false
@@ -103,7 +104,7 @@ class KoParameterDeclarationForKoAnnotationProviderTest {
                 setOf(
                     "com.lemonappdev.konsist.testdata.SampleAnnotation",
                     "com.lemonappdev.konsist.testdata.NonExistingAnnotation",
-                )
+                ),
             ).shouldBeEqualTo(true)
             it?.hasAnnotationsWithAllNames("SampleAnnotation") shouldBeEqualTo true
             it?.hasAnnotationsWithAllNames("SampleAnnotation", "OtherAnnotation") shouldBeEqualTo false
@@ -119,7 +120,7 @@ class KoParameterDeclarationForKoAnnotationProviderTest {
                 listOf(
                     "com.lemonappdev.konsist.testdata.SampleAnnotation",
                     "com.lemonappdev.konsist.testdata.NonExistingAnnotation",
-                )
+                ),
             ).shouldBeEqualTo(false)
             it?.hasAnnotation { it.hasNameStartingWith("Sample") } shouldBeEqualTo true
             it?.hasAnnotation { it.hasNameStartingWith("Other") } shouldBeEqualTo false
@@ -187,19 +188,23 @@ class KoParameterDeclarationForKoAnnotationProviderTest {
             it?.hasAnnotationWithName(listOf("SampleAnnotation1", "OtherAnnotation")) shouldBeEqualTo true
             it?.hasAnnotationWithName(listOf("com.lemonappdev.konsist.testdata.SampleAnnotation1")) shouldBeEqualTo true
             it?.hasAnnotationWithName(listOf("com.lemonappdev.konsist.testdata.NonExistingAnnotation")) shouldBeEqualTo false
-            it?.hasAnnotationWithName(listOf(
-                "com.lemonappdev.konsist.testdata.SampleAnnotation1",
-                "com.lemonappdev.konsist.testdata.NonExistingAnnotation",
-            )).shouldBeEqualTo(true)
+            it?.hasAnnotationWithName(
+                listOf(
+                    "com.lemonappdev.konsist.testdata.SampleAnnotation1",
+                    "com.lemonappdev.konsist.testdata.NonExistingAnnotation",
+                ),
+            ).shouldBeEqualTo(true)
             it?.hasAnnotationWithName(setOf("SampleAnnotation1")) shouldBeEqualTo true
             it?.hasAnnotationWithName(setOf("OtherAnnotation")) shouldBeEqualTo false
             it?.hasAnnotationWithName(setOf("SampleAnnotation1", "OtherAnnotation")) shouldBeEqualTo true
             it?.hasAnnotationWithName(setOf("com.lemonappdev.konsist.testdata.SampleAnnotation1")) shouldBeEqualTo true
             it?.hasAnnotationWithName(setOf("com.lemonappdev.konsist.testdata.NonExistingAnnotation")) shouldBeEqualTo false
-            it?.hasAnnotationWithName(setOf(
-                "com.lemonappdev.konsist.testdata.SampleAnnotation1",
-                "com.lemonappdev.konsist.testdata.NonExistingAnnotation",
-            )).shouldBeEqualTo(true)
+            it?.hasAnnotationWithName(
+                setOf(
+                    "com.lemonappdev.konsist.testdata.SampleAnnotation1",
+                    "com.lemonappdev.konsist.testdata.NonExistingAnnotation",
+                ),
+            ).shouldBeEqualTo(true)
             it?.hasAnnotationsWithAllNames("SampleAnnotation1") shouldBeEqualTo true
             it?.hasAnnotationsWithAllNames("SampleAnnotation1", "SampleAnnotation2") shouldBeEqualTo true
             it?.hasAnnotationsWithAllNames("SampleAnnotation1", "OtherAnnotation") shouldBeEqualTo false
@@ -217,14 +222,18 @@ class KoParameterDeclarationForKoAnnotationProviderTest {
             it?.hasAnnotationsWithAllNames(listOf("SampleAnnotation1", "SampleAnnotation2")) shouldBeEqualTo true
             it?.hasAnnotationsWithAllNames(listOf("SampleAnnotation1", "OtherAnnotation")) shouldBeEqualTo false
             it?.hasAnnotationsWithAllNames(listOf("com.lemonappdev.konsist.testdata.SampleAnnotation1")) shouldBeEqualTo true
-            it?.hasAnnotationsWithAllNames(listOf(
-                "com.lemonappdev.konsist.testdata.SampleAnnotation1",
-                "com.lemonappdev.konsist.testdata.NonExistingAnnotation",
-            )).shouldBeEqualTo(false)
-            it?.hasAnnotationsWithAllNames(listOf(
-                "com.lemonappdev.konsist.testdata.SampleAnnotation1",
-                "com.lemonappdev.konsist.testdata.SampleAnnotation2",
-            )).shouldBeEqualTo(true)
+            it?.hasAnnotationsWithAllNames(
+                listOf(
+                    "com.lemonappdev.konsist.testdata.SampleAnnotation1",
+                    "com.lemonappdev.konsist.testdata.NonExistingAnnotation",
+                ),
+            ).shouldBeEqualTo(false)
+            it?.hasAnnotationsWithAllNames(
+                listOf(
+                    "com.lemonappdev.konsist.testdata.SampleAnnotation1",
+                    "com.lemonappdev.konsist.testdata.SampleAnnotation2",
+                ),
+            ).shouldBeEqualTo(true)
             it?.hasAnnotation { it.name == "SampleAnnotation1" } shouldBeEqualTo true
             it?.hasAnnotation { it.name == "OtherAnnotation1" } shouldBeEqualTo false
             it?.hasAllAnnotations { !it.hasArguments() } shouldBeEqualTo true

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koparameter/forkomodifier/KoParameterDeclarationForKoModifierProviderTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koparameter/forkomodifier/KoParameterDeclarationForKoModifierProviderTest.kt
@@ -1,11 +1,9 @@
 package com.lemonappdev.konsist.core.declaration.koparameter.forkomodifier
 
 import com.lemonappdev.konsist.TestSnippetProvider.getSnippetKoScope
-import com.lemonappdev.konsist.api.KoModifier
 import com.lemonappdev.konsist.api.KoModifier.DATA
 import com.lemonappdev.konsist.api.KoModifier.OPEN
 import com.lemonappdev.konsist.api.KoModifier.PRIVATE
-import com.lemonappdev.konsist.api.KoModifier.PROTECTED
 import com.lemonappdev.konsist.api.KoModifier.PUBLIC
 import org.amshove.kluent.assertSoftly
 import org.amshove.kluent.shouldBeEqualTo

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koparameter/forkomodifier/KoParameterDeclarationForKoModifierProviderTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koparameter/forkomodifier/KoParameterDeclarationForKoModifierProviderTest.kt
@@ -1,9 +1,11 @@
 package com.lemonappdev.konsist.core.declaration.koparameter.forkomodifier
 
 import com.lemonappdev.konsist.TestSnippetProvider.getSnippetKoScope
+import com.lemonappdev.konsist.api.KoModifier
 import com.lemonappdev.konsist.api.KoModifier.DATA
 import com.lemonappdev.konsist.api.KoModifier.OPEN
 import com.lemonappdev.konsist.api.KoModifier.PRIVATE
+import com.lemonappdev.konsist.api.KoModifier.PROTECTED
 import com.lemonappdev.konsist.api.KoModifier.PUBLIC
 import org.amshove.kluent.assertSoftly
 import org.amshove.kluent.shouldBeEqualTo
@@ -27,10 +29,22 @@ class KoParameterDeclarationForKoModifierProviderTest {
             it?.modifiers shouldBeEqualTo emptyList()
             it?.numModifiers shouldBeEqualTo 0
             it?.hasModifiers() shouldBeEqualTo false
+            it?.hasModifier(emptyList()) shouldBeEqualTo false
+            it?.hasModifier(emptySet()) shouldBeEqualTo false
+            it?.hasAllModifiers(emptyList()) shouldBeEqualTo false
+            it?.hasAllModifiers(emptySet()) shouldBeEqualTo false
             it?.hasModifier(OPEN) shouldBeEqualTo false
             it?.hasModifier(OPEN, DATA) shouldBeEqualTo false
+            it?.hasModifier(listOf(OPEN)) shouldBeEqualTo false
+            it?.hasModifier(listOf(OPEN, DATA)) shouldBeEqualTo false
+            it?.hasModifier(setOf(OPEN)) shouldBeEqualTo false
+            it?.hasModifier(setOf(OPEN, DATA)) shouldBeEqualTo false
             it?.hasAllModifiers(OPEN) shouldBeEqualTo false
             it?.hasAllModifiers(OPEN, DATA) shouldBeEqualTo false
+            it?.hasAllModifiers(listOf(OPEN)) shouldBeEqualTo false
+            it?.hasAllModifiers(listOf(OPEN, DATA)) shouldBeEqualTo false
+            it?.hasAllModifiers(setOf(OPEN)) shouldBeEqualTo false
+            it?.hasAllModifiers(setOf(OPEN, DATA)) shouldBeEqualTo false
             it?.hasModifiers(OPEN) shouldBeEqualTo false
             it?.hasModifiers(OPEN, DATA) shouldBeEqualTo false
         }
@@ -52,9 +66,19 @@ class KoParameterDeclarationForKoModifierProviderTest {
             it?.modifiers shouldNotBeEqualTo emptyList()
             it?.numModifiers shouldBeEqualTo 1
             it?.hasModifiers() shouldBeEqualTo true
+            it?.hasModifier(emptyList()) shouldBeEqualTo true
+            it?.hasModifier(emptySet()) shouldBeEqualTo true
+            it?.hasAllModifiers(emptyList()) shouldBeEqualTo true
+            it?.hasAllModifiers(emptySet()) shouldBeEqualTo true
             it?.hasModifier(PUBLIC) shouldBeEqualTo true
             it?.hasModifier(DATA) shouldBeEqualTo false
             it?.hasModifier(PUBLIC, DATA) shouldBeEqualTo true
+            it?.hasModifier(listOf(PUBLIC)) shouldBeEqualTo true
+            it?.hasModifier(listOf(DATA)) shouldBeEqualTo false
+            it?.hasModifier(listOf(PUBLIC, DATA)) shouldBeEqualTo true
+            it?.hasModifier(setOf(PUBLIC)) shouldBeEqualTo true
+            it?.hasModifier(setOf(DATA)) shouldBeEqualTo false
+            it?.hasModifier(setOf(PUBLIC, DATA)) shouldBeEqualTo true
             it?.hasAllModifiers(PUBLIC) shouldBeEqualTo true
             it?.hasAllModifiers(DATA) shouldBeEqualTo false
             it?.hasAllModifiers(PUBLIC, DATA) shouldBeEqualTo false

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koproperty/KoPropertyDeclarationForKoAnnotationProviderTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koproperty/KoPropertyDeclarationForKoAnnotationProviderTest.kt
@@ -9,6 +9,7 @@ import org.amshove.kluent.assertSoftly
 import org.amshove.kluent.shouldBeEqualTo
 import org.junit.jupiter.api.Test
 
+@Suppress("detekt.LongMethod")
 class KoPropertyDeclarationForKoAnnotationProviderTest {
     @Test
     fun `property-has-no-annotation`() {
@@ -82,19 +83,23 @@ class KoPropertyDeclarationForKoAnnotationProviderTest {
             hasAnnotationWithName(listOf("SampleAnnotation", "OtherAnnotation")) shouldBeEqualTo true
             hasAnnotationWithName(listOf("com.lemonappdev.konsist.testdata.SampleAnnotation")) shouldBeEqualTo true
             hasAnnotationWithName(listOf("com.lemonappdev.konsist.testdata.NonExistingAnnotation")) shouldBeEqualTo false
-            hasAnnotationWithName(listOf(
-                "com.lemonappdev.konsist.testdata.SampleAnnotation",
-                "com.lemonappdev.konsist.testdata.NonExistingAnnotation",
-            )).shouldBeEqualTo(true)
+            hasAnnotationWithName(
+                listOf(
+                    "com.lemonappdev.konsist.testdata.SampleAnnotation",
+                    "com.lemonappdev.konsist.testdata.NonExistingAnnotation",
+                ),
+            ).shouldBeEqualTo(true)
             hasAnnotationWithName(setOf("SampleAnnotation")) shouldBeEqualTo true
             hasAnnotationWithName(setOf("OtherAnnotation")) shouldBeEqualTo false
             hasAnnotationWithName(setOf("SampleAnnotation", "OtherAnnotation")) shouldBeEqualTo true
             hasAnnotationWithName(setOf("com.lemonappdev.konsist.testdata.SampleAnnotation")) shouldBeEqualTo true
             hasAnnotationWithName(setOf("com.lemonappdev.konsist.testdata.NonExistingAnnotation")) shouldBeEqualTo false
-            hasAnnotationWithName(setOf(
-                "com.lemonappdev.konsist.testdata.SampleAnnotation",
-                "com.lemonappdev.konsist.testdata.NonExistingAnnotation",
-            )).shouldBeEqualTo(true)
+            hasAnnotationWithName(
+                setOf(
+                    "com.lemonappdev.konsist.testdata.SampleAnnotation",
+                    "com.lemonappdev.konsist.testdata.NonExistingAnnotation",
+                ),
+            ).shouldBeEqualTo(true)
             hasAnnotationsWithAllNames("SampleAnnotation") shouldBeEqualTo true
             hasAnnotationsWithAllNames("SampleAnnotation", "OtherAnnotation") shouldBeEqualTo false
             hasAnnotationsWithAllNames("com.lemonappdev.konsist.testdata.SampleAnnotation") shouldBeEqualTo true
@@ -105,10 +110,12 @@ class KoPropertyDeclarationForKoAnnotationProviderTest {
             hasAnnotationsWithAllNames(listOf("SampleAnnotation")) shouldBeEqualTo true
             hasAnnotationsWithAllNames(listOf("SampleAnnotation", "OtherAnnotation")) shouldBeEqualTo false
             hasAnnotationsWithAllNames(listOf("com.lemonappdev.konsist.testdata.SampleAnnotation")) shouldBeEqualTo true
-            hasAnnotationsWithAllNames(listOf(
-                "com.lemonappdev.konsist.testdata.SampleAnnotation",
-                "com.lemonappdev.konsist.testdata.NonExistingAnnotation",
-            )).shouldBeEqualTo(false)
+            hasAnnotationsWithAllNames(
+                listOf(
+                    "com.lemonappdev.konsist.testdata.SampleAnnotation",
+                    "com.lemonappdev.konsist.testdata.NonExistingAnnotation",
+                ),
+            ).shouldBeEqualTo(false)
             hasAnnotation { it.hasNameStartingWith("Sample") } shouldBeEqualTo true
             hasAnnotation { it.hasNameStartingWith("Other") } shouldBeEqualTo false
             hasAllAnnotations { it.hasNameStartingWith("Sample") } shouldBeEqualTo true
@@ -172,19 +179,23 @@ class KoPropertyDeclarationForKoAnnotationProviderTest {
             hasAnnotationWithName(listOf("SampleAnnotation1", "OtherAnnotation")) shouldBeEqualTo true
             hasAnnotationWithName(listOf("com.lemonappdev.konsist.testdata.SampleAnnotation1")) shouldBeEqualTo true
             hasAnnotationWithName(listOf("com.lemonappdev.konsist.testdata.NonExistingAnnotation")) shouldBeEqualTo false
-            hasAnnotationWithName(listOf(
-                "com.lemonappdev.konsist.testdata.SampleAnnotation1",
-                "com.lemonappdev.konsist.testdata.NonExistingAnnotation",
-            )).shouldBeEqualTo(true)
+            hasAnnotationWithName(
+                listOf(
+                    "com.lemonappdev.konsist.testdata.SampleAnnotation1",
+                    "com.lemonappdev.konsist.testdata.NonExistingAnnotation",
+                ),
+            ).shouldBeEqualTo(true)
             hasAnnotationWithName(setOf("SampleAnnotation1")) shouldBeEqualTo true
             hasAnnotationWithName(setOf("OtherAnnotation")) shouldBeEqualTo false
             hasAnnotationWithName(setOf("SampleAnnotation1", "OtherAnnotation")) shouldBeEqualTo true
             hasAnnotationWithName(setOf("com.lemonappdev.konsist.testdata.SampleAnnotation1")) shouldBeEqualTo true
             hasAnnotationWithName(setOf("com.lemonappdev.konsist.testdata.NonExistingAnnotation")) shouldBeEqualTo false
-            hasAnnotationWithName(setOf(
-                "com.lemonappdev.konsist.testdata.SampleAnnotation1",
-                "com.lemonappdev.konsist.testdata.NonExistingAnnotation",
-            )).shouldBeEqualTo(true)
+            hasAnnotationWithName(
+                setOf(
+                    "com.lemonappdev.konsist.testdata.SampleAnnotation1",
+                    "com.lemonappdev.konsist.testdata.NonExistingAnnotation",
+                ),
+            ).shouldBeEqualTo(true)
             hasAnnotationsWithAllNames("SampleAnnotation1") shouldBeEqualTo true
             hasAnnotationsWithAllNames("SampleAnnotation1", "SampleAnnotation2") shouldBeEqualTo true
             hasAnnotationsWithAllNames("SampleAnnotation1", "OtherAnnotation") shouldBeEqualTo false
@@ -202,14 +213,18 @@ class KoPropertyDeclarationForKoAnnotationProviderTest {
             hasAnnotationsWithAllNames(listOf("SampleAnnotation1", "SampleAnnotation2")) shouldBeEqualTo true
             hasAnnotationsWithAllNames(listOf("SampleAnnotation1", "OtherAnnotation")) shouldBeEqualTo false
             hasAnnotationsWithAllNames(listOf("com.lemonappdev.konsist.testdata.SampleAnnotation1")) shouldBeEqualTo true
-            hasAnnotationsWithAllNames(listOf(
-                "com.lemonappdev.konsist.testdata.SampleAnnotation1",
-                "com.lemonappdev.konsist.testdata.NonExistingAnnotation",
-            )).shouldBeEqualTo(false)
-            hasAnnotationsWithAllNames(listOf(
-                "com.lemonappdev.konsist.testdata.SampleAnnotation1",
-                "com.lemonappdev.konsist.testdata.SampleAnnotation2",
-            )).shouldBeEqualTo(true)
+            hasAnnotationsWithAllNames(
+                listOf(
+                    "com.lemonappdev.konsist.testdata.SampleAnnotation1",
+                    "com.lemonappdev.konsist.testdata.NonExistingAnnotation",
+                ),
+            ).shouldBeEqualTo(false)
+            hasAnnotationsWithAllNames(
+                listOf(
+                    "com.lemonappdev.konsist.testdata.SampleAnnotation1",
+                    "com.lemonappdev.konsist.testdata.SampleAnnotation2",
+                ),
+            ).shouldBeEqualTo(true)
             hasAnnotation { it.name == "SampleAnnotation1" } shouldBeEqualTo true
             hasAnnotation { it.name == "OtherAnnotation1" } shouldBeEqualTo false
             hasAllAnnotations { !it.hasArguments() } shouldBeEqualTo true

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koproperty/KoPropertyDeclarationForKoAnnotationProviderTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koproperty/KoPropertyDeclarationForKoAnnotationProviderTest.kt
@@ -24,12 +24,28 @@ class KoPropertyDeclarationForKoAnnotationProviderTest {
             numAnnotations shouldBeEqualTo 0
             countAnnotations { it.name == "NonExistingAnnotation" } shouldBeEqualTo 0
             hasAnnotations() shouldBeEqualTo false
+            hasAnnotationWithName(emptyList()) shouldBeEqualTo false
+            hasAnnotationWithName(emptySet()) shouldBeEqualTo false
+            hasAnnotationsWithAllNames(emptyList()) shouldBeEqualTo false
+            hasAnnotationsWithAllNames(emptySet()) shouldBeEqualTo false
             hasAnnotationWithName("SampleAnnotation") shouldBeEqualTo false
+            hasAnnotationWithName(listOf("SampleAnnotation")) shouldBeEqualTo false
+            hasAnnotationWithName(setOf("SampleAnnotation")) shouldBeEqualTo false
             hasAnnotationsWithAllNames("SampleAnnotation1", "SampleAnnotation2") shouldBeEqualTo false
+            hasAnnotationsWithAllNames(listOf("SampleAnnotation1", "SampleAnnotation2")) shouldBeEqualTo false
+            hasAnnotationsWithAllNames(setOf("SampleAnnotation1", "SampleAnnotation2")) shouldBeEqualTo false
             hasAnnotation { it.hasArguments() } shouldBeEqualTo false
             hasAllAnnotations { it.hasArguments() } shouldBeEqualTo true
+            hasAnnotationOf(emptyList()) shouldBeEqualTo false
+            hasAnnotationOf(emptySet()) shouldBeEqualTo false
+            hasAllAnnotationsOf(emptyList()) shouldBeEqualTo false
+            hasAllAnnotationsOf(emptySet()) shouldBeEqualTo false
             hasAnnotationOf(SampleAnnotation::class) shouldBeEqualTo false
+            hasAnnotationOf(listOf(SampleAnnotation::class)) shouldBeEqualTo false
+            hasAnnotationOf(setOf(SampleAnnotation::class)) shouldBeEqualTo false
             hasAllAnnotationsOf(SampleAnnotation1::class, SampleAnnotation2::class) shouldBeEqualTo false
+            hasAllAnnotationsOf(listOf(SampleAnnotation1::class, SampleAnnotation2::class)) shouldBeEqualTo false
+            hasAllAnnotationsOf(setOf(SampleAnnotation1::class, SampleAnnotation2::class)) shouldBeEqualTo false
             hasAnnotations("SampleAnnotation") shouldBeEqualTo false
         }
     }
@@ -48,6 +64,10 @@ class KoPropertyDeclarationForKoAnnotationProviderTest {
             countAnnotations { it.name == "SampleAnnotation" } shouldBeEqualTo 1
             countAnnotations { it.name == "NonExistingAnnotation" } shouldBeEqualTo 0
             hasAnnotations() shouldBeEqualTo true
+            hasAnnotationWithName(emptyList()) shouldBeEqualTo true
+            hasAnnotationWithName(emptySet()) shouldBeEqualTo true
+            hasAnnotationsWithAllNames(emptyList()) shouldBeEqualTo true
+            hasAnnotationsWithAllNames(emptySet()) shouldBeEqualTo true
             hasAnnotationWithName("SampleAnnotation") shouldBeEqualTo true
             hasAnnotationWithName("OtherAnnotation") shouldBeEqualTo false
             hasAnnotationWithName("SampleAnnotation", "OtherAnnotation") shouldBeEqualTo true
@@ -57,6 +77,24 @@ class KoPropertyDeclarationForKoAnnotationProviderTest {
                 "com.lemonappdev.konsist.testdata.SampleAnnotation",
                 "com.lemonappdev.konsist.testdata.NonExistingAnnotation",
             ).shouldBeEqualTo(true)
+            hasAnnotationWithName(listOf("SampleAnnotation")) shouldBeEqualTo true
+            hasAnnotationWithName(listOf("OtherAnnotation")) shouldBeEqualTo false
+            hasAnnotationWithName(listOf("SampleAnnotation", "OtherAnnotation")) shouldBeEqualTo true
+            hasAnnotationWithName(listOf("com.lemonappdev.konsist.testdata.SampleAnnotation")) shouldBeEqualTo true
+            hasAnnotationWithName(listOf("com.lemonappdev.konsist.testdata.NonExistingAnnotation")) shouldBeEqualTo false
+            hasAnnotationWithName(listOf(
+                "com.lemonappdev.konsist.testdata.SampleAnnotation",
+                "com.lemonappdev.konsist.testdata.NonExistingAnnotation",
+            )).shouldBeEqualTo(true)
+            hasAnnotationWithName(setOf("SampleAnnotation")) shouldBeEqualTo true
+            hasAnnotationWithName(setOf("OtherAnnotation")) shouldBeEqualTo false
+            hasAnnotationWithName(setOf("SampleAnnotation", "OtherAnnotation")) shouldBeEqualTo true
+            hasAnnotationWithName(setOf("com.lemonappdev.konsist.testdata.SampleAnnotation")) shouldBeEqualTo true
+            hasAnnotationWithName(setOf("com.lemonappdev.konsist.testdata.NonExistingAnnotation")) shouldBeEqualTo false
+            hasAnnotationWithName(setOf(
+                "com.lemonappdev.konsist.testdata.SampleAnnotation",
+                "com.lemonappdev.konsist.testdata.NonExistingAnnotation",
+            )).shouldBeEqualTo(true)
             hasAnnotationsWithAllNames("SampleAnnotation") shouldBeEqualTo true
             hasAnnotationsWithAllNames("SampleAnnotation", "OtherAnnotation") shouldBeEqualTo false
             hasAnnotationsWithAllNames("com.lemonappdev.konsist.testdata.SampleAnnotation") shouldBeEqualTo true
@@ -64,15 +102,35 @@ class KoPropertyDeclarationForKoAnnotationProviderTest {
                 "com.lemonappdev.konsist.testdata.SampleAnnotation",
                 "com.lemonappdev.konsist.testdata.NonExistingAnnotation",
             ).shouldBeEqualTo(false)
+            hasAnnotationsWithAllNames(listOf("SampleAnnotation")) shouldBeEqualTo true
+            hasAnnotationsWithAllNames(listOf("SampleAnnotation", "OtherAnnotation")) shouldBeEqualTo false
+            hasAnnotationsWithAllNames(listOf("com.lemonappdev.konsist.testdata.SampleAnnotation")) shouldBeEqualTo true
+            hasAnnotationsWithAllNames(listOf(
+                "com.lemonappdev.konsist.testdata.SampleAnnotation",
+                "com.lemonappdev.konsist.testdata.NonExistingAnnotation",
+            )).shouldBeEqualTo(false)
             hasAnnotation { it.hasNameStartingWith("Sample") } shouldBeEqualTo true
             hasAnnotation { it.hasNameStartingWith("Other") } shouldBeEqualTo false
             hasAllAnnotations { it.hasNameStartingWith("Sample") } shouldBeEqualTo true
-            hasAnnotationOf(SampleAnnotation::class) shouldBeEqualTo true
-            hasAnnotationOf(NonExistingAnnotation::class) shouldBeEqualTo false
-            hasAnnotationOf(SampleAnnotation::class, NonExistingAnnotation::class) shouldBeEqualTo true
+            hasAnnotationOf(emptyList()) shouldBeEqualTo true
+            hasAnnotationOf(emptySet()) shouldBeEqualTo true
+            hasAllAnnotationsOf(emptyList()) shouldBeEqualTo true
+            hasAllAnnotationsOf(emptySet()) shouldBeEqualTo true
+            hasAnnotationOf(listOf(SampleAnnotation::class)) shouldBeEqualTo true
+            hasAnnotationOf(listOf(NonExistingAnnotation::class)) shouldBeEqualTo false
+            hasAnnotationOf(listOf(SampleAnnotation::class, NonExistingAnnotation::class)) shouldBeEqualTo true
+            hasAnnotationOf(setOf(SampleAnnotation::class)) shouldBeEqualTo true
+            hasAnnotationOf(setOf(NonExistingAnnotation::class)) shouldBeEqualTo false
+            hasAnnotationOf(setOf(SampleAnnotation::class, NonExistingAnnotation::class)) shouldBeEqualTo true
             hasAllAnnotationsOf(SampleAnnotation::class) shouldBeEqualTo true
             hasAllAnnotationsOf(NonExistingAnnotation::class) shouldBeEqualTo false
             hasAllAnnotationsOf(SampleAnnotation::class, NonExistingAnnotation::class) shouldBeEqualTo false
+            hasAllAnnotationsOf(listOf(SampleAnnotation::class)) shouldBeEqualTo true
+            hasAllAnnotationsOf(listOf(NonExistingAnnotation::class)) shouldBeEqualTo false
+            hasAllAnnotationsOf(listOf(SampleAnnotation::class, NonExistingAnnotation::class)) shouldBeEqualTo false
+            hasAllAnnotationsOf(setOf(SampleAnnotation::class)) shouldBeEqualTo true
+            hasAllAnnotationsOf(setOf(NonExistingAnnotation::class)) shouldBeEqualTo false
+            hasAllAnnotationsOf(setOf(SampleAnnotation::class, NonExistingAnnotation::class)) shouldBeEqualTo false
             hasAnnotations("SampleAnnotation") shouldBeEqualTo true
             hasAnnotations("NonExistingAnnotation") shouldBeEqualTo false
             hasAnnotations("com.lemonappdev.konsist.testdata.SampleAnnotation") shouldBeEqualTo true
@@ -96,6 +154,10 @@ class KoPropertyDeclarationForKoAnnotationProviderTest {
             countAnnotations { it.hasNameStartingWith("Sample") } shouldBeEqualTo 2
             countAnnotations { it.name == "SampleAnnotation1" } shouldBeEqualTo 1
             hasAnnotations() shouldBeEqualTo true
+            hasAnnotationOf(emptyList()) shouldBeEqualTo true
+            hasAnnotationOf(emptySet()) shouldBeEqualTo true
+            hasAllAnnotationsOf(emptyList()) shouldBeEqualTo true
+            hasAllAnnotationsOf(emptySet()) shouldBeEqualTo true
             hasAnnotationWithName("SampleAnnotation1") shouldBeEqualTo true
             hasAnnotationWithName("OtherAnnotation") shouldBeEqualTo false
             hasAnnotationWithName("SampleAnnotation1", "OtherAnnotation") shouldBeEqualTo true
@@ -105,6 +167,24 @@ class KoPropertyDeclarationForKoAnnotationProviderTest {
                 "com.lemonappdev.konsist.testdata.SampleAnnotation1",
                 "com.lemonappdev.konsist.testdata.NonExistingAnnotation",
             ).shouldBeEqualTo(true)
+            hasAnnotationWithName(listOf("SampleAnnotation1")) shouldBeEqualTo true
+            hasAnnotationWithName(listOf("OtherAnnotation")) shouldBeEqualTo false
+            hasAnnotationWithName(listOf("SampleAnnotation1", "OtherAnnotation")) shouldBeEqualTo true
+            hasAnnotationWithName(listOf("com.lemonappdev.konsist.testdata.SampleAnnotation1")) shouldBeEqualTo true
+            hasAnnotationWithName(listOf("com.lemonappdev.konsist.testdata.NonExistingAnnotation")) shouldBeEqualTo false
+            hasAnnotationWithName(listOf(
+                "com.lemonappdev.konsist.testdata.SampleAnnotation1",
+                "com.lemonappdev.konsist.testdata.NonExistingAnnotation",
+            )).shouldBeEqualTo(true)
+            hasAnnotationWithName(setOf("SampleAnnotation1")) shouldBeEqualTo true
+            hasAnnotationWithName(setOf("OtherAnnotation")) shouldBeEqualTo false
+            hasAnnotationWithName(setOf("SampleAnnotation1", "OtherAnnotation")) shouldBeEqualTo true
+            hasAnnotationWithName(setOf("com.lemonappdev.konsist.testdata.SampleAnnotation1")) shouldBeEqualTo true
+            hasAnnotationWithName(setOf("com.lemonappdev.konsist.testdata.NonExistingAnnotation")) shouldBeEqualTo false
+            hasAnnotationWithName(setOf(
+                "com.lemonappdev.konsist.testdata.SampleAnnotation1",
+                "com.lemonappdev.konsist.testdata.NonExistingAnnotation",
+            )).shouldBeEqualTo(true)
             hasAnnotationsWithAllNames("SampleAnnotation1") shouldBeEqualTo true
             hasAnnotationsWithAllNames("SampleAnnotation1", "SampleAnnotation2") shouldBeEqualTo true
             hasAnnotationsWithAllNames("SampleAnnotation1", "OtherAnnotation") shouldBeEqualTo false
@@ -117,17 +197,48 @@ class KoPropertyDeclarationForKoAnnotationProviderTest {
                 "com.lemonappdev.konsist.testdata.SampleAnnotation1",
                 "com.lemonappdev.konsist.testdata.SampleAnnotation2",
             ).shouldBeEqualTo(true)
+
+            hasAnnotationsWithAllNames(listOf("SampleAnnotation1")) shouldBeEqualTo true
+            hasAnnotationsWithAllNames(listOf("SampleAnnotation1", "SampleAnnotation2")) shouldBeEqualTo true
+            hasAnnotationsWithAllNames(listOf("SampleAnnotation1", "OtherAnnotation")) shouldBeEqualTo false
+            hasAnnotationsWithAllNames(listOf("com.lemonappdev.konsist.testdata.SampleAnnotation1")) shouldBeEqualTo true
+            hasAnnotationsWithAllNames(listOf(
+                "com.lemonappdev.konsist.testdata.SampleAnnotation1",
+                "com.lemonappdev.konsist.testdata.NonExistingAnnotation",
+            )).shouldBeEqualTo(false)
+            hasAnnotationsWithAllNames(listOf(
+                "com.lemonappdev.konsist.testdata.SampleAnnotation1",
+                "com.lemonappdev.konsist.testdata.SampleAnnotation2",
+            )).shouldBeEqualTo(true)
             hasAnnotation { it.name == "SampleAnnotation1" } shouldBeEqualTo true
             hasAnnotation { it.name == "OtherAnnotation1" } shouldBeEqualTo false
             hasAllAnnotations { !it.hasArguments() } shouldBeEqualTo true
             hasAllAnnotations { it.hasNameEndingWith("tion1") } shouldBeEqualTo false
+            hasAnnotationOf(emptyList()) shouldBeEqualTo true
+            hasAnnotationOf(emptySet()) shouldBeEqualTo true
+            hasAllAnnotationsOf(emptyList()) shouldBeEqualTo true
+            hasAllAnnotationsOf(emptySet()) shouldBeEqualTo true
             hasAnnotationOf(SampleAnnotation1::class) shouldBeEqualTo true
             hasAnnotationOf(NonExistingAnnotation::class) shouldBeEqualTo false
             hasAnnotationOf(SampleAnnotation1::class, NonExistingAnnotation::class) shouldBeEqualTo true
+            hasAnnotationOf(listOf(SampleAnnotation1::class)) shouldBeEqualTo true
+            hasAnnotationOf(listOf(NonExistingAnnotation::class)) shouldBeEqualTo false
+            hasAnnotationOf(listOf(SampleAnnotation1::class, NonExistingAnnotation::class)) shouldBeEqualTo true
+            hasAnnotationOf(setOf(SampleAnnotation1::class)) shouldBeEqualTo true
+            hasAnnotationOf(setOf(NonExistingAnnotation::class)) shouldBeEqualTo false
+            hasAnnotationOf(setOf(SampleAnnotation1::class, NonExistingAnnotation::class)) shouldBeEqualTo true
             hasAllAnnotationsOf(SampleAnnotation1::class) shouldBeEqualTo true
             hasAllAnnotationsOf(NonExistingAnnotation::class) shouldBeEqualTo false
             hasAllAnnotationsOf(SampleAnnotation1::class, SampleAnnotation2::class) shouldBeEqualTo true
             hasAllAnnotationsOf(SampleAnnotation1::class, NonExistingAnnotation::class) shouldBeEqualTo false
+            hasAllAnnotationsOf(listOf(SampleAnnotation1::class)) shouldBeEqualTo true
+            hasAllAnnotationsOf(listOf(NonExistingAnnotation::class)) shouldBeEqualTo false
+            hasAllAnnotationsOf(listOf(SampleAnnotation1::class, SampleAnnotation2::class)) shouldBeEqualTo true
+            hasAllAnnotationsOf(listOf(SampleAnnotation1::class, NonExistingAnnotation::class)) shouldBeEqualTo false
+            hasAllAnnotationsOf(setOf(SampleAnnotation1::class)) shouldBeEqualTo true
+            hasAllAnnotationsOf(setOf(NonExistingAnnotation::class)) shouldBeEqualTo false
+            hasAllAnnotationsOf(setOf(SampleAnnotation1::class, SampleAnnotation2::class)) shouldBeEqualTo true
+            hasAllAnnotationsOf(setOf(SampleAnnotation1::class, NonExistingAnnotation::class)) shouldBeEqualTo false
             hasAnnotations("SampleAnnotation1") shouldBeEqualTo true
             hasAnnotations("SampleAnnotation2") shouldBeEqualTo true
             hasAnnotations("NonExistingAnnotation") shouldBeEqualTo false

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koproperty/forkomodifier/KoPropertyDeclarationForKoModifierProviderTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koproperty/forkomodifier/KoPropertyDeclarationForKoModifierProviderTest.kt
@@ -27,10 +27,22 @@ class KoPropertyDeclarationForKoModifierProviderTest {
             modifiers shouldBeEqualTo emptyList()
             numModifiers shouldBeEqualTo 0
             hasModifiers() shouldBeEqualTo false
+            hasModifier(emptyList()) shouldBeEqualTo false
+            hasModifier(emptySet()) shouldBeEqualTo false
+            hasAllModifiers(emptyList()) shouldBeEqualTo false
+            hasAllModifiers(emptySet()) shouldBeEqualTo false
             hasModifier(OPEN) shouldBeEqualTo false
             hasModifier(OPEN, DATA) shouldBeEqualTo false
+            hasModifier(listOf(OPEN)) shouldBeEqualTo false
+            hasModifier(listOf(OPEN, DATA)) shouldBeEqualTo false
+            hasModifier(setOf(OPEN)) shouldBeEqualTo false
+            hasModifier(setOf(OPEN, DATA)) shouldBeEqualTo false
             hasAllModifiers(OPEN) shouldBeEqualTo false
             hasAllModifiers(OPEN, DATA) shouldBeEqualTo false
+            hasAllModifiers(listOf(OPEN)) shouldBeEqualTo false
+            hasAllModifiers(listOf(OPEN, DATA)) shouldBeEqualTo false
+            hasAllModifiers(setOf(OPEN)) shouldBeEqualTo false
+            hasAllModifiers(setOf(OPEN, DATA)) shouldBeEqualTo false
             hasModifiers(OPEN) shouldBeEqualTo false
             hasModifiers(OPEN, DATA) shouldBeEqualTo false
         }
@@ -48,13 +60,31 @@ class KoPropertyDeclarationForKoModifierProviderTest {
         assertSoftly(sut) {
             numModifiers shouldBeEqualTo 2
             hasModifiers() shouldBeEqualTo true
+            hasModifier(emptyList()) shouldBeEqualTo true
+            hasModifier(emptySet()) shouldBeEqualTo true
+            hasAllModifiers(emptyList()) shouldBeEqualTo true
+            hasAllModifiers(emptySet()) shouldBeEqualTo true
             hasModifier(OPEN) shouldBeEqualTo true
             hasModifier(DATA) shouldBeEqualTo false
             hasModifier(OPEN, DATA) shouldBeEqualTo true
+            hasModifier(listOf(OPEN)) shouldBeEqualTo true
+            hasModifier(listOf(DATA)) shouldBeEqualTo false
+            hasModifier(listOf(OPEN, DATA)) shouldBeEqualTo true
+            hasModifier(setOf(OPEN)) shouldBeEqualTo true
+            hasModifier(setOf(DATA)) shouldBeEqualTo false
+            hasModifier(setOf(OPEN, DATA)) shouldBeEqualTo true
             hasAllModifiers(OPEN) shouldBeEqualTo true
             hasAllModifiers(DATA) shouldBeEqualTo false
             hasAllModifiers(OPEN, DATA) shouldBeEqualTo false
             hasAllModifiers(OPEN, PROTECTED) shouldBeEqualTo true
+            hasAllModifiers(listOf(OPEN)) shouldBeEqualTo true
+            hasAllModifiers(listOf(DATA)) shouldBeEqualTo false
+            hasAllModifiers(listOf(OPEN, DATA)) shouldBeEqualTo false
+            hasAllModifiers(listOf(OPEN, PROTECTED)) shouldBeEqualTo true
+            hasAllModifiers(setOf(OPEN)) shouldBeEqualTo true
+            hasAllModifiers(setOf(DATA)) shouldBeEqualTo false
+            hasAllModifiers(setOf(OPEN, DATA)) shouldBeEqualTo false
+            hasAllModifiers(setOf(OPEN, PROTECTED)) shouldBeEqualTo true
             hasModifiers(PROTECTED) shouldBeEqualTo true
             hasModifiers(OPEN) shouldBeEqualTo true
             hasModifiers(FINAL) shouldBeEqualTo false

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/kosetter/KoSetterDeclarationForKoLocalClassProviderTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/kosetter/KoSetterDeclarationForKoLocalClassProviderTest.kt
@@ -49,7 +49,7 @@ class KoSetterDeclarationForKoLocalClassProviderTest {
         // then
         assertSoftly(sut) {
             it?.localClasses?.map { localClass -> localClass.name } shouldBeEqualTo
-                    it?.localClasses?.map { it.name } shouldBeEqualTo listOf("SampleClass1", "SampleClass2")
+                it?.localClasses?.map { it.name } shouldBeEqualTo listOf("SampleClass1", "SampleClass2")
             it?.numLocalClasses shouldBeEqualTo 2
             it?.countLocalClasses { it.name == "SampleClass1" } shouldBeEqualTo 1
             it?.hasLocalClasses() shouldBeEqualTo true

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/kosetter/KoSetterDeclarationForKoLocalClassProviderTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/kosetter/KoSetterDeclarationForKoLocalClassProviderTest.kt
@@ -19,12 +19,21 @@ class KoSetterDeclarationForKoLocalClassProviderTest {
         assertSoftly(sut) {
             it?.localClasses shouldBeEqualTo emptyList()
             it?.numLocalClasses shouldBeEqualTo 0
-            it?.countLocalClasses { localClass -> localClass.name == "SampleClass" } shouldBeEqualTo 0
+            it?.countLocalClasses { it.name == "SampleClass" } shouldBeEqualTo 0
             it?.hasLocalClasses() shouldBeEqualTo false
+            it?.hasLocalClassWithName(emptyList()) shouldBeEqualTo false
+            it?.hasLocalClassWithName(emptySet()) shouldBeEqualTo false
+            it?.hasLocalClassesWithAllNames(emptyList()) shouldBeEqualTo false
+            it?.hasLocalClassesWithAllNames(emptySet()) shouldBeEqualTo false
             it?.hasLocalClassWithName("SampleClass") shouldBeEqualTo false
+            it?.hasLocalClassWithName(listOf("SampleClass")) shouldBeEqualTo false
+            it?.hasLocalClassWithName(setOf("SampleClass")) shouldBeEqualTo false
             it?.hasLocalClassesWithAllNames("SampleClass1", "SampleClass2") shouldBeEqualTo false
-            it?.hasLocalClass { localClass -> localClass.name == "SampleClass" } shouldBeEqualTo false
-            it?.hasAllLocalClasses { localClass -> localClass.name == "SampleClass" } shouldBeEqualTo true
+            it?.hasLocalClassesWithAllNames(listOf("SampleClass1", "SampleClass2")) shouldBeEqualTo false
+            it?.hasLocalClassesWithAllNames(setOf("SampleClass1", "SampleClass2")) shouldBeEqualTo false
+            it?.hasLocalClass { it.name == "SampleClass" } shouldBeEqualTo false
+            it?.hasAllLocalClasses { it.name == "SampleClass" } shouldBeEqualTo true
+            it?.containsLocalClass { it.name == "SampleClass" } shouldBeEqualTo false
         }
     }
 
@@ -40,25 +49,38 @@ class KoSetterDeclarationForKoLocalClassProviderTest {
         // then
         assertSoftly(sut) {
             it?.localClasses?.map { localClass -> localClass.name } shouldBeEqualTo
-                listOf(
-                    "SampleClass1",
-                    "SampleClass2",
-                )
+                    it?.localClasses?.map { it.name } shouldBeEqualTo listOf("SampleClass1", "SampleClass2")
             it?.numLocalClasses shouldBeEqualTo 2
-            it?.countLocalClasses { localClass -> localClass.name == "SampleClass1" } shouldBeEqualTo 1
+            it?.countLocalClasses { it.name == "SampleClass1" } shouldBeEqualTo 1
             it?.hasLocalClasses() shouldBeEqualTo true
+            it?.hasLocalClassWithName(emptyList()) shouldBeEqualTo true
+            it?.hasLocalClassWithName(emptySet()) shouldBeEqualTo true
+            it?.hasLocalClassesWithAllNames(emptyList()) shouldBeEqualTo true
+            it?.hasLocalClassesWithAllNames(emptySet()) shouldBeEqualTo true
             it?.hasLocalClassWithName("SampleClass1") shouldBeEqualTo true
-            it?.hasLocalClassWithName("OtherClass") shouldBeEqualTo false
-            it?.hasLocalClassWithName("SampleClass1", "OtherClass") shouldBeEqualTo true
+            it?.hasLocalClassWithName("OtherLocalClass") shouldBeEqualTo false
+            it?.hasLocalClassWithName("SampleClass1", "OtherLocalClass") shouldBeEqualTo true
+            it?.hasLocalClassWithName(listOf("SampleClass1")) shouldBeEqualTo true
+            it?.hasLocalClassWithName(listOf("OtherLocalClass")) shouldBeEqualTo false
+            it?.hasLocalClassWithName(listOf("SampleClass1", "OtherLocalClass")) shouldBeEqualTo true
+            it?.hasLocalClassWithName(setOf("SampleClass1")) shouldBeEqualTo true
+            it?.hasLocalClassWithName(setOf("OtherLocalClass")) shouldBeEqualTo false
+            it?.hasLocalClassWithName(setOf("SampleClass1", "OtherLocalClass")) shouldBeEqualTo true
             it?.hasLocalClassesWithAllNames("SampleClass1") shouldBeEqualTo true
             it?.hasLocalClassesWithAllNames("SampleClass1", "SampleClass2") shouldBeEqualTo true
-            it?.hasLocalClassesWithAllNames("SampleClass1", "OtherClass") shouldBeEqualTo false
-            it?.hasLocalClass { localClass -> localClass.name == "SampleClass1" } shouldBeEqualTo true
-            it?.hasLocalClass { localClass -> localClass.name == "OtherClass" } shouldBeEqualTo false
-            it?.hasAllLocalClasses { localClass ->
-                localClass.name.endsWith("2") || localClass.name == "SampleClass1"
-            }.shouldBeEqualTo(true)
-            it?.hasAllLocalClasses { localClass -> localClass.name.endsWith("2") } shouldBeEqualTo false
+            it?.hasLocalClassesWithAllNames("SampleClass1", "OtherLocalClass") shouldBeEqualTo false
+            it?.hasLocalClassesWithAllNames(listOf("SampleClass1")) shouldBeEqualTo true
+            it?.hasLocalClassesWithAllNames(listOf("SampleClass1", "SampleClass2")) shouldBeEqualTo true
+            it?.hasLocalClassesWithAllNames(listOf("SampleClass1", "OtherLocalClass")) shouldBeEqualTo false
+            it?.hasLocalClassesWithAllNames(setOf("SampleClass1")) shouldBeEqualTo true
+            it?.hasLocalClassesWithAllNames(setOf("SampleClass1", "SampleClass2")) shouldBeEqualTo true
+            it?.hasLocalClassesWithAllNames(setOf("SampleClass1", "OtherLocalClass")) shouldBeEqualTo false
+            it?.hasLocalClass { it.name == "SampleClass1" } shouldBeEqualTo true
+            it?.hasLocalClass { it.name == "OtherLocalClass" } shouldBeEqualTo false
+            it?.hasAllLocalClasses { it.name.endsWith("2") || it.name == "SampleClass1" } shouldBeEqualTo true
+            it?.hasAllLocalClasses { it.name.endsWith("2") } shouldBeEqualTo false
+            it?.containsLocalClass { it.name == "SampleClass1" } shouldBeEqualTo true
+            it?.containsLocalClass { it.name == "OtherLocalClass" } shouldBeEqualTo false
         }
     }
 

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/kosetter/KoSetterDeclarationForKoLocalFunctionProviderTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/kosetter/KoSetterDeclarationForKoLocalFunctionProviderTest.kt
@@ -19,12 +19,21 @@ class KoSetterDeclarationForKoLocalFunctionProviderTest {
         assertSoftly(sut) {
             it?.localFunctions shouldBeEqualTo emptyList()
             it?.numLocalFunctions shouldBeEqualTo 0
-            it?.countLocalFunctions { function -> function.name == "sampleLocalFunction" } shouldBeEqualTo 0
+            it?.countLocalFunctions { it.name == "sampleLocalFunction" } shouldBeEqualTo 0
             it?.hasLocalFunctions() shouldBeEqualTo false
+            it?.hasLocalFunctionWithName(emptyList()) shouldBeEqualTo false
+            it?.hasLocalFunctionWithName(emptySet()) shouldBeEqualTo false
+            it?.hasLocalFunctionsWithAllNames(emptyList()) shouldBeEqualTo false
+            it?.hasLocalFunctionsWithAllNames(emptySet()) shouldBeEqualTo false
             it?.hasLocalFunctionWithName("sampleLocalFunction") shouldBeEqualTo false
+            it?.hasLocalFunctionWithName(listOf("sampleLocalFunction")) shouldBeEqualTo false
+            it?.hasLocalFunctionWithName(setOf("sampleLocalFunction")) shouldBeEqualTo false
             it?.hasLocalFunctionsWithAllNames("sampleLocalFunction1", "sampleLocalFunction2") shouldBeEqualTo false
-            it?.hasLocalFunction { function -> function.name == "sampleLocalFunction" } shouldBeEqualTo false
-            it?.hasAllLocalFunctions { function -> function.name == "sampleLocalFunction" } shouldBeEqualTo true
+            it?.hasLocalFunctionsWithAllNames(listOf("sampleLocalFunction1", "sampleLocalFunction2")) shouldBeEqualTo false
+            it?.hasLocalFunctionsWithAllNames(setOf("sampleLocalFunction1", "sampleLocalFunction2")) shouldBeEqualTo false
+            it?.hasLocalFunction { it.name == "sampleLocalFunction" } shouldBeEqualTo false
+            it?.hasAllLocalFunctions { it.name == "sampleLocalFunction" } shouldBeEqualTo true
+            it?.containsLocalFunction { it.name == "sampleLocalFunction" } shouldBeEqualTo false
         }
     }
 
@@ -40,21 +49,39 @@ class KoSetterDeclarationForKoLocalFunctionProviderTest {
         // then
         assertSoftly(sut) {
             it?.numLocalFunctions shouldBeEqualTo 2
-            it?.countLocalFunctions { function -> function.name == "sampleLocalFunction1" } shouldBeEqualTo 1
+            it?.countLocalFunctions { it.name == "sampleLocalFunction1" } shouldBeEqualTo 1
             it?.hasLocalFunctions() shouldBeEqualTo true
+            it?.hasLocalFunctionWithName(emptyList()) shouldBeEqualTo true
+            it?.hasLocalFunctionWithName(emptySet()) shouldBeEqualTo true
+            it?.hasLocalFunctionsWithAllNames(emptyList()) shouldBeEqualTo true
+            it?.hasLocalFunctionsWithAllNames(emptySet()) shouldBeEqualTo true
             it?.hasLocalFunctionWithName("sampleLocalFunction1") shouldBeEqualTo true
             it?.hasLocalFunctionWithName("otherLocalFunction") shouldBeEqualTo false
             it?.hasLocalFunctionWithName("sampleLocalFunction1", "otherLocalFunction") shouldBeEqualTo true
+            it?.hasLocalFunctionWithName(listOf("sampleLocalFunction1")) shouldBeEqualTo true
+            it?.hasLocalFunctionWithName(listOf("otherLocalFunction")) shouldBeEqualTo false
+            it?.hasLocalFunctionWithName(listOf("sampleLocalFunction1", "otherLocalFunction")) shouldBeEqualTo true
+            it?.hasLocalFunctionWithName(setOf("sampleLocalFunction1")) shouldBeEqualTo true
+            it?.hasLocalFunctionWithName(setOf("otherLocalFunction")) shouldBeEqualTo false
+            it?.hasLocalFunctionWithName(setOf("sampleLocalFunction1", "otherLocalFunction")) shouldBeEqualTo true
             it?.hasLocalFunctionsWithAllNames("sampleLocalFunction1") shouldBeEqualTo true
             it?.hasLocalFunctionsWithAllNames("sampleLocalFunction1", "sampleLocalFunction2") shouldBeEqualTo true
             it?.hasLocalFunctionsWithAllNames("sampleLocalFunction1", "otherLocalFunction") shouldBeEqualTo false
-            it?.hasLocalFunction { function -> function.name == "sampleLocalFunction1" } shouldBeEqualTo true
-            it?.hasLocalFunction { function -> function.name == "otherLocalFunction" } shouldBeEqualTo false
-            it?.hasAllLocalFunctions { function,
-                ->
-                function.name.endsWith("2") || function.name == "sampleLocalFunction1"
-            }.shouldBeEqualTo(true)
-            it?.hasAllLocalFunctions { function -> function.name.endsWith("2") } shouldBeEqualTo false
+            it?.hasLocalFunctionsWithAllNames(listOf("sampleLocalFunction1")) shouldBeEqualTo true
+            it?.hasLocalFunctionsWithAllNames(listOf("sampleLocalFunction1", "sampleLocalFunction2")) shouldBeEqualTo true
+            it?.hasLocalFunctionsWithAllNames(listOf("sampleLocalFunction1", "otherLocalFunction")) shouldBeEqualTo false
+            it?.hasLocalFunctionsWithAllNames(setOf("sampleLocalFunction1")) shouldBeEqualTo true
+            it?.hasLocalFunctionsWithAllNames(setOf("sampleLocalFunction1", "sampleLocalFunction2")) shouldBeEqualTo true
+            it?.hasLocalFunctionsWithAllNames(setOf("sampleLocalFunction1", "otherLocalFunction")) shouldBeEqualTo false
+            it?.hasLocalFunction { it.name == "sampleLocalFunction1" } shouldBeEqualTo true
+            it?.hasLocalFunction { it.name == "otherLocalFunction" } shouldBeEqualTo false
+            it?.hasAllLocalFunctions { it.name.endsWith("2") || it.name == "sampleLocalFunction1" } shouldBeEqualTo true
+            it?.hasAllLocalFunctions { it.name.endsWith("2") } shouldBeEqualTo false
+            it?.containsLocalFunction { it.name == "sampleLocalFunction1" } shouldBeEqualTo true
+            it?.containsLocalFunction { it.name == "otherLocalFunction1" } shouldBeEqualTo false
+            it?.localFunctions
+                ?.map { it.name }
+                .shouldBeEqualTo(listOf("sampleLocalFunction1", "sampleLocalFunction2"))
         }
     }
 

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/kosetter/KoSetterDeclarationForKoVariableProviderTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/kosetter/KoSetterDeclarationForKoVariableProviderTest.kt
@@ -22,8 +22,16 @@ class KoSetterDeclarationForKoVariableProviderTest {
             numVariables shouldBeEqualTo 0
             countVariables { it.name == "sampleVariable" } shouldBeEqualTo 0
             hasVariables() shouldBeEqualTo false
+            hasVariableWithName(emptyList()) shouldBeEqualTo false
+            hasVariableWithName(emptySet()) shouldBeEqualTo false
+            hasVariablesWithAllNames(emptyList()) shouldBeEqualTo false
+            hasVariablesWithAllNames(emptySet()) shouldBeEqualTo false
             hasVariableWithName("sampleVariable") shouldBeEqualTo false
+            hasVariableWithName(listOf("sampleVariable")) shouldBeEqualTo false
+            hasVariableWithName(setOf("sampleVariable")) shouldBeEqualTo false
             hasVariablesWithAllNames("sampleVariable1", "sampleVariable2") shouldBeEqualTo false
+            hasVariablesWithAllNames(listOf("sampleVariable1", "sampleVariable2")) shouldBeEqualTo false
+            hasVariablesWithAllNames(setOf("sampleVariable1", "sampleVariable2")) shouldBeEqualTo false
             hasVariable { it.name == "sampleVariable" } shouldBeEqualTo false
             hasAllVariables { it.name == "sampleVariable" } shouldBeEqualTo true
         }
@@ -43,12 +51,28 @@ class KoSetterDeclarationForKoVariableProviderTest {
             numVariables shouldBeEqualTo 2
             countVariables { it.name == "sampleVariable1" } shouldBeEqualTo 1
             hasVariables() shouldBeEqualTo true
+            hasVariableWithName(emptyList()) shouldBeEqualTo true
+            hasVariableWithName(emptySet()) shouldBeEqualTo true
+            hasVariablesWithAllNames(emptyList()) shouldBeEqualTo true
+            hasVariablesWithAllNames(emptySet()) shouldBeEqualTo true
             hasVariableWithName("sampleVariable1") shouldBeEqualTo true
             hasVariableWithName("otherVariable") shouldBeEqualTo false
             hasVariableWithName("sampleVariable1", "otherVariable") shouldBeEqualTo true
+            hasVariableWithName(listOf("sampleVariable1")) shouldBeEqualTo true
+            hasVariableWithName(listOf("otherVariable")) shouldBeEqualTo false
+            hasVariableWithName(listOf("sampleVariable1", "otherVariable")) shouldBeEqualTo true
+            hasVariableWithName(setOf("sampleVariable1")) shouldBeEqualTo true
+            hasVariableWithName(setOf("otherVariable")) shouldBeEqualTo false
+            hasVariableWithName(setOf("sampleVariable1", "otherVariable")) shouldBeEqualTo true
             hasVariablesWithAllNames("sampleVariable1") shouldBeEqualTo true
             hasVariablesWithAllNames("sampleVariable1", "sampleVariable2") shouldBeEqualTo true
             hasVariablesWithAllNames("sampleVariable1", "otherVariable") shouldBeEqualTo false
+            hasVariablesWithAllNames(listOf("sampleVariable1")) shouldBeEqualTo true
+            hasVariablesWithAllNames(listOf("sampleVariable1", "sampleVariable2")) shouldBeEqualTo true
+            hasVariablesWithAllNames(listOf("sampleVariable1", "otherVariable")) shouldBeEqualTo false
+            hasVariablesWithAllNames(setOf("sampleVariable1")) shouldBeEqualTo true
+            hasVariablesWithAllNames(setOf("sampleVariable1", "sampleVariable2")) shouldBeEqualTo true
+            hasVariablesWithAllNames(setOf("sampleVariable1", "otherVariable")) shouldBeEqualTo false
             hasVariable { it.name == "sampleVariable1" } shouldBeEqualTo true
             hasVariable { it.name == "otherVariable" } shouldBeEqualTo false
             hasAllVariables { it.name.endsWith("2") || it.name == "sampleVariable1" } shouldBeEqualTo true

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/kosetter/forkomodifier/KoSetterDeclarationForKoModifierProviderTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/kosetter/forkomodifier/KoSetterDeclarationForKoModifierProviderTest.kt
@@ -7,7 +7,6 @@ import com.lemonappdev.konsist.api.KoModifier.PRIVATE
 import com.lemonappdev.konsist.api.KoModifier.PROTECTED
 import org.amshove.kluent.assertSoftly
 import org.amshove.kluent.shouldBeEqualTo
-import org.amshove.kluent.shouldNotBeEqualTo
 import org.junit.jupiter.api.Test
 
 class KoSetterDeclarationForKoModifierProviderTest {

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/kosetter/forkomodifier/KoSetterDeclarationForKoModifierProviderTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/kosetter/forkomodifier/KoSetterDeclarationForKoModifierProviderTest.kt
@@ -1,8 +1,10 @@
 package com.lemonappdev.konsist.core.declaration.kosetter.forkomodifier
 
 import com.lemonappdev.konsist.TestSnippetProvider
+import com.lemonappdev.konsist.api.KoModifier
 import com.lemonappdev.konsist.api.KoModifier.DATA
 import com.lemonappdev.konsist.api.KoModifier.PRIVATE
+import com.lemonappdev.konsist.api.KoModifier.PROTECTED
 import org.amshove.kluent.assertSoftly
 import org.amshove.kluent.shouldBeEqualTo
 import org.amshove.kluent.shouldNotBeEqualTo
@@ -23,9 +25,24 @@ class KoSetterDeclarationForKoModifierProviderTest {
             it?.modifiers shouldBeEqualTo emptyList()
             it?.numModifiers shouldBeEqualTo 0
             it?.hasModifiers() shouldBeEqualTo false
-            it?.hasModifier(PRIVATE) shouldBeEqualTo false
-            it?.hasAllModifiers(PRIVATE) shouldBeEqualTo false
-            it?.hasAllModifiers(PRIVATE, DATA) shouldBeEqualTo false
+            it?.hasModifier(emptyList()) shouldBeEqualTo false
+            it?.hasModifier(emptySet()) shouldBeEqualTo false
+            it?.hasAllModifiers(emptyList()) shouldBeEqualTo false
+            it?.hasAllModifiers(emptySet()) shouldBeEqualTo false
+            it?.hasModifier(KoModifier.OPEN) shouldBeEqualTo false
+            it?.hasModifier(KoModifier.OPEN, DATA) shouldBeEqualTo false
+            it?.hasModifier(listOf(KoModifier.OPEN)) shouldBeEqualTo false
+            it?.hasModifier(listOf(KoModifier.OPEN, DATA)) shouldBeEqualTo false
+            it?.hasModifier(setOf(KoModifier.OPEN)) shouldBeEqualTo false
+            it?.hasModifier(setOf(KoModifier.OPEN, DATA)) shouldBeEqualTo false
+            it?.hasAllModifiers(KoModifier.OPEN) shouldBeEqualTo false
+            it?.hasAllModifiers(KoModifier.OPEN, DATA) shouldBeEqualTo false
+            it?.hasAllModifiers(listOf(KoModifier.OPEN)) shouldBeEqualTo false
+            it?.hasAllModifiers(listOf(KoModifier.OPEN, DATA)) shouldBeEqualTo false
+            it?.hasAllModifiers(setOf(KoModifier.OPEN)) shouldBeEqualTo false
+            it?.hasAllModifiers(setOf(KoModifier.OPEN, DATA)) shouldBeEqualTo false
+            it?.hasModifiers(KoModifier.OPEN) shouldBeEqualTo false
+            it?.hasModifiers(KoModifier.OPEN, DATA) shouldBeEqualTo false
         }
     }
 
@@ -40,15 +57,31 @@ class KoSetterDeclarationForKoModifierProviderTest {
 
         // then
         assertSoftly(sut) {
-            it?.modifiers shouldNotBeEqualTo emptyList()
+            it?.modifiers shouldBeEqualTo listOf(PRIVATE)
             it?.numModifiers shouldBeEqualTo 1
             it?.hasModifiers() shouldBeEqualTo true
+            it?.hasModifier(emptyList()) shouldBeEqualTo true
+            it?.hasModifier(emptySet()) shouldBeEqualTo true
+            it?.hasAllModifiers(emptyList()) shouldBeEqualTo true
+            it?.hasAllModifiers(emptySet()) shouldBeEqualTo true
             it?.hasModifier(PRIVATE) shouldBeEqualTo true
-            it?.hasModifier(DATA) shouldBeEqualTo false
+            it?.hasModifier(PROTECTED) shouldBeEqualTo false
             it?.hasModifier(PRIVATE, DATA) shouldBeEqualTo true
+            it?.hasModifier(listOf(PRIVATE)) shouldBeEqualTo true
+            it?.hasModifier(listOf(PROTECTED)) shouldBeEqualTo false
+            it?.hasModifier(listOf(PRIVATE, DATA)) shouldBeEqualTo true
+            it?.hasModifier(setOf(PRIVATE)) shouldBeEqualTo true
+            it?.hasModifier(setOf(PROTECTED)) shouldBeEqualTo false
+            it?.hasModifier(setOf(PRIVATE, DATA)) shouldBeEqualTo true
             it?.hasAllModifiers(PRIVATE) shouldBeEqualTo true
-            it?.hasAllModifiers(DATA) shouldBeEqualTo false
+            it?.hasAllModifiers(PROTECTED) shouldBeEqualTo false
             it?.hasAllModifiers(PRIVATE, DATA) shouldBeEqualTo false
+            it?.hasAllModifiers(listOf(PRIVATE)) shouldBeEqualTo true
+            it?.hasAllModifiers(listOf(PROTECTED)) shouldBeEqualTo false
+            it?.hasAllModifiers(listOf(PRIVATE, DATA)) shouldBeEqualTo false
+            it?.hasAllModifiers(setOf(PRIVATE)) shouldBeEqualTo true
+            it?.hasAllModifiers(setOf(PROTECTED)) shouldBeEqualTo false
+            it?.hasAllModifiers(setOf(PRIVATE, DATA)) shouldBeEqualTo false
         }
     }
 

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/kotypealias/KoTypeAliasDeclarationForKoAnnotationProviderTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/kotypealias/KoTypeAliasDeclarationForKoAnnotationProviderTest.kt
@@ -9,6 +9,7 @@ import org.amshove.kluent.assertSoftly
 import org.amshove.kluent.shouldBeEqualTo
 import org.junit.jupiter.api.Test
 
+@Suppress("detekt.LongMethod")
 class KoTypeAliasDeclarationForKoAnnotationProviderTest {
     @Test
     fun `typealias-has-no-annotation`() {
@@ -82,19 +83,23 @@ class KoTypeAliasDeclarationForKoAnnotationProviderTest {
             hasAnnotationWithName(listOf("SampleAnnotation", "OtherAnnotation")) shouldBeEqualTo true
             hasAnnotationWithName(listOf("com.lemonappdev.konsist.testdata.SampleAnnotation")) shouldBeEqualTo true
             hasAnnotationWithName(listOf("com.lemonappdev.konsist.testdata.NonExistingAnnotation")) shouldBeEqualTo false
-            hasAnnotationWithName(listOf(
-                "com.lemonappdev.konsist.testdata.SampleAnnotation",
-                "com.lemonappdev.konsist.testdata.NonExistingAnnotation",
-            )).shouldBeEqualTo(true)
+            hasAnnotationWithName(
+                listOf(
+                    "com.lemonappdev.konsist.testdata.SampleAnnotation",
+                    "com.lemonappdev.konsist.testdata.NonExistingAnnotation",
+                ),
+            ).shouldBeEqualTo(true)
             hasAnnotationWithName(setOf("SampleAnnotation")) shouldBeEqualTo true
             hasAnnotationWithName(setOf("OtherAnnotation")) shouldBeEqualTo false
             hasAnnotationWithName(setOf("SampleAnnotation", "OtherAnnotation")) shouldBeEqualTo true
             hasAnnotationWithName(setOf("com.lemonappdev.konsist.testdata.SampleAnnotation")) shouldBeEqualTo true
             hasAnnotationWithName(setOf("com.lemonappdev.konsist.testdata.NonExistingAnnotation")) shouldBeEqualTo false
-            hasAnnotationWithName(setOf(
-                "com.lemonappdev.konsist.testdata.SampleAnnotation",
-                "com.lemonappdev.konsist.testdata.NonExistingAnnotation",
-            )).shouldBeEqualTo(true)
+            hasAnnotationWithName(
+                setOf(
+                    "com.lemonappdev.konsist.testdata.SampleAnnotation",
+                    "com.lemonappdev.konsist.testdata.NonExistingAnnotation",
+                ),
+            ).shouldBeEqualTo(true)
             hasAnnotationsWithAllNames("SampleAnnotation") shouldBeEqualTo true
             hasAnnotationsWithAllNames("SampleAnnotation", "OtherAnnotation") shouldBeEqualTo false
             hasAnnotationsWithAllNames("com.lemonappdev.konsist.testdata.SampleAnnotation") shouldBeEqualTo true
@@ -105,10 +110,12 @@ class KoTypeAliasDeclarationForKoAnnotationProviderTest {
             hasAnnotationsWithAllNames(listOf("SampleAnnotation")) shouldBeEqualTo true
             hasAnnotationsWithAllNames(listOf("SampleAnnotation", "OtherAnnotation")) shouldBeEqualTo false
             hasAnnotationsWithAllNames(listOf("com.lemonappdev.konsist.testdata.SampleAnnotation")) shouldBeEqualTo true
-            hasAnnotationsWithAllNames(listOf(
-                "com.lemonappdev.konsist.testdata.SampleAnnotation",
-                "com.lemonappdev.konsist.testdata.NonExistingAnnotation",
-            )).shouldBeEqualTo(false)
+            hasAnnotationsWithAllNames(
+                listOf(
+                    "com.lemonappdev.konsist.testdata.SampleAnnotation",
+                    "com.lemonappdev.konsist.testdata.NonExistingAnnotation",
+                ),
+            ).shouldBeEqualTo(false)
             hasAnnotation { it.hasNameStartingWith("Sample") } shouldBeEqualTo true
             hasAnnotation { it.hasNameStartingWith("Other") } shouldBeEqualTo false
             hasAllAnnotations { it.hasNameStartingWith("Sample") } shouldBeEqualTo true
@@ -172,19 +179,23 @@ class KoTypeAliasDeclarationForKoAnnotationProviderTest {
             hasAnnotationWithName(listOf("SampleAnnotation1", "OtherAnnotation")) shouldBeEqualTo true
             hasAnnotationWithName(listOf("com.lemonappdev.konsist.testdata.SampleAnnotation1")) shouldBeEqualTo true
             hasAnnotationWithName(listOf("com.lemonappdev.konsist.testdata.NonExistingAnnotation")) shouldBeEqualTo false
-            hasAnnotationWithName(listOf(
-                "com.lemonappdev.konsist.testdata.SampleAnnotation1",
-                "com.lemonappdev.konsist.testdata.NonExistingAnnotation",
-            )).shouldBeEqualTo(true)
+            hasAnnotationWithName(
+                listOf(
+                    "com.lemonappdev.konsist.testdata.SampleAnnotation1",
+                    "com.lemonappdev.konsist.testdata.NonExistingAnnotation",
+                ),
+            ).shouldBeEqualTo(true)
             hasAnnotationWithName(setOf("SampleAnnotation1")) shouldBeEqualTo true
             hasAnnotationWithName(setOf("OtherAnnotation")) shouldBeEqualTo false
             hasAnnotationWithName(setOf("SampleAnnotation1", "OtherAnnotation")) shouldBeEqualTo true
             hasAnnotationWithName(setOf("com.lemonappdev.konsist.testdata.SampleAnnotation1")) shouldBeEqualTo true
             hasAnnotationWithName(setOf("com.lemonappdev.konsist.testdata.NonExistingAnnotation")) shouldBeEqualTo false
-            hasAnnotationWithName(setOf(
-                "com.lemonappdev.konsist.testdata.SampleAnnotation1",
-                "com.lemonappdev.konsist.testdata.NonExistingAnnotation",
-            )).shouldBeEqualTo(true)
+            hasAnnotationWithName(
+                setOf(
+                    "com.lemonappdev.konsist.testdata.SampleAnnotation1",
+                    "com.lemonappdev.konsist.testdata.NonExistingAnnotation",
+                ),
+            ).shouldBeEqualTo(true)
             hasAnnotationsWithAllNames("SampleAnnotation1") shouldBeEqualTo true
             hasAnnotationsWithAllNames("SampleAnnotation1", "SampleAnnotation2") shouldBeEqualTo true
             hasAnnotationsWithAllNames("SampleAnnotation1", "OtherAnnotation") shouldBeEqualTo false
@@ -202,14 +213,18 @@ class KoTypeAliasDeclarationForKoAnnotationProviderTest {
             hasAnnotationsWithAllNames(listOf("SampleAnnotation1", "SampleAnnotation2")) shouldBeEqualTo true
             hasAnnotationsWithAllNames(listOf("SampleAnnotation1", "OtherAnnotation")) shouldBeEqualTo false
             hasAnnotationsWithAllNames(listOf("com.lemonappdev.konsist.testdata.SampleAnnotation1")) shouldBeEqualTo true
-            hasAnnotationsWithAllNames(listOf(
-                "com.lemonappdev.konsist.testdata.SampleAnnotation1",
-                "com.lemonappdev.konsist.testdata.NonExistingAnnotation",
-            )).shouldBeEqualTo(false)
-            hasAnnotationsWithAllNames(listOf(
-                "com.lemonappdev.konsist.testdata.SampleAnnotation1",
-                "com.lemonappdev.konsist.testdata.SampleAnnotation2",
-            )).shouldBeEqualTo(true)
+            hasAnnotationsWithAllNames(
+                listOf(
+                    "com.lemonappdev.konsist.testdata.SampleAnnotation1",
+                    "com.lemonappdev.konsist.testdata.NonExistingAnnotation",
+                ),
+            ).shouldBeEqualTo(false)
+            hasAnnotationsWithAllNames(
+                listOf(
+                    "com.lemonappdev.konsist.testdata.SampleAnnotation1",
+                    "com.lemonappdev.konsist.testdata.SampleAnnotation2",
+                ),
+            ).shouldBeEqualTo(true)
             hasAnnotation { it.name == "SampleAnnotation1" } shouldBeEqualTo true
             hasAnnotation { it.name == "OtherAnnotation1" } shouldBeEqualTo false
             hasAllAnnotations { !it.hasArguments() } shouldBeEqualTo true

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/kotypealias/KoTypeAliasDeclarationForKoAnnotationProviderTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/kotypealias/KoTypeAliasDeclarationForKoAnnotationProviderTest.kt
@@ -24,12 +24,28 @@ class KoTypeAliasDeclarationForKoAnnotationProviderTest {
             numAnnotations shouldBeEqualTo 0
             countAnnotations { it.name == "NonExistingAnnotation" } shouldBeEqualTo 0
             hasAnnotations() shouldBeEqualTo false
+            hasAnnotationWithName(emptyList()) shouldBeEqualTo false
+            hasAnnotationWithName(emptySet()) shouldBeEqualTo false
+            hasAnnotationsWithAllNames(emptyList()) shouldBeEqualTo false
+            hasAnnotationsWithAllNames(emptySet()) shouldBeEqualTo false
             hasAnnotationWithName("SampleAnnotation") shouldBeEqualTo false
+            hasAnnotationWithName(listOf("SampleAnnotation")) shouldBeEqualTo false
+            hasAnnotationWithName(setOf("SampleAnnotation")) shouldBeEqualTo false
             hasAnnotationsWithAllNames("SampleAnnotation1", "SampleAnnotation2") shouldBeEqualTo false
+            hasAnnotationsWithAllNames(listOf("SampleAnnotation1", "SampleAnnotation2")) shouldBeEqualTo false
+            hasAnnotationsWithAllNames(setOf("SampleAnnotation1", "SampleAnnotation2")) shouldBeEqualTo false
             hasAnnotation { it.hasArguments() } shouldBeEqualTo false
             hasAllAnnotations { it.hasArguments() } shouldBeEqualTo true
+            hasAnnotationOf(emptyList()) shouldBeEqualTo false
+            hasAnnotationOf(emptySet()) shouldBeEqualTo false
+            hasAllAnnotationsOf(emptyList()) shouldBeEqualTo false
+            hasAllAnnotationsOf(emptySet()) shouldBeEqualTo false
             hasAnnotationOf(SampleAnnotation::class) shouldBeEqualTo false
+            hasAnnotationOf(listOf(SampleAnnotation::class)) shouldBeEqualTo false
+            hasAnnotationOf(setOf(SampleAnnotation::class)) shouldBeEqualTo false
             hasAllAnnotationsOf(SampleAnnotation1::class, SampleAnnotation2::class) shouldBeEqualTo false
+            hasAllAnnotationsOf(listOf(SampleAnnotation1::class, SampleAnnotation2::class)) shouldBeEqualTo false
+            hasAllAnnotationsOf(setOf(SampleAnnotation1::class, SampleAnnotation2::class)) shouldBeEqualTo false
             hasAnnotations("SampleAnnotation") shouldBeEqualTo false
         }
     }
@@ -48,6 +64,10 @@ class KoTypeAliasDeclarationForKoAnnotationProviderTest {
             countAnnotations { it.name == "SampleAnnotation" } shouldBeEqualTo 1
             countAnnotations { it.name == "NonExistingAnnotation" } shouldBeEqualTo 0
             hasAnnotations() shouldBeEqualTo true
+            hasAnnotationWithName(emptyList()) shouldBeEqualTo true
+            hasAnnotationWithName(emptySet()) shouldBeEqualTo true
+            hasAnnotationsWithAllNames(emptyList()) shouldBeEqualTo true
+            hasAnnotationsWithAllNames(emptySet()) shouldBeEqualTo true
             hasAnnotationWithName("SampleAnnotation") shouldBeEqualTo true
             hasAnnotationWithName("OtherAnnotation") shouldBeEqualTo false
             hasAnnotationWithName("SampleAnnotation", "OtherAnnotation") shouldBeEqualTo true
@@ -57,6 +77,24 @@ class KoTypeAliasDeclarationForKoAnnotationProviderTest {
                 "com.lemonappdev.konsist.testdata.SampleAnnotation",
                 "com.lemonappdev.konsist.testdata.NonExistingAnnotation",
             ).shouldBeEqualTo(true)
+            hasAnnotationWithName(listOf("SampleAnnotation")) shouldBeEqualTo true
+            hasAnnotationWithName(listOf("OtherAnnotation")) shouldBeEqualTo false
+            hasAnnotationWithName(listOf("SampleAnnotation", "OtherAnnotation")) shouldBeEqualTo true
+            hasAnnotationWithName(listOf("com.lemonappdev.konsist.testdata.SampleAnnotation")) shouldBeEqualTo true
+            hasAnnotationWithName(listOf("com.lemonappdev.konsist.testdata.NonExistingAnnotation")) shouldBeEqualTo false
+            hasAnnotationWithName(listOf(
+                "com.lemonappdev.konsist.testdata.SampleAnnotation",
+                "com.lemonappdev.konsist.testdata.NonExistingAnnotation",
+            )).shouldBeEqualTo(true)
+            hasAnnotationWithName(setOf("SampleAnnotation")) shouldBeEqualTo true
+            hasAnnotationWithName(setOf("OtherAnnotation")) shouldBeEqualTo false
+            hasAnnotationWithName(setOf("SampleAnnotation", "OtherAnnotation")) shouldBeEqualTo true
+            hasAnnotationWithName(setOf("com.lemonappdev.konsist.testdata.SampleAnnotation")) shouldBeEqualTo true
+            hasAnnotationWithName(setOf("com.lemonappdev.konsist.testdata.NonExistingAnnotation")) shouldBeEqualTo false
+            hasAnnotationWithName(setOf(
+                "com.lemonappdev.konsist.testdata.SampleAnnotation",
+                "com.lemonappdev.konsist.testdata.NonExistingAnnotation",
+            )).shouldBeEqualTo(true)
             hasAnnotationsWithAllNames("SampleAnnotation") shouldBeEqualTo true
             hasAnnotationsWithAllNames("SampleAnnotation", "OtherAnnotation") shouldBeEqualTo false
             hasAnnotationsWithAllNames("com.lemonappdev.konsist.testdata.SampleAnnotation") shouldBeEqualTo true
@@ -64,15 +102,35 @@ class KoTypeAliasDeclarationForKoAnnotationProviderTest {
                 "com.lemonappdev.konsist.testdata.SampleAnnotation",
                 "com.lemonappdev.konsist.testdata.NonExistingAnnotation",
             ).shouldBeEqualTo(false)
+            hasAnnotationsWithAllNames(listOf("SampleAnnotation")) shouldBeEqualTo true
+            hasAnnotationsWithAllNames(listOf("SampleAnnotation", "OtherAnnotation")) shouldBeEqualTo false
+            hasAnnotationsWithAllNames(listOf("com.lemonappdev.konsist.testdata.SampleAnnotation")) shouldBeEqualTo true
+            hasAnnotationsWithAllNames(listOf(
+                "com.lemonappdev.konsist.testdata.SampleAnnotation",
+                "com.lemonappdev.konsist.testdata.NonExistingAnnotation",
+            )).shouldBeEqualTo(false)
             hasAnnotation { it.hasNameStartingWith("Sample") } shouldBeEqualTo true
             hasAnnotation { it.hasNameStartingWith("Other") } shouldBeEqualTo false
             hasAllAnnotations { it.hasNameStartingWith("Sample") } shouldBeEqualTo true
-            hasAnnotationOf(SampleAnnotation::class) shouldBeEqualTo true
-            hasAnnotationOf(NonExistingAnnotation::class) shouldBeEqualTo false
-            hasAnnotationOf(SampleAnnotation::class, NonExistingAnnotation::class) shouldBeEqualTo true
+            hasAnnotationOf(emptyList()) shouldBeEqualTo true
+            hasAnnotationOf(emptySet()) shouldBeEqualTo true
+            hasAllAnnotationsOf(emptyList()) shouldBeEqualTo true
+            hasAllAnnotationsOf(emptySet()) shouldBeEqualTo true
+            hasAnnotationOf(listOf(SampleAnnotation::class)) shouldBeEqualTo true
+            hasAnnotationOf(listOf(NonExistingAnnotation::class)) shouldBeEqualTo false
+            hasAnnotationOf(listOf(SampleAnnotation::class, NonExistingAnnotation::class)) shouldBeEqualTo true
+            hasAnnotationOf(setOf(SampleAnnotation::class)) shouldBeEqualTo true
+            hasAnnotationOf(setOf(NonExistingAnnotation::class)) shouldBeEqualTo false
+            hasAnnotationOf(setOf(SampleAnnotation::class, NonExistingAnnotation::class)) shouldBeEqualTo true
             hasAllAnnotationsOf(SampleAnnotation::class) shouldBeEqualTo true
             hasAllAnnotationsOf(NonExistingAnnotation::class) shouldBeEqualTo false
             hasAllAnnotationsOf(SampleAnnotation::class, NonExistingAnnotation::class) shouldBeEqualTo false
+            hasAllAnnotationsOf(listOf(SampleAnnotation::class)) shouldBeEqualTo true
+            hasAllAnnotationsOf(listOf(NonExistingAnnotation::class)) shouldBeEqualTo false
+            hasAllAnnotationsOf(listOf(SampleAnnotation::class, NonExistingAnnotation::class)) shouldBeEqualTo false
+            hasAllAnnotationsOf(setOf(SampleAnnotation::class)) shouldBeEqualTo true
+            hasAllAnnotationsOf(setOf(NonExistingAnnotation::class)) shouldBeEqualTo false
+            hasAllAnnotationsOf(setOf(SampleAnnotation::class, NonExistingAnnotation::class)) shouldBeEqualTo false
             hasAnnotations("SampleAnnotation") shouldBeEqualTo true
             hasAnnotations("NonExistingAnnotation") shouldBeEqualTo false
             hasAnnotations("com.lemonappdev.konsist.testdata.SampleAnnotation") shouldBeEqualTo true
@@ -96,6 +154,10 @@ class KoTypeAliasDeclarationForKoAnnotationProviderTest {
             countAnnotations { it.hasNameStartingWith("Sample") } shouldBeEqualTo 2
             countAnnotations { it.name == "SampleAnnotation1" } shouldBeEqualTo 1
             hasAnnotations() shouldBeEqualTo true
+            hasAnnotationOf(emptyList()) shouldBeEqualTo true
+            hasAnnotationOf(emptySet()) shouldBeEqualTo true
+            hasAllAnnotationsOf(emptyList()) shouldBeEqualTo true
+            hasAllAnnotationsOf(emptySet()) shouldBeEqualTo true
             hasAnnotationWithName("SampleAnnotation1") shouldBeEqualTo true
             hasAnnotationWithName("OtherAnnotation") shouldBeEqualTo false
             hasAnnotationWithName("SampleAnnotation1", "OtherAnnotation") shouldBeEqualTo true
@@ -105,6 +167,24 @@ class KoTypeAliasDeclarationForKoAnnotationProviderTest {
                 "com.lemonappdev.konsist.testdata.SampleAnnotation1",
                 "com.lemonappdev.konsist.testdata.NonExistingAnnotation",
             ).shouldBeEqualTo(true)
+            hasAnnotationWithName(listOf("SampleAnnotation1")) shouldBeEqualTo true
+            hasAnnotationWithName(listOf("OtherAnnotation")) shouldBeEqualTo false
+            hasAnnotationWithName(listOf("SampleAnnotation1", "OtherAnnotation")) shouldBeEqualTo true
+            hasAnnotationWithName(listOf("com.lemonappdev.konsist.testdata.SampleAnnotation1")) shouldBeEqualTo true
+            hasAnnotationWithName(listOf("com.lemonappdev.konsist.testdata.NonExistingAnnotation")) shouldBeEqualTo false
+            hasAnnotationWithName(listOf(
+                "com.lemonappdev.konsist.testdata.SampleAnnotation1",
+                "com.lemonappdev.konsist.testdata.NonExistingAnnotation",
+            )).shouldBeEqualTo(true)
+            hasAnnotationWithName(setOf("SampleAnnotation1")) shouldBeEqualTo true
+            hasAnnotationWithName(setOf("OtherAnnotation")) shouldBeEqualTo false
+            hasAnnotationWithName(setOf("SampleAnnotation1", "OtherAnnotation")) shouldBeEqualTo true
+            hasAnnotationWithName(setOf("com.lemonappdev.konsist.testdata.SampleAnnotation1")) shouldBeEqualTo true
+            hasAnnotationWithName(setOf("com.lemonappdev.konsist.testdata.NonExistingAnnotation")) shouldBeEqualTo false
+            hasAnnotationWithName(setOf(
+                "com.lemonappdev.konsist.testdata.SampleAnnotation1",
+                "com.lemonappdev.konsist.testdata.NonExistingAnnotation",
+            )).shouldBeEqualTo(true)
             hasAnnotationsWithAllNames("SampleAnnotation1") shouldBeEqualTo true
             hasAnnotationsWithAllNames("SampleAnnotation1", "SampleAnnotation2") shouldBeEqualTo true
             hasAnnotationsWithAllNames("SampleAnnotation1", "OtherAnnotation") shouldBeEqualTo false
@@ -117,17 +197,48 @@ class KoTypeAliasDeclarationForKoAnnotationProviderTest {
                 "com.lemonappdev.konsist.testdata.SampleAnnotation1",
                 "com.lemonappdev.konsist.testdata.SampleAnnotation2",
             ).shouldBeEqualTo(true)
+
+            hasAnnotationsWithAllNames(listOf("SampleAnnotation1")) shouldBeEqualTo true
+            hasAnnotationsWithAllNames(listOf("SampleAnnotation1", "SampleAnnotation2")) shouldBeEqualTo true
+            hasAnnotationsWithAllNames(listOf("SampleAnnotation1", "OtherAnnotation")) shouldBeEqualTo false
+            hasAnnotationsWithAllNames(listOf("com.lemonappdev.konsist.testdata.SampleAnnotation1")) shouldBeEqualTo true
+            hasAnnotationsWithAllNames(listOf(
+                "com.lemonappdev.konsist.testdata.SampleAnnotation1",
+                "com.lemonappdev.konsist.testdata.NonExistingAnnotation",
+            )).shouldBeEqualTo(false)
+            hasAnnotationsWithAllNames(listOf(
+                "com.lemonappdev.konsist.testdata.SampleAnnotation1",
+                "com.lemonappdev.konsist.testdata.SampleAnnotation2",
+            )).shouldBeEqualTo(true)
             hasAnnotation { it.name == "SampleAnnotation1" } shouldBeEqualTo true
             hasAnnotation { it.name == "OtherAnnotation1" } shouldBeEqualTo false
             hasAllAnnotations { !it.hasArguments() } shouldBeEqualTo true
             hasAllAnnotations { it.hasNameEndingWith("tion1") } shouldBeEqualTo false
+            hasAnnotationOf(emptyList()) shouldBeEqualTo true
+            hasAnnotationOf(emptySet()) shouldBeEqualTo true
+            hasAllAnnotationsOf(emptyList()) shouldBeEqualTo true
+            hasAllAnnotationsOf(emptySet()) shouldBeEqualTo true
             hasAnnotationOf(SampleAnnotation1::class) shouldBeEqualTo true
             hasAnnotationOf(NonExistingAnnotation::class) shouldBeEqualTo false
             hasAnnotationOf(SampleAnnotation1::class, NonExistingAnnotation::class) shouldBeEqualTo true
+            hasAnnotationOf(listOf(SampleAnnotation1::class)) shouldBeEqualTo true
+            hasAnnotationOf(listOf(NonExistingAnnotation::class)) shouldBeEqualTo false
+            hasAnnotationOf(listOf(SampleAnnotation1::class, NonExistingAnnotation::class)) shouldBeEqualTo true
+            hasAnnotationOf(setOf(SampleAnnotation1::class)) shouldBeEqualTo true
+            hasAnnotationOf(setOf(NonExistingAnnotation::class)) shouldBeEqualTo false
+            hasAnnotationOf(setOf(SampleAnnotation1::class, NonExistingAnnotation::class)) shouldBeEqualTo true
             hasAllAnnotationsOf(SampleAnnotation1::class) shouldBeEqualTo true
             hasAllAnnotationsOf(NonExistingAnnotation::class) shouldBeEqualTo false
             hasAllAnnotationsOf(SampleAnnotation1::class, SampleAnnotation2::class) shouldBeEqualTo true
             hasAllAnnotationsOf(SampleAnnotation1::class, NonExistingAnnotation::class) shouldBeEqualTo false
+            hasAllAnnotationsOf(listOf(SampleAnnotation1::class)) shouldBeEqualTo true
+            hasAllAnnotationsOf(listOf(NonExistingAnnotation::class)) shouldBeEqualTo false
+            hasAllAnnotationsOf(listOf(SampleAnnotation1::class, SampleAnnotation2::class)) shouldBeEqualTo true
+            hasAllAnnotationsOf(listOf(SampleAnnotation1::class, NonExistingAnnotation::class)) shouldBeEqualTo false
+            hasAllAnnotationsOf(setOf(SampleAnnotation1::class)) shouldBeEqualTo true
+            hasAllAnnotationsOf(setOf(NonExistingAnnotation::class)) shouldBeEqualTo false
+            hasAllAnnotationsOf(setOf(SampleAnnotation1::class, SampleAnnotation2::class)) shouldBeEqualTo true
+            hasAllAnnotationsOf(setOf(SampleAnnotation1::class, NonExistingAnnotation::class)) shouldBeEqualTo false
             hasAnnotations("SampleAnnotation1") shouldBeEqualTo true
             hasAnnotations("SampleAnnotation2") shouldBeEqualTo true
             hasAnnotations("NonExistingAnnotation") shouldBeEqualTo false

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/kotypealias/forkomodifier/KoTypeAliasDeclarationForKoModifierProviderTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/kotypealias/forkomodifier/KoTypeAliasDeclarationForKoModifierProviderTest.kt
@@ -26,10 +26,22 @@ class KoTypeAliasDeclarationForKoModifierProviderTest {
             modifiers shouldBeEqualTo emptyList()
             numModifiers shouldBeEqualTo 0
             hasModifiers() shouldBeEqualTo false
+            hasModifier(emptyList()) shouldBeEqualTo false
+            hasModifier(emptySet()) shouldBeEqualTo false
+            hasAllModifiers(emptyList()) shouldBeEqualTo false
+            hasAllModifiers(emptySet()) shouldBeEqualTo false
             hasModifier(OPEN) shouldBeEqualTo false
             hasModifier(OPEN, DATA) shouldBeEqualTo false
+            hasModifier(listOf(OPEN)) shouldBeEqualTo false
+            hasModifier(listOf(OPEN, DATA)) shouldBeEqualTo false
+            hasModifier(setOf(OPEN)) shouldBeEqualTo false
+            hasModifier(setOf(OPEN, DATA)) shouldBeEqualTo false
             hasAllModifiers(OPEN) shouldBeEqualTo false
             hasAllModifiers(OPEN, DATA) shouldBeEqualTo false
+            hasAllModifiers(listOf(OPEN)) shouldBeEqualTo false
+            hasAllModifiers(listOf(OPEN, DATA)) shouldBeEqualTo false
+            hasAllModifiers(setOf(OPEN)) shouldBeEqualTo false
+            hasAllModifiers(setOf(OPEN, DATA)) shouldBeEqualTo false
             hasModifiers(OPEN) shouldBeEqualTo false
             hasModifiers(OPEN, DATA) shouldBeEqualTo false
         }
@@ -48,12 +60,29 @@ class KoTypeAliasDeclarationForKoModifierProviderTest {
         assertSoftly(sut) {
             modifiers shouldBeEqualTo listOf(PRIVATE)
             numModifiers shouldBeEqualTo 1
+            hasModifiers() shouldBeEqualTo true
+            hasModifier(emptyList()) shouldBeEqualTo true
+            hasModifier(emptySet()) shouldBeEqualTo true
+            hasAllModifiers(emptyList()) shouldBeEqualTo true
+            hasAllModifiers(emptySet()) shouldBeEqualTo true
             hasModifier(PRIVATE) shouldBeEqualTo true
             hasModifier(PROTECTED) shouldBeEqualTo false
             hasModifier(PRIVATE, DATA) shouldBeEqualTo true
+            hasModifier(listOf(PRIVATE)) shouldBeEqualTo true
+            hasModifier(listOf(PROTECTED)) shouldBeEqualTo false
+            hasModifier(listOf(PRIVATE, DATA)) shouldBeEqualTo true
+            hasModifier(setOf(PRIVATE)) shouldBeEqualTo true
+            hasModifier(setOf(PROTECTED)) shouldBeEqualTo false
+            hasModifier(setOf(PRIVATE, DATA)) shouldBeEqualTo true
             hasAllModifiers(PRIVATE) shouldBeEqualTo true
             hasAllModifiers(PROTECTED) shouldBeEqualTo false
             hasAllModifiers(PRIVATE, DATA) shouldBeEqualTo false
+            hasAllModifiers(listOf(PRIVATE)) shouldBeEqualTo true
+            hasAllModifiers(listOf(PROTECTED)) shouldBeEqualTo false
+            hasAllModifiers(listOf(PRIVATE, DATA)) shouldBeEqualTo false
+            hasAllModifiers(setOf(PRIVATE)) shouldBeEqualTo true
+            hasAllModifiers(setOf(PROTECTED)) shouldBeEqualTo false
+            hasAllModifiers(setOf(PRIVATE, DATA)) shouldBeEqualTo false
         }
     }
 

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/kovariable/KoVariableDeclarationForKoAnnotationProviderTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/kovariable/KoVariableDeclarationForKoAnnotationProviderTest.kt
@@ -17,6 +17,7 @@ import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.Arguments.arguments
 import org.junit.jupiter.params.provider.MethodSource
 
+@Suppress("detekt.LongMethod")
 class KoVariableDeclarationForKoAnnotationProviderTest {
     @ParameterizedTest
     @MethodSource("provideValuesForNoAnnotation")
@@ -92,19 +93,23 @@ class KoVariableDeclarationForKoAnnotationProviderTest {
             hasAnnotationWithName(listOf("SampleAnnotation", "OtherAnnotation")) shouldBeEqualTo true
             hasAnnotationWithName(listOf("com.lemonappdev.konsist.testdata.SampleAnnotation")) shouldBeEqualTo true
             hasAnnotationWithName(listOf("com.lemonappdev.konsist.testdata.NonExistingAnnotation")) shouldBeEqualTo false
-            hasAnnotationWithName(listOf(
-                "com.lemonappdev.konsist.testdata.SampleAnnotation",
-                "com.lemonappdev.konsist.testdata.NonExistingAnnotation",
-            )).shouldBeEqualTo(true)
+            hasAnnotationWithName(
+                listOf(
+                    "com.lemonappdev.konsist.testdata.SampleAnnotation",
+                    "com.lemonappdev.konsist.testdata.NonExistingAnnotation",
+                ),
+            ).shouldBeEqualTo(true)
             hasAnnotationWithName(setOf("SampleAnnotation")) shouldBeEqualTo true
             hasAnnotationWithName(setOf("OtherAnnotation")) shouldBeEqualTo false
             hasAnnotationWithName(setOf("SampleAnnotation", "OtherAnnotation")) shouldBeEqualTo true
             hasAnnotationWithName(setOf("com.lemonappdev.konsist.testdata.SampleAnnotation")) shouldBeEqualTo true
             hasAnnotationWithName(setOf("com.lemonappdev.konsist.testdata.NonExistingAnnotation")) shouldBeEqualTo false
-            hasAnnotationWithName(setOf(
-                "com.lemonappdev.konsist.testdata.SampleAnnotation",
-                "com.lemonappdev.konsist.testdata.NonExistingAnnotation",
-            )).shouldBeEqualTo(true)
+            hasAnnotationWithName(
+                setOf(
+                    "com.lemonappdev.konsist.testdata.SampleAnnotation",
+                    "com.lemonappdev.konsist.testdata.NonExistingAnnotation",
+                ),
+            ).shouldBeEqualTo(true)
             hasAnnotationsWithAllNames("SampleAnnotation") shouldBeEqualTo true
             hasAnnotationsWithAllNames("SampleAnnotation", "OtherAnnotation") shouldBeEqualTo false
             hasAnnotationsWithAllNames("com.lemonappdev.konsist.testdata.SampleAnnotation") shouldBeEqualTo true
@@ -115,10 +120,12 @@ class KoVariableDeclarationForKoAnnotationProviderTest {
             hasAnnotationsWithAllNames(listOf("SampleAnnotation")) shouldBeEqualTo true
             hasAnnotationsWithAllNames(listOf("SampleAnnotation", "OtherAnnotation")) shouldBeEqualTo false
             hasAnnotationsWithAllNames(listOf("com.lemonappdev.konsist.testdata.SampleAnnotation")) shouldBeEqualTo true
-            hasAnnotationsWithAllNames(listOf(
-                "com.lemonappdev.konsist.testdata.SampleAnnotation",
-                "com.lemonappdev.konsist.testdata.NonExistingAnnotation",
-            )).shouldBeEqualTo(false)
+            hasAnnotationsWithAllNames(
+                listOf(
+                    "com.lemonappdev.konsist.testdata.SampleAnnotation",
+                    "com.lemonappdev.konsist.testdata.NonExistingAnnotation",
+                ),
+            ).shouldBeEqualTo(false)
             hasAnnotation { it.hasNameStartingWith("Sample") } shouldBeEqualTo true
             hasAnnotation { it.hasNameStartingWith("Other") } shouldBeEqualTo false
             hasAllAnnotations { it.hasNameStartingWith("Sample") } shouldBeEqualTo true
@@ -183,19 +190,23 @@ class KoVariableDeclarationForKoAnnotationProviderTest {
             hasAnnotationWithName(listOf("SampleAnnotation1", "OtherAnnotation")) shouldBeEqualTo true
             hasAnnotationWithName(listOf("com.lemonappdev.konsist.testdata.SampleAnnotation1")) shouldBeEqualTo true
             hasAnnotationWithName(listOf("com.lemonappdev.konsist.testdata.NonExistingAnnotation")) shouldBeEqualTo false
-            hasAnnotationWithName(listOf(
-                "com.lemonappdev.konsist.testdata.SampleAnnotation1",
-                "com.lemonappdev.konsist.testdata.NonExistingAnnotation",
-            )).shouldBeEqualTo(true)
+            hasAnnotationWithName(
+                listOf(
+                    "com.lemonappdev.konsist.testdata.SampleAnnotation1",
+                    "com.lemonappdev.konsist.testdata.NonExistingAnnotation",
+                ),
+            ).shouldBeEqualTo(true)
             hasAnnotationWithName(setOf("SampleAnnotation1")) shouldBeEqualTo true
             hasAnnotationWithName(setOf("OtherAnnotation")) shouldBeEqualTo false
             hasAnnotationWithName(setOf("SampleAnnotation1", "OtherAnnotation")) shouldBeEqualTo true
             hasAnnotationWithName(setOf("com.lemonappdev.konsist.testdata.SampleAnnotation1")) shouldBeEqualTo true
             hasAnnotationWithName(setOf("com.lemonappdev.konsist.testdata.NonExistingAnnotation")) shouldBeEqualTo false
-            hasAnnotationWithName(setOf(
-                "com.lemonappdev.konsist.testdata.SampleAnnotation1",
-                "com.lemonappdev.konsist.testdata.NonExistingAnnotation",
-            )).shouldBeEqualTo(true)
+            hasAnnotationWithName(
+                setOf(
+                    "com.lemonappdev.konsist.testdata.SampleAnnotation1",
+                    "com.lemonappdev.konsist.testdata.NonExistingAnnotation",
+                ),
+            ).shouldBeEqualTo(true)
             hasAnnotationsWithAllNames("SampleAnnotation1") shouldBeEqualTo true
             hasAnnotationsWithAllNames("SampleAnnotation1", "SampleAnnotation2") shouldBeEqualTo true
             hasAnnotationsWithAllNames("SampleAnnotation1", "OtherAnnotation") shouldBeEqualTo false
@@ -213,14 +224,18 @@ class KoVariableDeclarationForKoAnnotationProviderTest {
             hasAnnotationsWithAllNames(listOf("SampleAnnotation1", "SampleAnnotation2")) shouldBeEqualTo true
             hasAnnotationsWithAllNames(listOf("SampleAnnotation1", "OtherAnnotation")) shouldBeEqualTo false
             hasAnnotationsWithAllNames(listOf("com.lemonappdev.konsist.testdata.SampleAnnotation1")) shouldBeEqualTo true
-            hasAnnotationsWithAllNames(listOf(
-                "com.lemonappdev.konsist.testdata.SampleAnnotation1",
-                "com.lemonappdev.konsist.testdata.NonExistingAnnotation",
-            )).shouldBeEqualTo(false)
-            hasAnnotationsWithAllNames(listOf(
-                "com.lemonappdev.konsist.testdata.SampleAnnotation1",
-                "com.lemonappdev.konsist.testdata.SampleAnnotation2",
-            )).shouldBeEqualTo(true)
+            hasAnnotationsWithAllNames(
+                listOf(
+                    "com.lemonappdev.konsist.testdata.SampleAnnotation1",
+                    "com.lemonappdev.konsist.testdata.NonExistingAnnotation",
+                ),
+            ).shouldBeEqualTo(false)
+            hasAnnotationsWithAllNames(
+                listOf(
+                    "com.lemonappdev.konsist.testdata.SampleAnnotation1",
+                    "com.lemonappdev.konsist.testdata.SampleAnnotation2",
+                ),
+            ).shouldBeEqualTo(true)
             hasAnnotation { it.name == "SampleAnnotation1" } shouldBeEqualTo true
             hasAnnotation { it.name == "OtherAnnotation1" } shouldBeEqualTo false
             hasAllAnnotations { !it.hasArguments() } shouldBeEqualTo true

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/kovariable/KoVariableDeclarationForKoAnnotationProviderTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/kovariable/KoVariableDeclarationForKoAnnotationProviderTest.kt
@@ -33,12 +33,28 @@ class KoVariableDeclarationForKoAnnotationProviderTest {
             numAnnotations shouldBeEqualTo 0
             countAnnotations { it.name == "NonExistingAnnotation" } shouldBeEqualTo 0
             hasAnnotations() shouldBeEqualTo false
+            hasAnnotationWithName(emptyList()) shouldBeEqualTo false
+            hasAnnotationWithName(emptySet()) shouldBeEqualTo false
+            hasAnnotationsWithAllNames(emptyList()) shouldBeEqualTo false
+            hasAnnotationsWithAllNames(emptySet()) shouldBeEqualTo false
             hasAnnotationWithName("SampleAnnotation") shouldBeEqualTo false
+            hasAnnotationWithName(listOf("SampleAnnotation")) shouldBeEqualTo false
+            hasAnnotationWithName(setOf("SampleAnnotation")) shouldBeEqualTo false
             hasAnnotationsWithAllNames("SampleAnnotation1", "SampleAnnotation2") shouldBeEqualTo false
+            hasAnnotationsWithAllNames(listOf("SampleAnnotation1", "SampleAnnotation2")) shouldBeEqualTo false
+            hasAnnotationsWithAllNames(setOf("SampleAnnotation1", "SampleAnnotation2")) shouldBeEqualTo false
             hasAnnotation { it.hasArguments() } shouldBeEqualTo false
             hasAllAnnotations { it.hasArguments() } shouldBeEqualTo true
+            hasAnnotationOf(emptyList()) shouldBeEqualTo false
+            hasAnnotationOf(emptySet()) shouldBeEqualTo false
+            hasAllAnnotationsOf(emptyList()) shouldBeEqualTo false
+            hasAllAnnotationsOf(emptySet()) shouldBeEqualTo false
             hasAnnotationOf(SampleAnnotation::class) shouldBeEqualTo false
+            hasAnnotationOf(listOf(SampleAnnotation::class)) shouldBeEqualTo false
+            hasAnnotationOf(setOf(SampleAnnotation::class)) shouldBeEqualTo false
             hasAllAnnotationsOf(SampleAnnotation1::class, SampleAnnotation2::class) shouldBeEqualTo false
+            hasAllAnnotationsOf(listOf(SampleAnnotation1::class, SampleAnnotation2::class)) shouldBeEqualTo false
+            hasAllAnnotationsOf(setOf(SampleAnnotation1::class, SampleAnnotation2::class)) shouldBeEqualTo false
             hasAnnotations("SampleAnnotation") shouldBeEqualTo false
         }
     }
@@ -58,6 +74,10 @@ class KoVariableDeclarationForKoAnnotationProviderTest {
             countAnnotations { it.name == "SampleAnnotation" } shouldBeEqualTo 1
             countAnnotations { it.name == "NonExistingAnnotation" } shouldBeEqualTo 0
             hasAnnotations() shouldBeEqualTo true
+            hasAnnotationWithName(emptyList()) shouldBeEqualTo true
+            hasAnnotationWithName(emptySet()) shouldBeEqualTo true
+            hasAnnotationsWithAllNames(emptyList()) shouldBeEqualTo true
+            hasAnnotationsWithAllNames(emptySet()) shouldBeEqualTo true
             hasAnnotationWithName("SampleAnnotation") shouldBeEqualTo true
             hasAnnotationWithName("OtherAnnotation") shouldBeEqualTo false
             hasAnnotationWithName("SampleAnnotation", "OtherAnnotation") shouldBeEqualTo true
@@ -67,6 +87,24 @@ class KoVariableDeclarationForKoAnnotationProviderTest {
                 "com.lemonappdev.konsist.testdata.SampleAnnotation",
                 "com.lemonappdev.konsist.testdata.NonExistingAnnotation",
             ).shouldBeEqualTo(true)
+            hasAnnotationWithName(listOf("SampleAnnotation")) shouldBeEqualTo true
+            hasAnnotationWithName(listOf("OtherAnnotation")) shouldBeEqualTo false
+            hasAnnotationWithName(listOf("SampleAnnotation", "OtherAnnotation")) shouldBeEqualTo true
+            hasAnnotationWithName(listOf("com.lemonappdev.konsist.testdata.SampleAnnotation")) shouldBeEqualTo true
+            hasAnnotationWithName(listOf("com.lemonappdev.konsist.testdata.NonExistingAnnotation")) shouldBeEqualTo false
+            hasAnnotationWithName(listOf(
+                "com.lemonappdev.konsist.testdata.SampleAnnotation",
+                "com.lemonappdev.konsist.testdata.NonExistingAnnotation",
+            )).shouldBeEqualTo(true)
+            hasAnnotationWithName(setOf("SampleAnnotation")) shouldBeEqualTo true
+            hasAnnotationWithName(setOf("OtherAnnotation")) shouldBeEqualTo false
+            hasAnnotationWithName(setOf("SampleAnnotation", "OtherAnnotation")) shouldBeEqualTo true
+            hasAnnotationWithName(setOf("com.lemonappdev.konsist.testdata.SampleAnnotation")) shouldBeEqualTo true
+            hasAnnotationWithName(setOf("com.lemonappdev.konsist.testdata.NonExistingAnnotation")) shouldBeEqualTo false
+            hasAnnotationWithName(setOf(
+                "com.lemonappdev.konsist.testdata.SampleAnnotation",
+                "com.lemonappdev.konsist.testdata.NonExistingAnnotation",
+            )).shouldBeEqualTo(true)
             hasAnnotationsWithAllNames("SampleAnnotation") shouldBeEqualTo true
             hasAnnotationsWithAllNames("SampleAnnotation", "OtherAnnotation") shouldBeEqualTo false
             hasAnnotationsWithAllNames("com.lemonappdev.konsist.testdata.SampleAnnotation") shouldBeEqualTo true
@@ -74,15 +112,35 @@ class KoVariableDeclarationForKoAnnotationProviderTest {
                 "com.lemonappdev.konsist.testdata.SampleAnnotation",
                 "com.lemonappdev.konsist.testdata.NonExistingAnnotation",
             ).shouldBeEqualTo(false)
+            hasAnnotationsWithAllNames(listOf("SampleAnnotation")) shouldBeEqualTo true
+            hasAnnotationsWithAllNames(listOf("SampleAnnotation", "OtherAnnotation")) shouldBeEqualTo false
+            hasAnnotationsWithAllNames(listOf("com.lemonappdev.konsist.testdata.SampleAnnotation")) shouldBeEqualTo true
+            hasAnnotationsWithAllNames(listOf(
+                "com.lemonappdev.konsist.testdata.SampleAnnotation",
+                "com.lemonappdev.konsist.testdata.NonExistingAnnotation",
+            )).shouldBeEqualTo(false)
             hasAnnotation { it.hasNameStartingWith("Sample") } shouldBeEqualTo true
             hasAnnotation { it.hasNameStartingWith("Other") } shouldBeEqualTo false
             hasAllAnnotations { it.hasNameStartingWith("Sample") } shouldBeEqualTo true
-            hasAnnotationOf(SampleAnnotation::class) shouldBeEqualTo true
-            hasAnnotationOf(NonExistingAnnotation::class) shouldBeEqualTo false
-            hasAnnotationOf(SampleAnnotation::class, NonExistingAnnotation::class) shouldBeEqualTo true
+            hasAnnotationOf(emptyList()) shouldBeEqualTo true
+            hasAnnotationOf(emptySet()) shouldBeEqualTo true
+            hasAllAnnotationsOf(emptyList()) shouldBeEqualTo true
+            hasAllAnnotationsOf(emptySet()) shouldBeEqualTo true
+            hasAnnotationOf(listOf(SampleAnnotation::class)) shouldBeEqualTo true
+            hasAnnotationOf(listOf(NonExistingAnnotation::class)) shouldBeEqualTo false
+            hasAnnotationOf(listOf(SampleAnnotation::class, NonExistingAnnotation::class)) shouldBeEqualTo true
+            hasAnnotationOf(setOf(SampleAnnotation::class)) shouldBeEqualTo true
+            hasAnnotationOf(setOf(NonExistingAnnotation::class)) shouldBeEqualTo false
+            hasAnnotationOf(setOf(SampleAnnotation::class, NonExistingAnnotation::class)) shouldBeEqualTo true
             hasAllAnnotationsOf(SampleAnnotation::class) shouldBeEqualTo true
             hasAllAnnotationsOf(NonExistingAnnotation::class) shouldBeEqualTo false
             hasAllAnnotationsOf(SampleAnnotation::class, NonExistingAnnotation::class) shouldBeEqualTo false
+            hasAllAnnotationsOf(listOf(SampleAnnotation::class)) shouldBeEqualTo true
+            hasAllAnnotationsOf(listOf(NonExistingAnnotation::class)) shouldBeEqualTo false
+            hasAllAnnotationsOf(listOf(SampleAnnotation::class, NonExistingAnnotation::class)) shouldBeEqualTo false
+            hasAllAnnotationsOf(setOf(SampleAnnotation::class)) shouldBeEqualTo true
+            hasAllAnnotationsOf(setOf(NonExistingAnnotation::class)) shouldBeEqualTo false
+            hasAllAnnotationsOf(setOf(SampleAnnotation::class, NonExistingAnnotation::class)) shouldBeEqualTo false
             hasAnnotations("SampleAnnotation") shouldBeEqualTo true
             hasAnnotations("NonExistingAnnotation") shouldBeEqualTo false
             hasAnnotations("com.lemonappdev.konsist.testdata.SampleAnnotation") shouldBeEqualTo true
@@ -107,6 +165,10 @@ class KoVariableDeclarationForKoAnnotationProviderTest {
             countAnnotations { it.hasNameStartingWith("Sample") } shouldBeEqualTo 2
             countAnnotations { it.name == "SampleAnnotation1" } shouldBeEqualTo 1
             hasAnnotations() shouldBeEqualTo true
+            hasAnnotationOf(emptyList()) shouldBeEqualTo true
+            hasAnnotationOf(emptySet()) shouldBeEqualTo true
+            hasAllAnnotationsOf(emptyList()) shouldBeEqualTo true
+            hasAllAnnotationsOf(emptySet()) shouldBeEqualTo true
             hasAnnotationWithName("SampleAnnotation1") shouldBeEqualTo true
             hasAnnotationWithName("OtherAnnotation") shouldBeEqualTo false
             hasAnnotationWithName("SampleAnnotation1", "OtherAnnotation") shouldBeEqualTo true
@@ -116,6 +178,24 @@ class KoVariableDeclarationForKoAnnotationProviderTest {
                 "com.lemonappdev.konsist.testdata.SampleAnnotation1",
                 "com.lemonappdev.konsist.testdata.NonExistingAnnotation",
             ).shouldBeEqualTo(true)
+            hasAnnotationWithName(listOf("SampleAnnotation1")) shouldBeEqualTo true
+            hasAnnotationWithName(listOf("OtherAnnotation")) shouldBeEqualTo false
+            hasAnnotationWithName(listOf("SampleAnnotation1", "OtherAnnotation")) shouldBeEqualTo true
+            hasAnnotationWithName(listOf("com.lemonappdev.konsist.testdata.SampleAnnotation1")) shouldBeEqualTo true
+            hasAnnotationWithName(listOf("com.lemonappdev.konsist.testdata.NonExistingAnnotation")) shouldBeEqualTo false
+            hasAnnotationWithName(listOf(
+                "com.lemonappdev.konsist.testdata.SampleAnnotation1",
+                "com.lemonappdev.konsist.testdata.NonExistingAnnotation",
+            )).shouldBeEqualTo(true)
+            hasAnnotationWithName(setOf("SampleAnnotation1")) shouldBeEqualTo true
+            hasAnnotationWithName(setOf("OtherAnnotation")) shouldBeEqualTo false
+            hasAnnotationWithName(setOf("SampleAnnotation1", "OtherAnnotation")) shouldBeEqualTo true
+            hasAnnotationWithName(setOf("com.lemonappdev.konsist.testdata.SampleAnnotation1")) shouldBeEqualTo true
+            hasAnnotationWithName(setOf("com.lemonappdev.konsist.testdata.NonExistingAnnotation")) shouldBeEqualTo false
+            hasAnnotationWithName(setOf(
+                "com.lemonappdev.konsist.testdata.SampleAnnotation1",
+                "com.lemonappdev.konsist.testdata.NonExistingAnnotation",
+            )).shouldBeEqualTo(true)
             hasAnnotationsWithAllNames("SampleAnnotation1") shouldBeEqualTo true
             hasAnnotationsWithAllNames("SampleAnnotation1", "SampleAnnotation2") shouldBeEqualTo true
             hasAnnotationsWithAllNames("SampleAnnotation1", "OtherAnnotation") shouldBeEqualTo false
@@ -128,17 +208,48 @@ class KoVariableDeclarationForKoAnnotationProviderTest {
                 "com.lemonappdev.konsist.testdata.SampleAnnotation1",
                 "com.lemonappdev.konsist.testdata.SampleAnnotation2",
             ).shouldBeEqualTo(true)
+
+            hasAnnotationsWithAllNames(listOf("SampleAnnotation1")) shouldBeEqualTo true
+            hasAnnotationsWithAllNames(listOf("SampleAnnotation1", "SampleAnnotation2")) shouldBeEqualTo true
+            hasAnnotationsWithAllNames(listOf("SampleAnnotation1", "OtherAnnotation")) shouldBeEqualTo false
+            hasAnnotationsWithAllNames(listOf("com.lemonappdev.konsist.testdata.SampleAnnotation1")) shouldBeEqualTo true
+            hasAnnotationsWithAllNames(listOf(
+                "com.lemonappdev.konsist.testdata.SampleAnnotation1",
+                "com.lemonappdev.konsist.testdata.NonExistingAnnotation",
+            )).shouldBeEqualTo(false)
+            hasAnnotationsWithAllNames(listOf(
+                "com.lemonappdev.konsist.testdata.SampleAnnotation1",
+                "com.lemonappdev.konsist.testdata.SampleAnnotation2",
+            )).shouldBeEqualTo(true)
             hasAnnotation { it.name == "SampleAnnotation1" } shouldBeEqualTo true
             hasAnnotation { it.name == "OtherAnnotation1" } shouldBeEqualTo false
             hasAllAnnotations { !it.hasArguments() } shouldBeEqualTo true
             hasAllAnnotations { it.hasNameEndingWith("tion1") } shouldBeEqualTo false
+            hasAnnotationOf(emptyList()) shouldBeEqualTo true
+            hasAnnotationOf(emptySet()) shouldBeEqualTo true
+            hasAllAnnotationsOf(emptyList()) shouldBeEqualTo true
+            hasAllAnnotationsOf(emptySet()) shouldBeEqualTo true
             hasAnnotationOf(SampleAnnotation1::class) shouldBeEqualTo true
             hasAnnotationOf(NonExistingAnnotation::class) shouldBeEqualTo false
             hasAnnotationOf(SampleAnnotation1::class, NonExistingAnnotation::class) shouldBeEqualTo true
+            hasAnnotationOf(listOf(SampleAnnotation1::class)) shouldBeEqualTo true
+            hasAnnotationOf(listOf(NonExistingAnnotation::class)) shouldBeEqualTo false
+            hasAnnotationOf(listOf(SampleAnnotation1::class, NonExistingAnnotation::class)) shouldBeEqualTo true
+            hasAnnotationOf(setOf(SampleAnnotation1::class)) shouldBeEqualTo true
+            hasAnnotationOf(setOf(NonExistingAnnotation::class)) shouldBeEqualTo false
+            hasAnnotationOf(setOf(SampleAnnotation1::class, NonExistingAnnotation::class)) shouldBeEqualTo true
             hasAllAnnotationsOf(SampleAnnotation1::class) shouldBeEqualTo true
             hasAllAnnotationsOf(NonExistingAnnotation::class) shouldBeEqualTo false
             hasAllAnnotationsOf(SampleAnnotation1::class, SampleAnnotation2::class) shouldBeEqualTo true
             hasAllAnnotationsOf(SampleAnnotation1::class, NonExistingAnnotation::class) shouldBeEqualTo false
+            hasAllAnnotationsOf(listOf(SampleAnnotation1::class)) shouldBeEqualTo true
+            hasAllAnnotationsOf(listOf(NonExistingAnnotation::class)) shouldBeEqualTo false
+            hasAllAnnotationsOf(listOf(SampleAnnotation1::class, SampleAnnotation2::class)) shouldBeEqualTo true
+            hasAllAnnotationsOf(listOf(SampleAnnotation1::class, NonExistingAnnotation::class)) shouldBeEqualTo false
+            hasAllAnnotationsOf(setOf(SampleAnnotation1::class)) shouldBeEqualTo true
+            hasAllAnnotationsOf(setOf(NonExistingAnnotation::class)) shouldBeEqualTo false
+            hasAllAnnotationsOf(setOf(SampleAnnotation1::class, SampleAnnotation2::class)) shouldBeEqualTo true
+            hasAllAnnotationsOf(setOf(SampleAnnotation1::class, NonExistingAnnotation::class)) shouldBeEqualTo false
             hasAnnotations("SampleAnnotation1") shouldBeEqualTo true
             hasAnnotations("SampleAnnotation2") shouldBeEqualTo true
             hasAnnotations("NonExistingAnnotation") shouldBeEqualTo false

--- a/lib/src/konsistTest/kotlin/com/lemonappdev/konsist/api/ApiKonsistTest.kt
+++ b/lib/src/konsistTest/kotlin/com/lemonappdev/konsist/api/ApiKonsistTest.kt
@@ -83,8 +83,7 @@ class ApiKonsistTest {
 
     @Test
     fun `every method with vararg parameter calls the method with the same name and list parameter`() {
-        Konsist
-            .scopeFromPackage("com.lemonappdev.konsist.api.ext..", sourceSetName = "main")
+        apiPackageScope
             .functions()
             .withoutAnnotationOf(Deprecated::class)
             .withParameter { it.hasVarArgModifier }

--- a/lib/src/konsistTest/kotlin/com/lemonappdev/konsist/api/ApiKonsistTest.kt
+++ b/lib/src/konsistTest/kotlin/com/lemonappdev/konsist/api/ApiKonsistTest.kt
@@ -83,7 +83,8 @@ class ApiKonsistTest {
 
     @Test
     fun `every method with vararg parameter calls the method with the same name and list parameter`() {
-        apiPackageScope
+        Konsist
+            .scopeFromPackage("com.lemonappdev.konsist.api.ext..", sourceSetName = "main")
             .functions()
             .withoutAnnotationOf(Deprecated::class)
             .withParameter { it.hasVarArgModifier }

--- a/lib/src/konsistTest/kotlin/com/lemonappdev/konsist/core/ProviderKonsistTest.kt
+++ b/lib/src/konsistTest/kotlin/com/lemonappdev/konsist/core/ProviderKonsistTest.kt
@@ -3,6 +3,8 @@ package com.lemonappdev.konsist.core
 import com.lemonappdev.konsist.api.Konsist
 import com.lemonappdev.konsist.api.ext.list.returnTypes
 import com.lemonappdev.konsist.api.ext.list.types
+import com.lemonappdev.konsist.api.ext.list.withParameter
+import com.lemonappdev.konsist.api.ext.list.withoutAnnotationOf
 import com.lemonappdev.konsist.api.ext.list.withoutName
 import com.lemonappdev.konsist.api.verify.assertFalse
 import com.lemonappdev.konsist.api.verify.assertTrue
@@ -60,5 +62,14 @@ class ProviderKonsistTest {
 
                 it.hasParentWithName(name, indirectParents = true)
             }
+    }
+
+    @Test
+    fun `every method with vararg parameter calls the method with the same name and list parameter`() {
+        providerPackageScope
+            .functions()
+            .withoutAnnotationOf(Deprecated::class)
+            .withParameter { it.hasVarArgModifier }
+            .assertTrue { it.hasExpressionBody && it.text.contains("${it.name}(listOf(") }
     }
 }

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/api/container/KoScopeCreator.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/api/container/KoScopeCreator.kt
@@ -47,7 +47,7 @@ interface KoScopeCreator {
      * @param moduleNames Set of the module names.
      * @return a [KoScope] containing all of Kotlin files in the module.
      */
-    fun scopeFromModules(moduleNames: Set<String>): KoScope
+    fun scopeFromModules(moduleNames: Collection<String>): KoScope
 
     /**
      * Creates a [KoScope] containing all of Kotlin files in the given package.
@@ -86,7 +86,7 @@ interface KoScopeCreator {
      * @param sourceSetNames Set of the source set names.
      * @return a [KoScope] containing all of Kotlin files in source set.
      */
-    fun scopeFromSourceSets(sourceSetNames: Set<String>): KoScope
+    fun scopeFromSourceSets(sourceSetNames: Collection<String>): KoScope
 
     /**
      * Creates a [KoScope] containing all of Kotlin files in the production source sets.
@@ -138,7 +138,7 @@ interface KoScopeCreator {
      * @param paths The set of paths relative to the project root directory.
      * @return a [KoScope] containing all of Kotlin files in the given directories.
      */
-    fun scopeFromDirectories(paths: Set<String>): KoScope
+    fun scopeFromDirectories(paths: Collection<String>): KoScope
 
     /**
      * Creates a [KoScope] containing all of Kotlin files in the given directory.
@@ -160,7 +160,7 @@ interface KoScopeCreator {
      * @param absolutePaths Set of the absolute paths to the directory from outside the project.
      * @return a [KoScope] containing all of Kotlin files in the given directory.
      */
-    fun scopeFromExternalDirectories(absolutePaths: Set<String>): KoScope
+    fun scopeFromExternalDirectories(absolutePaths: Collection<String>): KoScope
 
     /**
      * Creates a [KoScope] of a given file.
@@ -180,5 +180,5 @@ interface KoScopeCreator {
      * @param paths The set of paths relative to the project root directory.
      * @return a [KoScope] of a given files.
      */
-    fun scopeFromFiles(paths: Set<String>): KoScope
+    fun scopeFromFiles(paths: Collection<String>): KoScope
 }

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/api/ext/list/KoAnnotationProviderListExt.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/api/ext/list/KoAnnotationProviderListExt.kt
@@ -48,7 +48,7 @@ fun <T : KoAnnotationProvider> List<T>.withAnnotationNamed(names: Collection<Str
     filter {
         when {
             names.isEmpty() -> it.hasAnnotations()
-            else -> it.hasAnnotationWithName(names.first(), *names.drop(1).toTypedArray())
+            else -> it.hasAnnotationWithName(names)
         }
     }
 
@@ -74,7 +74,7 @@ fun <T : KoAnnotationProvider> List<T>.withoutAnnotationNamed(names: Collection<
     filterNot {
         when {
             names.isEmpty() -> it.hasAnnotations()
-            else -> it.hasAnnotationWithName(names.first(), *names.drop(1).toTypedArray())
+            else -> it.hasAnnotationWithName(names)
         }
     }
 
@@ -100,7 +100,7 @@ fun <T : KoAnnotationProvider> List<T>.withAllAnnotationsNamed(names: Collection
     filter {
         when {
             names.isEmpty() -> it.hasAnnotations()
-            else -> it.hasAnnotationsWithAllNames(names.first(), *names.drop(1).toTypedArray())
+            else -> it.hasAnnotationsWithAllNames(names)
         }
     }
 
@@ -126,7 +126,7 @@ fun <T : KoAnnotationProvider> List<T>.withoutAllAnnotationsNamed(names: Collect
     filterNot {
         when {
             names.isEmpty() -> it.hasAnnotations()
-            else -> it.hasAnnotationsWithAllNames(names.first(), *names.drop(1).toTypedArray())
+            else -> it.hasAnnotationsWithAllNames(names)
         }
     }
 
@@ -206,7 +206,7 @@ fun <T : KoAnnotationProvider> List<T>.withAnnotationOf(kClasses: Collection<KCl
     filter {
         when {
             kClasses.isEmpty() -> it.hasAnnotations()
-            else -> it.hasAnnotationOf(kClasses.first(), *kClasses.drop(1).toTypedArray())
+            else -> it.hasAnnotationOf(kClasses)
         }
     }
 
@@ -232,7 +232,7 @@ fun <T : KoAnnotationProvider> List<T>.withoutAnnotationOf(kClasses: Collection<
     filterNot {
         when {
             kClasses.isEmpty() -> it.hasAnnotations()
-            else -> it.hasAnnotationOf(kClasses.first(), *kClasses.drop(1).toTypedArray())
+            else -> it.hasAnnotationOf(kClasses)
         }
     }
 
@@ -258,7 +258,7 @@ fun <T : KoAnnotationProvider> List<T>.withAllAnnotationsOf(kClasses: Collection
     filter {
         when {
             kClasses.isEmpty() -> it.hasAnnotations()
-            else -> it.hasAllAnnotationsOf(kClasses.first(), *kClasses.drop(1).toTypedArray())
+            else -> it.hasAllAnnotationsOf(kClasses)
         }
     }
 
@@ -284,7 +284,7 @@ fun <T : KoAnnotationProvider> List<T>.withoutAllAnnotationsOf(kClasses: Collect
     filterNot {
         when {
             kClasses.isEmpty() -> it.hasAnnotations()
-            else -> it.hasAllAnnotationsOf(kClasses.first(), *kClasses.drop(1).toTypedArray())
+            else -> it.hasAllAnnotationsOf(kClasses)
         }
     }
 

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/api/ext/list/KoArgumentProviderListExt.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/api/ext/list/KoArgumentProviderListExt.kt
@@ -45,7 +45,7 @@ fun <T : KoArgumentProvider> List<T>.withArgumentNamed(names: Collection<String>
     filter {
         when {
             names.isEmpty() -> it.hasArguments()
-            else -> it.hasArgumentWithName(names.first(), *names.drop(1).toTypedArray())
+            else -> it.hasArgumentWithName(names)
         }
     }
 
@@ -71,7 +71,7 @@ fun <T : KoArgumentProvider> List<T>.withoutArgumentNamed(names: Collection<Stri
     filterNot {
         when {
             names.isEmpty() -> it.hasArguments()
-            else -> it.hasArgumentWithName(names.first(), *names.drop(1).toTypedArray())
+            else -> it.hasArgumentWithName(names)
         }
     }
 
@@ -97,7 +97,7 @@ fun <T : KoArgumentProvider> List<T>.withAllArgumentsNamed(names: Collection<Str
     filter {
         when {
             names.isEmpty() -> it.hasArguments()
-            else -> it.hasArgumentsWithAllNames(names.first(), *names.drop(1).toTypedArray())
+            else -> it.hasArgumentsWithAllNames(names)
         }
     }
 
@@ -123,7 +123,7 @@ fun <T : KoArgumentProvider> List<T>.withoutAllArgumentsNamed(names: Collection<
     filterNot {
         when {
             names.isEmpty() -> it.hasArguments()
-            else -> it.hasArgumentsWithAllNames(names.first(), *names.drop(1).toTypedArray())
+            else -> it.hasArgumentsWithAllNames(names)
         }
     }
 

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/api/ext/list/KoChildProviderListExt.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/api/ext/list/KoChildProviderListExt.kt
@@ -61,7 +61,7 @@ fun <T : KoChildProvider> List<T>.withChildNamed(
     filter {
         when {
             names.isEmpty() -> it.hasChildren(indirectChildren = indirectChildren)
-            else -> it.hasChildWithName(names, indirectChildren = indirectChildren,)
+            else -> it.hasChildWithName(names, indirectChildren = indirectChildren)
         }
     }
 
@@ -93,7 +93,7 @@ fun <T : KoChildProvider> List<T>.withoutChildNamed(
     filterNot {
         when {
             names.isEmpty() -> it.hasChildren(indirectChildren = indirectChildren)
-            else -> it.hasChildWithName(names, indirectChildren = indirectChildren,)
+            else -> it.hasChildWithName(names, indirectChildren = indirectChildren)
         }
     }
 
@@ -125,7 +125,7 @@ fun <T : KoChildProvider> List<T>.withAllChildrenNamed(
     filter {
         when {
             names.isEmpty() -> it.hasChildren(indirectChildren = indirectChildren)
-            else -> it.hasChildrenWithAllNames(names, indirectChildren = indirectChildren,)
+            else -> it.hasChildrenWithAllNames(names, indirectChildren = indirectChildren)
         }
     }
 
@@ -157,7 +157,7 @@ fun <T : KoChildProvider> List<T>.withoutAllChildrenNamed(
     filterNot {
         when {
             names.isEmpty() -> it.hasChildren(indirectChildren = indirectChildren)
-            else -> it.hasChildrenWithAllNames(names, indirectChildren = indirectChildren,)
+            else -> it.hasChildrenWithAllNames(names, indirectChildren = indirectChildren)
         }
     }
 
@@ -276,7 +276,7 @@ fun <T : KoChildProvider> List<T>.withChildOf(
     filter {
         when {
             kClasses.isEmpty() -> it.hasChildren(indirectChildren)
-            else -> it.hasChildOf(kClasses, indirectChildren = indirectChildren,)
+            else -> it.hasChildOf(kClasses, indirectChildren = indirectChildren)
         }
     }
 
@@ -308,7 +308,7 @@ fun <T : KoChildProvider> List<T>.withoutChildOf(
     filterNot {
         when {
             kClasses.isEmpty() -> it.hasChildren(indirectChildren)
-            else -> it.hasChildOf(kClasses, indirectChildren = indirectChildren,)
+            else -> it.hasChildOf(kClasses, indirectChildren = indirectChildren)
         }
     }
 
@@ -340,7 +340,7 @@ fun <T : KoChildProvider> List<T>.withAllChildrenOf(
     filter {
         when {
             kClasses.isEmpty() -> it.hasChildren(indirectChildren)
-            else -> it.hasAllChildrenOf(kClasses, indirectChildren = indirectChildren,)
+            else -> it.hasAllChildrenOf(kClasses, indirectChildren = indirectChildren)
         }
     }
 
@@ -372,6 +372,6 @@ fun <T : KoChildProvider> List<T>.withoutAllChildrenOf(
     filterNot {
         when {
             kClasses.isEmpty() -> it.hasChildren(indirectChildren)
-            else -> it.hasAllChildrenOf(kClasses, indirectChildren = indirectChildren,)
+            else -> it.hasAllChildrenOf(kClasses, indirectChildren = indirectChildren)
         }
     }

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/api/ext/list/KoChildProviderListExt.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/api/ext/list/KoChildProviderListExt.kt
@@ -61,12 +61,7 @@ fun <T : KoChildProvider> List<T>.withChildNamed(
     filter {
         when {
             names.isEmpty() -> it.hasChildren(indirectChildren = indirectChildren)
-            else ->
-                it.hasChildWithName(
-                    names.first(),
-                    *names.drop(1).toTypedArray(),
-                    indirectChildren = indirectChildren,
-                )
+            else -> it.hasChildWithName(names, indirectChildren = indirectChildren,)
         }
     }
 
@@ -98,12 +93,7 @@ fun <T : KoChildProvider> List<T>.withoutChildNamed(
     filterNot {
         when {
             names.isEmpty() -> it.hasChildren(indirectChildren = indirectChildren)
-            else ->
-                it.hasChildWithName(
-                    names.first(),
-                    *names.drop(1).toTypedArray(),
-                    indirectChildren = indirectChildren,
-                )
+            else -> it.hasChildWithName(names, indirectChildren = indirectChildren,)
         }
     }
 
@@ -135,12 +125,7 @@ fun <T : KoChildProvider> List<T>.withAllChildrenNamed(
     filter {
         when {
             names.isEmpty() -> it.hasChildren(indirectChildren = indirectChildren)
-            else ->
-                it.hasChildrenWithAllNames(
-                    names.first(),
-                    *names.drop(1).toTypedArray(),
-                    indirectChildren = indirectChildren,
-                )
+            else -> it.hasChildrenWithAllNames(names, indirectChildren = indirectChildren,)
         }
     }
 
@@ -172,12 +157,7 @@ fun <T : KoChildProvider> List<T>.withoutAllChildrenNamed(
     filterNot {
         when {
             names.isEmpty() -> it.hasChildren(indirectChildren = indirectChildren)
-            else ->
-                it.hasChildrenWithAllNames(
-                    names.first(),
-                    *names.drop(1).toTypedArray(),
-                    indirectChildren = indirectChildren,
-                )
+            else -> it.hasChildrenWithAllNames(names, indirectChildren = indirectChildren,)
         }
     }
 
@@ -296,12 +276,7 @@ fun <T : KoChildProvider> List<T>.withChildOf(
     filter {
         when {
             kClasses.isEmpty() -> it.hasChildren(indirectChildren)
-            else ->
-                it.hasChildOf(
-                    kClasses.first(),
-                    *kClasses.drop(1).toTypedArray(),
-                    indirectChildren = indirectChildren,
-                )
+            else -> it.hasChildOf(kClasses, indirectChildren = indirectChildren,)
         }
     }
 
@@ -333,12 +308,7 @@ fun <T : KoChildProvider> List<T>.withoutChildOf(
     filterNot {
         when {
             kClasses.isEmpty() -> it.hasChildren(indirectChildren)
-            else ->
-                it.hasChildOf(
-                    kClasses.first(),
-                    *kClasses.drop(1).toTypedArray(),
-                    indirectChildren = indirectChildren,
-                )
+            else -> it.hasChildOf(kClasses, indirectChildren = indirectChildren,)
         }
     }
 
@@ -370,12 +340,7 @@ fun <T : KoChildProvider> List<T>.withAllChildrenOf(
     filter {
         when {
             kClasses.isEmpty() -> it.hasChildren(indirectChildren)
-            else ->
-                it.hasAllChildrenOf(
-                    kClasses.first(),
-                    *kClasses.drop(1).toTypedArray(),
-                    indirectChildren = indirectChildren,
-                )
+            else -> it.hasAllChildrenOf(kClasses, indirectChildren = indirectChildren,)
         }
     }
 
@@ -407,11 +372,6 @@ fun <T : KoChildProvider> List<T>.withoutAllChildrenOf(
     filterNot {
         when {
             kClasses.isEmpty() -> it.hasChildren(indirectChildren)
-            else ->
-                it.hasAllChildrenOf(
-                    kClasses.first(),
-                    *kClasses.drop(1).toTypedArray(),
-                    indirectChildren = indirectChildren,
-                )
+            else -> it.hasAllChildrenOf(kClasses, indirectChildren = indirectChildren,)
         }
     }

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/api/ext/list/KoClassProviderListExt.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/api/ext/list/KoClassProviderListExt.kt
@@ -107,7 +107,7 @@ fun <T : KoClassProvider> List<T>.withoutClassNamed(
     filterNot {
         when {
             names.isEmpty() -> it.hasClasses(includeNested, includeLocal)
-            else -> it.hasClassWithName(names, includeNested = includeNested, includeLocal = includeLocal,)
+            else -> it.hasClassWithName(names, includeNested = includeNested, includeLocal = includeLocal)
         }
     }
 
@@ -143,7 +143,7 @@ fun <T : KoClassProvider> List<T>.withAllClassesNamed(
     filter {
         when {
             names.isEmpty() -> it.hasClasses(includeNested, includeLocal)
-            else -> it.hasClassesWithAllNames(names, includeNested = includeNested, includeLocal = includeLocal,)
+            else -> it.hasClassesWithAllNames(names, includeNested = includeNested, includeLocal = includeLocal)
         }
     }
 
@@ -179,7 +179,7 @@ fun <T : KoClassProvider> List<T>.withoutAllClassesNamed(
     filterNot {
         when {
             names.isEmpty() -> it.hasClasses(includeNested, includeLocal)
-            else -> it.hasClassesWithAllNames(names, includeNested = includeNested, includeLocal = includeLocal,)
+            else -> it.hasClassesWithAllNames(names, includeNested = includeNested, includeLocal = includeLocal)
         }
     }
 

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/api/ext/list/KoClassProviderListExt.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/api/ext/list/KoClassProviderListExt.kt
@@ -71,13 +71,7 @@ fun <T : KoClassProvider> List<T>.withClassNamed(
     filter {
         when {
             names.isEmpty() -> it.hasClasses(includeNested, includeLocal)
-            else ->
-                it.hasClassWithName(
-                    names.first(),
-                    *names.drop(1).toTypedArray(),
-                    includeNested = includeNested,
-                    includeLocal = includeLocal,
-                )
+            else -> it.hasClassWithName(names, includeNested = includeNested, includeLocal = includeLocal)
         }
     }
 
@@ -113,13 +107,7 @@ fun <T : KoClassProvider> List<T>.withoutClassNamed(
     filterNot {
         when {
             names.isEmpty() -> it.hasClasses(includeNested, includeLocal)
-            else ->
-                it.hasClassWithName(
-                    names.first(),
-                    *names.drop(1).toTypedArray(),
-                    includeNested = includeNested,
-                    includeLocal = includeLocal,
-                )
+            else -> it.hasClassWithName(names, includeNested = includeNested, includeLocal = includeLocal,)
         }
     }
 
@@ -155,13 +143,7 @@ fun <T : KoClassProvider> List<T>.withAllClassesNamed(
     filter {
         when {
             names.isEmpty() -> it.hasClasses(includeNested, includeLocal)
-            else ->
-                it.hasClassesWithAllNames(
-                    names.first(),
-                    *names.drop(1).toTypedArray(),
-                    includeNested = includeNested,
-                    includeLocal = includeLocal,
-                )
+            else -> it.hasClassesWithAllNames(names, includeNested = includeNested, includeLocal = includeLocal,)
         }
     }
 
@@ -197,13 +179,7 @@ fun <T : KoClassProvider> List<T>.withoutAllClassesNamed(
     filterNot {
         when {
             names.isEmpty() -> it.hasClasses(includeNested, includeLocal)
-            else ->
-                it.hasClassesWithAllNames(
-                    names.first(),
-                    *names.drop(1).toTypedArray(),
-                    includeNested = includeNested,
-                    includeLocal = includeLocal,
-                )
+            else -> it.hasClassesWithAllNames(names, includeNested = includeNested, includeLocal = includeLocal,)
         }
     }
 

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/api/ext/list/KoEnumConstantProviderListExt.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/api/ext/list/KoEnumConstantProviderListExt.kt
@@ -45,7 +45,7 @@ fun <T : KoEnumConstantProvider> List<T>.withEnumConstantNamed(names: Collection
     filter {
         when {
             names.isEmpty() -> it.hasEnumConstants()
-            else -> it.hasEnumConstantWithName(names.first(), *names.drop(1).toTypedArray())
+            else -> it.hasEnumConstantWithName(names)
         }
     }
 
@@ -71,7 +71,7 @@ fun <T : KoEnumConstantProvider> List<T>.withoutEnumConstantNamed(names: Collect
     filterNot {
         when {
             names.isEmpty() -> it.hasEnumConstants()
-            else -> it.hasEnumConstantWithName(names.first(), *names.drop(1).toTypedArray())
+            else -> it.hasEnumConstantWithName(names)
         }
     }
 
@@ -97,7 +97,7 @@ fun <T : KoEnumConstantProvider> List<T>.withAllEnumConstantsNamed(names: Collec
     filter {
         when {
             names.isEmpty() -> it.hasEnumConstants()
-            else -> it.hasEnumConstantsWithAllNames(names.first(), *names.drop(1).toTypedArray())
+            else -> it.hasEnumConstantsWithAllNames(names)
         }
     }
 
@@ -123,7 +123,7 @@ fun <T : KoEnumConstantProvider> List<T>.withoutAllEnumConstantsNamed(names: Col
     filterNot {
         when {
             names.isEmpty() -> it.hasEnumConstants()
-            else -> it.hasEnumConstantsWithAllNames(names.first(), *names.drop(1).toTypedArray())
+            else -> it.hasEnumConstantsWithAllNames(names)
         }
     }
 

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/api/ext/list/KoExternalParentProviderListExt.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/api/ext/list/KoExternalParentProviderListExt.kt
@@ -66,7 +66,7 @@ fun <T : KoExternalParentProvider> List<T>.withExternalParentNamed(
     filter {
         when {
             names.isEmpty() -> it.hasExternalParents(indirectParents)
-            else -> it.hasExternalParentWithName(names, indirectParents = indirectParents,)
+            else -> it.hasExternalParentWithName(names, indirectParents = indirectParents)
         }
     }
 
@@ -100,7 +100,7 @@ fun <T : KoExternalParentProvider> List<T>.withoutExternalParentNamed(
     filterNot {
         when {
             names.isEmpty() -> it.hasExternalParents(indirectParents)
-            else -> it.hasExternalParentWithName(names, indirectParents = indirectParents,)
+            else -> it.hasExternalParentWithName(names, indirectParents = indirectParents)
         }
     }
 
@@ -134,7 +134,7 @@ fun <T : KoExternalParentProvider> List<T>.withAllExternalParentsNamed(
     filter {
         when {
             names.isEmpty() -> it.hasExternalParents(indirectParents)
-            else -> it.hasExternalParentsWithAllNames(names, indirectParents = indirectParents,)
+            else -> it.hasExternalParentsWithAllNames(names, indirectParents = indirectParents)
         }
     }
 
@@ -168,7 +168,7 @@ fun <T : KoExternalParentProvider> List<T>.withoutAllExternalParentsNamed(
     filterNot {
         when {
             names.isEmpty() -> it.hasExternalParents(indirectParents)
-            else -> it.hasExternalParentsWithAllNames(names, indirectParents = indirectParents,)
+            else -> it.hasExternalParentsWithAllNames(names, indirectParents = indirectParents)
         }
     }
 
@@ -280,7 +280,7 @@ fun <T : KoExternalParentProvider> List<T>.withExternalParentOf(
     filter {
         when {
             kClasses.isEmpty() -> it.hasExternalParents(indirectParents)
-            else -> it.hasExternalParentOf(kClasses, indirectParents = indirectParents,)
+            else -> it.hasExternalParentOf(kClasses, indirectParents = indirectParents)
         }
     }
 
@@ -314,7 +314,7 @@ fun <T : KoExternalParentProvider> List<T>.withoutExternalParentOf(
     filterNot {
         when {
             kClasses.isEmpty() -> it.hasExternalParents(indirectParents)
-            else -> it.hasExternalParentOf(kClasses, indirectParents = indirectParents,)
+            else -> it.hasExternalParentOf(kClasses, indirectParents = indirectParents)
         }
     }
 
@@ -348,7 +348,7 @@ fun <T : KoExternalParentProvider> List<T>.withAllExternalParentsOf(
     filter {
         when {
             kClasses.isEmpty() -> it.hasExternalParents(indirectParents)
-            else -> it.hasAllExternalParentsOf(kClasses, indirectParents = indirectParents,)
+            else -> it.hasAllExternalParentsOf(kClasses, indirectParents = indirectParents)
         }
     }
 
@@ -382,6 +382,6 @@ fun <T : KoExternalParentProvider> List<T>.withoutAllExternalParentsOf(
     filterNot {
         when {
             kClasses.isEmpty() -> it.hasExternalParents(indirectParents)
-            else -> it.hasAllExternalParentsOf(kClasses, indirectParents = indirectParents,)
+            else -> it.hasAllExternalParentsOf(kClasses, indirectParents = indirectParents)
         }
     }

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/api/ext/list/KoExternalParentProviderListExt.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/api/ext/list/KoExternalParentProviderListExt.kt
@@ -66,12 +66,7 @@ fun <T : KoExternalParentProvider> List<T>.withExternalParentNamed(
     filter {
         when {
             names.isEmpty() -> it.hasExternalParents(indirectParents)
-            else ->
-                it.hasExternalParentWithName(
-                    names.first(),
-                    *names.drop(1).toTypedArray(),
-                    indirectParents = indirectParents,
-                )
+            else -> it.hasExternalParentWithName(names, indirectParents = indirectParents,)
         }
     }
 
@@ -105,12 +100,7 @@ fun <T : KoExternalParentProvider> List<T>.withoutExternalParentNamed(
     filterNot {
         when {
             names.isEmpty() -> it.hasExternalParents(indirectParents)
-            else ->
-                it.hasExternalParentWithName(
-                    names.first(),
-                    *names.drop(1).toTypedArray(),
-                    indirectParents = indirectParents,
-                )
+            else -> it.hasExternalParentWithName(names, indirectParents = indirectParents,)
         }
     }
 
@@ -144,12 +134,7 @@ fun <T : KoExternalParentProvider> List<T>.withAllExternalParentsNamed(
     filter {
         when {
             names.isEmpty() -> it.hasExternalParents(indirectParents)
-            else ->
-                it.hasExternalParentsWithAllNames(
-                    names.first(),
-                    *names.drop(1).toTypedArray(),
-                    indirectParents = indirectParents,
-                )
+            else -> it.hasExternalParentsWithAllNames(names, indirectParents = indirectParents,)
         }
     }
 
@@ -183,12 +168,7 @@ fun <T : KoExternalParentProvider> List<T>.withoutAllExternalParentsNamed(
     filterNot {
         when {
             names.isEmpty() -> it.hasExternalParents(indirectParents)
-            else ->
-                it.hasExternalParentsWithAllNames(
-                    names.first(),
-                    *names.drop(1).toTypedArray(),
-                    indirectParents = indirectParents,
-                )
+            else -> it.hasExternalParentsWithAllNames(names, indirectParents = indirectParents,)
         }
     }
 
@@ -300,12 +280,7 @@ fun <T : KoExternalParentProvider> List<T>.withExternalParentOf(
     filter {
         when {
             kClasses.isEmpty() -> it.hasExternalParents(indirectParents)
-            else ->
-                it.hasExternalParentOf(
-                    kClasses.first(),
-                    *kClasses.drop(1).toTypedArray(),
-                    indirectParents = indirectParents,
-                )
+            else -> it.hasExternalParentOf(kClasses, indirectParents = indirectParents,)
         }
     }
 
@@ -339,12 +314,7 @@ fun <T : KoExternalParentProvider> List<T>.withoutExternalParentOf(
     filterNot {
         when {
             kClasses.isEmpty() -> it.hasExternalParents(indirectParents)
-            else ->
-                it.hasExternalParentOf(
-                    kClasses.first(),
-                    *kClasses.drop(1).toTypedArray(),
-                    indirectParents = indirectParents,
-                )
+            else -> it.hasExternalParentOf(kClasses, indirectParents = indirectParents,)
         }
     }
 
@@ -378,12 +348,7 @@ fun <T : KoExternalParentProvider> List<T>.withAllExternalParentsOf(
     filter {
         when {
             kClasses.isEmpty() -> it.hasExternalParents(indirectParents)
-            else ->
-                it.hasAllExternalParentsOf(
-                    kClasses.first(),
-                    *kClasses.drop(1).toTypedArray(),
-                    indirectParents = indirectParents,
-                )
+            else -> it.hasAllExternalParentsOf(kClasses, indirectParents = indirectParents,)
         }
     }
 
@@ -417,11 +382,6 @@ fun <T : KoExternalParentProvider> List<T>.withoutAllExternalParentsOf(
     filterNot {
         when {
             kClasses.isEmpty() -> it.hasExternalParents(indirectParents)
-            else ->
-                it.hasAllExternalParentsOf(
-                    kClasses.first(),
-                    *kClasses.drop(1).toTypedArray(),
-                    indirectParents = indirectParents,
-                )
+            else -> it.hasAllExternalParentsOf(kClasses, indirectParents = indirectParents,)
         }
     }

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/api/ext/list/KoFunctionProviderListExt.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/api/ext/list/KoFunctionProviderListExt.kt
@@ -71,13 +71,7 @@ fun <T : KoFunctionProvider> List<T>.withFunctionNamed(
     filter {
         when {
             names.isEmpty() -> it.hasFunctions(includeNested, includeLocal)
-            else ->
-                it.hasFunctionWithName(
-                    names.first(),
-                    *names.drop(1).toTypedArray(),
-                    includeNested = includeNested,
-                    includeLocal = includeLocal,
-                )
+            else -> it.hasFunctionWithName(names, includeNested = includeNested, includeLocal = includeLocal,)
         }
     }
 
@@ -113,13 +107,7 @@ fun <T : KoFunctionProvider> List<T>.withoutFunctionNamed(
     filterNot {
         when {
             names.isEmpty() -> it.hasFunctions(includeNested, includeLocal)
-            else ->
-                it.hasFunctionWithName(
-                    names.first(),
-                    *names.drop(1).toTypedArray(),
-                    includeNested = includeNested,
-                    includeLocal = includeLocal,
-                )
+            else -> it.hasFunctionWithName(names, includeNested = includeNested, includeLocal = includeLocal,)
         }
     }
 
@@ -155,13 +143,7 @@ fun <T : KoFunctionProvider> List<T>.withAllFunctionsNamed(
     filter {
         when {
             names.isEmpty() -> it.hasFunctions(includeNested, includeLocal)
-            else ->
-                it.hasFunctionsWithAllNames(
-                    names.first(),
-                    *names.drop(1).toTypedArray(),
-                    includeNested = includeNested,
-                    includeLocal = includeLocal,
-                )
+            else -> it.hasFunctionsWithAllNames(names, includeNested = includeNested, includeLocal = includeLocal,)
         }
     }
 
@@ -197,13 +179,7 @@ fun <T : KoFunctionProvider> List<T>.withoutAllFunctionsNamed(
     filterNot {
         when {
             names.isEmpty() -> it.hasFunctions(includeNested, includeLocal)
-            else ->
-                it.hasFunctionsWithAllNames(
-                    names.first(),
-                    *names.drop(1).toTypedArray(),
-                    includeNested = includeNested,
-                    includeLocal = includeLocal,
-                )
+            else -> it.hasFunctionsWithAllNames(names, includeNested = includeNested, includeLocal = includeLocal,)
         }
     }
 

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/api/ext/list/KoFunctionProviderListExt.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/api/ext/list/KoFunctionProviderListExt.kt
@@ -71,7 +71,7 @@ fun <T : KoFunctionProvider> List<T>.withFunctionNamed(
     filter {
         when {
             names.isEmpty() -> it.hasFunctions(includeNested, includeLocal)
-            else -> it.hasFunctionWithName(names, includeNested = includeNested, includeLocal = includeLocal,)
+            else -> it.hasFunctionWithName(names, includeNested = includeNested, includeLocal = includeLocal)
         }
     }
 
@@ -107,7 +107,7 @@ fun <T : KoFunctionProvider> List<T>.withoutFunctionNamed(
     filterNot {
         when {
             names.isEmpty() -> it.hasFunctions(includeNested, includeLocal)
-            else -> it.hasFunctionWithName(names, includeNested = includeNested, includeLocal = includeLocal,)
+            else -> it.hasFunctionWithName(names, includeNested = includeNested, includeLocal = includeLocal)
         }
     }
 
@@ -143,7 +143,7 @@ fun <T : KoFunctionProvider> List<T>.withAllFunctionsNamed(
     filter {
         when {
             names.isEmpty() -> it.hasFunctions(includeNested, includeLocal)
-            else -> it.hasFunctionsWithAllNames(names, includeNested = includeNested, includeLocal = includeLocal,)
+            else -> it.hasFunctionsWithAllNames(names, includeNested = includeNested, includeLocal = includeLocal)
         }
     }
 
@@ -179,7 +179,7 @@ fun <T : KoFunctionProvider> List<T>.withoutAllFunctionsNamed(
     filterNot {
         when {
             names.isEmpty() -> it.hasFunctions(includeNested, includeLocal)
-            else -> it.hasFunctionsWithAllNames(names, includeNested = includeNested, includeLocal = includeLocal,)
+            else -> it.hasFunctionsWithAllNames(names, includeNested = includeNested, includeLocal = includeLocal)
         }
     }
 

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/api/ext/list/KoImportAliasProviderListExt.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/api/ext/list/KoImportAliasProviderListExt.kt
@@ -46,7 +46,7 @@ fun <T : KoImportAliasProvider> List<T>.withImportAliasNamed(names: Collection<S
     filter {
         when {
             names.isEmpty() -> it.hasImportAliases()
-            else -> it.hasImportAliasWithName(names.first(), *names.drop(1).toTypedArray())
+            else -> it.hasImportAliasWithName(names)
         }
     }
 
@@ -72,7 +72,7 @@ fun <T : KoImportAliasProvider> List<T>.withoutImportAliasNamed(names: Collectio
     filterNot {
         when {
             names.isEmpty() -> it.hasImportAliases()
-            else -> it.hasImportAliasWithName(names.first(), *names.drop(1).toTypedArray())
+            else -> it.hasImportAliasWithName(names)
         }
     }
 
@@ -98,7 +98,7 @@ fun <T : KoImportAliasProvider> List<T>.withAllImportAliasesNamed(names: Collect
     filter {
         when {
             names.isEmpty() -> it.hasImportAliases()
-            else -> it.hasImportAliasesWithAllNames(names.first(), *names.drop(1).toTypedArray())
+            else -> it.hasImportAliasesWithAllNames(names)
         }
     }
 
@@ -124,7 +124,7 @@ fun <T : KoImportAliasProvider> List<T>.withoutAllImportAliasesNamed(names: Coll
     filterNot {
         when {
             names.isEmpty() -> it.hasImportAliases()
-            else -> it.hasImportAliasesWithAllNames(names.first(), *names.drop(1).toTypedArray())
+            else -> it.hasImportAliasesWithAllNames(names)
         }
     }
 

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/api/ext/list/KoImportProviderListExt.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/api/ext/list/KoImportProviderListExt.kt
@@ -46,7 +46,7 @@ fun <T : KoImportProvider> List<T>.withImportNamed(names: Collection<String>): L
     filter {
         when {
             names.isEmpty() -> it.hasImports()
-            else -> it.hasImportWithName(names.first(), *names.drop(1).toTypedArray())
+            else -> it.hasImportWithName(names)
         }
     }
 
@@ -72,7 +72,7 @@ fun <T : KoImportProvider> List<T>.withoutImportNamed(names: Collection<String>)
     filterNot {
         when {
             names.isEmpty() -> it.hasImports()
-            else -> it.hasImportWithName(names.first(), *names.drop(1).toTypedArray())
+            else -> it.hasImportWithName(names)
         }
     }
 
@@ -98,7 +98,7 @@ fun <T : KoImportProvider> List<T>.withAllImportsNamed(names: Collection<String>
     filter {
         when {
             names.isEmpty() -> it.hasImports()
-            else -> it.hasImportsWithAllNames(names.first(), *names.drop(1).toTypedArray())
+            else -> it.hasImportsWithAllNames(names)
         }
     }
 
@@ -124,7 +124,7 @@ fun <T : KoImportProvider> List<T>.withoutAllImportsNamed(names: Collection<Stri
     filterNot {
         when {
             names.isEmpty() -> it.hasImports()
-            else -> it.hasImportsWithAllNames(names.first(), *names.drop(1).toTypedArray())
+            else -> it.hasImportsWithAllNames(names)
         }
     }
 

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/api/ext/list/KoInterfaceProviderListExt.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/api/ext/list/KoInterfaceProviderListExt.kt
@@ -57,7 +57,7 @@ fun <T : KoInterfaceProvider> List<T>.withInterfaceNamed(
     filter {
         when {
             names.isEmpty() -> it.hasInterfaces(includeNested)
-            else -> it.hasInterfaceWithName(names.first(), *names.drop(1).toTypedArray(), includeNested = includeNested)
+            else -> it.hasInterfaceWithName(names, includeNested = includeNested)
         }
     }
 
@@ -89,7 +89,7 @@ fun <T : KoInterfaceProvider> List<T>.withoutInterfaceNamed(
     filterNot {
         when {
             names.isEmpty() -> it.hasInterfaces(includeNested)
-            else -> it.hasInterfaceWithName(names.first(), *names.drop(1).toTypedArray(), includeNested = includeNested)
+            else -> it.hasInterfaceWithName(names, includeNested = includeNested)
         }
     }
 
@@ -121,12 +121,7 @@ fun <T : KoInterfaceProvider> List<T>.withAllInterfacesNamed(
     filter {
         when {
             names.isEmpty() -> it.hasInterfaces(includeNested)
-            else ->
-                it.hasInterfacesWithAllNames(
-                    names.first(),
-                    *names.drop(1).toTypedArray(),
-                    includeNested = includeNested,
-                )
+            else -> it.hasInterfacesWithAllNames(names, includeNested = includeNested,)
         }
     }
 
@@ -159,11 +154,7 @@ fun <T : KoInterfaceProvider> List<T>.withoutAllInterfacesNamed(
         when {
             names.isEmpty() -> it.hasInterfaces(includeNested)
             else ->
-                it.hasInterfacesWithAllNames(
-                    names.first(),
-                    *names.drop(1).toTypedArray(),
-                    includeNested = includeNested,
-                )
+                it.hasInterfacesWithAllNames(names, includeNested = includeNested,)
         }
     }
 

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/api/ext/list/KoInterfaceProviderListExt.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/api/ext/list/KoInterfaceProviderListExt.kt
@@ -121,7 +121,7 @@ fun <T : KoInterfaceProvider> List<T>.withAllInterfacesNamed(
     filter {
         when {
             names.isEmpty() -> it.hasInterfaces(includeNested)
-            else -> it.hasInterfacesWithAllNames(names, includeNested = includeNested,)
+            else -> it.hasInterfacesWithAllNames(names, includeNested = includeNested)
         }
     }
 
@@ -154,7 +154,7 @@ fun <T : KoInterfaceProvider> List<T>.withoutAllInterfacesNamed(
         when {
             names.isEmpty() -> it.hasInterfaces(includeNested)
             else ->
-                it.hasInterfacesWithAllNames(names, includeNested = includeNested,)
+                it.hasInterfacesWithAllNames(names, includeNested = includeNested)
         }
     }
 

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/api/ext/list/KoLocalClassProviderListExt.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/api/ext/list/KoLocalClassProviderListExt.kt
@@ -45,7 +45,7 @@ fun <T : KoLocalClassProvider> List<T>.withLocalClassNamed(names: Collection<Str
     filter {
         when {
             names.isEmpty() -> it.hasLocalClasses()
-            else -> it.hasLocalClassWithName(names.first(), *names.drop(1).toTypedArray())
+            else -> it.hasLocalClassWithName(names)
         }
     }
 
@@ -71,7 +71,7 @@ fun <T : KoLocalClassProvider> List<T>.withoutLocalClassNamed(names: Collection<
     filterNot {
         when {
             names.isEmpty() -> it.hasLocalClasses()
-            else -> it.hasLocalClassWithName(names.first(), *names.drop(1).toTypedArray())
+            else -> it.hasLocalClassWithName(names)
         }
     }
 
@@ -97,7 +97,7 @@ fun <T : KoLocalClassProvider> List<T>.withAllLocalClassesNamed(names: Collectio
     filter {
         when {
             names.isEmpty() -> it.hasLocalClasses()
-            else -> it.hasLocalClassesWithAllNames(names.first(), *names.drop(1).toTypedArray())
+            else -> it.hasLocalClassesWithAllNames(names)
         }
     }
 
@@ -123,7 +123,7 @@ fun <T : KoLocalClassProvider> List<T>.withoutAllLocalClassesNamed(names: Collec
     filterNot {
         when {
             names.isEmpty() -> it.hasLocalClasses()
-            else -> it.hasLocalClassesWithAllNames(names.first(), *names.drop(1).toTypedArray())
+            else -> it.hasLocalClassesWithAllNames(names)
         }
     }
 

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/api/ext/list/KoLocalFunctionProviderListExt.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/api/ext/list/KoLocalFunctionProviderListExt.kt
@@ -45,7 +45,7 @@ fun <T : KoLocalFunctionProvider> List<T>.withLocalFunctionNamed(names: Collecti
     filter {
         when {
             names.isEmpty() -> it.hasLocalFunctions()
-            else -> it.hasLocalFunctionWithName(names.first(), *names.drop(1).toTypedArray())
+            else -> it.hasLocalFunctionWithName(names)
         }
     }
 
@@ -71,7 +71,7 @@ fun <T : KoLocalFunctionProvider> List<T>.withoutLocalFunctionNamed(names: Colle
     filterNot {
         when {
             names.isEmpty() -> it.hasLocalFunctions()
-            else -> it.hasLocalFunctionWithName(names.first(), *names.drop(1).toTypedArray())
+            else -> it.hasLocalFunctionWithName(names)
         }
     }
 
@@ -97,7 +97,7 @@ fun <T : KoLocalFunctionProvider> List<T>.withAllLocalFunctionsNamed(names: Coll
     filter {
         when {
             names.isEmpty() -> it.hasLocalFunctions()
-            else -> it.hasLocalFunctionsWithAllNames(names.first(), *names.drop(1).toTypedArray())
+            else -> it.hasLocalFunctionsWithAllNames(names)
         }
     }
 
@@ -123,7 +123,7 @@ fun <T : KoLocalFunctionProvider> List<T>.withoutAllLocalFunctionsNamed(names: C
     filterNot {
         when {
             names.isEmpty() -> it.hasLocalFunctions()
-            else -> it.hasLocalFunctionsWithAllNames(names.first(), *names.drop(1).toTypedArray())
+            else -> it.hasLocalFunctionsWithAllNames(names)
         }
     }
 

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/api/ext/list/KoObjectProviderListExt.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/api/ext/list/KoObjectProviderListExt.kt
@@ -55,7 +55,7 @@ fun <T : KoObjectProvider> List<T>.withObjectNamed(
     filter {
         when {
             names.isEmpty() -> it.hasObjects(includeNested)
-            else -> it.hasObjectWithName(names.first(), *names.drop(1).toTypedArray(), includeNested = includeNested)
+            else -> it.hasObjectWithName(names, includeNested = includeNested)
         }
     }
 
@@ -87,7 +87,7 @@ fun <T : KoObjectProvider> List<T>.withoutObjectNamed(
     filterNot {
         when {
             names.isEmpty() -> it.hasObjects(includeNested)
-            else -> it.hasObjectWithName(names.first(), *names.drop(1).toTypedArray(), includeNested = includeNested)
+            else -> it.hasObjectWithName(names, includeNested = includeNested)
         }
     }
 
@@ -119,12 +119,7 @@ fun <T : KoObjectProvider> List<T>.withAllObjectsNamed(
     filter {
         when {
             names.isEmpty() -> it.hasObjects(includeNested)
-            else ->
-                it.hasObjectsWithAllNames(
-                    names.first(),
-                    *names.drop(1).toTypedArray(),
-                    includeNested = includeNested,
-                )
+            else -> it.hasObjectsWithAllNames(names, includeNested = includeNested)
         }
     }
 
@@ -156,12 +151,7 @@ fun <T : KoObjectProvider> List<T>.withoutAllObjectsNamed(
     filterNot {
         when {
             names.isEmpty() -> it.hasObjects(includeNested)
-            else ->
-                it.hasObjectsWithAllNames(
-                    names.first(),
-                    *names.drop(1).toTypedArray(),
-                    includeNested = includeNested,
-                )
+            else -> it.hasObjectsWithAllNames(names, includeNested = includeNested)
         }
     }
 

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/api/ext/list/KoParametersProviderListExt.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/api/ext/list/KoParametersProviderListExt.kt
@@ -45,7 +45,7 @@ fun <T : KoParametersProvider> List<T>.withParameterNamed(names: Collection<Stri
     filter {
         when {
             names.isEmpty() -> it.hasParameters()
-            else -> it.hasParameterWithName(names.first(), *names.drop(1).toTypedArray())
+            else -> it.hasParameterWithName(names)
         }
     }
 
@@ -71,7 +71,7 @@ fun <T : KoParametersProvider> List<T>.withoutParameterNamed(names: Collection<S
     filterNot {
         when {
             names.isEmpty() -> it.hasParameters()
-            else -> it.hasParameterWithName(names.first(), *names.drop(1).toTypedArray())
+            else -> it.hasParameterWithName(names)
         }
     }
 
@@ -97,7 +97,7 @@ fun <T : KoParametersProvider> List<T>.withAllParametersNamed(names: Collection<
     filter {
         when {
             names.isEmpty() -> it.hasParameters()
-            else -> it.hasParametersWithAllNames(names.first(), *names.drop(1).toTypedArray())
+            else -> it.hasParametersWithAllNames(names)
         }
     }
 
@@ -123,7 +123,7 @@ fun <T : KoParametersProvider> List<T>.withoutAllParametersNamed(names: Collecti
     filterNot {
         when {
             names.isEmpty() -> it.hasParameters()
-            else -> it.hasParametersWithAllNames(names.first(), *names.drop(1).toTypedArray())
+            else -> it.hasParametersWithAllNames(names)
         }
     }
 

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/api/ext/list/KoParentClassProviderListExt.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/api/ext/list/KoParentClassProviderListExt.kt
@@ -153,12 +153,7 @@ fun <T : KoParentClassProvider> List<T>.withParentClassNamed(
     filter {
         when {
             names.isEmpty() -> it.hasParentClasses(indirectParents)
-            else ->
-                it.hasParentClassWithName(
-                    names.first(),
-                    *names.drop(1).toTypedArray(),
-                    indirectParents = indirectParents,
-                )
+            else -> it.hasParentClassWithName(names, indirectParents = indirectParents)
         }
     }
 
@@ -190,12 +185,7 @@ fun <T : KoParentClassProvider> List<T>.withoutParentClassNamed(
     filterNot {
         when {
             names.isEmpty() -> it.hasParentClasses(indirectParents)
-            else ->
-                it.hasParentClassWithName(
-                    names.first(),
-                    *names.drop(1).toTypedArray(),
-                    indirectParents = indirectParents,
-                )
+            else -> it.hasParentClassWithName(names, indirectParents = indirectParents)
         }
     }
 
@@ -227,12 +217,7 @@ fun <T : KoParentClassProvider> List<T>.withAllParentClassesNamed(
     filter {
         when {
             names.isEmpty() -> it.hasParentClasses(indirectParents)
-            else ->
-                it.hasParentClassesWithAllNames(
-                    names.first(),
-                    *names.drop(1).toTypedArray(),
-                    indirectParents = indirectParents,
-                )
+            else -> it.hasParentClassesWithAllNames(names, indirectParents = indirectParents)
         }
     }
 
@@ -264,12 +249,7 @@ fun <T : KoParentClassProvider> List<T>.withoutAllParentClassesNamed(
     filterNot {
         when {
             names.isEmpty() -> it.hasParentClasses(indirectParents)
-            else ->
-                it.hasParentClassesWithAllNames(
-                    names.first(),
-                    *names.drop(1).toTypedArray(),
-                    indirectParents = indirectParents,
-                )
+            else -> it.hasParentClassesWithAllNames(names, indirectParents = indirectParents)
         }
     }
 
@@ -301,12 +281,7 @@ fun <T : KoParentClassProvider> List<T>.withParentClassOf(
     filter {
         when {
             kClasses.isEmpty() -> it.hasParentClasses(indirectParents)
-            else ->
-                it.hasParentClassOf(
-                    kClasses.first(),
-                    *kClasses.drop(1).toTypedArray(),
-                    indirectParents = indirectParents,
-                )
+            else -> it.hasParentClassOf(kClasses, indirectParents = indirectParents,)
         }
     }
 
@@ -338,12 +313,7 @@ fun <T : KoParentClassProvider> List<T>.withoutParentClassOf(
     filterNot {
         when {
             kClasses.isEmpty() -> it.hasParentClasses(indirectParents)
-            else ->
-                it.hasParentClassOf(
-                    kClasses.first(),
-                    *kClasses.drop(1).toTypedArray(),
-                    indirectParents = indirectParents,
-                )
+            else -> it.hasParentClassOf(kClasses, indirectParents = indirectParents,)
         }
     }
 
@@ -375,12 +345,7 @@ fun <T : KoParentClassProvider> List<T>.withAllParentClassesOf(
     filter {
         when {
             kClasses.isEmpty() -> it.hasParentClasses(indirectParents)
-            else ->
-                it.hasAllParentClassesOf(
-                    kClasses.first(),
-                    *kClasses.drop(1).toTypedArray(),
-                    indirectParents = indirectParents,
-                )
+            else -> it.hasAllParentClassesOf(kClasses, indirectParents = indirectParents,)
         }
     }
 
@@ -412,12 +377,7 @@ fun <T : KoParentClassProvider> List<T>.withoutAllParentClassesOf(
     filterNot {
         when {
             kClasses.isEmpty() -> it.hasParentClasses(indirectParents)
-            else ->
-                it.hasAllParentClassesOf(
-                    kClasses.first(),
-                    *kClasses.drop(1).toTypedArray(),
-                    indirectParents = indirectParents,
-                )
+            else -> it.hasAllParentClassesOf(kClasses, indirectParents = indirectParents,)
         }
     }
 

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/api/ext/list/KoParentClassProviderListExt.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/api/ext/list/KoParentClassProviderListExt.kt
@@ -281,7 +281,7 @@ fun <T : KoParentClassProvider> List<T>.withParentClassOf(
     filter {
         when {
             kClasses.isEmpty() -> it.hasParentClasses(indirectParents)
-            else -> it.hasParentClassOf(kClasses, indirectParents = indirectParents,)
+            else -> it.hasParentClassOf(kClasses, indirectParents = indirectParents)
         }
     }
 
@@ -313,7 +313,7 @@ fun <T : KoParentClassProvider> List<T>.withoutParentClassOf(
     filterNot {
         when {
             kClasses.isEmpty() -> it.hasParentClasses(indirectParents)
-            else -> it.hasParentClassOf(kClasses, indirectParents = indirectParents,)
+            else -> it.hasParentClassOf(kClasses, indirectParents = indirectParents)
         }
     }
 
@@ -345,7 +345,7 @@ fun <T : KoParentClassProvider> List<T>.withAllParentClassesOf(
     filter {
         when {
             kClasses.isEmpty() -> it.hasParentClasses(indirectParents)
-            else -> it.hasAllParentClassesOf(kClasses, indirectParents = indirectParents,)
+            else -> it.hasAllParentClassesOf(kClasses, indirectParents = indirectParents)
         }
     }
 
@@ -377,7 +377,7 @@ fun <T : KoParentClassProvider> List<T>.withoutAllParentClassesOf(
     filterNot {
         when {
             kClasses.isEmpty() -> it.hasParentClasses(indirectParents)
-            else -> it.hasAllParentClassesOf(kClasses, indirectParents = indirectParents,)
+            else -> it.hasAllParentClassesOf(kClasses, indirectParents = indirectParents)
         }
     }
 

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/api/ext/list/KoParentInterfaceProviderListExt.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/api/ext/list/KoParentInterfaceProviderListExt.kt
@@ -68,12 +68,7 @@ fun <T : KoParentInterfaceProvider> List<T>.withParentInterfaceNamed(
     filter {
         when {
             names.isEmpty() -> it.hasParentInterfaces(indirectParents = indirectParents)
-            else ->
-                it.hasParentInterfaceWithName(
-                    names.first(),
-                    *names.drop(1).toTypedArray(),
-                    indirectParents = indirectParents,
-                )
+            else -> it.hasParentInterfaceWithName(names, indirectParents = indirectParents,)
         }
     }
 
@@ -105,12 +100,7 @@ fun <T : KoParentInterfaceProvider> List<T>.withoutParentInterfaceNamed(
     filterNot {
         when {
             names.isEmpty() -> it.hasParentInterfaces(indirectParents = indirectParents)
-            else ->
-                it.hasParentInterfaceWithName(
-                    names.first(),
-                    *names.drop(1).toTypedArray(),
-                    indirectParents = indirectParents,
-                )
+            else -> it.hasParentInterfaceWithName(names, indirectParents = indirectParents,)
         }
     }
 
@@ -142,12 +132,7 @@ fun <T : KoParentInterfaceProvider> List<T>.withAllParentInterfacesNamed(
     filter {
         when {
             names.isEmpty() -> it.hasParentInterfaces(indirectParents = indirectParents)
-            else ->
-                it.hasParentInterfacesWithAllNames(
-                    names.first(),
-                    *names.drop(1).toTypedArray(),
-                    indirectParents = indirectParents,
-                )
+            else -> it.hasParentInterfacesWithAllNames(names, indirectParents = indirectParents,)
         }
     }
 
@@ -179,12 +164,7 @@ fun <T : KoParentInterfaceProvider> List<T>.withoutAllParentInterfacesNamed(
     filterNot {
         when {
             names.isEmpty() -> it.hasParentInterfaces(indirectParents = indirectParents)
-            else ->
-                it.hasParentInterfacesWithAllNames(
-                    names.first(),
-                    *names.drop(1).toTypedArray(),
-                    indirectParents = indirectParents,
-                )
+            else -> it.hasParentInterfacesWithAllNames(names, indirectParents = indirectParents,)
         }
     }
 
@@ -288,12 +268,7 @@ fun <T : KoParentInterfaceProvider> List<T>.withParentInterfaceOf(
     filter {
         when {
             kClasses.isEmpty() -> it.hasParentInterfaces(indirectParents)
-            else ->
-                it.hasParentInterfaceOf(
-                    kClasses.first(),
-                    *kClasses.drop(1).toTypedArray(),
-                    indirectParents = indirectParents,
-                )
+            else -> it.hasParentInterfaceOf(kClasses, indirectParents = indirectParents,)
         }
     }
 
@@ -325,12 +300,7 @@ fun <T : KoParentInterfaceProvider> List<T>.withoutParentInterfaceOf(
     filterNot {
         when {
             kClasses.isEmpty() -> it.hasParentInterfaces(indirectParents)
-            else ->
-                it.hasParentInterfaceOf(
-                    kClasses.first(),
-                    *kClasses.drop(1).toTypedArray(),
-                    indirectParents = indirectParents,
-                )
+            else -> it.hasParentInterfaceOf(kClasses, indirectParents = indirectParents,)
         }
     }
 
@@ -362,12 +332,7 @@ fun <T : KoParentInterfaceProvider> List<T>.withAllParentInterfacesOf(
     filter {
         when {
             kClasses.isEmpty() -> it.hasParentInterfaces(indirectParents)
-            else ->
-                it.hasAllParentInterfacesOf(
-                    kClasses.first(),
-                    *kClasses.drop(1).toTypedArray(),
-                    indirectParents = indirectParents,
-                )
+            else -> it.hasAllParentInterfacesOf(kClasses, indirectParents = indirectParents,)
         }
     }
 
@@ -399,12 +364,7 @@ fun <T : KoParentInterfaceProvider> List<T>.withoutAllParentInterfacesOf(
     filterNot {
         when {
             kClasses.isEmpty() -> it.hasParentInterfaces(indirectParents)
-            else ->
-                it.hasAllParentInterfacesOf(
-                    kClasses.first(),
-                    *kClasses.drop(1).toTypedArray(),
-                    indirectParents = indirectParents,
-                )
+            else -> it.hasAllParentInterfacesOf(kClasses, indirectParents = indirectParents,)
         }
     }
 

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/api/ext/list/KoParentInterfaceProviderListExt.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/api/ext/list/KoParentInterfaceProviderListExt.kt
@@ -68,7 +68,7 @@ fun <T : KoParentInterfaceProvider> List<T>.withParentInterfaceNamed(
     filter {
         when {
             names.isEmpty() -> it.hasParentInterfaces(indirectParents = indirectParents)
-            else -> it.hasParentInterfaceWithName(names, indirectParents = indirectParents,)
+            else -> it.hasParentInterfaceWithName(names, indirectParents = indirectParents)
         }
     }
 
@@ -100,7 +100,7 @@ fun <T : KoParentInterfaceProvider> List<T>.withoutParentInterfaceNamed(
     filterNot {
         when {
             names.isEmpty() -> it.hasParentInterfaces(indirectParents = indirectParents)
-            else -> it.hasParentInterfaceWithName(names, indirectParents = indirectParents,)
+            else -> it.hasParentInterfaceWithName(names, indirectParents = indirectParents)
         }
     }
 
@@ -132,7 +132,7 @@ fun <T : KoParentInterfaceProvider> List<T>.withAllParentInterfacesNamed(
     filter {
         when {
             names.isEmpty() -> it.hasParentInterfaces(indirectParents = indirectParents)
-            else -> it.hasParentInterfacesWithAllNames(names, indirectParents = indirectParents,)
+            else -> it.hasParentInterfacesWithAllNames(names, indirectParents = indirectParents)
         }
     }
 
@@ -164,7 +164,7 @@ fun <T : KoParentInterfaceProvider> List<T>.withoutAllParentInterfacesNamed(
     filterNot {
         when {
             names.isEmpty() -> it.hasParentInterfaces(indirectParents = indirectParents)
-            else -> it.hasParentInterfacesWithAllNames(names, indirectParents = indirectParents,)
+            else -> it.hasParentInterfacesWithAllNames(names, indirectParents = indirectParents)
         }
     }
 
@@ -268,7 +268,7 @@ fun <T : KoParentInterfaceProvider> List<T>.withParentInterfaceOf(
     filter {
         when {
             kClasses.isEmpty() -> it.hasParentInterfaces(indirectParents)
-            else -> it.hasParentInterfaceOf(kClasses, indirectParents = indirectParents,)
+            else -> it.hasParentInterfaceOf(kClasses, indirectParents = indirectParents)
         }
     }
 
@@ -300,7 +300,7 @@ fun <T : KoParentInterfaceProvider> List<T>.withoutParentInterfaceOf(
     filterNot {
         when {
             kClasses.isEmpty() -> it.hasParentInterfaces(indirectParents)
-            else -> it.hasParentInterfaceOf(kClasses, indirectParents = indirectParents,)
+            else -> it.hasParentInterfaceOf(kClasses, indirectParents = indirectParents)
         }
     }
 
@@ -332,7 +332,7 @@ fun <T : KoParentInterfaceProvider> List<T>.withAllParentInterfacesOf(
     filter {
         when {
             kClasses.isEmpty() -> it.hasParentInterfaces(indirectParents)
-            else -> it.hasAllParentInterfacesOf(kClasses, indirectParents = indirectParents,)
+            else -> it.hasAllParentInterfacesOf(kClasses, indirectParents = indirectParents)
         }
     }
 
@@ -364,7 +364,7 @@ fun <T : KoParentInterfaceProvider> List<T>.withoutAllParentInterfacesOf(
     filterNot {
         when {
             kClasses.isEmpty() -> it.hasParentInterfaces(indirectParents)
-            else -> it.hasAllParentInterfacesOf(kClasses, indirectParents = indirectParents,)
+            else -> it.hasAllParentInterfacesOf(kClasses, indirectParents = indirectParents)
         }
     }
 

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/api/ext/list/KoParentProviderListExt.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/api/ext/list/KoParentProviderListExt.kt
@@ -67,7 +67,7 @@ fun <T : KoParentProvider> List<T>.withParentNamed(
     filter {
         when {
             names.isEmpty() -> it.hasParents(indirectParents)
-            else -> it.hasParentWithName(names, indirectParents = indirectParents,)
+            else -> it.hasParentWithName(names, indirectParents = indirectParents)
         }
     }
 
@@ -99,7 +99,7 @@ fun <T : KoParentProvider> List<T>.withoutParentNamed(
     filterNot {
         when {
             names.isEmpty() -> it.hasParents(indirectParents)
-            else -> it.hasParentWithName(names, indirectParents = indirectParents,)
+            else -> it.hasParentWithName(names, indirectParents = indirectParents)
         }
     }
 
@@ -131,7 +131,7 @@ fun <T : KoParentProvider> List<T>.withAllParentsNamed(
     filter {
         when {
             names.isEmpty() -> it.hasParents(indirectParents)
-            else -> it.hasParentsWithAllNames(names, indirectParents = indirectParents,)
+            else -> it.hasParentsWithAllNames(names, indirectParents = indirectParents)
         }
     }
 
@@ -163,7 +163,7 @@ fun <T : KoParentProvider> List<T>.withoutAllParentsNamed(
     filterNot {
         when {
             names.isEmpty() -> it.hasParents(indirectParents)
-            else -> it.hasParentsWithAllNames(names, indirectParents = indirectParents,)
+            else -> it.hasParentsWithAllNames(names, indirectParents = indirectParents)
         }
     }
 
@@ -282,7 +282,7 @@ fun <T : KoParentProvider> List<T>.withParentOf(
     filter {
         when {
             kClasses.isEmpty() -> it.hasParents(indirectParents)
-            else -> it.hasParentOf(kClasses, indirectParents = indirectParents,)
+            else -> it.hasParentOf(kClasses, indirectParents = indirectParents)
         }
     }
 
@@ -314,7 +314,7 @@ fun <T : KoParentProvider> List<T>.withoutParentOf(
     filterNot {
         when {
             kClasses.isEmpty() -> it.hasParents(indirectParents)
-            else -> it.hasParentOf(kClasses, indirectParents = indirectParents,)
+            else -> it.hasParentOf(kClasses, indirectParents = indirectParents)
         }
     }
 
@@ -346,7 +346,7 @@ fun <T : KoParentProvider> List<T>.withAllParentsOf(
     filter {
         when {
             kClasses.isEmpty() -> it.hasParents(indirectParents)
-            else -> it.hasAllParentsOf(kClasses, indirectParents = indirectParents,)
+            else -> it.hasAllParentsOf(kClasses, indirectParents = indirectParents)
         }
     }
 
@@ -378,7 +378,7 @@ fun <T : KoParentProvider> List<T>.withoutAllParentsOf(
     filterNot {
         when {
             kClasses.isEmpty() -> it.hasParents(indirectParents)
-            else -> it.hasAllParentsOf(kClasses, indirectParents = indirectParents,)
+            else -> it.hasAllParentsOf(kClasses, indirectParents = indirectParents)
         }
     }
 

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/api/ext/list/KoParentProviderListExt.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/api/ext/list/KoParentProviderListExt.kt
@@ -67,12 +67,7 @@ fun <T : KoParentProvider> List<T>.withParentNamed(
     filter {
         when {
             names.isEmpty() -> it.hasParents(indirectParents)
-            else ->
-                it.hasParentWithName(
-                    names.first(),
-                    *names.drop(1).toTypedArray(),
-                    indirectParents = indirectParents,
-                )
+            else -> it.hasParentWithName(names, indirectParents = indirectParents,)
         }
     }
 
@@ -104,12 +99,7 @@ fun <T : KoParentProvider> List<T>.withoutParentNamed(
     filterNot {
         when {
             names.isEmpty() -> it.hasParents(indirectParents)
-            else ->
-                it.hasParentWithName(
-                    names.first(),
-                    *names.drop(1).toTypedArray(),
-                    indirectParents = indirectParents,
-                )
+            else -> it.hasParentWithName(names, indirectParents = indirectParents,)
         }
     }
 
@@ -141,12 +131,7 @@ fun <T : KoParentProvider> List<T>.withAllParentsNamed(
     filter {
         when {
             names.isEmpty() -> it.hasParents(indirectParents)
-            else ->
-                it.hasParentsWithAllNames(
-                    names.first(),
-                    *names.drop(1).toTypedArray(),
-                    indirectParents = indirectParents,
-                )
+            else -> it.hasParentsWithAllNames(names, indirectParents = indirectParents,)
         }
     }
 
@@ -178,12 +163,7 @@ fun <T : KoParentProvider> List<T>.withoutAllParentsNamed(
     filterNot {
         when {
             names.isEmpty() -> it.hasParents(indirectParents)
-            else ->
-                it.hasParentsWithAllNames(
-                    names.first(),
-                    *names.drop(1).toTypedArray(),
-                    indirectParents = indirectParents,
-                )
+            else -> it.hasParentsWithAllNames(names, indirectParents = indirectParents,)
         }
     }
 
@@ -302,12 +282,7 @@ fun <T : KoParentProvider> List<T>.withParentOf(
     filter {
         when {
             kClasses.isEmpty() -> it.hasParents(indirectParents)
-            else ->
-                it.hasParentOf(
-                    kClasses.first(),
-                    *kClasses.drop(1).toTypedArray(),
-                    indirectParents = indirectParents,
-                )
+            else -> it.hasParentOf(kClasses, indirectParents = indirectParents,)
         }
     }
 
@@ -339,12 +314,7 @@ fun <T : KoParentProvider> List<T>.withoutParentOf(
     filterNot {
         when {
             kClasses.isEmpty() -> it.hasParents(indirectParents)
-            else ->
-                it.hasParentOf(
-                    kClasses.first(),
-                    *kClasses.drop(1).toTypedArray(),
-                    indirectParents = indirectParents,
-                )
+            else -> it.hasParentOf(kClasses, indirectParents = indirectParents,)
         }
     }
 
@@ -376,12 +346,7 @@ fun <T : KoParentProvider> List<T>.withAllParentsOf(
     filter {
         when {
             kClasses.isEmpty() -> it.hasParents(indirectParents)
-            else ->
-                it.hasAllParentsOf(
-                    kClasses.first(),
-                    *kClasses.drop(1).toTypedArray(),
-                    indirectParents = indirectParents,
-                )
+            else -> it.hasAllParentsOf(kClasses, indirectParents = indirectParents,)
         }
     }
 
@@ -413,12 +378,7 @@ fun <T : KoParentProvider> List<T>.withoutAllParentsOf(
     filterNot {
         when {
             kClasses.isEmpty() -> it.hasParents(indirectParents)
-            else ->
-                it.hasAllParentsOf(
-                    kClasses.first(),
-                    *kClasses.drop(1).toTypedArray(),
-                    indirectParents = indirectParents,
-                )
+            else -> it.hasAllParentsOf(kClasses, indirectParents = indirectParents,)
         }
     }
 

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/api/ext/list/KoPropertyProviderListExt.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/api/ext/list/KoPropertyProviderListExt.kt
@@ -57,7 +57,7 @@ fun <T : KoPropertyProvider> List<T>.withPropertyNamed(
     filter {
         when {
             names.isEmpty() -> it.hasProperties(includeNested)
-            else -> it.hasPropertyWithName(names.first(), *names.drop(1).toTypedArray(), includeNested = includeNested)
+            else -> it.hasPropertyWithName(names, includeNested = includeNested)
         }
     }
 
@@ -89,7 +89,7 @@ fun <T : KoPropertyProvider> List<T>.withoutPropertyNamed(
     filterNot {
         when {
             names.isEmpty() -> it.hasProperties(includeNested)
-            else -> it.hasPropertyWithName(names.first(), *names.drop(1).toTypedArray(), includeNested = includeNested)
+            else -> it.hasPropertyWithName(names, includeNested = includeNested)
         }
     }
 
@@ -121,7 +121,7 @@ fun <T : KoPropertyProvider> List<T>.withAllPropertiesNamed(
     filter {
         when {
             names.isEmpty() -> it.hasProperties(includeNested)
-            else -> it.hasPropertiesWithAllNames(names.first(), *names.drop(1).toTypedArray(), includeNested = includeNested)
+            else -> it.hasPropertiesWithAllNames(names, includeNested = includeNested)
         }
     }
 
@@ -153,7 +153,7 @@ fun <T : KoPropertyProvider> List<T>.withoutAllPropertiesNamed(
     filterNot {
         when {
             names.isEmpty() -> it.hasProperties(includeNested)
-            else -> it.hasPropertiesWithAllNames(names.first(), *names.drop(1).toTypedArray(), includeNested = includeNested)
+            else -> it.hasPropertiesWithAllNames(names, includeNested = includeNested)
         }
     }
 

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/api/ext/list/KoTypeAliasProviderListExt.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/api/ext/list/KoTypeAliasProviderListExt.kt
@@ -45,7 +45,7 @@ fun <T : KoTypeAliasProvider> List<T>.withTypeAliasNamed(names: Collection<Strin
     filter {
         when {
             names.isEmpty() -> it.hasTypeAliases()
-            else -> it.hasTypeAliasWithName(names.first(), *names.drop(1).toTypedArray())
+            else -> it.hasTypeAliasWithName(names)
         }
     }
 
@@ -71,7 +71,7 @@ fun <T : KoTypeAliasProvider> List<T>.withoutTypeAliasNamed(names: Collection<St
     filterNot {
         when {
             names.isEmpty() -> it.hasTypeAliases()
-            else -> it.hasTypeAliasWithName(names.first(), *names.drop(1).toTypedArray())
+            else -> it.hasTypeAliasWithName(names)
         }
     }
 
@@ -97,7 +97,7 @@ fun <T : KoTypeAliasProvider> List<T>.withAllTypeAliasesNamed(names: Collection<
     filter {
         when {
             names.isEmpty() -> it.hasTypeAliases()
-            else -> it.hasTypeAliasesWithAllNames(names.first(), *names.drop(1).toTypedArray())
+            else -> it.hasTypeAliasesWithAllNames(names)
         }
     }
 
@@ -123,7 +123,7 @@ fun <T : KoTypeAliasProvider> List<T>.withoutAllTypeAliasesNamed(names: Collecti
     filterNot {
         when {
             names.isEmpty() -> it.hasTypeAliases()
-            else -> it.hasTypeAliasesWithAllNames(names.first(), *names.drop(1).toTypedArray())
+            else -> it.hasTypeAliasesWithAllNames(names)
         }
     }
 

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/api/ext/list/KoVariableProviderListExt.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/api/ext/list/KoVariableProviderListExt.kt
@@ -45,7 +45,7 @@ fun <T : KoVariableProvider> List<T>.withVariableNamed(names: Collection<String>
     filter {
         when {
             names.isEmpty() -> it.hasVariables()
-            else -> it.hasVariableWithName(names.first(), *names.drop(1).toTypedArray())
+            else -> it.hasVariableWithName(names)
         }
     }
 
@@ -71,7 +71,7 @@ fun <T : KoVariableProvider> List<T>.withoutVariableNamed(names: Collection<Stri
     filterNot {
         when {
             names.isEmpty() -> it.hasVariables()
-            else -> it.hasVariableWithName(names.first(), *names.drop(1).toTypedArray())
+            else -> it.hasVariableWithName(names)
         }
     }
 
@@ -97,7 +97,7 @@ fun <T : KoVariableProvider> List<T>.withAllVariablesNamed(names: Collection<Str
     filter {
         when {
             names.isEmpty() -> it.hasVariables()
-            else -> it.hasVariablesWithAllNames(names.first(), *names.drop(1).toTypedArray())
+            else -> it.hasVariablesWithAllNames(names)
         }
     }
 
@@ -123,7 +123,7 @@ fun <T : KoVariableProvider> List<T>.withoutAllVariablesNamed(names: Collection<
     filterNot {
         when {
             names.isEmpty() -> it.hasVariables()
-            else -> it.hasVariablesWithAllNames(names.first(), *names.drop(1).toTypedArray())
+            else -> it.hasVariablesWithAllNames(names)
         }
     }
 

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/api/ext/list/modifierprovider/KoModifierProviderListExt.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/api/ext/list/modifierprovider/KoModifierProviderListExt.kt
@@ -45,7 +45,7 @@ fun <T : KoModifierProvider> List<T>.withModifier(modifiers: Collection<KoModifi
     filter {
         when {
             modifiers.isEmpty() -> it.hasModifiers()
-            else -> it.hasModifier(modifiers.first(), *modifiers.drop(1).toTypedArray())
+            else -> it.hasModifier(modifiers)
         }
     }
 
@@ -71,7 +71,7 @@ fun <T : KoModifierProvider> List<T>.withoutModifier(modifiers: Collection<KoMod
     filterNot {
         when {
             modifiers.isEmpty() -> it.hasModifiers()
-            else -> it.hasModifier(modifiers.first(), *modifiers.drop(1).toTypedArray())
+            else -> it.hasModifier(modifiers)
         }
     }
 
@@ -97,7 +97,7 @@ fun <T : KoModifierProvider> List<T>.withAllModifiers(modifiers: Collection<KoMo
     filter {
         when {
             modifiers.isEmpty() -> it.hasModifiers()
-            else -> it.hasAllModifiers(modifiers.first(), *modifiers.drop(1).toTypedArray())
+            else -> it.hasAllModifiers(modifiers)
         }
     }
 
@@ -123,7 +123,7 @@ fun <T : KoModifierProvider> List<T>.withoutAllModifiers(modifiers: Collection<K
     filterNot {
         when {
             modifiers.isEmpty() -> it.hasModifiers()
-            else -> it.hasAllModifiers(modifiers.first(), *modifiers.drop(1).toTypedArray())
+            else -> it.hasAllModifiers(modifiers)
         }
     }
 

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/api/ext/list/tagprovider/KoKDocTagProviderListExt.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/api/ext/list/tagprovider/KoKDocTagProviderListExt.kt
@@ -46,7 +46,7 @@ fun <T : KoKDocTagProvider> List<T>.withTag(tags: Collection<KoKDocTag>): List<T
     filter {
         when {
             tags.isEmpty() -> it.hasTags()
-            else -> it.hasTag(tags.first(), *tags.drop(1).toTypedArray())
+            else -> it.hasTag(tags)
         }
     }
 
@@ -72,7 +72,7 @@ fun <T : KoKDocTagProvider> List<T>.withoutTag(tags: Collection<KoKDocTag>): Lis
     filterNot {
         when {
             tags.isEmpty() -> it.hasTags()
-            else -> it.hasTag(tags.first(), *tags.drop(1).toTypedArray())
+            else -> it.hasTag(tags)
         }
     }
 
@@ -98,7 +98,7 @@ fun <T : KoKDocTagProvider> List<T>.withAllTags(tags: Collection<KoKDocTag>): Li
     filter {
         when {
             tags.isEmpty() -> it.hasTags()
-            else -> it.hasAllTags(tags.first(), *tags.drop(1).toTypedArray())
+            else -> it.hasAllTags(tags)
         }
     }
 
@@ -124,6 +124,6 @@ fun <T : KoKDocTagProvider> List<T>.withoutAllTags(tags: Collection<KoKDocTag>):
     filterNot {
         when {
             tags.isEmpty() -> it.hasTags()
-            else -> it.hasAllTags(tags.first(), *tags.drop(1).toTypedArray())
+            else -> it.hasAllTags(tags)
         }
     }

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/api/provider/KoAnnotationProvider.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/api/provider/KoAnnotationProvider.kt
@@ -83,7 +83,7 @@ interface KoAnnotationProvider : KoBaseProvider {
      * @param names the names of the annotations to check. It can be either a simple name or a fully qualified name.
      * @return `true` if there is a matching declaration, `false` otherwise.
      */
-    fun hasAnnotationWithName(names: Collection<String>, ): Boolean
+    fun hasAnnotationWithName(names: Collection<String>): Boolean
 
     /**
      * Determines whether the declaration has annotations with all the specified names.
@@ -103,7 +103,7 @@ interface KoAnnotationProvider : KoBaseProvider {
      * @param names The names of the annotations to check. It can be either a simple name or a fully qualified name.
      * @return `true` if there are declarations with all the specified names, `false` otherwise.
      */
-    fun hasAnnotationsWithAllNames(names: Collection<String>, ): Boolean
+    fun hasAnnotationsWithAllNames(names: Collection<String>): Boolean
 
     /**
      * Determines whether the declaration has at least one annotation that satisfies the provided predicate.
@@ -136,7 +136,7 @@ interface KoAnnotationProvider : KoBaseProvider {
         vararg names: KClass<*>,
     ): Boolean
 
-        /**
+    /**
      * Determines whether the declaration has at least one annotation of the specified `KClass` type.
      *
      * @param names the `KClass` types of the annotations to check.
@@ -156,7 +156,7 @@ interface KoAnnotationProvider : KoBaseProvider {
         vararg names: KClass<*>,
     ): Boolean
 
-        /**
+    /**
      * Determines whether the declaration has annotations with all the specified `KClass` type.
      *
      * @param names the `KClass` types of the annotations to check.

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/api/provider/KoAnnotationProvider.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/api/provider/KoAnnotationProvider.kt
@@ -78,6 +78,14 @@ interface KoAnnotationProvider : KoBaseProvider {
     ): Boolean
 
     /**
+     * Determines whether the declaration has at least one annotation whose name matches any of the specified names.
+     *
+     * @param names the names of the annotations to check. It can be either a simple name or a fully qualified name.
+     * @return `true` if there is a matching declaration, `false` otherwise.
+     */
+    fun hasAnnotationWithName(names: Collection<String>, ): Boolean
+
+    /**
      * Determines whether the declaration has annotations with all the specified names.
      *
      * @param name the name of the annotations to check. It can be either a simple name or a fully qualified name.
@@ -88,6 +96,14 @@ interface KoAnnotationProvider : KoBaseProvider {
         name: String,
         vararg names: String,
     ): Boolean
+
+    /**
+     * Determines whether the declaration has annotations with all the specified names.
+     *
+     * @param names The names of the annotations to check. It can be either a simple name or a fully qualified name.
+     * @return `true` if there are declarations with all the specified names, `false` otherwise.
+     */
+    fun hasAnnotationsWithAllNames(names: Collection<String>, ): Boolean
 
     /**
      * Determines whether the declaration has at least one annotation that satisfies the provided predicate.
@@ -120,6 +136,14 @@ interface KoAnnotationProvider : KoBaseProvider {
         vararg names: KClass<*>,
     ): Boolean
 
+        /**
+     * Determines whether the declaration has at least one annotation of the specified `KClass` type.
+     *
+     * @param names the `KClass` types of the annotations to check.
+     * @return `true` if there is a matching declaration, `false` otherwise.
+     */
+    fun hasAnnotationOf(names: Collection<KClass<*>>): Boolean
+
     /**
      * Determines whether the declaration has annotations with all the specified `KClass` type.
      *
@@ -131,4 +155,12 @@ interface KoAnnotationProvider : KoBaseProvider {
         name: KClass<*>,
         vararg names: KClass<*>,
     ): Boolean
+
+        /**
+     * Determines whether the declaration has annotations with all the specified `KClass` type.
+     *
+     * @param names the `KClass` types of the annotations to check.
+     * @return `true` if the declaration has annotations of all the specified `KClass` types, `false` otherwise.
+     */
+    fun hasAllAnnotationsOf(names: Collection<KClass<*>>): Boolean
 }

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/api/provider/KoArgumentProvider.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/api/provider/KoArgumentProvider.kt
@@ -45,6 +45,14 @@ interface KoArgumentProvider : KoBaseProvider {
     ): Boolean
 
     /**
+     * Determines whether the declaration has at least one argument whose name matches any of the specified names.
+     *
+     * @param names the names of the arguments to check.
+     * @return `true` if there is a matching declaration, `false` otherwise.
+     */
+    fun hasArgumentWithName(names: Collection<String>): Boolean
+
+    /**
      * Determines whether the declaration has arguments with all the specified names.
      *
      * @param name The name of the argument to check.
@@ -55,6 +63,14 @@ interface KoArgumentProvider : KoBaseProvider {
         name: String,
         vararg names: String,
     ): Boolean
+
+    /**
+     * Determines whether the declaration has arguments with all the specified names.
+     *
+     * @param names The names of the arguments to check.
+     * @return `true` if there are declarations with all the specified names, `false` otherwise.
+     */
+    fun hasArgumentsWithAllNames(names: Collection<String>): Boolean
 
     /**
      * Determines whether the declaration has at least one argument that satisfies the provided predicate.

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/api/provider/KoChildProvider.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/api/provider/KoChildProvider.kt
@@ -59,6 +59,16 @@ interface KoChildProvider : KoBaseProvider {
     ): Boolean
 
     /**
+     * Determines whether the declaration has at least one child defined directly
+     * in the Kotlin file whose name matches any of the specified names.
+     *
+     * @param names the names of the children to check.
+     * @param indirectChildren specifies whether to include children defined in other files such as child of the child.
+     * @return `true` if there is a matching declaration, `false` otherwise.
+     */
+    fun hasChildWithName(names: Collection<String>, indirectChildren: Boolean = false): Boolean
+
+    /**
      * Determines whether the declaration has children defined directly in the Kotlin
      * file with all the specified names.
      *
@@ -72,6 +82,16 @@ interface KoChildProvider : KoBaseProvider {
         vararg names: String,
         indirectChildren: Boolean = false,
     ): Boolean
+
+    /**
+     * Determines whether the declaration has children defined directly in the Kotlin
+     * file with all the specified names.
+     *
+     * @param names The names of the children to check.
+     * @param indirectChildren specifies whether to include children defined in other files such as child of the child.
+     * @return `true` if there are declarations with all the specified names, `false` otherwise.
+     */
+    fun hasChildrenWithAllNames(names: Collection<String>, indirectChildren: Boolean = false): Boolean
 
     /**
      * Determines whether the declaration has at least one child defined directly
@@ -118,6 +138,15 @@ interface KoChildProvider : KoBaseProvider {
     ): Boolean
 
     /**
+     * Determines whether the declaration has at least one child of the specified `KClass` type.
+     *
+     * @param names the `KClass` types of the children to check.
+     * @param indirectChildren specifies whether to include children defined in other files such as child of the child.
+     * @return `true` if there is a matching declaration, `false` otherwise.
+     */
+    fun hasChildOf(names: Collection<KClass<*>>, indirectChildren: Boolean = false): Boolean
+
+    /**
      * Determines whether the declaration has children with all the specified `KClass` type.
      *
      * @param name the `KClass` type of the child to check.
@@ -130,4 +159,13 @@ interface KoChildProvider : KoBaseProvider {
         vararg names: KClass<*>,
         indirectChildren: Boolean = false,
     ): Boolean
+
+    /**
+     * Determines whether the declaration has children with all the specified `KClass` type.
+     *
+     * @param names the `KClass` types of the children to check.
+     * @param indirectChildren specifies whether to include children defined in other files such as child of the child.
+     * @return `true` if the declaration has children of all the specified `KClass` types, `false` otherwise.
+     */
+    fun hasAllChildrenOf(names: Collection<KClass<*>>, indirectChildren: Boolean = false): Boolean
 }

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/api/provider/KoChildProvider.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/api/provider/KoChildProvider.kt
@@ -66,7 +66,10 @@ interface KoChildProvider : KoBaseProvider {
      * @param indirectChildren specifies whether to include children defined in other files such as child of the child.
      * @return `true` if there is a matching declaration, `false` otherwise.
      */
-    fun hasChildWithName(names: Collection<String>, indirectChildren: Boolean = false): Boolean
+    fun hasChildWithName(
+        names: Collection<String>,
+        indirectChildren: Boolean = false,
+    ): Boolean
 
     /**
      * Determines whether the declaration has children defined directly in the Kotlin
@@ -91,7 +94,10 @@ interface KoChildProvider : KoBaseProvider {
      * @param indirectChildren specifies whether to include children defined in other files such as child of the child.
      * @return `true` if there are declarations with all the specified names, `false` otherwise.
      */
-    fun hasChildrenWithAllNames(names: Collection<String>, indirectChildren: Boolean = false): Boolean
+    fun hasChildrenWithAllNames(
+        names: Collection<String>,
+        indirectChildren: Boolean = false,
+    ): Boolean
 
     /**
      * Determines whether the declaration has at least one child defined directly
@@ -144,7 +150,10 @@ interface KoChildProvider : KoBaseProvider {
      * @param indirectChildren specifies whether to include children defined in other files such as child of the child.
      * @return `true` if there is a matching declaration, `false` otherwise.
      */
-    fun hasChildOf(names: Collection<KClass<*>>, indirectChildren: Boolean = false): Boolean
+    fun hasChildOf(
+        names: Collection<KClass<*>>,
+        indirectChildren: Boolean = false,
+    ): Boolean
 
     /**
      * Determines whether the declaration has children with all the specified `KClass` type.
@@ -167,5 +176,8 @@ interface KoChildProvider : KoBaseProvider {
      * @param indirectChildren specifies whether to include children defined in other files such as child of the child.
      * @return `true` if the declaration has children of all the specified `KClass` types, `false` otherwise.
      */
-    fun hasAllChildrenOf(names: Collection<KClass<*>>, indirectChildren: Boolean = false): Boolean
+    fun hasAllChildrenOf(
+        names: Collection<KClass<*>>,
+        indirectChildren: Boolean = false,
+    ): Boolean
 }

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/api/provider/KoClassProvider.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/api/provider/KoClassProvider.kt
@@ -88,6 +88,20 @@ interface KoClassProvider : KoBaseProvider {
     ): Boolean
 
     /**
+     * Determines whether the declaration has at least one class whose name matches any of the specified names.
+     *
+     * @param names the names of the classes to check.
+     * @param includeNested Specifies whether to include nested classes in the check (optional, default is `true`).
+     * @param includeLocal Specifies whether to include local classes in the check (optional, default is `true`).
+     * @return `true` if there is a matching declaration, `false` otherwise.
+     */
+    fun hasClassWithName(
+        names: Collection<String>,
+        includeNested: Boolean = true,
+        includeLocal: Boolean = true,
+    ): Boolean
+
+    /**
      * Determines whether the declaration has classes with all the specified names.
      *
      * @param name The name of the class to check.
@@ -99,6 +113,20 @@ interface KoClassProvider : KoBaseProvider {
     fun hasClassesWithAllNames(
         name: String,
         vararg names: String,
+        includeNested: Boolean = true,
+        includeLocal: Boolean = true,
+    ): Boolean
+
+    /**
+     * Determines whether the declaration has classes with all the specified names.
+     *
+     * @param names The names of the classes to check.
+     * @param includeNested Specifies whether to include nested classes in the check (optional, default is `true`).
+     * @param includeLocal Specifies whether to include local classes in the check (optional, default is `true`).
+     * @return `true` if there are declarations with all the specified names, `false` otherwise.
+     */
+    fun hasClassesWithAllNames(
+        names: Collection<String>,
         includeNested: Boolean = true,
         includeLocal: Boolean = true,
     ): Boolean

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/api/provider/KoEnumConstantProvider.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/api/provider/KoEnumConstantProvider.kt
@@ -59,7 +59,7 @@ interface KoEnumConstantProvider : KoBaseProvider {
         vararg names: String,
     ): Boolean
 
-     /**
+    /**
      * Determines whether the declaration has at least one enum constant whose name matches any of the specified names.
      *
      * @param names the names of the enum constants to check.
@@ -79,7 +79,7 @@ interface KoEnumConstantProvider : KoBaseProvider {
         vararg names: String,
     ): Boolean
 
-     /**
+    /**
      * Determines whether the declaration has enum constants with all the specified names.
      *
      * @param names The names of the enum constants to check.

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/api/provider/KoEnumConstantProvider.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/api/provider/KoEnumConstantProvider.kt
@@ -59,6 +59,14 @@ interface KoEnumConstantProvider : KoBaseProvider {
         vararg names: String,
     ): Boolean
 
+     /**
+     * Determines whether the declaration has at least one enum constant whose name matches any of the specified names.
+     *
+     * @param names the names of the enum constants to check.
+     * @return `true` if there is a matching declaration, `false` otherwise.
+     */
+    fun hasEnumConstantWithName(names: Collection<String>): Boolean
+
     /**
      * Determines whether the declaration has enum constants with all the specified names.
      *
@@ -70,6 +78,14 @@ interface KoEnumConstantProvider : KoBaseProvider {
         name: String,
         vararg names: String,
     ): Boolean
+
+     /**
+     * Determines whether the declaration has enum constants with all the specified names.
+     *
+     * @param names The names of the enum constants to check.
+     * @return `true` if there are declarations with all the specified names, `false` otherwise.
+     */
+    fun hasEnumConstantsWithAllNames(names: Collection<String>): Boolean
 
     /**
      * Determines whether the declaration has at least one enum constant that satisfies the provided predicate.

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/api/provider/KoExternalParentProvider.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/api/provider/KoExternalParentProvider.kt
@@ -120,6 +120,30 @@ interface KoExternalParentProvider : KoBaseProvider {
     ): Boolean
 
     /**
+     * Determines whether the declaration has at least one external parent whose name matches any of the specified.
+     *
+     * @param names the names of the external parents to check.
+     * @param indirectParents specifies whether to include external parents defined in other files such as parent of the parent.
+     *                        If `true`, it includes only those external parents defined within our scope and those used
+     *                        by our declarations.
+     *                        For example:
+     *
+     *                        // Android
+     *                        class AppCompactActivity: Activity
+     *                        interface Activity
+     *
+     *                        // Project
+     *                        class BaseActivity: AppCompactActivity() // externalParents(indirectParents = true) returns [AppCompactActivity]
+     *                        class MyActivity: BaseActivity() // externalParents(indirectParents = true) returns [AppCompactActivity]
+     * @return `true` if there is a matching declaration, `false` otherwise.
+     * @see com.lemonappdev.konsist.api.declaration.KoExternalDeclaration
+     */
+    fun hasExternalParentWithName(
+        names: Collection<String>,
+        indirectParents: Boolean = false,
+    ): Boolean
+
+    /**
      * Determines whether the declaration has parents interface defined project codebase (external == false)
      *
      * @param name The name of the external parent to check.
@@ -142,6 +166,30 @@ interface KoExternalParentProvider : KoBaseProvider {
     fun hasExternalParentsWithAllNames(
         name: String,
         vararg names: String,
+        indirectParents: Boolean = false,
+    ): Boolean
+
+    /**
+     * Determines whether the declaration has parents interface defined project codebase (external == false)
+     *
+     * @param names The names of the external parents to check.
+     * @param indirectParents specifies whether to include external parents defined in other files such as parent of the parent.
+     *                        If `true`, it includes only those external parents defined within our scope and those used
+     *                        by our declarations.
+     *                        For example:
+     *
+     *                        // Android
+     *                        class AppCompactActivity: Activity
+     *                        interface Activity
+     *
+     *                        // Project
+     *                        class BaseActivity: AppCompactActivity() // externalParents(indirectParents = true) returns [AppCompactActivity]
+     *                        class MyActivity: BaseActivity() // externalParents(indirectParents = true) returns [AppCompactActivity]
+     * @return `true` if there are declarations with all the specified names, `false` otherwise.
+     * @see com.lemonappdev.konsist.api.declaration.KoExternalDeclaration
+     */
+    fun hasExternalParentsWithAllNames(
+        names: Collection<String>,
         indirectParents: Boolean = false,
     ): Boolean
 
@@ -223,6 +271,30 @@ interface KoExternalParentProvider : KoBaseProvider {
     ): Boolean
 
     /**
+     * Determines whether the declaration has at least one external parent of the specified `KClass` type.
+     *
+     * @param names the `KClass` types of the external parents to check.
+     * @param indirectParents specifies whether to include external parents defined in other files such as parent of the parent.
+     *                        If `true`, it includes only those external parents defined within our scope and those used
+     *                        by our declarations.
+     *                        For example:
+     *
+     *                        // Android
+     *                        class AppCompactActivity: Activity
+     *                        interface Activity
+     *
+     *                        // Project
+     *                        class BaseActivity: AppCompactActivity() // externalParents(indirectParents = true) returns [AppCompactActivity]
+     *                        class MyActivity: BaseActivity() // externalParents(indirectParents = true) returns [AppCompactActivity]
+     * @return `true` if there is a matching declaration, `false` otherwise.
+     * @see com.lemonappdev.konsist.api.declaration.KoExternalDeclaration
+     */
+    fun hasExternalParentOf(
+        names: Collection<KClass<*>>,
+        indirectParents: Boolean = false,
+    ): Boolean
+
+    /**
      * Determines whether the declaration has external parents with all the specified `KClass` type.
      *
      * @param name the `KClass` type of the external parent to check.
@@ -245,6 +317,30 @@ interface KoExternalParentProvider : KoBaseProvider {
     fun hasAllExternalParentsOf(
         name: KClass<*>,
         vararg names: KClass<*>,
+        indirectParents: Boolean = false,
+    ): Boolean
+
+    /**
+     * Determines whether the declaration has external parents with all the specified `KClass` type.
+     *
+     * @param names the `KClass` types of the external parents to check.
+     * @param indirectParents specifies whether to include external parents defined in other files such as parent of the parent.
+     *                        If `true`, it includes only those external parents defined within our scope and those used
+     *                        by our declarations.
+     *                        For example:
+     *
+     *                        // Android
+     *                        class AppCompactActivity: Activity
+     *                        interface Activity
+     *
+     *                        // Project
+     *                        class BaseActivity: AppCompactActivity() // externalParents(indirectParents = true) returns [AppCompactActivity]
+     *                        class MyActivity: BaseActivity() // externalParents(indirectParents = true) returns [AppCompactActivity]
+     * @return `true` if the declaration has external parents of all the specified `KClass` types, `false` otherwise.
+     * @see com.lemonappdev.konsist.api.declaration.KoExternalDeclaration
+     */
+    fun hasAllExternalParentsOf(
+        names: Collection<KClass<*>>,
         indirectParents: Boolean = false,
     ): Boolean
 }

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/api/provider/KoFunctionProvider.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/api/provider/KoFunctionProvider.kt
@@ -88,6 +88,20 @@ interface KoFunctionProvider : KoBaseProvider {
     ): Boolean
 
     /**
+     * Determines whether the declaration has at least one function whose name matches any of the specified names.
+     *
+     * @param names the names of the functions to check.
+     * @param includeNested Specifies whether to include nested functions in the check (optional, default is `true`).
+     * @param includeLocal Specifies whether to include local functions in the check (optional, default is `true`).
+     * @return `true` if there is a matching declaration, `false` otherwise.
+     */
+    fun hasFunctionWithName(
+        names: Collection<String>,
+        includeNested: Boolean = true,
+        includeLocal: Boolean = true,
+    ): Boolean
+
+    /**
      * Determines whether the declaration has functions with all the specified names.
      *
      * @param name The name of the function to check.
@@ -99,6 +113,20 @@ interface KoFunctionProvider : KoBaseProvider {
     fun hasFunctionsWithAllNames(
         name: String,
         vararg names: String,
+        includeNested: Boolean = true,
+        includeLocal: Boolean = true,
+    ): Boolean
+
+    /**
+     * Determines whether the declaration has functions with all the specified names.
+     *
+     * @param names The names of the functions to check.
+     * @param includeNested Specifies whether to include nested functions in the check (optional, default is `true`).
+     * @param includeLocal Specifies whether to include local functions in the check (optional, default is `true`).
+     * @return `true` if there are declarations with all the specified names, `false` otherwise.
+     */
+    fun hasFunctionsWithAllNames(
+        names: Collection<String>,
         includeNested: Boolean = true,
         includeLocal: Boolean = true,
     ): Boolean

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/api/provider/KoImportAliasProvider.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/api/provider/KoImportAliasProvider.kt
@@ -45,6 +45,14 @@ interface KoImportAliasProvider : KoBaseProvider {
     ): Boolean
 
     /**
+     * Determines whether the declaration has at least one import alias whose name matches any of the specified names.
+     *
+     * @param names the names of the import aliases to check.
+     * @return `true` if there is a matching declaration, `false` otherwise.
+     */
+    fun hasImportAliasWithName(names: Collection<String>): Boolean
+
+    /**
      * Determines whether the declaration has import aliases with all the specified names.
      *
      * @param name The name of the import alias to check.
@@ -55,6 +63,14 @@ interface KoImportAliasProvider : KoBaseProvider {
         name: String,
         vararg names: String,
     ): Boolean
+
+    /**
+     * Determines whether the declaration has import aliases with all the specified names.
+     *
+     * @param names The names of the import aliases to check.
+     * @return `true` if there are declarations with all the specified names, `false` otherwise.
+     */
+    fun hasImportAliasesWithAllNames(names: Collection<String>): Boolean
 
     /**
      * Determines whether the declaration has at least one import alias that satisfies the provided predicate.

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/api/provider/KoImportProvider.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/api/provider/KoImportProvider.kt
@@ -58,6 +58,14 @@ interface KoImportProvider : KoBaseProvider {
     ): Boolean
 
     /**
+     * Determines whether the declaration has at least one import whose name matches any of the specified names.
+     *
+     * @param names the names of the imports to check.
+     * @return `true` if there is a matching declaration, `false` otherwise.
+     */
+    fun hasImportWithName(names: Collection<String>): Boolean
+
+    /**
      * Determines whether the declaration has imports with all the specified names.
      *
      * @param name The name of the import to check.
@@ -68,6 +76,14 @@ interface KoImportProvider : KoBaseProvider {
         name: String,
         vararg names: String,
     ): Boolean
+
+    /**
+     * Determines whether the declaration has imports with all the specified names.
+     *
+     * @param names The names of the imports to check.
+     * @return `true` if there are declarations with all the specified names, `false` otherwise.
+     */
+    fun hasImportsWithAllNames(names: Collection<String>): Boolean
 
     /**
      * Determines whatever the declaration has any import with the specified predicate.

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/api/provider/KoInterfaceProvider.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/api/provider/KoInterfaceProvider.kt
@@ -70,6 +70,18 @@ interface KoInterfaceProvider : KoBaseProvider {
     ): Boolean
 
     /**
+     * Determines whether the declaration has at least one interface whose name matches any of the specified names.
+     *
+     * @param names the names of the interfaces to check.
+     * @param includeNested Specifies whether to include nested interfaces in the check (optional, default is `true`).
+     * @return `true` if there is a matching declaration, `false` otherwise.
+     */
+    fun hasInterfaceWithName(
+        names: Collection<String>,
+        includeNested: Boolean = true,
+    ): Boolean
+
+    /**
      * Determines whether the declaration has interfaces with all the specified names.
      *
      * @param name The name of the interface to check.
@@ -80,6 +92,18 @@ interface KoInterfaceProvider : KoBaseProvider {
     fun hasInterfacesWithAllNames(
         name: String,
         vararg names: String,
+        includeNested: Boolean = true,
+    ): Boolean
+
+    /**
+     * Determines whether the declaration has interfaces with all the specified names.
+     *
+     * @param names The names of the interfaces to check.
+     * @param includeNested Specifies whether to include nested interfaces in the check (optional, default is `true`).
+     * @return `true` if there are declarations with all the specified names, `false` otherwise.
+     */
+    fun hasInterfacesWithAllNames(
+        names: Collection<String>,
         includeNested: Boolean = true,
     ): Boolean
 

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/api/provider/KoLocalClassProvider.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/api/provider/KoLocalClassProvider.kt
@@ -53,6 +53,14 @@ interface KoLocalClassProvider : KoBaseProvider {
     ): Boolean
 
     /**
+     * Determines whether the declaration has at least one local class whose name matches any of the specified names.
+     *
+     * @param names the names of the local classes to check.
+     * @return `true` if there is a matching declaration, `false` otherwise.
+     */
+    fun hasLocalClassWithName(names: Collection<String>): Boolean
+
+    /**
      * Determines whether the declaration has local classes with all the specified names.
      *
      * @param name The name of the local class to check.
@@ -63,6 +71,14 @@ interface KoLocalClassProvider : KoBaseProvider {
         name: String,
         vararg names: String,
     ): Boolean
+
+    /**
+     * Determines whether the declaration has local classes with all the specified names.
+     *
+     * @param names The names of the local classes to check.
+     * @return `true` if there are declarations with all the specified names, `false` otherwise.
+     */
+    fun hasLocalClassesWithAllNames(names: Collection<String>): Boolean
 
     /**
      * Determines whether the declaration has at least one local class that satisfies the provided predicate.

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/api/provider/KoLocalFunctionProvider.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/api/provider/KoLocalFunctionProvider.kt
@@ -53,6 +53,14 @@ interface KoLocalFunctionProvider : KoBaseProvider {
     ): Boolean
 
     /**
+     * Determines whether the declaration has at least one local function whose name matches any of the specified names.
+     *
+     * @param names the names of the local functions to check.
+     * @return `true` if there is a matching declaration, `false` otherwise.
+     */
+    fun hasLocalFunctionWithName(names: Collection<String>): Boolean
+
+    /**
      * Determines whether the declaration has local functions with all the specified names.
      *
      * @param name The name of the local function to check.
@@ -63,6 +71,14 @@ interface KoLocalFunctionProvider : KoBaseProvider {
         name: String,
         vararg names: String,
     ): Boolean
+
+    /**
+     * Determines whether the declaration has local functions with all the specified names.
+     *
+     * @param names The names of the local functions to check.
+     * @return `true` if there are declarations with all the specified names, `false` otherwise.
+     */
+    fun hasLocalFunctionsWithAllNames(names: Collection<String>): Boolean
 
     /**
      * Determines whether the declaration has at least one local function that satisfies the provided predicate.

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/api/provider/KoObjectProvider.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/api/provider/KoObjectProvider.kt
@@ -70,6 +70,18 @@ interface KoObjectProvider : KoBaseProvider {
     ): Boolean
 
     /**
+     * Determines whether the declaration has at least one object whose name matches any of the specified names.
+     *
+     * @param names the names of the objects to check.
+     * @param includeNested Specifies whether to include nested objects in the check (optional, default is `true`).
+     * @return `true` if there is a matching declaration, `false` otherwise.
+     */
+    fun hasObjectWithName(
+        names: Collection<String>,
+        includeNested: Boolean = true,
+    ): Boolean
+
+    /**
      * Determines whether the declaration has objects with all the specified names.
      *
      * @param name The name of the object to check.
@@ -80,6 +92,18 @@ interface KoObjectProvider : KoBaseProvider {
     fun hasObjectsWithAllNames(
         name: String,
         vararg names: String,
+        includeNested: Boolean = true,
+    ): Boolean
+
+    /**
+     * Determines whether the declaration has objects with all the specified names.
+     *
+     * @param names The names of the objects to check.
+     * @param includeNested Specifies whether to include nested objects in the check (optional, default is `true`).
+     * @return `true` if there are declarations with all the specified names, `false` otherwise.
+     */
+    fun hasObjectsWithAllNames(
+        names: Collection<String>,
         includeNested: Boolean = true,
     ): Boolean
 

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/api/provider/KoParametersProvider.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/api/provider/KoParametersProvider.kt
@@ -53,6 +53,14 @@ interface KoParametersProvider : KoBaseProvider {
     ): Boolean
 
     /**
+     * Determines whether the declaration has at least one parameter whose name matches any of the specified names.
+     *
+     * @param names the names of the parameters to check.
+     * @return `true` if there is a matching declaration, `false` otherwise.
+     */
+    fun hasParameterWithName(names: Collection<String>): Boolean
+
+    /**
      * Determines whether the declaration has parameters with all the specified names.
      *
      * @param name The name of the parameter to check.
@@ -63,6 +71,14 @@ interface KoParametersProvider : KoBaseProvider {
         name: String,
         vararg names: String,
     ): Boolean
+
+    /**
+     * Determines whether the declaration has parameters with all the specified names.
+     *
+     * @param names The names of the parameters to check.
+     * @return `true` if there are declarations with all the specified names, `false` otherwise.
+     */
+    fun hasParametersWithAllNames(names: Collection<String>): Boolean
 
     /**
      * Determines whether the declaration has at least one parameter that satisfies the provided predicate.

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/api/provider/KoParentClassProvider.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/api/provider/KoParentClassProvider.kt
@@ -117,7 +117,7 @@ interface KoParentClassProvider : KoBaseProvider {
      */
     fun hasParentClassWithName(
         names: Collection<String>,
-        indirectParents: Boolean = false
+        indirectParents: Boolean = false,
     ): Boolean
 
     /**

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/api/provider/KoParentClassProvider.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/api/provider/KoParentClassProvider.kt
@@ -108,6 +108,19 @@ interface KoParentClassProvider : KoBaseProvider {
     ): Boolean
 
     /**
+     * Determines whether the declaration has a parent class whose name matches any of the specified names.
+     * If `indirectParents` is set to `true`, it verifies if there's at least one parent class that matches.
+     *
+     * @param names the names of the parent classes to check.
+     * @param indirectParents specifies whether to include parent classes defined in other files such as parent of the parent.
+     * @return `true` if there is a matching declaration, `false` otherwise.
+     */
+    fun hasParentClassWithName(
+        names: Collection<String>,
+        indirectParents: Boolean = false
+    ): Boolean
+
+    /**
      * Determines whether the declaration has parent classes with all the specified names.
      *
      * @param name The name of the parent class to check.
@@ -118,6 +131,18 @@ interface KoParentClassProvider : KoBaseProvider {
     fun hasParentClassesWithAllNames(
         name: String,
         vararg names: String,
+        indirectParents: Boolean = false,
+    ): Boolean
+
+    /**
+     * Determines whether the declaration has parent classes with all the specified names.
+     *
+     * @param names The names of the parent classes to check.
+     * @param indirectParents specifies whether to include parent classes defined in other files such as parent of the parent.
+     * @return `true` if there are declarations with all the specified names, `false` otherwise.
+     */
+    fun hasParentClassesWithAllNames(
+        names: Collection<String>,
         indirectParents: Boolean = false,
     ): Boolean
 
@@ -137,6 +162,19 @@ interface KoParentClassProvider : KoBaseProvider {
     ): Boolean
 
     /**
+     * Determines whether the declaration has a parent class of the specified Kotlin class.
+     * If `indirectParents` is set to `true`, it verifies if there's at least one parent class that matches.
+     *
+     * @param names the `KClass` types of the parent classes to check.
+     * @param indirectParents specifies whether to include parent classes defined in other files such as parent of the parent.
+     * @return `true` if there is a matching declaration, `false` otherwise.
+     */
+    fun hasParentClassOf(
+        names: Collection<KClass<*>>,
+        indirectParents: Boolean = false,
+    ): Boolean
+
+    /**
      * Determines whether the declaration has parent classes with all the specified `KClass` type.
      *
      * @param name the `KClass` type of the parent class to check.
@@ -147,6 +185,18 @@ interface KoParentClassProvider : KoBaseProvider {
     fun hasAllParentClassesOf(
         name: KClass<*>,
         vararg names: KClass<*>,
+        indirectParents: Boolean = false,
+    ): Boolean
+
+    /**
+     * Determines whether the declaration has parent classes with all the specified `KClass` type.
+     *
+     * @param names the `KClass` types of the parent classes to check.
+     * @param indirectParents specifies whether to include parent classes defined in other files such as parent of the parent.
+     * @return `true` if the declaration has parent classes of all the specified `KClass` types, `false` otherwise.
+     */
+    fun hasAllParentClassesOf(
+        names: Collection<KClass<*>>,
         indirectParents: Boolean = false,
     ): Boolean
 }

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/api/provider/KoParentInterfaceProvider.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/api/provider/KoParentInterfaceProvider.kt
@@ -81,6 +81,18 @@ interface KoParentInterfaceProvider : KoBaseProvider {
     ): Boolean
 
     /**
+     * Determines whether the declaration has at least one parent interface whose name matches any of the specified names.
+     *
+     * @param names the names of the parent interfaces to check.
+     * @param indirectParents specifies whether to include parent interfaces defined in other files such as parent of the parent.
+     * @return `true` if there is a matching declaration, `false` otherwise.
+     */
+    fun hasParentInterfaceWithName(
+        names: Collection<String>,
+        indirectParents: Boolean = false,
+    ): Boolean
+
+    /**
      * Determines whether the declaration has parent interfaces defined with all the specified names.
      *
      * @param name The name of the parent interface to check.
@@ -91,6 +103,18 @@ interface KoParentInterfaceProvider : KoBaseProvider {
     fun hasParentInterfacesWithAllNames(
         name: String,
         vararg names: String,
+        indirectParents: Boolean = false,
+    ): Boolean
+
+    /**
+     * Determines whether the declaration has parent interfaces defined with all the specified names.
+     *
+     * @param names The names of the parent interfaces to check.
+     * @param indirectParents specifies whether to include parent interfaces defined in other files such as parent of the parent.
+     * @return `true` if there are declarations with all the specified names, `false` otherwise.
+     */
+    fun hasParentInterfacesWithAllNames(
+        names: Collection<String>,
         indirectParents: Boolean = false,
     ): Boolean
 
@@ -136,6 +160,18 @@ interface KoParentInterfaceProvider : KoBaseProvider {
     ): Boolean
 
     /**
+     * Determines whether the declaration has at least one parent interface of the specified `KClass` type.
+     *
+     * @param names the `KClass` types of the parent interfaces to check.
+     * @param indirectParents specifies whether to include parent interfaces defined in other files such as parent of the parent.
+     * @return `true` if there is a matching declaration, `false` otherwise.
+     */
+    fun hasParentInterfaceOf(
+        names: Collection<KClass<*>>,
+        indirectParents: Boolean = false,
+    ): Boolean
+
+    /**
      * Determines whether the declaration has parent interfaces with all the specified `KClass` type.
      *
      * @param name the `KClass` type of the parent interface to check.
@@ -146,6 +182,18 @@ interface KoParentInterfaceProvider : KoBaseProvider {
     fun hasAllParentInterfacesOf(
         name: KClass<*>,
         vararg names: KClass<*>,
+        indirectParents: Boolean = false,
+    ): Boolean
+
+    /**
+     * Determines whether the declaration has parent interfaces with all the specified `KClass` type.
+     *
+     * @param names the `KClass` types of the parent interfaces to check.
+     * @param indirectParents specifies whether to include parent interfaces defined in other files such as parent of the parent.
+     * @return `true` if the declaration has parent interfaces of all the specified `KClass` types, `false` otherwise.
+     */
+    fun hasAllParentInterfacesOf(
+        names: Collection<KClass<*>>,
         indirectParents: Boolean = false,
     ): Boolean
 }

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/api/provider/KoParentProvider.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/api/provider/KoParentProvider.kt
@@ -160,7 +160,7 @@ interface KoParentProvider : KoBaseProvider {
      * @return `true` if there is a matching declaration, `false` otherwise.
      */
     fun hasParentWithName(
-       names: Collection<String>,
+        names: Collection<String>,
         indirectParents: Boolean = false,
     ): Boolean
 

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/api/provider/KoParentProvider.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/api/provider/KoParentProvider.kt
@@ -141,6 +141,30 @@ interface KoParentProvider : KoBaseProvider {
     ): Boolean
 
     /**
+     * Determines whether the declaration has at least one parent (parent class and parent interfaces) whose name
+     * matches any of the specified names.
+     *
+     * @param names the names of the parents to check.
+     * @param indirectParents specifies whether to include parents defined in other files such as parent of the parent.
+     *                        If `true`, it includes only those parents defined within our scope and those used
+     *                        by our declarations.
+     *                        For example:
+     *
+     *                        // Android
+     *                        class AppCompactActivity: Activity
+     *                        interface Activity
+     *
+     *                        // Project
+     *                        class BaseActivity: AppCompactActivity() // parents(indirectParents = true) returns [AppCompactActivity]
+     *                        class MyActivity: BaseActivity() // parents(indirectParents = true) returns [BaseActivity, AppCompactActivity]
+     * @return `true` if there is a matching declaration, `false` otherwise.
+     */
+    fun hasParentWithName(
+       names: Collection<String>,
+        indirectParents: Boolean = false,
+    ): Boolean
+
+    /**
      * Determines whether the declaration has parents (parent classes and parent interfaces) with all the specified names.
      *
      * @param name The name of the parent to check.
@@ -162,6 +186,29 @@ interface KoParentProvider : KoBaseProvider {
     fun hasParentsWithAllNames(
         name: String,
         vararg names: String,
+        indirectParents: Boolean = false,
+    ): Boolean
+
+    /**
+     * Determines whether the declaration has parents (parent classes and parent interfaces) with all the specified names.
+     *
+     * @param names The names of the parents to check.
+     * @param indirectParents specifies whether to include parents defined in other files such as parent of the parent.
+     *                        If `true`, it includes only those parents defined within our scope and those used
+     *                        by our declarations.
+     *                        For example:
+     *
+     *                        // Android
+     *                        class AppCompactActivity: Activity
+     *                        interface Activity
+     *
+     *                        // Project
+     *                        class BaseActivity: AppCompactActivity() // parents(indirectParents = true) returns [AppCompactActivity]
+     *                        class MyActivity: BaseActivity() // parents(indirectParents = true) returns [BaseActivity, AppCompactActivity]
+     * @return `true` if there are declarations with all the specified names, `false` otherwise.
+     */
+    fun hasParentsWithAllNames(
+        names: Collection<String>,
         indirectParents: Boolean = false,
     ): Boolean
 
@@ -242,6 +289,29 @@ interface KoParentProvider : KoBaseProvider {
     ): Boolean
 
     /**
+     * Determines whether the declaration has at least one parent of the specified `KClass` type.
+     *
+     * @param names the `KClass` types of the parents to check.
+     * @param indirectParents specifies whether to include parents defined in other files such as parent of the parent.
+     *                        If `true`, it includes only those parents defined within our scope and those used
+     *                        by our declarations.
+     *                        For example:
+     *
+     *                        // Android
+     *                        class AppCompactActivity: Activity
+     *                        interface Activity
+     *
+     *                        // Project
+     *                        class BaseActivity: AppCompactActivity() // parents(indirectParents = true) returns [AppCompactActivity]
+     *                        class MyActivity: BaseActivity() // parents(indirectParents = true) returns [BaseActivity, AppCompactActivity]
+     * @return `true` if there is a matching declaration, `false` otherwise.
+     */
+    fun hasParentOf(
+        names: Collection<KClass<*>>,
+        indirectParents: Boolean = false,
+    ): Boolean
+
+    /**
      * Determines whether the declaration has parents with all the specified `KClass` type.
      *
      * @param name the `KClass` type of the parent to check.
@@ -263,6 +333,29 @@ interface KoParentProvider : KoBaseProvider {
     fun hasAllParentsOf(
         name: KClass<*>,
         vararg names: KClass<*>,
+        indirectParents: Boolean = false,
+    ): Boolean
+
+    /**
+     * Determines whether the declaration has parents with all the specified `KClass` type.
+     *
+     * @param names the `KClass` types of the parents to check.
+     * @param indirectParents specifies whether to include parents defined in other files such as parent of the parent.
+     *                        If `true`, it includes only those parents defined within our scope and those used
+     *                        by our declarations.
+     *                        For example:
+     *
+     *                        // Android
+     *                        class AppCompactActivity: Activity
+     *                        interface Activity
+     *
+     *                        // Project
+     *                        class BaseActivity: AppCompactActivity() // parents(indirectParents = true) returns [AppCompactActivity]
+     *                        class MyActivity: BaseActivity() // parents(indirectParents = true) returns [BaseActivity, AppCompactActivity]
+     * @return `true` if the declaration has parents of all the specified `KClass` types, `false` otherwise.
+     */
+    fun hasAllParentsOf(
+        names: Collection<KClass<*>>,
         indirectParents: Boolean = false,
     ): Boolean
 }

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/api/provider/KoPropertyProvider.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/api/provider/KoPropertyProvider.kt
@@ -70,6 +70,18 @@ interface KoPropertyProvider : KoBaseProvider {
     ): Boolean
 
     /**
+     * Determines whether the declaration has at least one property whose name matches any of the specified names.
+     *
+     * @param names the names of the properties to check.
+     * @param includeNested Specifies whether to include nested properties in the check (optional, default is `true`).
+     * @return `true` if there is a matching declaration, `false` otherwise.
+     */
+    fun hasPropertyWithName(
+        names: Collection<String>,
+        includeNested: Boolean = true,
+    ): Boolean
+
+    /**
      * Determines whether the declaration has properties with all the specified names.
      *
      * @param name The name of the property to check.
@@ -80,6 +92,18 @@ interface KoPropertyProvider : KoBaseProvider {
     fun hasPropertiesWithAllNames(
         name: String,
         vararg names: String,
+        includeNested: Boolean = true,
+    ): Boolean
+
+    /**
+     * Determines whether the declaration has properties with all the specified names.
+     *
+     * @param names The names of the properties to check.
+     * @param includeNested Specifies whether to include nested properties in the check (optional, default is `true`).
+     * @return `true` if there are declarations with all the specified names, `false` otherwise.
+     */
+    fun hasPropertiesWithAllNames(
+        names: Collection<String>,
         includeNested: Boolean = true,
     ): Boolean
 

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/api/provider/KoTypeAliasProvider.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/api/provider/KoTypeAliasProvider.kt
@@ -60,6 +60,14 @@ interface KoTypeAliasProvider : KoBaseProvider {
     ): Boolean
 
     /**
+     * Determines whether the declaration has at least one type alias whose name matches any of the specified names.
+     *
+     * @param names the names of the type aliases to check.
+     * @return `true` if there is a matching declaration, `false` otherwise.
+     */
+    fun hasTypeAliasWithName(names: Collection<String>): Boolean
+
+    /**
      * Determines whether the declaration has type aliases with all the specified names.
      *
      * @param name The name of the type alias to check.
@@ -70,6 +78,14 @@ interface KoTypeAliasProvider : KoBaseProvider {
         name: String,
         vararg names: String,
     ): Boolean
+
+    /**
+     * Determines whether the declaration has type aliases with all the specified names.
+     *
+     * @param names The names of the type aliases to check.
+     * @return `true` if there are declarations with all the specified names, `false` otherwise.
+     */
+    fun hasTypeAliasesWithAllNames(names: Collection<String>): Boolean
 
     /**
      * Determines whether the declaration has at least one type alias that satisfies the provided predicate.

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/api/provider/KoVariableProvider.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/api/provider/KoVariableProvider.kt
@@ -44,6 +44,14 @@ interface KoVariableProvider : KoBaseProvider {
     ): Boolean
 
     /**
+     * Determines whether the declaration has at least one variable whose name matches any of the specified names.
+     *
+     * @param names the names of the variables to check.
+     * @return `true` if there is a matching declaration, `false` otherwise.
+     */
+    fun hasVariableWithName(names: Collection<String>): Boolean
+
+    /**
      * Determines whether the declaration has variables with all the specified names.
      *
      * @param name The name of the variable to check.
@@ -54,6 +62,14 @@ interface KoVariableProvider : KoBaseProvider {
         name: String,
         vararg names: String,
     ): Boolean
+
+    /**
+     * Determines whether the declaration has variables with all the specified names.
+     *
+     * @param names The names of the variables to check.
+     * @return `true` if there are declarations with all the specified names, `false` otherwise.
+     */
+    fun hasVariablesWithAllNames(names: Collection<String>): Boolean
 
     /**
      * Determines whether the declaration has at least one variable that satisfies the provided predicate.

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/api/provider/modifier/KoModifierProvider.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/api/provider/modifier/KoModifierProvider.kt
@@ -51,6 +51,14 @@ interface KoModifierProvider : KoBaseProvider {
     ): Boolean
 
     /**
+     * Determines whether the declaration has at least one specified modifier.
+     *
+     * @param modifiers the modifiers to check.
+     * @return `true` if there is a matching declaration, `false` otherwise.
+     */
+    fun hasModifier(modifiers: Collection<KoModifier>): Boolean
+
+    /**
      * Determines whether the declaration has all specified modifiers.
      *
      * @param modifier the modifier to check.
@@ -61,4 +69,12 @@ interface KoModifierProvider : KoBaseProvider {
         modifier: KoModifier,
         vararg modifiers: KoModifier,
     ): Boolean
+
+    /**
+     * Determines whether the declaration has all specified modifiers.
+     *
+     * @param modifiers the modifiers to check.
+     * @return `true` if there are declarations with all the specified modifiers, `false` otherwise.
+     */
+    fun hasAllModifiers(modifiers: Collection<KoModifier>): Boolean
 }

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/api/provider/tag/KoKDocTagProvider.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/api/provider/tag/KoKDocTagProvider.kt
@@ -52,6 +52,14 @@ interface KoKDocTagProvider : KoBaseProvider {
     ): Boolean
 
     /**
+     * Determines whether the declaration has at least one specified tag.
+     *
+     * @param tags the tags to check.
+     * @return `true` if there is a matching declaration, `false` otherwise.
+     */
+    fun hasTag( tags: Collection<KoKDocTag>): Boolean
+
+    /**
      * Determines whether the declaration has all specified tags.
      *
      * @param tag the tag to check.
@@ -62,4 +70,12 @@ interface KoKDocTagProvider : KoBaseProvider {
         tag: KoKDocTag,
         vararg tags: KoKDocTag,
     ): Boolean
+
+    /**
+     * Determines whether the declaration has all specified tags.
+     *
+     * @param tags the tags to check.
+     * @return `true` if there are declarations with all the specified tags, `false` otherwise.
+     */
+    fun hasAllTags(tags: Collection<KoKDocTag>): Boolean
 }

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/api/provider/tag/KoKDocTagProvider.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/api/provider/tag/KoKDocTagProvider.kt
@@ -57,7 +57,7 @@ interface KoKDocTagProvider : KoBaseProvider {
      * @param tags the tags to check.
      * @return `true` if there is a matching declaration, `false` otherwise.
      */
-    fun hasTag( tags: Collection<KoKDocTag>): Boolean
+    fun hasTag(tags: Collection<KoKDocTag>): Boolean
 
     /**
      * Determines whether the declaration has all specified tags.

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/core/container/KoScopeCreatorCore.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/core/container/KoScopeCreatorCore.kt
@@ -33,7 +33,7 @@ internal class KoScopeCreatorCore : KoScopeCreator {
         vararg moduleNames: String,
     ): KoScope = scopeFromModules(setOf(moduleName) + moduleNames)
 
-    override fun scopeFromModules(moduleNames: Set<String>): KoScopeCore =
+    override fun scopeFromModules(moduleNames: Collection<String>): KoScopeCore =
         runBlocking {
             moduleNames
                 .flatMap { getFiles(it) }
@@ -58,7 +58,7 @@ internal class KoScopeCreatorCore : KoScopeCreator {
         vararg sourceSetNames: String,
     ): KoScope = scopeFromSourceSets(setOf(sourceSetName) + sourceSetNames)
 
-    override fun scopeFromSourceSets(sourceSetNames: Set<String>): KoScope =
+    override fun scopeFromSourceSets(sourceSetNames: Collection<String>): KoScope =
         runBlocking {
             sourceSetNames
                 .flatMap { getFiles(sourceSetName = it) }
@@ -142,7 +142,7 @@ internal class KoScopeCreatorCore : KoScopeCreator {
     /**
      * Get the scope of the paths obtaining the absolute path of it and, getting the files from that directory
      */
-    private fun getScopeFromPaths(paths: Set<String>): KoScope {
+    private fun getScopeFromPaths(paths: Collection<String>): KoScope {
         val filesFromPaths =
             paths
                 .map { getAbsolutePath(projectPath = it) }
@@ -172,7 +172,7 @@ internal class KoScopeCreatorCore : KoScopeCreator {
         return getScopeFromPaths(paths = setOf(path) + paths)
     }
 
-    override fun scopeFromDirectories(paths: Set<String>): KoScope {
+    override fun scopeFromDirectories(paths: Collection<String>): KoScope {
         return getScopeFromPaths(paths = paths)
     }
 
@@ -186,7 +186,7 @@ internal class KoScopeCreatorCore : KoScopeCreator {
         return KoScopeCore(koFiles = filesFromPaths)
     }
 
-    override fun scopeFromExternalDirectories(absolutePaths: Set<String>): KoScope {
+    override fun scopeFromExternalDirectories(absolutePaths: Collection<String>): KoScope {
         val filesFromPaths = absolutePaths.flatMap { getFilesFromDirectory(absolutePath = it) }
 
         return KoScopeCore(koFiles = filesFromPaths)
@@ -197,7 +197,7 @@ internal class KoScopeCreatorCore : KoScopeCreator {
         vararg paths: String,
     ): KoScope = scopeFromFiles(setOf(path) + paths)
 
-    override fun scopeFromFiles(paths: Set<String>): KoScope {
+    override fun scopeFromFiles(paths: Collection<String>): KoScope {
         val files =
             paths
                 .map { getAbsolutePath(it) }

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/KoAnnotationProviderCore.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/KoAnnotationProviderCore.kt
@@ -64,24 +64,28 @@ internal interface KoAnnotationProviderCore :
     override fun hasAnnotationWithName(
         name: String,
         vararg names: String,
-    ): Boolean {
-        val givenNames = names.toList() + name
+    ): Boolean = hasAnnotationWithName(listOf(name, *names))
 
-        return givenNames.any {
-            annotations.any { annotation -> annotation.representsType(it) }
+    override fun hasAnnotationWithName(names: Collection<String>): Boolean =
+        when {
+            names.isEmpty() -> hasAnnotations()
+            else -> names.any {
+                annotations.any { annotation -> annotation.representsType(it) }
+            }
         }
-    }
 
     override fun hasAnnotationsWithAllNames(
         name: String,
         vararg names: String,
-    ): Boolean {
-        val givenNames = names.toList() + name
+    ): Boolean = hasAnnotationsWithAllNames(listOf(name, *names))
 
-        return givenNames.all {
-            annotations.any { annotation -> annotation.representsType(it) }
+    override fun hasAnnotationsWithAllNames(names: Collection<String>): Boolean =
+        when {
+            names.isEmpty() -> hasAnnotations()
+            else -> names.all {
+                annotations.any { annotation -> annotation.representsType(it) }
+            }
         }
-    }
 
     override fun hasAnnotation(predicate: (KoAnnotationDeclaration) -> Boolean): Boolean = annotations.any(predicate)
 
@@ -90,10 +94,20 @@ internal interface KoAnnotationProviderCore :
     override fun hasAnnotationOf(
         name: KClass<*>,
         vararg names: KClass<*>,
-    ): Boolean = checkIfAnnotated(name) || names.any { checkIfAnnotated(it) }
+    ): Boolean = hasAnnotationOf(listOf(name, *names))
+
+    override fun hasAnnotationOf(names: Collection<KClass<*>>): Boolean =  when {
+        names.isEmpty() -> hasAnnotations()
+        else -> names.any { checkIfAnnotated(it) }
+    }
 
     override fun hasAllAnnotationsOf(
         name: KClass<*>,
         vararg names: KClass<*>,
-    ): Boolean = checkIfAnnotated(name) && names.all { checkIfAnnotated(it) }
+    ): Boolean = hasAllAnnotationsOf(listOf(name, *names))
+
+    override fun hasAllAnnotationsOf(names: Collection<KClass<*>>): Boolean =  when {
+        names.isEmpty() -> hasAnnotations()
+        else -> names.all { checkIfAnnotated(it) }
+    }
 }

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/KoAnnotationProviderCore.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/KoAnnotationProviderCore.kt
@@ -69,9 +69,10 @@ internal interface KoAnnotationProviderCore :
     override fun hasAnnotationWithName(names: Collection<String>): Boolean =
         when {
             names.isEmpty() -> hasAnnotations()
-            else -> names.any {
-                annotations.any { annotation -> annotation.representsType(it) }
-            }
+            else ->
+                names.any {
+                    annotations.any { annotation -> annotation.representsType(it) }
+                }
         }
 
     override fun hasAnnotationsWithAllNames(
@@ -82,9 +83,10 @@ internal interface KoAnnotationProviderCore :
     override fun hasAnnotationsWithAllNames(names: Collection<String>): Boolean =
         when {
             names.isEmpty() -> hasAnnotations()
-            else -> names.all {
-                annotations.any { annotation -> annotation.representsType(it) }
-            }
+            else ->
+                names.all {
+                    annotations.any { annotation -> annotation.representsType(it) }
+                }
         }
 
     override fun hasAnnotation(predicate: (KoAnnotationDeclaration) -> Boolean): Boolean = annotations.any(predicate)
@@ -96,18 +98,20 @@ internal interface KoAnnotationProviderCore :
         vararg names: KClass<*>,
     ): Boolean = hasAnnotationOf(listOf(name, *names))
 
-    override fun hasAnnotationOf(names: Collection<KClass<*>>): Boolean =  when {
-        names.isEmpty() -> hasAnnotations()
-        else -> names.any { checkIfAnnotated(it) }
-    }
+    override fun hasAnnotationOf(names: Collection<KClass<*>>): Boolean =
+        when {
+            names.isEmpty() -> hasAnnotations()
+            else -> names.any { checkIfAnnotated(it) }
+        }
 
     override fun hasAllAnnotationsOf(
         name: KClass<*>,
         vararg names: KClass<*>,
     ): Boolean = hasAllAnnotationsOf(listOf(name, *names))
 
-    override fun hasAllAnnotationsOf(names: Collection<KClass<*>>): Boolean =  when {
-        names.isEmpty() -> hasAnnotations()
-        else -> names.all { checkIfAnnotated(it) }
-    }
+    override fun hasAllAnnotationsOf(names: Collection<KClass<*>>): Boolean =
+        when {
+            names.isEmpty() -> hasAnnotations()
+            else -> names.all { checkIfAnnotated(it) }
+        }
 }

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/KoArgumentProviderCore.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/KoArgumentProviderCore.kt
@@ -17,10 +17,11 @@ internal interface KoArgumentProviderCore :
     override fun hasArgumentWithName(
         name: String,
         vararg names: String,
-    ): Boolean {
-        val givenNames = names.toList() + name
+    ): Boolean = hasArgumentWithName(listOf(name, *names))
 
-        return givenNames.any {
+    override fun hasArgumentWithName(names: Collection<String>): Boolean = when {
+        names.isEmpty() -> hasArguments()
+        else -> names.any {
             arguments.any { argument -> it == argument.name }
         }
     }
@@ -28,10 +29,11 @@ internal interface KoArgumentProviderCore :
     override fun hasArgumentsWithAllNames(
         name: String,
         vararg names: String,
-    ): Boolean {
-        val givenNames = names.toList() + name
+    ): Boolean = hasArgumentsWithAllNames(listOf(name, *names))
 
-        return givenNames.all {
+    override fun hasArgumentsWithAllNames(names: Collection<String>): Boolean = when {
+        names.isEmpty() -> hasArguments()
+        else -> names.all {
             arguments.any { argument -> it == argument.name }
         }
     }

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/KoArgumentProviderCore.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/KoArgumentProviderCore.kt
@@ -19,24 +19,28 @@ internal interface KoArgumentProviderCore :
         vararg names: String,
     ): Boolean = hasArgumentWithName(listOf(name, *names))
 
-    override fun hasArgumentWithName(names: Collection<String>): Boolean = when {
-        names.isEmpty() -> hasArguments()
-        else -> names.any {
-            arguments.any { argument -> it == argument.name }
+    override fun hasArgumentWithName(names: Collection<String>): Boolean =
+        when {
+            names.isEmpty() -> hasArguments()
+            else ->
+                names.any {
+                    arguments.any { argument -> it == argument.name }
+                }
         }
-    }
 
     override fun hasArgumentsWithAllNames(
         name: String,
         vararg names: String,
     ): Boolean = hasArgumentsWithAllNames(listOf(name, *names))
 
-    override fun hasArgumentsWithAllNames(names: Collection<String>): Boolean = when {
-        names.isEmpty() -> hasArguments()
-        else -> names.all {
-            arguments.any { argument -> it == argument.name }
+    override fun hasArgumentsWithAllNames(names: Collection<String>): Boolean =
+        when {
+            names.isEmpty() -> hasArguments()
+            else ->
+                names.all {
+                    arguments.any { argument -> it == argument.name }
+                }
         }
-    }
 
     override fun hasArgument(predicate: (KoArgumentDeclaration) -> Boolean): Boolean = arguments.any(predicate)
 

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/KoChildProviderCore.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/KoChildProviderCore.kt
@@ -35,10 +35,11 @@ internal interface KoChildProviderCore :
         name: String,
         vararg names: String,
         indirectChildren: Boolean,
-    ): Boolean {
-        val givenNames = names.toList() + name
+    ): Boolean = hasChildWithName(listOf(name, *names), indirectChildren)
 
-        return givenNames.any {
+    override fun hasChildWithName(names: Collection<String>, indirectChildren: Boolean): Boolean = when {
+        names.isEmpty() -> hasChildren(indirectChildren)
+        else -> names.any {
             children(indirectChildren).any { child -> it == child.name }
         }
     }
@@ -47,10 +48,11 @@ internal interface KoChildProviderCore :
         name: String,
         vararg names: String,
         indirectChildren: Boolean,
-    ): Boolean {
-        val givenNames = names.toList() + name
+    ): Boolean = hasChildrenWithAllNames(listOf(name, *names), indirectChildren)
 
-        return givenNames.all {
+    override fun hasChildrenWithAllNames(names: Collection<String>, indirectChildren: Boolean): Boolean = when {
+        names.isEmpty() -> hasChildren(indirectChildren)
+        else -> names.all {
             children(indirectChildren).any { child -> it == child.name }
         }
     }
@@ -69,15 +71,21 @@ internal interface KoChildProviderCore :
         name: KClass<*>,
         vararg names: KClass<*>,
         indirectChildren: Boolean,
-    ): Boolean =
-        checkIfKClassOf(name, children(indirectChildren)) ||
-            names.any { checkIfKClassOf(it, children(indirectChildren)) }
+    ): Boolean = hasChildOf(listOf(name, *names))
+
+    override fun hasChildOf(names: Collection<KClass<*>>, indirectChildren: Boolean): Boolean = when {
+        names.isEmpty() -> hasChildren(indirectChildren)
+        else -> names.any { checkIfKClassOf(it, children(indirectChildren)) }
+    }
 
     override fun hasAllChildrenOf(
         name: KClass<*>,
         vararg names: KClass<*>,
         indirectChildren: Boolean,
-    ): Boolean =
-        checkIfKClassOf(name, children(indirectChildren)) &&
-            names.all { checkIfKClassOf(it, children(indirectChildren)) }
+    ): Boolean = hasAllChildrenOf(listOf(name, *names))
+
+    override fun hasAllChildrenOf(names: Collection<KClass<*>>, indirectChildren: Boolean): Boolean = when {
+        names.isEmpty() -> hasChildren(indirectChildren)
+        else -> names.all { checkIfKClassOf(it, children(indirectChildren)) }
+    }
 }

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/KoChildProviderCore.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/KoChildProviderCore.kt
@@ -37,12 +37,17 @@ internal interface KoChildProviderCore :
         indirectChildren: Boolean,
     ): Boolean = hasChildWithName(listOf(name, *names), indirectChildren)
 
-    override fun hasChildWithName(names: Collection<String>, indirectChildren: Boolean): Boolean = when {
-        names.isEmpty() -> hasChildren(indirectChildren)
-        else -> names.any {
-            children(indirectChildren).any { child -> it == child.name }
+    override fun hasChildWithName(
+        names: Collection<String>,
+        indirectChildren: Boolean,
+    ): Boolean =
+        when {
+            names.isEmpty() -> hasChildren(indirectChildren)
+            else ->
+                names.any {
+                    children(indirectChildren).any { child -> it == child.name }
+                }
         }
-    }
 
     override fun hasChildrenWithAllNames(
         name: String,
@@ -50,12 +55,17 @@ internal interface KoChildProviderCore :
         indirectChildren: Boolean,
     ): Boolean = hasChildrenWithAllNames(listOf(name, *names), indirectChildren)
 
-    override fun hasChildrenWithAllNames(names: Collection<String>, indirectChildren: Boolean): Boolean = when {
-        names.isEmpty() -> hasChildren(indirectChildren)
-        else -> names.all {
-            children(indirectChildren).any { child -> it == child.name }
+    override fun hasChildrenWithAllNames(
+        names: Collection<String>,
+        indirectChildren: Boolean,
+    ): Boolean =
+        when {
+            names.isEmpty() -> hasChildren(indirectChildren)
+            else ->
+                names.all {
+                    children(indirectChildren).any { child -> it == child.name }
+                }
         }
-    }
 
     override fun hasChild(
         indirectChildren: Boolean,
@@ -73,10 +83,14 @@ internal interface KoChildProviderCore :
         indirectChildren: Boolean,
     ): Boolean = hasChildOf(listOf(name, *names))
 
-    override fun hasChildOf(names: Collection<KClass<*>>, indirectChildren: Boolean): Boolean = when {
-        names.isEmpty() -> hasChildren(indirectChildren)
-        else -> names.any { checkIfKClassOf(it, children(indirectChildren)) }
-    }
+    override fun hasChildOf(
+        names: Collection<KClass<*>>,
+        indirectChildren: Boolean,
+    ): Boolean =
+        when {
+            names.isEmpty() -> hasChildren(indirectChildren)
+            else -> names.any { checkIfKClassOf(it, children(indirectChildren)) }
+        }
 
     override fun hasAllChildrenOf(
         name: KClass<*>,
@@ -84,8 +98,12 @@ internal interface KoChildProviderCore :
         indirectChildren: Boolean,
     ): Boolean = hasAllChildrenOf(listOf(name, *names))
 
-    override fun hasAllChildrenOf(names: Collection<KClass<*>>, indirectChildren: Boolean): Boolean = when {
-        names.isEmpty() -> hasChildren(indirectChildren)
-        else -> names.all { checkIfKClassOf(it, children(indirectChildren)) }
-    }
+    override fun hasAllChildrenOf(
+        names: Collection<KClass<*>>,
+        indirectChildren: Boolean,
+    ): Boolean =
+        when {
+            names.isEmpty() -> hasChildren(indirectChildren)
+            else -> names.all { checkIfKClassOf(it, children(indirectChildren)) }
+        }
 }

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/KoClassProviderCore.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/KoClassProviderCore.kt
@@ -49,12 +49,14 @@ internal interface KoClassProviderCore : KoClassProvider, KoDeclarationProviderC
         names: Collection<String>,
         includeNested: Boolean,
         includeLocal: Boolean,
-    ): Boolean = when {
-        names.isEmpty() -> hasClasses(includeNested, includeLocal)
-        else -> names.any {
-            classes(includeNested, includeLocal).any { koClass -> it == koClass.name }
+    ): Boolean =
+        when {
+            names.isEmpty() -> hasClasses(includeNested, includeLocal)
+            else ->
+                names.any {
+                    classes(includeNested, includeLocal).any { koClass -> it == koClass.name }
+                }
         }
-    }
 
     override fun hasClassesWithAllNames(
         name: String,
@@ -67,12 +69,14 @@ internal interface KoClassProviderCore : KoClassProvider, KoDeclarationProviderC
         names: Collection<String>,
         includeNested: Boolean,
         includeLocal: Boolean,
-    ): Boolean = when {
-        names.isEmpty() -> hasClasses(includeNested, includeLocal)
-        else -> names.all {
-            classes(includeNested, includeLocal).any { koClass -> it == koClass.name }
+    ): Boolean =
+        when {
+            names.isEmpty() -> hasClasses(includeNested, includeLocal)
+            else ->
+                names.all {
+                    classes(includeNested, includeLocal).any { koClass -> it == koClass.name }
+                }
         }
-    }
 
     override fun hasClass(
         includeNested: Boolean,

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/KoClassProviderCore.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/KoClassProviderCore.kt
@@ -43,10 +43,15 @@ internal interface KoClassProviderCore : KoClassProvider, KoDeclarationProviderC
         vararg names: String,
         includeNested: Boolean,
         includeLocal: Boolean,
-    ): Boolean {
-        val givenNames = names.toList() + name
+    ): Boolean = hasClassWithName(listOf(name, *names), includeNested, includeLocal)
 
-        return givenNames.any {
+    override fun hasClassWithName(
+        names: Collection<String>,
+        includeNested: Boolean,
+        includeLocal: Boolean,
+    ): Boolean = when {
+        names.isEmpty() -> hasClasses(includeNested, includeLocal)
+        else -> names.any {
             classes(includeNested, includeLocal).any { koClass -> it == koClass.name }
         }
     }
@@ -56,10 +61,15 @@ internal interface KoClassProviderCore : KoClassProvider, KoDeclarationProviderC
         vararg names: String,
         includeNested: Boolean,
         includeLocal: Boolean,
-    ): Boolean {
-        val givenNames = names.toList() + name
+    ): Boolean = hasClassesWithAllNames(listOf(name, *names), includeNested, includeLocal)
 
-        return givenNames.all {
+    override fun hasClassesWithAllNames(
+        names: Collection<String>,
+        includeNested: Boolean,
+        includeLocal: Boolean,
+    ): Boolean = when {
+        names.isEmpty() -> hasClasses(includeNested, includeLocal)
+        else -> names.all {
             classes(includeNested, includeLocal).any { koClass -> it == koClass.name }
         }
     }

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/KoEnumConstantProviderCore.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/KoEnumConstantProviderCore.kt
@@ -52,24 +52,28 @@ internal interface KoEnumConstantProviderCore :
         vararg names: String,
     ): Boolean = hasEnumConstantWithName(listOf(name, *names))
 
-    override fun hasEnumConstantWithName(names: Collection<String>): Boolean = when {
-        names.isEmpty() -> hasEnumConstants()
-        else -> names.any {
-            enumConstants.any { enumConstant -> it == enumConstant.name }
+    override fun hasEnumConstantWithName(names: Collection<String>): Boolean =
+        when {
+            names.isEmpty() -> hasEnumConstants()
+            else ->
+                names.any {
+                    enumConstants.any { enumConstant -> it == enumConstant.name }
+                }
         }
-    }
 
     override fun hasEnumConstantsWithAllNames(
         name: String,
         vararg names: String,
     ): Boolean = hasEnumConstantsWithAllNames(listOf(name, *names))
 
-    override fun hasEnumConstantsWithAllNames(names: Collection<String>): Boolean = when {
-        names.isEmpty() -> hasEnumConstants()
-        else -> names.all {
-            enumConstants.any { enumConstant -> it == enumConstant.name }
+    override fun hasEnumConstantsWithAllNames(names: Collection<String>): Boolean =
+        when {
+            names.isEmpty() -> hasEnumConstants()
+            else ->
+                names.all {
+                    enumConstants.any { enumConstant -> it == enumConstant.name }
+                }
         }
-    }
 
     override fun hasEnumConstant(predicate: (KoEnumConstantDeclaration) -> Boolean): Boolean = enumConstants.any(predicate)
 

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/KoEnumConstantProviderCore.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/KoEnumConstantProviderCore.kt
@@ -50,10 +50,11 @@ internal interface KoEnumConstantProviderCore :
     override fun hasEnumConstantWithName(
         name: String,
         vararg names: String,
-    ): Boolean {
-        val givenNames = names.toList() + name
+    ): Boolean = hasEnumConstantWithName(listOf(name, *names))
 
-        return givenNames.any {
+    override fun hasEnumConstantWithName(names: Collection<String>): Boolean = when {
+        names.isEmpty() -> hasEnumConstants()
+        else -> names.any {
             enumConstants.any { enumConstant -> it == enumConstant.name }
         }
     }
@@ -61,10 +62,11 @@ internal interface KoEnumConstantProviderCore :
     override fun hasEnumConstantsWithAllNames(
         name: String,
         vararg names: String,
-    ): Boolean {
-        val givenNames = names.toList() + name
+    ): Boolean = hasEnumConstantsWithAllNames(listOf(name, *names))
 
-        return givenNames.all {
+    override fun hasEnumConstantsWithAllNames(names: Collection<String>): Boolean = when {
+        names.isEmpty() -> hasEnumConstants()
+        else -> names.all {
             enumConstants.any { enumConstant -> it == enumConstant.name }
         }
     }

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/KoExternalParentProviderCore.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/KoExternalParentProviderCore.kt
@@ -26,10 +26,14 @@ internal interface KoExternalParentProviderCore :
         name: String,
         vararg names: String,
         indirectParents: Boolean,
-    ): Boolean {
-        val givenNames = names.toList() + name
+    ): Boolean = hasExternalParentWithName(listOf(name, *names), indirectParents)
 
-        return givenNames.any {
+    override fun hasExternalParentWithName(
+        names: Collection<String>,
+        indirectParents: Boolean,
+    ): Boolean = when {
+        names.isEmpty() -> hasExternalParents(indirectParents)
+        else -> names.any {
             externalParents(indirectParents).any { parentInterface -> it == parentInterface.name }
         }
     }
@@ -38,10 +42,14 @@ internal interface KoExternalParentProviderCore :
         name: String,
         vararg names: String,
         indirectParents: Boolean,
-    ): Boolean {
-        val givenNames = names.toList() + name
+    ): Boolean = hasExternalParentsWithAllNames(listOf(name, *names), indirectParents)
 
-        return givenNames.all {
+    override fun hasExternalParentsWithAllNames(
+        names: Collection<String>,
+        indirectParents: Boolean,
+    ): Boolean = when {
+        names.isEmpty() -> hasExternalParents(indirectParents)
+        else -> names.all {
             externalParents(indirectParents).any { parentInterface -> it == parentInterface.name }
         }
     }
@@ -60,15 +68,27 @@ internal interface KoExternalParentProviderCore :
         name: KClass<*>,
         vararg names: KClass<*>,
         indirectParents: Boolean,
-    ): Boolean =
-        checkIfParentOf(name, externalParents(indirectParents)) ||
-            names.any { checkIfParentOf(it, externalParents(indirectParents)) }
+    ): Boolean = hasExternalParentOf(listOf(name, *names), indirectParents)
+
+    override fun hasExternalParentOf(
+        names: Collection<KClass<*>>,
+        indirectParents: Boolean,
+    ): Boolean = when {
+        names.isEmpty() -> hasExternalParents(indirectParents)
+        else -> names.any { checkIfParentOf(it, externalParents(indirectParents)) }
+    }
 
     override fun hasAllExternalParentsOf(
         name: KClass<*>,
         vararg names: KClass<*>,
         indirectParents: Boolean,
-    ): Boolean =
-        checkIfParentOf(name, externalParents(indirectParents)) &&
-            names.all { checkIfParentOf(it, externalParents(indirectParents)) }
+    ): Boolean = hasAllExternalParentsOf(listOf(name, *names), indirectParents)
+
+    override fun hasAllExternalParentsOf(
+        names: Collection<KClass<*>>,
+        indirectParents: Boolean,
+    ): Boolean = when {
+        names.isEmpty() -> hasExternalParents(indirectParents)
+        else -> names.all { checkIfParentOf(it, externalParents(indirectParents)) }
+    }
 }

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/KoExternalParentProviderCore.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/KoExternalParentProviderCore.kt
@@ -31,12 +31,14 @@ internal interface KoExternalParentProviderCore :
     override fun hasExternalParentWithName(
         names: Collection<String>,
         indirectParents: Boolean,
-    ): Boolean = when {
-        names.isEmpty() -> hasExternalParents(indirectParents)
-        else -> names.any {
-            externalParents(indirectParents).any { parentInterface -> it == parentInterface.name }
+    ): Boolean =
+        when {
+            names.isEmpty() -> hasExternalParents(indirectParents)
+            else ->
+                names.any {
+                    externalParents(indirectParents).any { parentInterface -> it == parentInterface.name }
+                }
         }
-    }
 
     override fun hasExternalParentsWithAllNames(
         name: String,
@@ -47,12 +49,14 @@ internal interface KoExternalParentProviderCore :
     override fun hasExternalParentsWithAllNames(
         names: Collection<String>,
         indirectParents: Boolean,
-    ): Boolean = when {
-        names.isEmpty() -> hasExternalParents(indirectParents)
-        else -> names.all {
-            externalParents(indirectParents).any { parentInterface -> it == parentInterface.name }
+    ): Boolean =
+        when {
+            names.isEmpty() -> hasExternalParents(indirectParents)
+            else ->
+                names.all {
+                    externalParents(indirectParents).any { parentInterface -> it == parentInterface.name }
+                }
         }
-    }
 
     override fun hasExternalParent(
         indirectParents: Boolean,
@@ -73,10 +77,11 @@ internal interface KoExternalParentProviderCore :
     override fun hasExternalParentOf(
         names: Collection<KClass<*>>,
         indirectParents: Boolean,
-    ): Boolean = when {
-        names.isEmpty() -> hasExternalParents(indirectParents)
-        else -> names.any { checkIfParentOf(it, externalParents(indirectParents)) }
-    }
+    ): Boolean =
+        when {
+            names.isEmpty() -> hasExternalParents(indirectParents)
+            else -> names.any { checkIfParentOf(it, externalParents(indirectParents)) }
+        }
 
     override fun hasAllExternalParentsOf(
         name: KClass<*>,
@@ -87,8 +92,9 @@ internal interface KoExternalParentProviderCore :
     override fun hasAllExternalParentsOf(
         names: Collection<KClass<*>>,
         indirectParents: Boolean,
-    ): Boolean = when {
-        names.isEmpty() -> hasExternalParents(indirectParents)
-        else -> names.all { checkIfParentOf(it, externalParents(indirectParents)) }
-    }
+    ): Boolean =
+        when {
+            names.isEmpty() -> hasExternalParents(indirectParents)
+            else -> names.all { checkIfParentOf(it, externalParents(indirectParents)) }
+        }
 }

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/KoFunctionProviderCore.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/KoFunctionProviderCore.kt
@@ -49,12 +49,14 @@ internal interface KoFunctionProviderCore : KoFunctionProvider, KoDeclarationPro
         names: Collection<String>,
         includeNested: Boolean,
         includeLocal: Boolean,
-    ): Boolean = when {
-        names.isEmpty() -> hasFunctions(includeNested, includeLocal)
-        else -> names.any {
-            functions(includeNested, includeLocal).any { function -> it == function.name }
+    ): Boolean =
+        when {
+            names.isEmpty() -> hasFunctions(includeNested, includeLocal)
+            else ->
+                names.any {
+                    functions(includeNested, includeLocal).any { function -> it == function.name }
+                }
         }
-    }
 
     override fun hasFunctionsWithAllNames(
         name: String,
@@ -67,12 +69,14 @@ internal interface KoFunctionProviderCore : KoFunctionProvider, KoDeclarationPro
         names: Collection<String>,
         includeNested: Boolean,
         includeLocal: Boolean,
-    ): Boolean = when {
-        names.isEmpty() -> hasFunctions(includeNested, includeLocal)
-        else -> names.all {
-            functions(includeNested, includeLocal).any { function -> it == function.name }
+    ): Boolean =
+        when {
+            names.isEmpty() -> hasFunctions(includeNested, includeLocal)
+            else ->
+                names.all {
+                    functions(includeNested, includeLocal).any { function -> it == function.name }
+                }
         }
-    }
 
     override fun hasFunction(
         includeNested: Boolean,

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/KoFunctionProviderCore.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/KoFunctionProviderCore.kt
@@ -43,10 +43,15 @@ internal interface KoFunctionProviderCore : KoFunctionProvider, KoDeclarationPro
         vararg names: String,
         includeNested: Boolean,
         includeLocal: Boolean,
-    ): Boolean {
-        val givenNames = names.toList() + name
+    ): Boolean = hasFunctionWithName(listOf(name, *names), includeNested, includeLocal)
 
-        return givenNames.any {
+    override fun hasFunctionWithName(
+        names: Collection<String>,
+        includeNested: Boolean,
+        includeLocal: Boolean,
+    ): Boolean = when {
+        names.isEmpty() -> hasFunctions(includeNested, includeLocal)
+        else -> names.any {
             functions(includeNested, includeLocal).any { function -> it == function.name }
         }
     }
@@ -56,10 +61,15 @@ internal interface KoFunctionProviderCore : KoFunctionProvider, KoDeclarationPro
         vararg names: String,
         includeNested: Boolean,
         includeLocal: Boolean,
-    ): Boolean {
-        val givenNames = names.toList() + name
+    ): Boolean = hasFunctionsWithAllNames(listOf(name, *names), includeNested, includeLocal)
 
-        return givenNames.all {
+    override fun hasFunctionsWithAllNames(
+        names: Collection<String>,
+        includeNested: Boolean,
+        includeLocal: Boolean,
+    ): Boolean = when {
+        names.isEmpty() -> hasFunctions(includeNested, includeLocal)
+        else -> names.all {
             functions(includeNested, includeLocal).any { function -> it == function.name }
         }
     }

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/KoImportAliasProviderCore.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/KoImportAliasProviderCore.kt
@@ -26,24 +26,28 @@ internal interface KoImportAliasProviderCore :
         vararg names: String,
     ): Boolean = hasImportAliasWithName(listOf(name, *names))
 
-    override fun hasImportAliasWithName(names: Collection<String>, ): Boolean = when {
-        names.isEmpty() -> hasImportAliases()
-        else -> names.any {
-            importAliases.any { importAlias -> it == importAlias.name }
+    override fun hasImportAliasWithName(names: Collection<String>): Boolean =
+        when {
+            names.isEmpty() -> hasImportAliases()
+            else ->
+                names.any {
+                    importAliases.any { importAlias -> it == importAlias.name }
+                }
         }
-    }
 
     override fun hasImportAliasesWithAllNames(
         name: String,
         vararg names: String,
     ): Boolean = hasImportAliasesWithAllNames(listOf(name, *names))
 
-    override fun hasImportAliasesWithAllNames(names: Collection<String>, ): Boolean = when {
-        names.isEmpty() -> hasImportAliases()
-        else -> names.all {
-            importAliases.any { importAlias -> it == importAlias.name }
+    override fun hasImportAliasesWithAllNames(names: Collection<String>): Boolean =
+        when {
+            names.isEmpty() -> hasImportAliases()
+            else ->
+                names.all {
+                    importAliases.any { importAlias -> it == importAlias.name }
+                }
         }
-    }
 
     override fun hasImportAlias(predicate: (KoImportAliasDeclaration) -> Boolean): Boolean = importAliases.any(predicate)
 

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/KoImportAliasProviderCore.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/KoImportAliasProviderCore.kt
@@ -24,10 +24,11 @@ internal interface KoImportAliasProviderCore :
     override fun hasImportAliasWithName(
         name: String,
         vararg names: String,
-    ): Boolean {
-        val givenNames = names.toList() + name
+    ): Boolean = hasImportAliasWithName(listOf(name, *names))
 
-        return givenNames.any {
+    override fun hasImportAliasWithName(names: Collection<String>, ): Boolean = when {
+        names.isEmpty() -> hasImportAliases()
+        else -> names.any {
             importAliases.any { importAlias -> it == importAlias.name }
         }
     }
@@ -35,10 +36,11 @@ internal interface KoImportAliasProviderCore :
     override fun hasImportAliasesWithAllNames(
         name: String,
         vararg names: String,
-    ): Boolean {
-        val givenNames = names.toList() + name
+    ): Boolean = hasImportAliasesWithAllNames(listOf(name, *names))
 
-        return givenNames.all {
+    override fun hasImportAliasesWithAllNames(names: Collection<String>, ): Boolean = when {
+        names.isEmpty() -> hasImportAliases()
+        else -> names.all {
             importAliases.any { importAlias -> it == importAlias.name }
         }
     }

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/KoImportProviderCore.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/KoImportProviderCore.kt
@@ -50,10 +50,11 @@ internal interface KoImportProviderCore : KoImportProvider, KoContainingDeclarat
     override fun hasImportWithName(
         name: String,
         vararg names: String,
-    ): Boolean {
-        val givenNames = names.toList() + name
+    ): Boolean = hasImportWithName(listOf(name, *names))
 
-        return givenNames.any {
+    override fun hasImportWithName(names: Collection<String>): Boolean = when {
+        names.isEmpty() -> hasImports()
+        else -> names.any {
             imports.any { import -> it == import.name }
         }
     }
@@ -61,10 +62,11 @@ internal interface KoImportProviderCore : KoImportProvider, KoContainingDeclarat
     override fun hasImportsWithAllNames(
         name: String,
         vararg names: String,
-    ): Boolean {
-        val givenNames = names.toList() + name
+    ): Boolean = hasImportsWithAllNames(listOf(name, *names))
 
-        return givenNames.all {
+    override fun hasImportsWithAllNames(names: Collection<String>): Boolean = when {
+        names.isEmpty() -> hasImports()
+        else -> names.all {
             imports.any { import -> it == import.name }
         }
     }

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/KoImportProviderCore.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/KoImportProviderCore.kt
@@ -52,24 +52,28 @@ internal interface KoImportProviderCore : KoImportProvider, KoContainingDeclarat
         vararg names: String,
     ): Boolean = hasImportWithName(listOf(name, *names))
 
-    override fun hasImportWithName(names: Collection<String>): Boolean = when {
-        names.isEmpty() -> hasImports()
-        else -> names.any {
-            imports.any { import -> it == import.name }
+    override fun hasImportWithName(names: Collection<String>): Boolean =
+        when {
+            names.isEmpty() -> hasImports()
+            else ->
+                names.any {
+                    imports.any { import -> it == import.name }
+                }
         }
-    }
 
     override fun hasImportsWithAllNames(
         name: String,
         vararg names: String,
     ): Boolean = hasImportsWithAllNames(listOf(name, *names))
 
-    override fun hasImportsWithAllNames(names: Collection<String>): Boolean = when {
-        names.isEmpty() -> hasImports()
-        else -> names.all {
-            imports.any { import -> it == import.name }
+    override fun hasImportsWithAllNames(names: Collection<String>): Boolean =
+        when {
+            names.isEmpty() -> hasImports()
+            else ->
+                names.all {
+                    imports.any { import -> it == import.name }
+                }
         }
-    }
 
     override fun hasImport(predicate: (KoImportDeclaration) -> Boolean): Boolean = imports.any(predicate)
 

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/KoInterfaceProviderCore.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/KoInterfaceProviderCore.kt
@@ -35,12 +35,14 @@ internal interface KoInterfaceProviderCore : KoInterfaceProvider, KoDeclarationP
     override fun hasInterfaceWithName(
         names: Collection<String>,
         includeNested: Boolean,
-    ): Boolean = when {
-        names.isEmpty() -> hasInterfaces(includeNested)
-        else -> names.any {
-            interfaces(includeNested).any { koInterface -> it == koInterface.name }
+    ): Boolean =
+        when {
+            names.isEmpty() -> hasInterfaces(includeNested)
+            else ->
+                names.any {
+                    interfaces(includeNested).any { koInterface -> it == koInterface.name }
+                }
         }
-    }
 
     override fun hasInterfacesWithAllNames(
         name: String,
@@ -51,12 +53,14 @@ internal interface KoInterfaceProviderCore : KoInterfaceProvider, KoDeclarationP
     override fun hasInterfacesWithAllNames(
         names: Collection<String>,
         includeNested: Boolean,
-    ): Boolean = when {
-        names.isEmpty() -> hasInterfaces(includeNested)
-        else -> names.all {
-            interfaces(includeNested).any { koInterface -> it == koInterface.name }
+    ): Boolean =
+        when {
+            names.isEmpty() -> hasInterfaces(includeNested)
+            else ->
+                names.all {
+                    interfaces(includeNested).any { koInterface -> it == koInterface.name }
+                }
         }
-    }
 
     override fun hasInterface(
         includeNested: Boolean,

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/KoInterfaceProviderCore.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/KoInterfaceProviderCore.kt
@@ -30,10 +30,14 @@ internal interface KoInterfaceProviderCore : KoInterfaceProvider, KoDeclarationP
         name: String,
         vararg names: String,
         includeNested: Boolean,
-    ): Boolean {
-        val givenNames = names.toList() + name
+    ): Boolean = hasInterfaceWithName(listOf(name, *names), includeNested)
 
-        return givenNames.any {
+    override fun hasInterfaceWithName(
+        names: Collection<String>,
+        includeNested: Boolean,
+    ): Boolean = when {
+        names.isEmpty() -> hasInterfaces(includeNested)
+        else -> names.any {
             interfaces(includeNested).any { koInterface -> it == koInterface.name }
         }
     }
@@ -42,10 +46,14 @@ internal interface KoInterfaceProviderCore : KoInterfaceProvider, KoDeclarationP
         name: String,
         vararg names: String,
         includeNested: Boolean,
-    ): Boolean {
-        val givenNames = names.toList() + name
+    ): Boolean = hasInterfacesWithAllNames(listOf(name, *names), includeNested)
 
-        return givenNames.all {
+    override fun hasInterfacesWithAllNames(
+        names: Collection<String>,
+        includeNested: Boolean,
+    ): Boolean = when {
+        names.isEmpty() -> hasInterfaces(includeNested)
+        else -> names.all {
             interfaces(includeNested).any { koInterface -> it == koInterface.name }
         }
     }

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/KoLocalClassProviderCore.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/KoLocalClassProviderCore.kt
@@ -22,24 +22,28 @@ internal interface KoLocalClassProviderCore : KoLocalClassProvider, KoLocalDecla
         vararg names: String,
     ): Boolean = hasLocalClassWithName(listOf(name, *names))
 
-    override fun hasLocalClassWithName(names: Collection<String>): Boolean = when {
-        names.isEmpty() -> hasLocalClasses()
-        else -> names.any {
-            localClasses.any { localClass -> it == localClass.name }
+    override fun hasLocalClassWithName(names: Collection<String>): Boolean =
+        when {
+            names.isEmpty() -> hasLocalClasses()
+            else ->
+                names.any {
+                    localClasses.any { localClass -> it == localClass.name }
+                }
         }
-    }
 
     override fun hasLocalClassesWithAllNames(
         name: String,
         vararg names: String,
     ): Boolean = hasLocalClassesWithAllNames(listOf(name, *names))
 
-    override fun hasLocalClassesWithAllNames(names: Collection<String>): Boolean = when {
-        names.isEmpty() -> hasLocalClasses()
-        else -> names.all {
-            localClasses.any { localClass -> it == localClass.name }
+    override fun hasLocalClassesWithAllNames(names: Collection<String>): Boolean =
+        when {
+            names.isEmpty() -> hasLocalClasses()
+            else ->
+                names.all {
+                    localClasses.any { localClass -> it == localClass.name }
+                }
         }
-    }
 
     override fun hasLocalClass(predicate: (KoClassDeclaration) -> Boolean): Boolean = localClasses.any(predicate)
 

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/KoLocalClassProviderCore.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/KoLocalClassProviderCore.kt
@@ -20,10 +20,11 @@ internal interface KoLocalClassProviderCore : KoLocalClassProvider, KoLocalDecla
     override fun hasLocalClassWithName(
         name: String,
         vararg names: String,
-    ): Boolean {
-        val givenNames = names.toList() + name
+    ): Boolean = hasLocalClassWithName(listOf(name, *names))
 
-        return givenNames.any {
+    override fun hasLocalClassWithName(names: Collection<String>): Boolean = when {
+        names.isEmpty() -> hasLocalClasses()
+        else -> names.any {
             localClasses.any { localClass -> it == localClass.name }
         }
     }
@@ -31,10 +32,11 @@ internal interface KoLocalClassProviderCore : KoLocalClassProvider, KoLocalDecla
     override fun hasLocalClassesWithAllNames(
         name: String,
         vararg names: String,
-    ): Boolean {
-        val givenNames = names.toList() + name
+    ): Boolean = hasLocalClassesWithAllNames(listOf(name, *names))
 
-        return givenNames.all {
+    override fun hasLocalClassesWithAllNames(names: Collection<String>): Boolean = when {
+        names.isEmpty() -> hasLocalClasses()
+        else -> names.all {
             localClasses.any { localClass -> it == localClass.name }
         }
     }

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/KoLocalFunctionProviderCore.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/KoLocalFunctionProviderCore.kt
@@ -25,24 +25,28 @@ internal interface KoLocalFunctionProviderCore :
         vararg names: String,
     ): Boolean = hasLocalFunctionWithName(listOf(name, *names))
 
-    override fun hasLocalFunctionWithName(names: Collection<String>): Boolean = when {
-        names.isEmpty() -> hasLocalFunctions()
-        else -> names.any {
-            localFunctions.any { localFunction -> it == localFunction.name }
+    override fun hasLocalFunctionWithName(names: Collection<String>): Boolean =
+        when {
+            names.isEmpty() -> hasLocalFunctions()
+            else ->
+                names.any {
+                    localFunctions.any { localFunction -> it == localFunction.name }
+                }
         }
-    }
 
     override fun hasLocalFunctionsWithAllNames(
         name: String,
         vararg names: String,
     ): Boolean = hasLocalFunctionsWithAllNames(listOf(name, *names))
 
-    override fun hasLocalFunctionsWithAllNames(names: Collection<String>): Boolean = when {
-        names.isEmpty() -> hasLocalFunctions()
-        else -> names.all {
-            localFunctions.any { localFunction -> it == localFunction.name }
+    override fun hasLocalFunctionsWithAllNames(names: Collection<String>): Boolean =
+        when {
+            names.isEmpty() -> hasLocalFunctions()
+            else ->
+                names.all {
+                    localFunctions.any { localFunction -> it == localFunction.name }
+                }
         }
-    }
 
     override fun hasLocalFunction(predicate: (KoFunctionDeclaration) -> Boolean): Boolean = localFunctions.any(predicate)
 

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/KoLocalFunctionProviderCore.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/KoLocalFunctionProviderCore.kt
@@ -23,10 +23,11 @@ internal interface KoLocalFunctionProviderCore :
     override fun hasLocalFunctionWithName(
         name: String,
         vararg names: String,
-    ): Boolean {
-        val givenNames = names.toList() + name
+    ): Boolean = hasLocalFunctionWithName(listOf(name, *names))
 
-        return givenNames.any {
+    override fun hasLocalFunctionWithName(names: Collection<String>): Boolean = when {
+        names.isEmpty() -> hasLocalFunctions()
+        else -> names.any {
             localFunctions.any { localFunction -> it == localFunction.name }
         }
     }
@@ -34,10 +35,11 @@ internal interface KoLocalFunctionProviderCore :
     override fun hasLocalFunctionsWithAllNames(
         name: String,
         vararg names: String,
-    ): Boolean {
-        val givenNames = names.toList() + name
+    ): Boolean = hasLocalFunctionsWithAllNames(listOf(name, *names))
 
-        return givenNames.all {
+    override fun hasLocalFunctionsWithAllNames(names: Collection<String>): Boolean = when {
+        names.isEmpty() -> hasLocalFunctions()
+        else -> names.all {
             localFunctions.any { localFunction -> it == localFunction.name }
         }
     }

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/KoObjectProviderCore.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/KoObjectProviderCore.kt
@@ -30,10 +30,14 @@ internal interface KoObjectProviderCore : KoObjectProvider, KoDeclarationProvide
         name: String,
         vararg names: String,
         includeNested: Boolean,
-    ): Boolean {
-        val givenNames = names.toList() + name
+    ): Boolean = hasObjectWithName(listOf(name, *names), includeNested)
 
-        return givenNames.any {
+    override fun hasObjectWithName(
+        names: Collection<String>,
+        includeNested: Boolean,
+    ): Boolean = when {
+        names.isEmpty() -> hasObjects(includeNested)
+        else -> names.any {
             objects(includeNested).any { koObject -> it == koObject.name }
         }
     }
@@ -42,10 +46,14 @@ internal interface KoObjectProviderCore : KoObjectProvider, KoDeclarationProvide
         name: String,
         vararg names: String,
         includeNested: Boolean,
-    ): Boolean {
-        val givenNames = names.toList() + name
+    ): Boolean = hasObjectsWithAllNames(listOf(name, *names), includeNested)
 
-        return givenNames.all {
+    override fun hasObjectsWithAllNames(
+        names: Collection<String>,
+        includeNested: Boolean,
+    ): Boolean = when {
+        names.isEmpty() -> hasObjects(includeNested)
+        else -> names.all {
             objects(includeNested).any { koObject -> it == koObject.name }
         }
     }

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/KoObjectProviderCore.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/KoObjectProviderCore.kt
@@ -35,12 +35,14 @@ internal interface KoObjectProviderCore : KoObjectProvider, KoDeclarationProvide
     override fun hasObjectWithName(
         names: Collection<String>,
         includeNested: Boolean,
-    ): Boolean = when {
-        names.isEmpty() -> hasObjects(includeNested)
-        else -> names.any {
-            objects(includeNested).any { koObject -> it == koObject.name }
+    ): Boolean =
+        when {
+            names.isEmpty() -> hasObjects(includeNested)
+            else ->
+                names.any {
+                    objects(includeNested).any { koObject -> it == koObject.name }
+                }
         }
-    }
 
     override fun hasObjectsWithAllNames(
         name: String,
@@ -51,12 +53,14 @@ internal interface KoObjectProviderCore : KoObjectProvider, KoDeclarationProvide
     override fun hasObjectsWithAllNames(
         names: Collection<String>,
         includeNested: Boolean,
-    ): Boolean = when {
-        names.isEmpty() -> hasObjects(includeNested)
-        else -> names.all {
-            objects(includeNested).any { koObject -> it == koObject.name }
+    ): Boolean =
+        when {
+            names.isEmpty() -> hasObjects(includeNested)
+            else ->
+                names.all {
+                    objects(includeNested).any { koObject -> it == koObject.name }
+                }
         }
-    }
 
     override fun hasObject(
         includeNested: Boolean,

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/KoParametersProviderCore.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/KoParametersProviderCore.kt
@@ -34,24 +34,28 @@ internal interface KoParametersProviderCore :
         vararg names: String,
     ): Boolean = hasParameterWithName(listOf(name, *names))
 
-    override fun hasParameterWithName(names: Collection<String>): Boolean = when {
-        names.isEmpty() -> hasParameters()
-        else -> names.any {
-            parameters.any { parameter -> it == parameter.name }
+    override fun hasParameterWithName(names: Collection<String>): Boolean =
+        when {
+            names.isEmpty() -> hasParameters()
+            else ->
+                names.any {
+                    parameters.any { parameter -> it == parameter.name }
+                }
         }
-    }
 
     override fun hasParametersWithAllNames(
         name: String,
         vararg names: String,
     ): Boolean = hasParametersWithAllNames(listOf(name, *names))
 
-    override fun hasParametersWithAllNames(names: Collection<String>): Boolean = when {
-        names.isEmpty() -> hasParameters()
-        else -> names.all {
-            parameters.any { parameter -> it == parameter.name }
+    override fun hasParametersWithAllNames(names: Collection<String>): Boolean =
+        when {
+            names.isEmpty() -> hasParameters()
+            else ->
+                names.all {
+                    parameters.any { parameter -> it == parameter.name }
+                }
         }
-    }
 
     override fun hasParameter(predicate: (KoParameterDeclaration) -> Boolean): Boolean = parameters.any(predicate)
 

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/KoParametersProviderCore.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/KoParametersProviderCore.kt
@@ -32,10 +32,11 @@ internal interface KoParametersProviderCore :
     override fun hasParameterWithName(
         name: String,
         vararg names: String,
-    ): Boolean {
-        val givenNames = names.toList() + name
+    ): Boolean = hasParameterWithName(listOf(name, *names))
 
-        return givenNames.any {
+    override fun hasParameterWithName(names: Collection<String>): Boolean = when {
+        names.isEmpty() -> hasParameters()
+        else -> names.any {
             parameters.any { parameter -> it == parameter.name }
         }
     }
@@ -43,10 +44,11 @@ internal interface KoParametersProviderCore :
     override fun hasParametersWithAllNames(
         name: String,
         vararg names: String,
-    ): Boolean {
-        val givenNames = names.toList() + name
+    ): Boolean = hasParametersWithAllNames(listOf(name, *names))
 
-        return givenNames.all {
+    override fun hasParametersWithAllNames(names: Collection<String>): Boolean = when {
+        names.isEmpty() -> hasParameters()
+        else -> names.all {
             parameters.any { parameter -> it == parameter.name }
         }
     }

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/KoParentClassProviderCore.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/KoParentClassProviderCore.kt
@@ -45,13 +45,14 @@ internal interface KoParentClassProviderCore :
         indirectParents: Boolean,
     ): Boolean = hasParentClassWithName(listOf(name, *names), indirectParents)
 
-     override fun hasParentClassWithName(
-         names: Collection<String>,
+    override fun hasParentClassWithName(
+        names: Collection<String>,
         indirectParents: Boolean,
-    ): Boolean = when {
-        names.isEmpty() -> hasParentClasses(indirectParents)
-         else -> names.any { parentClasses(indirectParents).any { parentClass -> it == parentClass.name } }
-    }
+    ): Boolean =
+        when {
+            names.isEmpty() -> hasParentClasses(indirectParents)
+            else -> names.any { parentClasses(indirectParents).any { parentClass -> it == parentClass.name } }
+        }
 
     override fun hasParentClassesWithAllNames(
         name: String,
@@ -59,39 +60,42 @@ internal interface KoParentClassProviderCore :
         indirectParents: Boolean,
     ): Boolean = hasParentClassesWithAllNames(listOf(name, *names), indirectParents)
 
-     override fun hasParentClassesWithAllNames(
-         names: Collection<String>,
+    override fun hasParentClassesWithAllNames(
+        names: Collection<String>,
         indirectParents: Boolean,
-    ): Boolean = when {
-        names.isEmpty() -> hasParentClasses(indirectParents)
-         else -> names.all { parentClasses(indirectParents).any { parentClass -> it == parentClass.name } }
-    }
+    ): Boolean =
+        when {
+            names.isEmpty() -> hasParentClasses(indirectParents)
+            else -> names.all { parentClasses(indirectParents).any { parentClass -> it == parentClass.name } }
+        }
 
     override fun hasParentClassOf(
         name: KClass<*>,
         vararg names: KClass<*>,
         indirectParents: Boolean,
-    ): Boolean =hasParentClassOf(listOf(name, *names), indirectParents)
+    ): Boolean = hasParentClassOf(listOf(name, *names), indirectParents)
 
     override fun hasParentClassOf(
         names: Collection<KClass<*>>,
         indirectParents: Boolean,
-    ): Boolean = when {
-        names.isEmpty() -> hasParentClasses(indirectParents)
-        else -> names.any { checkIfParentOf(it, parentClasses(indirectParents)) }
-    }
+    ): Boolean =
+        when {
+            names.isEmpty() -> hasParentClasses(indirectParents)
+            else -> names.any { checkIfParentOf(it, parentClasses(indirectParents)) }
+        }
 
     override fun hasAllParentClassesOf(
         name: KClass<*>,
         vararg names: KClass<*>,
         indirectParents: Boolean,
-    ): Boolean =hasAllParentClassesOf(listOf(name, *names), indirectParents)
+    ): Boolean = hasAllParentClassesOf(listOf(name, *names), indirectParents)
 
     override fun hasAllParentClassesOf(
         names: Collection<KClass<*>>,
         indirectParents: Boolean,
-    ): Boolean = when {
-        names.isEmpty() -> hasParentClasses(indirectParents)
-        else -> names.all { checkIfParentOf(it, parentClasses(indirectParents)) }
-    }
+    ): Boolean =
+        when {
+            names.isEmpty() -> hasParentClasses(indirectParents)
+            else -> names.all { checkIfParentOf(it, parentClasses(indirectParents)) }
+        }
 }

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/KoParentClassProviderCore.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/KoParentClassProviderCore.kt
@@ -43,37 +43,55 @@ internal interface KoParentClassProviderCore :
         name: String,
         vararg names: String,
         indirectParents: Boolean,
-    ): Boolean {
-        val givenNames = names.toList() + name
+    ): Boolean = hasParentClassWithName(listOf(name, *names), indirectParents)
 
-        return givenNames.any { parentClasses(indirectParents).any { parentClass -> it == parentClass.name } }
+     override fun hasParentClassWithName(
+         names: Collection<String>,
+        indirectParents: Boolean,
+    ): Boolean = when {
+        names.isEmpty() -> hasParentClasses(indirectParents)
+         else -> names.any { parentClasses(indirectParents).any { parentClass -> it == parentClass.name } }
     }
 
     override fun hasParentClassesWithAllNames(
         name: String,
         vararg names: String,
         indirectParents: Boolean,
-    ): Boolean {
-        val givenNames = names.toList() + name
+    ): Boolean = hasParentClassesWithAllNames(listOf(name, *names), indirectParents)
 
-        return givenNames.all {
-            parentClasses(indirectParents).any { parentClass -> it == parentClass.name }
-        }
+     override fun hasParentClassesWithAllNames(
+         names: Collection<String>,
+        indirectParents: Boolean,
+    ): Boolean = when {
+        names.isEmpty() -> hasParentClasses(indirectParents)
+         else -> names.all { parentClasses(indirectParents).any { parentClass -> it == parentClass.name } }
     }
 
     override fun hasParentClassOf(
         name: KClass<*>,
         vararg names: KClass<*>,
         indirectParents: Boolean,
-    ): Boolean =
-        checkIfParentOf(name, parentClasses(indirectParents)) ||
-            names.any { checkIfParentOf(it, parentClasses(indirectParents)) }
+    ): Boolean =hasParentClassOf(listOf(name, *names), indirectParents)
+
+    override fun hasParentClassOf(
+        names: Collection<KClass<*>>,
+        indirectParents: Boolean,
+    ): Boolean = when {
+        names.isEmpty() -> hasParentClasses(indirectParents)
+        else -> names.any { checkIfParentOf(it, parentClasses(indirectParents)) }
+    }
 
     override fun hasAllParentClassesOf(
         name: KClass<*>,
         vararg names: KClass<*>,
         indirectParents: Boolean,
-    ): Boolean =
-        checkIfParentOf(name, parentClasses(indirectParents)) &&
-            names.all { checkIfParentOf(it, parentClasses(indirectParents)) }
+    ): Boolean =hasAllParentClassesOf(listOf(name, *names), indirectParents)
+
+    override fun hasAllParentClassesOf(
+        names: Collection<KClass<*>>,
+        indirectParents: Boolean,
+    ): Boolean = when {
+        names.isEmpty() -> hasParentClasses(indirectParents)
+        else -> names.all { checkIfParentOf(it, parentClasses(indirectParents)) }
+    }
 }

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/KoParentInterfaceProviderCore.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/KoParentInterfaceProviderCore.kt
@@ -43,10 +43,14 @@ internal interface KoParentInterfaceProviderCore :
         name: String,
         vararg names: String,
         indirectParents: Boolean,
-    ): Boolean {
-        val givenNames = names.toList() + name
+    ): Boolean = hasParentInterfaceWithName(listOf(name, *names), indirectParents)
 
-        return givenNames.any {
+    override fun hasParentInterfaceWithName(
+         names: Collection<String>,
+        indirectParents: Boolean,
+    ): Boolean = when {
+        names.isEmpty() -> hasParentInterfaces(indirectParents)
+        else -> names.any {
             parentInterfaces(indirectParents).any { parentInterface -> it == parentInterface.name }
         }
     }
@@ -55,10 +59,14 @@ internal interface KoParentInterfaceProviderCore :
         name: String,
         vararg names: String,
         indirectParents: Boolean,
-    ): Boolean {
-        val givenNames = names.toList() + name
+    ): Boolean = hasParentInterfacesWithAllNames(listOf(name, *names), indirectParents)
 
-        return givenNames.all {
+    override fun hasParentInterfacesWithAllNames(
+         names: Collection<String>,
+        indirectParents: Boolean,
+    ): Boolean = when {
+        names.isEmpty() -> hasParentInterfaces(indirectParents)
+        else -> names.all {
             parentInterfaces(indirectParents).any { parentInterface -> it == parentInterface.name }
         }
     }
@@ -77,15 +85,27 @@ internal interface KoParentInterfaceProviderCore :
         name: KClass<*>,
         vararg names: KClass<*>,
         indirectParents: Boolean,
-    ): Boolean =
-        checkIfParentOf(name, parentInterfaces(indirectParents)) ||
-            names.any { checkIfParentOf(it, parentInterfaces(indirectParents)) }
+    ): Boolean = hasParentInterfaceOf(listOf(name, *names), indirectParents)
+
+        override fun hasParentInterfaceOf(
+        names: Collection<KClass<*>>,
+        indirectParents: Boolean,
+    ): Boolean = when {
+        names.isEmpty() -> hasParentInterfaces(indirectParents)
+            else -> names.any { checkIfParentOf(it, parentInterfaces(indirectParents)) }
+    }
 
     override fun hasAllParentInterfacesOf(
         name: KClass<*>,
         vararg names: KClass<*>,
         indirectParents: Boolean,
-    ): Boolean =
-        checkIfParentOf(name, parentInterfaces(indirectParents)) &&
-            names.all { checkIfParentOf(it, parentInterfaces(indirectParents)) }
+    ): Boolean = hasAllParentInterfacesOf(listOf(name, *names), indirectParents)
+
+        override fun hasAllParentInterfacesOf(
+        names: Collection<KClass<*>>,
+        indirectParents: Boolean,
+    ): Boolean = when {
+        names.isEmpty() -> hasParentInterfaces(indirectParents)
+            else -> names.all { checkIfParentOf(it, parentInterfaces(indirectParents)) }
+    }
 }

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/KoParentInterfaceProviderCore.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/KoParentInterfaceProviderCore.kt
@@ -46,14 +46,16 @@ internal interface KoParentInterfaceProviderCore :
     ): Boolean = hasParentInterfaceWithName(listOf(name, *names), indirectParents)
 
     override fun hasParentInterfaceWithName(
-         names: Collection<String>,
+        names: Collection<String>,
         indirectParents: Boolean,
-    ): Boolean = when {
-        names.isEmpty() -> hasParentInterfaces(indirectParents)
-        else -> names.any {
-            parentInterfaces(indirectParents).any { parentInterface -> it == parentInterface.name }
+    ): Boolean =
+        when {
+            names.isEmpty() -> hasParentInterfaces(indirectParents)
+            else ->
+                names.any {
+                    parentInterfaces(indirectParents).any { parentInterface -> it == parentInterface.name }
+                }
         }
-    }
 
     override fun hasParentInterfacesWithAllNames(
         name: String,
@@ -62,14 +64,16 @@ internal interface KoParentInterfaceProviderCore :
     ): Boolean = hasParentInterfacesWithAllNames(listOf(name, *names), indirectParents)
 
     override fun hasParentInterfacesWithAllNames(
-         names: Collection<String>,
+        names: Collection<String>,
         indirectParents: Boolean,
-    ): Boolean = when {
-        names.isEmpty() -> hasParentInterfaces(indirectParents)
-        else -> names.all {
-            parentInterfaces(indirectParents).any { parentInterface -> it == parentInterface.name }
+    ): Boolean =
+        when {
+            names.isEmpty() -> hasParentInterfaces(indirectParents)
+            else ->
+                names.all {
+                    parentInterfaces(indirectParents).any { parentInterface -> it == parentInterface.name }
+                }
         }
-    }
 
     override fun hasParentInterface(
         indirectParents: Boolean,
@@ -87,13 +91,14 @@ internal interface KoParentInterfaceProviderCore :
         indirectParents: Boolean,
     ): Boolean = hasParentInterfaceOf(listOf(name, *names), indirectParents)
 
-        override fun hasParentInterfaceOf(
+    override fun hasParentInterfaceOf(
         names: Collection<KClass<*>>,
         indirectParents: Boolean,
-    ): Boolean = when {
-        names.isEmpty() -> hasParentInterfaces(indirectParents)
+    ): Boolean =
+        when {
+            names.isEmpty() -> hasParentInterfaces(indirectParents)
             else -> names.any { checkIfParentOf(it, parentInterfaces(indirectParents)) }
-    }
+        }
 
     override fun hasAllParentInterfacesOf(
         name: KClass<*>,
@@ -101,11 +106,12 @@ internal interface KoParentInterfaceProviderCore :
         indirectParents: Boolean,
     ): Boolean = hasAllParentInterfacesOf(listOf(name, *names), indirectParents)
 
-        override fun hasAllParentInterfacesOf(
+    override fun hasAllParentInterfacesOf(
         names: Collection<KClass<*>>,
         indirectParents: Boolean,
-    ): Boolean = when {
-        names.isEmpty() -> hasParentInterfaces(indirectParents)
+    ): Boolean =
+        when {
+            names.isEmpty() -> hasParentInterfaces(indirectParents)
             else -> names.all { checkIfParentOf(it, parentInterfaces(indirectParents)) }
-    }
+        }
 }

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/KoParentProviderCore.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/KoParentProviderCore.kt
@@ -104,10 +104,14 @@ internal interface KoParentProviderCore :
         name: String,
         vararg names: String,
         indirectParents: Boolean,
-    ): Boolean {
-        val givenNames = names.toList() + name
+    ): Boolean = hasParentWithName(listOf(name, *names), indirectParents)
 
-        return givenNames.any {
+    override fun hasParentWithName(
+        names: Collection<String>,
+        indirectParents: Boolean,
+    ): Boolean = when {
+        names.isEmpty() -> hasParents(indirectParents)
+        else -> names.any {
             parents(indirectParents).any { parent -> it == parent.name }
         }
     }
@@ -116,10 +120,14 @@ internal interface KoParentProviderCore :
         name: String,
         vararg names: String,
         indirectParents: Boolean,
-    ): Boolean {
-        val givenNames = names.toList() + name
+    ): Boolean = hasParentsWithAllNames(listOf(name, *names), indirectParents)
 
-        return givenNames.all {
+    override fun hasParentsWithAllNames(
+        names: Collection<String>,
+        indirectParents: Boolean,
+    ): Boolean = when {
+        names.isEmpty() -> hasParents(indirectParents)
+        else -> names.all {
             parents(indirectParents).any { parent -> it == parent.name }
         }
     }
@@ -138,11 +146,27 @@ internal interface KoParentProviderCore :
         name: KClass<*>,
         vararg names: KClass<*>,
         indirectParents: Boolean,
-    ): Boolean = checkIfParentOf(name, parents(indirectParents)) || names.any { checkIfParentOf(it, parents(indirectParents)) }
+    ): Boolean = hasParentOf(listOf(name, *names), indirectParents)
+
+    override fun hasParentOf(
+         names: Collection<KClass<*>>,
+        indirectParents: Boolean,
+    ): Boolean = when {
+        names.isEmpty() -> hasParents(indirectParents)
+        else -> names.any { checkIfParentOf(it, parents(indirectParents)) }
+    }
 
     override fun hasAllParentsOf(
         name: KClass<*>,
         vararg names: KClass<*>,
         indirectParents: Boolean,
-    ): Boolean = checkIfParentOf(name, parents(indirectParents)) && names.all { checkIfParentOf(it, parents(indirectParents)) }
+    ): Boolean = hasAllParentsOf(listOf(name, *names), indirectParents)
+
+    override fun hasAllParentsOf(
+         names: Collection<KClass<*>>,
+        indirectParents: Boolean,
+    ): Boolean = when {
+        names.isEmpty() -> hasParents(indirectParents)
+        else -> names.all { checkIfParentOf(it, parents(indirectParents)) }
+    }
 }

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/KoParentProviderCore.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/KoParentProviderCore.kt
@@ -109,12 +109,14 @@ internal interface KoParentProviderCore :
     override fun hasParentWithName(
         names: Collection<String>,
         indirectParents: Boolean,
-    ): Boolean = when {
-        names.isEmpty() -> hasParents(indirectParents)
-        else -> names.any {
-            parents(indirectParents).any { parent -> it == parent.name }
+    ): Boolean =
+        when {
+            names.isEmpty() -> hasParents(indirectParents)
+            else ->
+                names.any {
+                    parents(indirectParents).any { parent -> it == parent.name }
+                }
         }
-    }
 
     override fun hasParentsWithAllNames(
         name: String,
@@ -125,12 +127,14 @@ internal interface KoParentProviderCore :
     override fun hasParentsWithAllNames(
         names: Collection<String>,
         indirectParents: Boolean,
-    ): Boolean = when {
-        names.isEmpty() -> hasParents(indirectParents)
-        else -> names.all {
-            parents(indirectParents).any { parent -> it == parent.name }
+    ): Boolean =
+        when {
+            names.isEmpty() -> hasParents(indirectParents)
+            else ->
+                names.all {
+                    parents(indirectParents).any { parent -> it == parent.name }
+                }
         }
-    }
 
     override fun hasParent(
         indirectParents: Boolean,
@@ -149,12 +153,13 @@ internal interface KoParentProviderCore :
     ): Boolean = hasParentOf(listOf(name, *names), indirectParents)
 
     override fun hasParentOf(
-         names: Collection<KClass<*>>,
+        names: Collection<KClass<*>>,
         indirectParents: Boolean,
-    ): Boolean = when {
-        names.isEmpty() -> hasParents(indirectParents)
-        else -> names.any { checkIfParentOf(it, parents(indirectParents)) }
-    }
+    ): Boolean =
+        when {
+            names.isEmpty() -> hasParents(indirectParents)
+            else -> names.any { checkIfParentOf(it, parents(indirectParents)) }
+        }
 
     override fun hasAllParentsOf(
         name: KClass<*>,
@@ -163,10 +168,11 @@ internal interface KoParentProviderCore :
     ): Boolean = hasAllParentsOf(listOf(name, *names), indirectParents)
 
     override fun hasAllParentsOf(
-         names: Collection<KClass<*>>,
+        names: Collection<KClass<*>>,
         indirectParents: Boolean,
-    ): Boolean = when {
-        names.isEmpty() -> hasParents(indirectParents)
-        else -> names.all { checkIfParentOf(it, parents(indirectParents)) }
-    }
+    ): Boolean =
+        when {
+            names.isEmpty() -> hasParents(indirectParents)
+            else -> names.all { checkIfParentOf(it, parents(indirectParents)) }
+        }
 }

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/KoPropertyProviderCore.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/KoPropertyProviderCore.kt
@@ -30,10 +30,14 @@ internal interface KoPropertyProviderCore : KoPropertyProvider, KoDeclarationPro
         name: String,
         vararg names: String,
         includeNested: Boolean,
-    ): Boolean {
-        val givenNames = names.toList() + name
+    ): Boolean = hasPropertyWithName(listOf(name, *names), includeNested)
 
-        return givenNames.any {
+    override fun hasPropertyWithName(
+         names: Collection<String>,
+        includeNested: Boolean,
+    ): Boolean = when {
+        names.isEmpty() -> hasProperties(includeNested)
+        else -> names.any {
             properties(includeNested).any { koProperty -> it == koProperty.name }
         }
     }
@@ -42,10 +46,14 @@ internal interface KoPropertyProviderCore : KoPropertyProvider, KoDeclarationPro
         name: String,
         vararg names: String,
         includeNested: Boolean,
-    ): Boolean {
-        val givenNames = names.toList() + name
+    ): Boolean = hasPropertiesWithAllNames(listOf(name, *names), includeNested)
 
-        return givenNames.all {
+    override fun hasPropertiesWithAllNames(
+         names: Collection<String>,
+        includeNested: Boolean,
+    ): Boolean = when {
+        names.isEmpty() -> hasProperties(includeNested)
+        else -> names.all {
             properties(includeNested).any { koProperty -> it == koProperty.name }
         }
     }

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/KoPropertyProviderCore.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/KoPropertyProviderCore.kt
@@ -33,14 +33,16 @@ internal interface KoPropertyProviderCore : KoPropertyProvider, KoDeclarationPro
     ): Boolean = hasPropertyWithName(listOf(name, *names), includeNested)
 
     override fun hasPropertyWithName(
-         names: Collection<String>,
+        names: Collection<String>,
         includeNested: Boolean,
-    ): Boolean = when {
-        names.isEmpty() -> hasProperties(includeNested)
-        else -> names.any {
-            properties(includeNested).any { koProperty -> it == koProperty.name }
+    ): Boolean =
+        when {
+            names.isEmpty() -> hasProperties(includeNested)
+            else ->
+                names.any {
+                    properties(includeNested).any { koProperty -> it == koProperty.name }
+                }
         }
-    }
 
     override fun hasPropertiesWithAllNames(
         name: String,
@@ -49,14 +51,16 @@ internal interface KoPropertyProviderCore : KoPropertyProvider, KoDeclarationPro
     ): Boolean = hasPropertiesWithAllNames(listOf(name, *names), includeNested)
 
     override fun hasPropertiesWithAllNames(
-         names: Collection<String>,
+        names: Collection<String>,
         includeNested: Boolean,
-    ): Boolean = when {
-        names.isEmpty() -> hasProperties(includeNested)
-        else -> names.all {
-            properties(includeNested).any { koProperty -> it == koProperty.name }
+    ): Boolean =
+        when {
+            names.isEmpty() -> hasProperties(includeNested)
+            else ->
+                names.all {
+                    properties(includeNested).any { koProperty -> it == koProperty.name }
+                }
         }
-    }
 
     override fun hasProperty(
         includeNested: Boolean,

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/KoTypeAliasProviderCore.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/KoTypeAliasProviderCore.kt
@@ -47,24 +47,28 @@ internal interface KoTypeAliasProviderCore :
         vararg names: String,
     ): Boolean = hasTypeAliasWithName(listOf(name, *names))
 
-    override fun hasTypeAliasWithName(names: Collection<String>): Boolean = when {
-        names.isEmpty() -> hasTypeAliases()
-        else -> names.any {
-            typeAliases.any { typeAlias -> it == typeAlias.name }
+    override fun hasTypeAliasWithName(names: Collection<String>): Boolean =
+        when {
+            names.isEmpty() -> hasTypeAliases()
+            else ->
+                names.any {
+                    typeAliases.any { typeAlias -> it == typeAlias.name }
+                }
         }
-    }
 
     override fun hasTypeAliasesWithAllNames(
         name: String,
         vararg names: String,
     ): Boolean = hasTypeAliasesWithAllNames(listOf(name, *names))
 
-    override fun hasTypeAliasesWithAllNames(names: Collection<String>): Boolean = when {
-        names.isEmpty() -> hasTypeAliases()
-        else -> names.all {
-            typeAliases.any { typeAlias -> it == typeAlias.name }
+    override fun hasTypeAliasesWithAllNames(names: Collection<String>): Boolean =
+        when {
+            names.isEmpty() -> hasTypeAliases()
+            else ->
+                names.all {
+                    typeAliases.any { typeAlias -> it == typeAlias.name }
+                }
         }
-    }
 
     override fun hasTypeAlias(predicate: (KoTypeAliasDeclaration) -> Boolean): Boolean = typeAliases.any(predicate)
 

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/KoTypeAliasProviderCore.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/KoTypeAliasProviderCore.kt
@@ -45,10 +45,11 @@ internal interface KoTypeAliasProviderCore :
     override fun hasTypeAliasWithName(
         name: String,
         vararg names: String,
-    ): Boolean {
-        val givenNames = names.toList() + name
+    ): Boolean = hasTypeAliasWithName(listOf(name, *names))
 
-        return givenNames.any {
+    override fun hasTypeAliasWithName(names: Collection<String>): Boolean = when {
+        names.isEmpty() -> hasTypeAliases()
+        else -> names.any {
             typeAliases.any { typeAlias -> it == typeAlias.name }
         }
     }
@@ -56,10 +57,11 @@ internal interface KoTypeAliasProviderCore :
     override fun hasTypeAliasesWithAllNames(
         name: String,
         vararg names: String,
-    ): Boolean {
-        val givenNames = names.toList() + name
+    ): Boolean = hasTypeAliasesWithAllNames(listOf(name, *names))
 
-        return givenNames.all {
+    override fun hasTypeAliasesWithAllNames(names: Collection<String>): Boolean = when {
+        names.isEmpty() -> hasTypeAliases()
+        else -> names.all {
             typeAliases.any { typeAlias -> it == typeAlias.name }
         }
     }

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/KoVariableProviderCore.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/KoVariableProviderCore.kt
@@ -20,10 +20,11 @@ internal interface KoVariableProviderCore :
     override fun hasVariableWithName(
         name: String,
         vararg names: String,
-    ): Boolean {
-        val givenNames = names.toList() + name
+    ): Boolean = hasVariableWithName(listOf(name, *names))
 
-        return givenNames.any {
+    override fun hasVariableWithName(names: Collection<String>): Boolean = when {
+        names.isEmpty() -> hasVariables()
+        else -> names.any {
             variables.any { variable -> it == variable.name }
         }
     }
@@ -31,10 +32,11 @@ internal interface KoVariableProviderCore :
     override fun hasVariablesWithAllNames(
         name: String,
         vararg names: String,
-    ): Boolean {
-        val givenNames = names.toList() + name
+    ): Boolean = hasVariablesWithAllNames(listOf(name, *names))
 
-        return givenNames.all {
+    override fun hasVariablesWithAllNames(names: Collection<String>): Boolean = when {
+        names.isEmpty() -> hasVariables()
+        else -> names.all {
             variables.any { variable -> it == variable.name }
         }
     }

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/KoVariableProviderCore.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/KoVariableProviderCore.kt
@@ -22,24 +22,28 @@ internal interface KoVariableProviderCore :
         vararg names: String,
     ): Boolean = hasVariableWithName(listOf(name, *names))
 
-    override fun hasVariableWithName(names: Collection<String>): Boolean = when {
-        names.isEmpty() -> hasVariables()
-        else -> names.any {
-            variables.any { variable -> it == variable.name }
+    override fun hasVariableWithName(names: Collection<String>): Boolean =
+        when {
+            names.isEmpty() -> hasVariables()
+            else ->
+                names.any {
+                    variables.any { variable -> it == variable.name }
+                }
         }
-    }
 
     override fun hasVariablesWithAllNames(
         name: String,
         vararg names: String,
     ): Boolean = hasVariablesWithAllNames(listOf(name, *names))
 
-    override fun hasVariablesWithAllNames(names: Collection<String>): Boolean = when {
-        names.isEmpty() -> hasVariables()
-        else -> names.all {
-            variables.any { variable -> it == variable.name }
+    override fun hasVariablesWithAllNames(names: Collection<String>): Boolean =
+        when {
+            names.isEmpty() -> hasVariables()
+            else ->
+                names.all {
+                    variables.any { variable -> it == variable.name }
+                }
         }
-    }
 
     override fun hasVariable(predicate: (KoVariableDeclaration) -> Boolean): Boolean = variables.any(predicate)
 

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/modifier/KoModifierProviderCore.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/modifier/KoModifierProviderCore.kt
@@ -51,16 +51,23 @@ internal interface KoModifierProviderCore : KoModifierProvider, KoBaseProviderCo
     override fun hasModifier(
         modifier: KoModifier,
         vararg modifiers: KoModifier,
-    ): Boolean {
-        val givenModifiers = modifiers.toList() + modifier
+    ): Boolean  = hasModifier(listOf(modifier, *modifiers))
 
-        return givenModifiers.any { this.modifiers.any { modifier -> modifier == it } }
-    }
+    override fun hasModifier(modifiers: Collection<KoModifier>, ): Boolean =
+        when {
+            modifiers.isEmpty() -> hasModifiers()
+            else -> modifiers.any { this.modifiers.any { modifier -> modifier == it } }
+        }
 
     override fun hasAllModifiers(
         modifier: KoModifier,
         vararg modifiers: KoModifier,
-    ): Boolean = this.modifiers.containsAll(modifiers.toList() + modifier)
+    ): Boolean = hasAllModifiers(listOf(modifier, *modifiers))
+
+    override fun hasAllModifiers(modifiers: Collection<KoModifier>): Boolean =   when {
+        modifiers.isEmpty() -> hasModifiers()
+        else -> this.modifiers.containsAll(modifiers)
+    }
 
     private fun String.isKDocLine(): Boolean {
         val trimmed = trim()

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/modifier/KoModifierProviderCore.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/modifier/KoModifierProviderCore.kt
@@ -51,9 +51,9 @@ internal interface KoModifierProviderCore : KoModifierProvider, KoBaseProviderCo
     override fun hasModifier(
         modifier: KoModifier,
         vararg modifiers: KoModifier,
-    ): Boolean  = hasModifier(listOf(modifier, *modifiers))
+    ): Boolean = hasModifier(listOf(modifier, *modifiers))
 
-    override fun hasModifier(modifiers: Collection<KoModifier>, ): Boolean =
+    override fun hasModifier(modifiers: Collection<KoModifier>): Boolean =
         when {
             modifiers.isEmpty() -> hasModifiers()
             else -> modifiers.any { this.modifiers.any { modifier -> modifier == it } }
@@ -64,10 +64,11 @@ internal interface KoModifierProviderCore : KoModifierProvider, KoBaseProviderCo
         vararg modifiers: KoModifier,
     ): Boolean = hasAllModifiers(listOf(modifier, *modifiers))
 
-    override fun hasAllModifiers(modifiers: Collection<KoModifier>): Boolean =   when {
-        modifiers.isEmpty() -> hasModifiers()
-        else -> this.modifiers.containsAll(modifiers)
-    }
+    override fun hasAllModifiers(modifiers: Collection<KoModifier>): Boolean =
+        when {
+            modifiers.isEmpty() -> hasModifiers()
+            else -> this.modifiers.containsAll(modifiers)
+        }
 
     private fun String.isKDocLine(): Boolean {
         val trimmed = trim()

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/tag/KoKDocTagProviderCore.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/tag/KoKDocTagProviderCore.kt
@@ -68,16 +68,23 @@ internal interface KoKDocTagProviderCore : KoKDocTagProvider, KoTextProviderCore
     override fun hasTag(
         tag: KoKDocTag,
         vararg tags: KoKDocTag,
-    ): Boolean {
-        val givenKoKDocTags = tags.toList() + tag
+    ): Boolean = hasTag(listOf(tag, *tags))
 
-        return givenKoKDocTags.any { this.tags.any { tag -> tag.name == it } }
+    override fun hasTag(tags: Collection<KoKDocTag>): Boolean = when {
+        tags.isEmpty() -> hasTags()
+        else -> tags.any { this.tags.any { tag -> tag.name == it } }
     }
 
     override fun hasAllTags(
         tag: KoKDocTag,
         vararg tags: KoKDocTag,
-    ): Boolean = this.tags.map { it.name }.containsAll(tags.toList() + tag)
+    ): Boolean = hasAllTags(listOf(tag, *tags))
+
+    override fun hasAllTags(tags: Collection<KoKDocTag>): Boolean =
+        when {
+            tags.isEmpty() -> hasTags()
+            else -> this.tags.map { it.name }.containsAll(tags)
+        }
 
     private fun parseToValuedTag(
         koKDocTag: KoKDocTag,

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/tag/KoKDocTagProviderCore.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/tag/KoKDocTagProviderCore.kt
@@ -70,10 +70,11 @@ internal interface KoKDocTagProviderCore : KoKDocTagProvider, KoTextProviderCore
         vararg tags: KoKDocTag,
     ): Boolean = hasTag(listOf(tag, *tags))
 
-    override fun hasTag(tags: Collection<KoKDocTag>): Boolean = when {
-        tags.isEmpty() -> hasTags()
-        else -> tags.any { this.tags.any { tag -> tag.name == it } }
-    }
+    override fun hasTag(tags: Collection<KoKDocTag>): Boolean =
+        when {
+            tags.isEmpty() -> hasTags()
+            else -> tags.any { this.tags.any { tag -> tag.name == it } }
+        }
 
     override fun hasAllTags(
         tag: KoKDocTag,

--- a/lib/src/test/kotlin/com/lemonappdev/konsist/api/ext/list/KoAnnotationProviderListExtTest.kt
+++ b/lib/src/test/kotlin/com/lemonappdev/konsist/api/ext/list/KoAnnotationProviderListExtTest.kt
@@ -244,11 +244,11 @@ class KoAnnotationProviderListExtTest {
         val name = "SampleName"
         val declaration1: KoAnnotationProvider =
             mockk {
-                every { hasAnnotationWithName(name) } returns true
+                every { hasAnnotationWithName(listOf(name)) } returns true
             }
         val declaration2: KoAnnotationProvider =
             mockk {
-                every { hasAnnotationWithName(name) } returns false
+                every { hasAnnotationWithName(listOf(name)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
 
@@ -266,11 +266,11 @@ class KoAnnotationProviderListExtTest {
         val name2 = "SampleName2"
         val declaration1: KoAnnotationProvider =
             mockk {
-                every { hasAnnotationWithName(name1, name2) } returns true
+                every { hasAnnotationWithName(listOf(name1, name2)) } returns true
             }
         val declaration2: KoAnnotationProvider =
             mockk {
-                every { hasAnnotationWithName(name1, name2) } returns false
+                every { hasAnnotationWithName(listOf(name1, name2)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
 
@@ -288,11 +288,11 @@ class KoAnnotationProviderListExtTest {
         val name2 = "SampleName2"
         val declaration1: KoAnnotationProvider =
             mockk {
-                every { hasAnnotationWithName(name1, name2) } returns true
+                every { hasAnnotationWithName(listOf(name1, name2)) } returns true
             }
         val declaration2: KoAnnotationProvider =
             mockk {
-                every { hasAnnotationWithName(name1, name2) } returns false
+                every { hasAnnotationWithName(listOf(name1, name2)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
         val names = listOf(name1, name2)
@@ -311,11 +311,11 @@ class KoAnnotationProviderListExtTest {
         val name2 = "SampleName2"
         val declaration1: KoAnnotationProvider =
             mockk {
-                every { hasAnnotationWithName(name1, name2) } returns true
+                every { hasAnnotationWithName(setOf(name1, name2)) } returns true
             }
         val declaration2: KoAnnotationProvider =
             mockk {
-                every { hasAnnotationWithName(name1, name2) } returns false
+                every { hasAnnotationWithName(setOf(name1, name2)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
         val names = setOf(name1, name2)
@@ -333,11 +333,11 @@ class KoAnnotationProviderListExtTest {
         val name = "SampleName"
         val declaration1: KoAnnotationProvider =
             mockk {
-                every { hasAnnotationWithName(name) } returns true
+                every { hasAnnotationWithName(listOf(name)) } returns true
             }
         val declaration2: KoAnnotationProvider =
             mockk {
-                every { hasAnnotationWithName(name) } returns false
+                every { hasAnnotationWithName(listOf(name)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
 
@@ -355,11 +355,11 @@ class KoAnnotationProviderListExtTest {
         val name2 = "SampleName2"
         val declaration1: KoAnnotationProvider =
             mockk {
-                every { hasAnnotationWithName(name1, name2) } returns true
+                every { hasAnnotationWithName(listOf(name1, name2)) } returns true
             }
         val declaration2: KoAnnotationProvider =
             mockk {
-                every { hasAnnotationWithName(name1, name2) } returns false
+                every { hasAnnotationWithName(listOf(name1, name2)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
 
@@ -377,11 +377,11 @@ class KoAnnotationProviderListExtTest {
         val name2 = "SampleName2"
         val declaration1: KoAnnotationProvider =
             mockk {
-                every { hasAnnotationWithName(name1, name2) } returns true
+                every { hasAnnotationWithName(listOf(name1, name2)) } returns true
             }
         val declaration2: KoAnnotationProvider =
             mockk {
-                every { hasAnnotationWithName(name1, name2) } returns false
+                every { hasAnnotationWithName(listOf(name1, name2)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
         val names = listOf(name1, name2)
@@ -400,11 +400,11 @@ class KoAnnotationProviderListExtTest {
         val name2 = "SampleName2"
         val declaration1: KoAnnotationProvider =
             mockk {
-                every { hasAnnotationWithName(name1, name2) } returns true
+                every { hasAnnotationWithName(setOf(name1, name2)) } returns true
             }
         val declaration2: KoAnnotationProvider =
             mockk {
-                every { hasAnnotationWithName(name1, name2) } returns false
+                every { hasAnnotationWithName(setOf(name1, name2)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
         val names = setOf(name1, name2)
@@ -422,11 +422,11 @@ class KoAnnotationProviderListExtTest {
         val name = "SampleName"
         val declaration1: KoAnnotationProvider =
             mockk {
-                every { hasAnnotationsWithAllNames(name) } returns true
+                every { hasAnnotationsWithAllNames(listOf(name)) } returns true
             }
         val declaration2: KoAnnotationProvider =
             mockk {
-                every { hasAnnotationsWithAllNames(name) } returns false
+                every { hasAnnotationsWithAllNames(listOf(name)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
 
@@ -444,11 +444,11 @@ class KoAnnotationProviderListExtTest {
         val name2 = "SampleName2"
         val declaration1: KoAnnotationProvider =
             mockk {
-                every { hasAnnotationsWithAllNames(name1, name2) } returns true
+                every { hasAnnotationsWithAllNames(listOf(name1, name2)) } returns true
             }
         val declaration2: KoAnnotationProvider =
             mockk {
-                every { hasAnnotationsWithAllNames(name1, name2) } returns false
+                every { hasAnnotationsWithAllNames(listOf(name1, name2)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
 
@@ -466,11 +466,11 @@ class KoAnnotationProviderListExtTest {
         val name2 = "SampleName2"
         val declaration1: KoAnnotationProvider =
             mockk {
-                every { hasAnnotationsWithAllNames(name1, name2) } returns true
+                every { hasAnnotationsWithAllNames(listOf(name1, name2)) } returns true
             }
         val declaration2: KoAnnotationProvider =
             mockk {
-                every { hasAnnotationsWithAllNames(name1, name2) } returns false
+                every { hasAnnotationsWithAllNames(listOf(name1, name2)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
         val names = listOf(name1, name2)
@@ -489,11 +489,11 @@ class KoAnnotationProviderListExtTest {
         val name2 = "SampleName2"
         val declaration1: KoAnnotationProvider =
             mockk {
-                every { hasAnnotationsWithAllNames(name1, name2) } returns true
+                every { hasAnnotationsWithAllNames(setOf(name1, name2)) } returns true
             }
         val declaration2: KoAnnotationProvider =
             mockk {
-                every { hasAnnotationsWithAllNames(name1, name2) } returns false
+                every { hasAnnotationsWithAllNames(setOf(name1, name2)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
         val names = setOf(name1, name2)
@@ -511,11 +511,11 @@ class KoAnnotationProviderListExtTest {
         val name = "SampleName"
         val declaration1: KoAnnotationProvider =
             mockk {
-                every { hasAnnotationsWithAllNames(name) } returns true
+                every { hasAnnotationsWithAllNames(listOf(name)) } returns true
             }
         val declaration2: KoAnnotationProvider =
             mockk {
-                every { hasAnnotationsWithAllNames(name) } returns false
+                every { hasAnnotationsWithAllNames(listOf(name)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
 
@@ -533,11 +533,11 @@ class KoAnnotationProviderListExtTest {
         val name2 = "SampleName2"
         val declaration1: KoAnnotationProvider =
             mockk {
-                every { hasAnnotationsWithAllNames(name1, name2) } returns true
+                every { hasAnnotationsWithAllNames(listOf(name1, name2)) } returns true
             }
         val declaration2: KoAnnotationProvider =
             mockk {
-                every { hasAnnotationsWithAllNames(name1, name2) } returns false
+                every { hasAnnotationsWithAllNames(listOf(name1, name2)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
 
@@ -555,11 +555,11 @@ class KoAnnotationProviderListExtTest {
         val name2 = "SampleName2"
         val declaration1: KoAnnotationProvider =
             mockk {
-                every { hasAnnotationsWithAllNames(name1, name2) } returns true
+                every { hasAnnotationsWithAllNames(listOf(name1, name2)) } returns true
             }
         val declaration2: KoAnnotationProvider =
             mockk {
-                every { hasAnnotationsWithAllNames(name1, name2) } returns false
+                every { hasAnnotationsWithAllNames(listOf(name1, name2)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
         val names = listOf(name1, name2)
@@ -578,11 +578,11 @@ class KoAnnotationProviderListExtTest {
         val name2 = "SampleName2"
         val declaration1: KoAnnotationProvider =
             mockk {
-                every { hasAnnotationsWithAllNames(name1, name2) } returns true
+                every { hasAnnotationsWithAllNames(setOf(name1, name2)) } returns true
             }
         val declaration2: KoAnnotationProvider =
             mockk {
-                every { hasAnnotationsWithAllNames(name1, name2) } returns false
+                every { hasAnnotationsWithAllNames(setOf(name1, name2)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
         val names = setOf(name1, name2)
@@ -917,11 +917,11 @@ class KoAnnotationProviderListExtTest {
         // given
         val declaration1: KoAnnotationProvider =
             mockk {
-                every { hasAnnotationOf(SampleAnnotation1::class, SampleAnnotation2::class) } returns true
+                every { hasAnnotationOf(listOf(SampleAnnotation1::class, SampleAnnotation2::class)) } returns true
             }
         val declaration2: KoAnnotationProvider =
             mockk {
-                every { hasAnnotationOf(SampleAnnotation1::class, SampleAnnotation2::class) } returns false
+                every { hasAnnotationOf(listOf(SampleAnnotation1::class, SampleAnnotation2::class)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
 
@@ -937,11 +937,11 @@ class KoAnnotationProviderListExtTest {
         // given
         val declaration1: KoAnnotationProvider =
             mockk {
-                every { hasAnnotationOf(SampleAnnotation1::class, SampleAnnotation2::class) } returns true
+                every { hasAnnotationOf(listOf(SampleAnnotation1::class, SampleAnnotation2::class)) } returns true
             }
         val declaration2: KoAnnotationProvider =
             mockk {
-                every { hasAnnotationOf(SampleAnnotation1::class, SampleAnnotation2::class) } returns false
+                every { hasAnnotationOf(listOf(SampleAnnotation1::class, SampleAnnotation2::class)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
         val kClasses = listOf(SampleAnnotation1::class, SampleAnnotation2::class)
@@ -958,11 +958,11 @@ class KoAnnotationProviderListExtTest {
         // given
         val declaration1: KoAnnotationProvider =
             mockk {
-                every { hasAnnotationOf(SampleAnnotation1::class, SampleAnnotation2::class) } returns true
+                every { hasAnnotationOf(setOf(SampleAnnotation1::class, SampleAnnotation2::class)) } returns true
             }
         val declaration2: KoAnnotationProvider =
             mockk {
-                every { hasAnnotationOf(SampleAnnotation1::class, SampleAnnotation2::class) } returns false
+                every { hasAnnotationOf(setOf(SampleAnnotation1::class, SampleAnnotation2::class)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
         val kClasses = setOf(SampleAnnotation1::class, SampleAnnotation2::class)
@@ -979,11 +979,11 @@ class KoAnnotationProviderListExtTest {
         // given
         val declaration1: KoAnnotationProvider =
             mockk {
-                every { hasAnnotationOf(SampleAnnotation1::class, SampleAnnotation2::class) } returns true
+                every { hasAnnotationOf(listOf(SampleAnnotation1::class, SampleAnnotation2::class)) } returns true
             }
         val declaration2: KoAnnotationProvider =
             mockk {
-                every { hasAnnotationOf(SampleAnnotation1::class, SampleAnnotation2::class) } returns false
+                every { hasAnnotationOf(listOf(SampleAnnotation1::class, SampleAnnotation2::class)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
 
@@ -999,11 +999,11 @@ class KoAnnotationProviderListExtTest {
         // given
         val declaration1: KoAnnotationProvider =
             mockk {
-                every { hasAnnotationOf(SampleAnnotation1::class, SampleAnnotation2::class) } returns true
+                every { hasAnnotationOf(listOf(SampleAnnotation1::class, SampleAnnotation2::class)) } returns true
             }
         val declaration2: KoAnnotationProvider =
             mockk {
-                every { hasAnnotationOf(SampleAnnotation1::class, SampleAnnotation2::class) } returns false
+                every { hasAnnotationOf(listOf(SampleAnnotation1::class, SampleAnnotation2::class)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
         val kClasses = listOf(SampleAnnotation1::class, SampleAnnotation2::class)
@@ -1020,11 +1020,11 @@ class KoAnnotationProviderListExtTest {
         // given
         val declaration1: KoAnnotationProvider =
             mockk {
-                every { hasAnnotationOf(SampleAnnotation1::class, SampleAnnotation2::class) } returns true
+                every { hasAnnotationOf(setOf(SampleAnnotation1::class, SampleAnnotation2::class)) } returns true
             }
         val declaration2: KoAnnotationProvider =
             mockk {
-                every { hasAnnotationOf(SampleAnnotation1::class, SampleAnnotation2::class) } returns false
+                every { hasAnnotationOf(setOf(SampleAnnotation1::class, SampleAnnotation2::class)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
         val kClasses = setOf(SampleAnnotation1::class, SampleAnnotation2::class)
@@ -1041,11 +1041,11 @@ class KoAnnotationProviderListExtTest {
         // given
         val declaration1: KoAnnotationProvider =
             mockk {
-                every { hasAllAnnotationsOf(SampleAnnotation1::class, SampleAnnotation2::class) } returns true
+                every { hasAllAnnotationsOf(listOf(SampleAnnotation1::class, SampleAnnotation2::class)) } returns true
             }
         val declaration2: KoAnnotationProvider =
             mockk {
-                every { hasAllAnnotationsOf(SampleAnnotation1::class, SampleAnnotation2::class) } returns false
+                every { hasAllAnnotationsOf(listOf(SampleAnnotation1::class, SampleAnnotation2::class)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
 
@@ -1061,11 +1061,11 @@ class KoAnnotationProviderListExtTest {
         // given
         val declaration1: KoAnnotationProvider =
             mockk {
-                every { hasAllAnnotationsOf(SampleAnnotation1::class, SampleAnnotation2::class) } returns true
+                every { hasAllAnnotationsOf(listOf(SampleAnnotation1::class, SampleAnnotation2::class)) } returns true
             }
         val declaration2: KoAnnotationProvider =
             mockk {
-                every { hasAllAnnotationsOf(SampleAnnotation1::class, SampleAnnotation2::class) } returns false
+                every { hasAllAnnotationsOf(listOf(SampleAnnotation1::class, SampleAnnotation2::class)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
         val kClasses = listOf(SampleAnnotation1::class, SampleAnnotation2::class)
@@ -1082,11 +1082,11 @@ class KoAnnotationProviderListExtTest {
         // given
         val declaration1: KoAnnotationProvider =
             mockk {
-                every { hasAllAnnotationsOf(SampleAnnotation1::class, SampleAnnotation2::class) } returns true
+                every { hasAllAnnotationsOf(setOf(SampleAnnotation1::class, SampleAnnotation2::class)) } returns true
             }
         val declaration2: KoAnnotationProvider =
             mockk {
-                every { hasAllAnnotationsOf(SampleAnnotation1::class, SampleAnnotation2::class) } returns false
+                every { hasAllAnnotationsOf(setOf(SampleAnnotation1::class, SampleAnnotation2::class)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
         val kClasses = setOf(SampleAnnotation1::class, SampleAnnotation2::class)
@@ -1103,11 +1103,11 @@ class KoAnnotationProviderListExtTest {
         // given
         val declaration1: KoAnnotationProvider =
             mockk {
-                every { hasAllAnnotationsOf(SampleAnnotation1::class, SampleAnnotation2::class) } returns true
+                every { hasAllAnnotationsOf(listOf(SampleAnnotation1::class, SampleAnnotation2::class)) } returns true
             }
         val declaration2: KoAnnotationProvider =
             mockk {
-                every { hasAllAnnotationsOf(SampleAnnotation1::class, SampleAnnotation2::class) } returns false
+                every { hasAllAnnotationsOf(listOf(SampleAnnotation1::class, SampleAnnotation2::class)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
 
@@ -1123,11 +1123,11 @@ class KoAnnotationProviderListExtTest {
         // given
         val declaration1: KoAnnotationProvider =
             mockk {
-                every { hasAllAnnotationsOf(SampleAnnotation1::class, SampleAnnotation2::class) } returns true
+                every { hasAllAnnotationsOf(listOf(SampleAnnotation1::class, SampleAnnotation2::class)) } returns true
             }
         val declaration2: KoAnnotationProvider =
             mockk {
-                every { hasAllAnnotationsOf(SampleAnnotation1::class, SampleAnnotation2::class) } returns false
+                every { hasAllAnnotationsOf(listOf(SampleAnnotation1::class, SampleAnnotation2::class)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
         val kClasses = listOf(SampleAnnotation1::class, SampleAnnotation2::class)
@@ -1144,11 +1144,11 @@ class KoAnnotationProviderListExtTest {
         // given
         val declaration1: KoAnnotationProvider =
             mockk {
-                every { hasAllAnnotationsOf(SampleAnnotation1::class, SampleAnnotation2::class) } returns true
+                every { hasAllAnnotationsOf(setOf(SampleAnnotation1::class, SampleAnnotation2::class)) } returns true
             }
         val declaration2: KoAnnotationProvider =
             mockk {
-                every { hasAllAnnotationsOf(SampleAnnotation1::class, SampleAnnotation2::class) } returns false
+                every { hasAllAnnotationsOf(setOf(SampleAnnotation1::class, SampleAnnotation2::class)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
         val kClasses = setOf(SampleAnnotation1::class, SampleAnnotation2::class)

--- a/lib/src/test/kotlin/com/lemonappdev/konsist/api/ext/list/KoArgumentProviderListExtTest.kt
+++ b/lib/src/test/kotlin/com/lemonappdev/konsist/api/ext/list/KoArgumentProviderListExtTest.kt
@@ -241,11 +241,11 @@ class KoArgumentProviderListExtTest {
         val name = "SampleName"
         val declaration1: KoArgumentProvider =
             mockk {
-                every { hasArgumentWithName(name) } returns true
+                every { hasArgumentWithName(listOf(name)) } returns true
             }
         val declaration2: KoArgumentProvider =
             mockk {
-                every { hasArgumentWithName(name) } returns false
+                every { hasArgumentWithName(listOf(name)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
 
@@ -263,11 +263,11 @@ class KoArgumentProviderListExtTest {
         val name2 = "SampleName2"
         val declaration1: KoArgumentProvider =
             mockk {
-                every { hasArgumentWithName(name1, name2) } returns true
+                every { hasArgumentWithName(listOf(name1, name2)) } returns true
             }
         val declaration2: KoArgumentProvider =
             mockk {
-                every { hasArgumentWithName(name1, name2) } returns false
+                every { hasArgumentWithName(listOf(name1, name2)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
 
@@ -285,11 +285,11 @@ class KoArgumentProviderListExtTest {
         val name2 = "SampleName2"
         val declaration1: KoArgumentProvider =
             mockk {
-                every { hasArgumentWithName(name1, name2) } returns true
+                every { hasArgumentWithName(listOf(name1, name2)) } returns true
             }
         val declaration2: KoArgumentProvider =
             mockk {
-                every { hasArgumentWithName(name1, name2) } returns false
+                every { hasArgumentWithName(listOf(name1, name2)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
         val names = listOf(name1, name2)
@@ -308,14 +308,14 @@ class KoArgumentProviderListExtTest {
         val name2 = "SampleName2"
         val declaration1: KoArgumentProvider =
             mockk {
-                every { hasArgumentWithName(name1, name2) } returns true
+                every { hasArgumentWithName(setOf(name1, name2)) } returns true
             }
         val declaration2: KoArgumentProvider =
             mockk {
-                every { hasArgumentWithName(name1, name2) } returns false
+                every { hasArgumentWithName(setOf(name1, name2)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
-        val names = listOf(name1, name2)
+        val names = setOf(name1, name2)
 
         // when
         val sut = declarations.withArgumentNamed(names)
@@ -330,11 +330,11 @@ class KoArgumentProviderListExtTest {
         val name = "SampleName"
         val declaration1: KoArgumentProvider =
             mockk {
-                every { hasArgumentWithName(name) } returns true
+                every { hasArgumentWithName(listOf(name)) } returns true
             }
         val declaration2: KoArgumentProvider =
             mockk {
-                every { hasArgumentWithName(name) } returns false
+                every { hasArgumentWithName(listOf(name)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
 
@@ -352,11 +352,11 @@ class KoArgumentProviderListExtTest {
         val name2 = "SampleName2"
         val declaration1: KoArgumentProvider =
             mockk {
-                every { hasArgumentWithName(name1, name2) } returns true
+                every { hasArgumentWithName(listOf(name1, name2)) } returns true
             }
         val declaration2: KoArgumentProvider =
             mockk {
-                every { hasArgumentWithName(name1, name2) } returns false
+                every { hasArgumentWithName(listOf(name1, name2)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
 
@@ -374,11 +374,11 @@ class KoArgumentProviderListExtTest {
         val name2 = "SampleName2"
         val declaration1: KoArgumentProvider =
             mockk {
-                every { hasArgumentWithName(name1, name2) } returns true
+                every { hasArgumentWithName(listOf(name1, name2)) } returns true
             }
         val declaration2: KoArgumentProvider =
             mockk {
-                every { hasArgumentWithName(name1, name2) } returns false
+                every { hasArgumentWithName(listOf(name1, name2)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
         val names = listOf(name1, name2)
@@ -397,11 +397,11 @@ class KoArgumentProviderListExtTest {
         val name2 = "SampleName2"
         val declaration1: KoArgumentProvider =
             mockk {
-                every { hasArgumentWithName(name1, name2) } returns true
+                every { hasArgumentWithName(setOf(name1, name2)) } returns true
             }
         val declaration2: KoArgumentProvider =
             mockk {
-                every { hasArgumentWithName(name1, name2) } returns false
+                every { hasArgumentWithName(setOf(name1, name2)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
         val names = setOf(name1, name2)
@@ -419,11 +419,11 @@ class KoArgumentProviderListExtTest {
         val name = "SampleName"
         val declaration1: KoArgumentProvider =
             mockk {
-                every { hasArgumentsWithAllNames(name) } returns true
+                every { hasArgumentsWithAllNames(listOf(name)) } returns true
             }
         val declaration2: KoArgumentProvider =
             mockk {
-                every { hasArgumentsWithAllNames(name) } returns false
+                every { hasArgumentsWithAllNames(listOf(name)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
 
@@ -441,11 +441,11 @@ class KoArgumentProviderListExtTest {
         val name2 = "SampleName2"
         val declaration1: KoArgumentProvider =
             mockk {
-                every { hasArgumentsWithAllNames(name1, name2) } returns true
+                every { hasArgumentsWithAllNames(listOf(name1, name2)) } returns true
             }
         val declaration2: KoArgumentProvider =
             mockk {
-                every { hasArgumentsWithAllNames(name1, name2) } returns false
+                every { hasArgumentsWithAllNames(listOf(name1, name2)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
 
@@ -463,11 +463,11 @@ class KoArgumentProviderListExtTest {
         val name2 = "SampleName2"
         val declaration1: KoArgumentProvider =
             mockk {
-                every { hasArgumentsWithAllNames(name1, name2) } returns true
+                every { hasArgumentsWithAllNames(listOf(name1, name2)) } returns true
             }
         val declaration2: KoArgumentProvider =
             mockk {
-                every { hasArgumentsWithAllNames(name1, name2) } returns false
+                every { hasArgumentsWithAllNames(listOf(name1, name2)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
         val names = listOf(name1, name2)
@@ -486,14 +486,14 @@ class KoArgumentProviderListExtTest {
         val name2 = "SampleName2"
         val declaration1: KoArgumentProvider =
             mockk {
-                every { hasArgumentsWithAllNames(name1, name2) } returns true
+                every { hasArgumentsWithAllNames(setOf(name1, name2)) } returns true
             }
         val declaration2: KoArgumentProvider =
             mockk {
-                every { hasArgumentsWithAllNames(name1, name2) } returns false
+                every { hasArgumentsWithAllNames(setOf(name1, name2)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
-        val names = listOf(name1, name2)
+        val names = setOf(name1, name2)
 
         // when
         val sut = declarations.withAllArgumentsNamed(names)
@@ -508,11 +508,11 @@ class KoArgumentProviderListExtTest {
         val name = "SampleName"
         val declaration1: KoArgumentProvider =
             mockk {
-                every { hasArgumentsWithAllNames(name) } returns true
+                every { hasArgumentsWithAllNames(listOf(name)) } returns true
             }
         val declaration2: KoArgumentProvider =
             mockk {
-                every { hasArgumentsWithAllNames(name) } returns false
+                every { hasArgumentsWithAllNames(listOf(name)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
 
@@ -530,11 +530,11 @@ class KoArgumentProviderListExtTest {
         val name2 = "SampleName2"
         val declaration1: KoArgumentProvider =
             mockk {
-                every { hasArgumentsWithAllNames(name1, name2) } returns true
+                every { hasArgumentsWithAllNames(listOf(name1, name2)) } returns true
             }
         val declaration2: KoArgumentProvider =
             mockk {
-                every { hasArgumentsWithAllNames(name1, name2) } returns false
+                every { hasArgumentsWithAllNames(listOf(name1, name2)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
 
@@ -552,11 +552,11 @@ class KoArgumentProviderListExtTest {
         val name2 = "SampleName2"
         val declaration1: KoArgumentProvider =
             mockk {
-                every { hasArgumentsWithAllNames(name1, name2) } returns true
+                every { hasArgumentsWithAllNames(listOf(name1, name2)) } returns true
             }
         val declaration2: KoArgumentProvider =
             mockk {
-                every { hasArgumentsWithAllNames(name1, name2) } returns false
+                every { hasArgumentsWithAllNames(listOf(name1, name2)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
         val names = listOf(name1, name2)
@@ -575,14 +575,14 @@ class KoArgumentProviderListExtTest {
         val name2 = "SampleName2"
         val declaration1: KoArgumentProvider =
             mockk {
-                every { hasArgumentsWithAllNames(name1, name2) } returns true
+                every { hasArgumentsWithAllNames(setOf(name1, name2)) } returns true
             }
         val declaration2: KoArgumentProvider =
             mockk {
-                every { hasArgumentsWithAllNames(name1, name2) } returns false
+                every { hasArgumentsWithAllNames(setOf(name1, name2)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
-        val names = listOf(name1, name2)
+        val names = setOf(name1, name2)
 
         // when
         val sut = declarations.withoutAllArgumentsNamed(names)

--- a/lib/src/test/kotlin/com/lemonappdev/konsist/api/ext/list/KoChildProviderListExtTest.kt
+++ b/lib/src/test/kotlin/com/lemonappdev/konsist/api/ext/list/KoChildProviderListExtTest.kt
@@ -244,11 +244,11 @@ class KoChildProviderListExtTest {
         val name = "SampleName"
         val declaration1: KoChildProvider =
             mockk {
-                every { hasChildWithName(name) } returns true
+                every { hasChildWithName(listOf(name)) } returns true
             }
         val declaration2: KoChildProvider =
             mockk {
-                every { hasChildWithName(name) } returns false
+                every { hasChildWithName(listOf(name)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
 
@@ -266,11 +266,11 @@ class KoChildProviderListExtTest {
         val name2 = "SampleName2"
         val declaration1: KoChildProvider =
             mockk {
-                every { hasChildWithName(name1, name2) } returns true
+                every { hasChildWithName(listOf(name1, name2)) } returns true
             }
         val declaration2: KoChildProvider =
             mockk {
-                every { hasChildWithName(name1, name2) } returns false
+                every { hasChildWithName(listOf(name1, name2)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
 
@@ -288,11 +288,11 @@ class KoChildProviderListExtTest {
         val name2 = "SampleName2"
         val declaration1: KoChildProvider =
             mockk {
-                every { hasChildWithName(name1, name2) } returns true
+                every { hasChildWithName(listOf(name1, name2)) } returns true
             }
         val declaration2: KoChildProvider =
             mockk {
-                every { hasChildWithName(name1, name2) } returns false
+                every { hasChildWithName(listOf(name1, name2)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
         val names = listOf(name1, name2)
@@ -311,11 +311,11 @@ class KoChildProviderListExtTest {
         val name2 = "SampleName2"
         val declaration1: KoChildProvider =
             mockk {
-                every { hasChildWithName(name1, name2) } returns true
+                every { hasChildWithName(setOf(name1, name2)) } returns true
             }
         val declaration2: KoChildProvider =
             mockk {
-                every { hasChildWithName(name1, name2) } returns false
+                every { hasChildWithName(setOf(name1, name2)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
         val names = setOf(name1, name2)
@@ -333,11 +333,11 @@ class KoChildProviderListExtTest {
         val name = "SampleName"
         val declaration1: KoChildProvider =
             mockk {
-                every { hasChildWithName(name) } returns true
+                every { hasChildWithName(listOf(name)) } returns true
             }
         val declaration2: KoChildProvider =
             mockk {
-                every { hasChildWithName(name) } returns false
+                every { hasChildWithName(listOf(name)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
 
@@ -355,11 +355,11 @@ class KoChildProviderListExtTest {
         val name2 = "SampleName2"
         val declaration1: KoChildProvider =
             mockk {
-                every { hasChildWithName(name1, name2) } returns true
+                every { hasChildWithName(listOf(name1, name2)) } returns true
             }
         val declaration2: KoChildProvider =
             mockk {
-                every { hasChildWithName(name1, name2) } returns false
+                every { hasChildWithName(listOf(name1, name2)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
 
@@ -377,11 +377,11 @@ class KoChildProviderListExtTest {
         val name2 = "SampleName2"
         val declaration1: KoChildProvider =
             mockk {
-                every { hasChildWithName(name1, name2) } returns true
+                every { hasChildWithName(listOf(name1, name2)) } returns true
             }
         val declaration2: KoChildProvider =
             mockk {
-                every { hasChildWithName(name1, name2) } returns false
+                every { hasChildWithName(listOf(name1, name2)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
         val names = listOf(name1, name2)
@@ -400,11 +400,11 @@ class KoChildProviderListExtTest {
         val name2 = "SampleName2"
         val declaration1: KoChildProvider =
             mockk {
-                every { hasChildWithName(name1, name2) } returns true
+                every { hasChildWithName(setOf(name1, name2)) } returns true
             }
         val declaration2: KoChildProvider =
             mockk {
-                every { hasChildWithName(name1, name2) } returns false
+                every { hasChildWithName(setOf(name1, name2)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
         val names = setOf(name1, name2)
@@ -422,11 +422,11 @@ class KoChildProviderListExtTest {
         val name = "SampleName"
         val declaration1: KoChildProvider =
             mockk {
-                every { hasChildrenWithAllNames(name) } returns true
+                every { hasChildrenWithAllNames(listOf(name)) } returns true
             }
         val declaration2: KoChildProvider =
             mockk {
-                every { hasChildrenWithAllNames(name) } returns false
+                every { hasChildrenWithAllNames(listOf(name)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
 
@@ -444,11 +444,11 @@ class KoChildProviderListExtTest {
         val name2 = "SampleName2"
         val declaration1: KoChildProvider =
             mockk {
-                every { hasChildrenWithAllNames(name1, name2) } returns true
+                every { hasChildrenWithAllNames(listOf(name1, name2)) } returns true
             }
         val declaration2: KoChildProvider =
             mockk {
-                every { hasChildrenWithAllNames(name1, name2) } returns false
+                every { hasChildrenWithAllNames(listOf(name1, name2)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
 
@@ -466,11 +466,11 @@ class KoChildProviderListExtTest {
         val name2 = "SampleName2"
         val declaration1: KoChildProvider =
             mockk {
-                every { hasChildrenWithAllNames(name1, name2) } returns true
+                every { hasChildrenWithAllNames(listOf(name1, name2)) } returns true
             }
         val declaration2: KoChildProvider =
             mockk {
-                every { hasChildrenWithAllNames(name1, name2) } returns false
+                every { hasChildrenWithAllNames(listOf(name1, name2)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
         val names = listOf(name1, name2)
@@ -489,11 +489,11 @@ class KoChildProviderListExtTest {
         val name2 = "SampleName2"
         val declaration1: KoChildProvider =
             mockk {
-                every { hasChildrenWithAllNames(name1, name2) } returns true
+                every { hasChildrenWithAllNames(setOf(name1, name2)) } returns true
             }
         val declaration2: KoChildProvider =
             mockk {
-                every { hasChildrenWithAllNames(name1, name2) } returns false
+                every { hasChildrenWithAllNames(setOf(name1, name2)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
         val names = setOf(name1, name2)
@@ -511,11 +511,11 @@ class KoChildProviderListExtTest {
         val name = "SampleName"
         val declaration1: KoChildProvider =
             mockk {
-                every { hasChildrenWithAllNames(name) } returns true
+                every { hasChildrenWithAllNames(listOf(name)) } returns true
             }
         val declaration2: KoChildProvider =
             mockk {
-                every { hasChildrenWithAllNames(name) } returns false
+                every { hasChildrenWithAllNames(listOf(name)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
 
@@ -533,11 +533,11 @@ class KoChildProviderListExtTest {
         val name2 = "SampleName2"
         val declaration1: KoChildProvider =
             mockk {
-                every { hasChildrenWithAllNames(name1, name2) } returns true
+                every { hasChildrenWithAllNames(listOf(name1, name2)) } returns true
             }
         val declaration2: KoChildProvider =
             mockk {
-                every { hasChildrenWithAllNames(name1, name2) } returns false
+                every { hasChildrenWithAllNames(listOf(name1, name2)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
 
@@ -555,11 +555,11 @@ class KoChildProviderListExtTest {
         val name2 = "SampleName2"
         val declaration1: KoChildProvider =
             mockk {
-                every { hasChildrenWithAllNames(name1, name2) } returns true
+                every { hasChildrenWithAllNames(listOf(name1, name2)) } returns true
             }
         val declaration2: KoChildProvider =
             mockk {
-                every { hasChildrenWithAllNames(name1, name2) } returns false
+                every { hasChildrenWithAllNames(listOf(name1, name2)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
         val names = listOf(name1, name2)
@@ -578,11 +578,11 @@ class KoChildProviderListExtTest {
         val name2 = "SampleName2"
         val declaration1: KoChildProvider =
             mockk {
-                every { hasChildrenWithAllNames(name1, name2) } returns true
+                every { hasChildrenWithAllNames(setOf(name1, name2)) } returns true
             }
         val declaration2: KoChildProvider =
             mockk {
-                every { hasChildrenWithAllNames(name1, name2) } returns false
+                every { hasChildrenWithAllNames(setOf(name1, name2)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
         val names = setOf(name1, name2)
@@ -917,11 +917,11 @@ class KoChildProviderListExtTest {
         // given
         val declaration1: KoChildProvider =
             mockk {
-                every { hasChildOf(SampleClass::class, SampleInterface::class) } returns true
+                every { hasChildOf(listOf(SampleClass::class, SampleInterface::class)) } returns true
             }
         val declaration2: KoChildProvider =
             mockk {
-                every { hasChildOf(SampleClass::class, SampleInterface::class) } returns false
+                every { hasChildOf(listOf(SampleClass::class, SampleInterface::class)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
 
@@ -937,11 +937,11 @@ class KoChildProviderListExtTest {
         // given
         val declaration1: KoChildProvider =
             mockk {
-                every { hasChildOf(SampleClass::class, SampleInterface::class) } returns true
+                every { hasChildOf(listOf(SampleClass::class, SampleInterface::class)) } returns true
             }
         val declaration2: KoChildProvider =
             mockk {
-                every { hasChildOf(SampleClass::class, SampleInterface::class) } returns false
+                every { hasChildOf(listOf(SampleClass::class, SampleInterface::class)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
         val kClasses = listOf(SampleClass::class, SampleInterface::class)
@@ -958,11 +958,11 @@ class KoChildProviderListExtTest {
         // given
         val declaration1: KoChildProvider =
             mockk {
-                every { hasChildOf(SampleClass::class, SampleInterface::class) } returns true
+                every { hasChildOf(setOf(SampleClass::class, SampleInterface::class)) } returns true
             }
         val declaration2: KoChildProvider =
             mockk {
-                every { hasChildOf(SampleClass::class, SampleInterface::class) } returns false
+                every { hasChildOf(setOf(SampleClass::class, SampleInterface::class)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
         val kClasses = setOf(SampleClass::class, SampleInterface::class)
@@ -979,11 +979,11 @@ class KoChildProviderListExtTest {
         // given
         val declaration1: KoChildProvider =
             mockk {
-                every { hasChildOf(SampleClass::class, SampleInterface::class) } returns true
+                every { hasChildOf(listOf(SampleClass::class, SampleInterface::class)) } returns true
             }
         val declaration2: KoChildProvider =
             mockk {
-                every { hasChildOf(SampleClass::class, SampleInterface::class) } returns false
+                every { hasChildOf(listOf(SampleClass::class, SampleInterface::class)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
 
@@ -999,11 +999,11 @@ class KoChildProviderListExtTest {
         // given
         val declaration1: KoChildProvider =
             mockk {
-                every { hasChildOf(SampleClass::class, SampleInterface::class) } returns true
+                every { hasChildOf(listOf(SampleClass::class, SampleInterface::class)) } returns true
             }
         val declaration2: KoChildProvider =
             mockk {
-                every { hasChildOf(SampleClass::class, SampleInterface::class) } returns false
+                every { hasChildOf(listOf(SampleClass::class, SampleInterface::class)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
         val kClasses = listOf(SampleClass::class, SampleInterface::class)
@@ -1020,11 +1020,11 @@ class KoChildProviderListExtTest {
         // given
         val declaration1: KoChildProvider =
             mockk {
-                every { hasChildOf(SampleClass::class, SampleInterface::class) } returns true
+                every { hasChildOf(setOf(SampleClass::class, SampleInterface::class)) } returns true
             }
         val declaration2: KoChildProvider =
             mockk {
-                every { hasChildOf(SampleClass::class, SampleInterface::class) } returns false
+                every { hasChildOf(setOf(SampleClass::class, SampleInterface::class)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
         val kClasses = setOf(SampleClass::class, SampleInterface::class)
@@ -1041,11 +1041,11 @@ class KoChildProviderListExtTest {
         // given
         val declaration1: KoChildProvider =
             mockk {
-                every { hasAllChildrenOf(SampleClass::class, SampleInterface::class) } returns true
+                every { hasAllChildrenOf(listOf(SampleClass::class, SampleInterface::class)) } returns true
             }
         val declaration2: KoChildProvider =
             mockk {
-                every { hasAllChildrenOf(SampleClass::class, SampleInterface::class) } returns false
+                every { hasAllChildrenOf(listOf(SampleClass::class, SampleInterface::class)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
 
@@ -1061,11 +1061,11 @@ class KoChildProviderListExtTest {
         // given
         val declaration1: KoChildProvider =
             mockk {
-                every { hasAllChildrenOf(SampleClass::class, SampleInterface::class) } returns true
+                every { hasAllChildrenOf(listOf(SampleClass::class, SampleInterface::class)) } returns true
             }
         val declaration2: KoChildProvider =
             mockk {
-                every { hasAllChildrenOf(SampleClass::class, SampleInterface::class) } returns false
+                every { hasAllChildrenOf(listOf(SampleClass::class, SampleInterface::class)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
         val kClasses = listOf(SampleClass::class, SampleInterface::class)
@@ -1082,11 +1082,11 @@ class KoChildProviderListExtTest {
         // given
         val declaration1: KoChildProvider =
             mockk {
-                every { hasAllChildrenOf(SampleClass::class, SampleInterface::class) } returns true
+                every { hasAllChildrenOf(setOf(SampleClass::class, SampleInterface::class)) } returns true
             }
         val declaration2: KoChildProvider =
             mockk {
-                every { hasAllChildrenOf(SampleClass::class, SampleInterface::class) } returns false
+                every { hasAllChildrenOf(setOf(SampleClass::class, SampleInterface::class)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
         val kClasses = setOf(SampleClass::class, SampleInterface::class)
@@ -1103,11 +1103,11 @@ class KoChildProviderListExtTest {
         // given
         val declaration1: KoChildProvider =
             mockk {
-                every { hasAllChildrenOf(SampleClass::class, SampleInterface::class) } returns true
+                every { hasAllChildrenOf(listOf(SampleClass::class, SampleInterface::class)) } returns true
             }
         val declaration2: KoChildProvider =
             mockk {
-                every { hasAllChildrenOf(SampleClass::class, SampleInterface::class) } returns false
+                every { hasAllChildrenOf(listOf(SampleClass::class, SampleInterface::class)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
 
@@ -1123,11 +1123,11 @@ class KoChildProviderListExtTest {
         // given
         val declaration1: KoChildProvider =
             mockk {
-                every { hasAllChildrenOf(SampleClass::class, SampleInterface::class) } returns true
+                every { hasAllChildrenOf(listOf(SampleClass::class, SampleInterface::class)) } returns true
             }
         val declaration2: KoChildProvider =
             mockk {
-                every { hasAllChildrenOf(SampleClass::class, SampleInterface::class) } returns false
+                every { hasAllChildrenOf(listOf(SampleClass::class, SampleInterface::class)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
         val kClasses = listOf(SampleClass::class, SampleInterface::class)
@@ -1144,11 +1144,11 @@ class KoChildProviderListExtTest {
         // given
         val declaration1: KoChildProvider =
             mockk {
-                every { hasAllChildrenOf(SampleClass::class, SampleInterface::class) } returns true
+                every { hasAllChildrenOf(setOf(SampleClass::class, SampleInterface::class)) } returns true
             }
         val declaration2: KoChildProvider =
             mockk {
-                every { hasAllChildrenOf(SampleClass::class, SampleInterface::class) } returns false
+                every { hasAllChildrenOf(setOf(SampleClass::class, SampleInterface::class)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
         val kClasses = setOf(SampleClass::class, SampleInterface::class)

--- a/lib/src/test/kotlin/com/lemonappdev/konsist/api/ext/list/KoClassProviderListExtTest.kt
+++ b/lib/src/test/kotlin/com/lemonappdev/konsist/api/ext/list/KoClassProviderListExtTest.kt
@@ -242,11 +242,11 @@ class KoClassProviderListExtTest {
         val name = "SampleName"
         val declaration1: KoClassProvider =
             mockk {
-                every { hasClassWithName(name) } returns true
+                every { hasClassWithName(listOf(name)) } returns true
             }
         val declaration2: KoClassProvider =
             mockk {
-                every { hasClassWithName(name) } returns false
+                every { hasClassWithName(listOf(name)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
 
@@ -264,11 +264,11 @@ class KoClassProviderListExtTest {
         val name2 = "SampleName2"
         val declaration1: KoClassProvider =
             mockk {
-                every { hasClassWithName(name1, name2) } returns true
+                every { hasClassWithName(listOf(name1, name2)) } returns true
             }
         val declaration2: KoClassProvider =
             mockk {
-                every { hasClassWithName(name1, name2) } returns false
+                every { hasClassWithName(listOf(name1, name2)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
 
@@ -286,11 +286,11 @@ class KoClassProviderListExtTest {
         val name2 = "SampleName2"
         val declaration1: KoClassProvider =
             mockk {
-                every { hasClassWithName(name1, name2) } returns true
+                every { hasClassWithName(listOf(name1, name2)) } returns true
             }
         val declaration2: KoClassProvider =
             mockk {
-                every { hasClassWithName(name1, name2) } returns false
+                every { hasClassWithName(listOf(name1, name2)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
         val names = listOf(name1, name2)
@@ -309,11 +309,11 @@ class KoClassProviderListExtTest {
         val name2 = "SampleName2"
         val declaration1: KoClassProvider =
             mockk {
-                every { hasClassWithName(name1, name2) } returns true
+                every { hasClassWithName(setOf(name1, name2)) } returns true
             }
         val declaration2: KoClassProvider =
             mockk {
-                every { hasClassWithName(name1, name2) } returns false
+                every { hasClassWithName(setOf(name1, name2)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
         val names = setOf(name1, name2)
@@ -331,11 +331,11 @@ class KoClassProviderListExtTest {
         val name = "SampleName"
         val declaration1: KoClassProvider =
             mockk {
-                every { hasClassWithName(name) } returns true
+                every { hasClassWithName(listOf(name)) } returns true
             }
         val declaration2: KoClassProvider =
             mockk {
-                every { hasClassWithName(name) } returns false
+                every { hasClassWithName(listOf(name)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
 
@@ -353,11 +353,11 @@ class KoClassProviderListExtTest {
         val name2 = "SampleName2"
         val declaration1: KoClassProvider =
             mockk {
-                every { hasClassWithName(name1, name2) } returns true
+                every { hasClassWithName(listOf(name1, name2)) } returns true
             }
         val declaration2: KoClassProvider =
             mockk {
-                every { hasClassWithName(name1, name2) } returns false
+                every { hasClassWithName(listOf(name1, name2)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
 
@@ -375,11 +375,11 @@ class KoClassProviderListExtTest {
         val name2 = "SampleName2"
         val declaration1: KoClassProvider =
             mockk {
-                every { hasClassWithName(name1, name2) } returns true
+                every { hasClassWithName(listOf(name1, name2)) } returns true
             }
         val declaration2: KoClassProvider =
             mockk {
-                every { hasClassWithName(name1, name2) } returns false
+                every { hasClassWithName(listOf(name1, name2)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
         val names = listOf(name1, name2)
@@ -398,11 +398,11 @@ class KoClassProviderListExtTest {
         val name2 = "SampleName2"
         val declaration1: KoClassProvider =
             mockk {
-                every { hasClassWithName(name1, name2) } returns true
+                every { hasClassWithName(setOf(name1, name2)) } returns true
             }
         val declaration2: KoClassProvider =
             mockk {
-                every { hasClassWithName(name1, name2) } returns false
+                every { hasClassWithName(setOf(name1, name2)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
         val names = setOf(name1, name2)
@@ -420,11 +420,11 @@ class KoClassProviderListExtTest {
         val name = "SampleName"
         val declaration1: KoClassProvider =
             mockk {
-                every { hasClassesWithAllNames(name) } returns true
+                every { hasClassesWithAllNames(listOf(name)) } returns true
             }
         val declaration2: KoClassProvider =
             mockk {
-                every { hasClassesWithAllNames(name) } returns false
+                every { hasClassesWithAllNames(listOf(name)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
 
@@ -442,11 +442,11 @@ class KoClassProviderListExtTest {
         val name2 = "SampleName2"
         val declaration1: KoClassProvider =
             mockk {
-                every { hasClassesWithAllNames(name1, name2) } returns true
+                every { hasClassesWithAllNames(listOf(name1, name2)) } returns true
             }
         val declaration2: KoClassProvider =
             mockk {
-                every { hasClassesWithAllNames(name1, name2) } returns false
+                every { hasClassesWithAllNames(listOf(name1, name2)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
 
@@ -464,11 +464,11 @@ class KoClassProviderListExtTest {
         val name2 = "SampleName2"
         val declaration1: KoClassProvider =
             mockk {
-                every { hasClassesWithAllNames(name1, name2) } returns true
+                every { hasClassesWithAllNames(listOf(name1, name2)) } returns true
             }
         val declaration2: KoClassProvider =
             mockk {
-                every { hasClassesWithAllNames(name1, name2) } returns false
+                every { hasClassesWithAllNames(listOf(name1, name2)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
         val names = listOf(name1, name2)
@@ -487,11 +487,11 @@ class KoClassProviderListExtTest {
         val name2 = "SampleName2"
         val declaration1: KoClassProvider =
             mockk {
-                every { hasClassesWithAllNames(name1, name2) } returns true
+                every { hasClassesWithAllNames(setOf(name1, name2)) } returns true
             }
         val declaration2: KoClassProvider =
             mockk {
-                every { hasClassesWithAllNames(name1, name2) } returns false
+                every { hasClassesWithAllNames(setOf(name1, name2)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
         val names = setOf(name1, name2)
@@ -509,11 +509,11 @@ class KoClassProviderListExtTest {
         val name = "SampleName"
         val declaration1: KoClassProvider =
             mockk {
-                every { hasClassesWithAllNames(name) } returns true
+                every { hasClassesWithAllNames(listOf(name)) } returns true
             }
         val declaration2: KoClassProvider =
             mockk {
-                every { hasClassesWithAllNames(name) } returns false
+                every { hasClassesWithAllNames(listOf(name)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
 
@@ -531,11 +531,11 @@ class KoClassProviderListExtTest {
         val name2 = "SampleName2"
         val declaration1: KoClassProvider =
             mockk {
-                every { hasClassesWithAllNames(name1, name2) } returns true
+                every { hasClassesWithAllNames(listOf(name1, name2)) } returns true
             }
         val declaration2: KoClassProvider =
             mockk {
-                every { hasClassesWithAllNames(name1, name2) } returns false
+                every { hasClassesWithAllNames(listOf(name1, name2)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
 
@@ -553,11 +553,11 @@ class KoClassProviderListExtTest {
         val name2 = "SampleName2"
         val declaration1: KoClassProvider =
             mockk {
-                every { hasClassesWithAllNames(name1, name2) } returns true
+                every { hasClassesWithAllNames(listOf(name1, name2)) } returns true
             }
         val declaration2: KoClassProvider =
             mockk {
-                every { hasClassesWithAllNames(name1, name2) } returns false
+                every { hasClassesWithAllNames(listOf(name1, name2)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
         val names = listOf(name1, name2)
@@ -576,11 +576,11 @@ class KoClassProviderListExtTest {
         val name2 = "SampleName2"
         val declaration1: KoClassProvider =
             mockk {
-                every { hasClassesWithAllNames(name1, name2) } returns true
+                every { hasClassesWithAllNames(setOf(name1, name2)) } returns true
             }
         val declaration2: KoClassProvider =
             mockk {
-                every { hasClassesWithAllNames(name1, name2) } returns false
+                every { hasClassesWithAllNames(setOf(name1, name2)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
         val names = setOf(name1, name2)

--- a/lib/src/test/kotlin/com/lemonappdev/konsist/api/ext/list/KoEnumConstantProviderListExtTest.kt
+++ b/lib/src/test/kotlin/com/lemonappdev/konsist/api/ext/list/KoEnumConstantProviderListExtTest.kt
@@ -241,11 +241,11 @@ class KoEnumConstantProviderListExtTest {
         val name = "SampleName"
         val declaration1: KoEnumConstantProvider =
             mockk {
-                every { hasEnumConstantWithName(name) } returns true
+                every { hasEnumConstantWithName(listOf(name)) } returns true
             }
         val declaration2: KoEnumConstantProvider =
             mockk {
-                every { hasEnumConstantWithName(name) } returns false
+                every { hasEnumConstantWithName(listOf(name)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
 
@@ -263,11 +263,11 @@ class KoEnumConstantProviderListExtTest {
         val name2 = "SampleName2"
         val declaration1: KoEnumConstantProvider =
             mockk {
-                every { hasEnumConstantWithName(name1, name2) } returns true
+                every { hasEnumConstantWithName(listOf(name1, name2)) } returns true
             }
         val declaration2: KoEnumConstantProvider =
             mockk {
-                every { hasEnumConstantWithName(name1, name2) } returns false
+                every { hasEnumConstantWithName(listOf(name1, name2)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
 
@@ -285,11 +285,11 @@ class KoEnumConstantProviderListExtTest {
         val name2 = "SampleName2"
         val declaration1: KoEnumConstantProvider =
             mockk {
-                every { hasEnumConstantWithName(name1, name2) } returns true
+                every { hasEnumConstantWithName(listOf(name1, name2)) } returns true
             }
         val declaration2: KoEnumConstantProvider =
             mockk {
-                every { hasEnumConstantWithName(name1, name2) } returns false
+                every { hasEnumConstantWithName(listOf(name1, name2)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
         val names = listOf(name1, name2)
@@ -308,11 +308,11 @@ class KoEnumConstantProviderListExtTest {
         val name2 = "SampleName2"
         val declaration1: KoEnumConstantProvider =
             mockk {
-                every { hasEnumConstantWithName(name1, name2) } returns true
+                every { hasEnumConstantWithName(setOf(name1, name2)) } returns true
             }
         val declaration2: KoEnumConstantProvider =
             mockk {
-                every { hasEnumConstantWithName(name1, name2) } returns false
+                every { hasEnumConstantWithName(setOf(name1, name2)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
         val names = setOf(name1, name2)
@@ -330,11 +330,11 @@ class KoEnumConstantProviderListExtTest {
         val name = "SampleName"
         val declaration1: KoEnumConstantProvider =
             mockk {
-                every { hasEnumConstantWithName(name) } returns true
+                every { hasEnumConstantWithName(listOf(name)) } returns true
             }
         val declaration2: KoEnumConstantProvider =
             mockk {
-                every { hasEnumConstantWithName(name) } returns false
+                every { hasEnumConstantWithName(listOf(name)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
 
@@ -352,11 +352,11 @@ class KoEnumConstantProviderListExtTest {
         val name2 = "SampleName2"
         val declaration1: KoEnumConstantProvider =
             mockk {
-                every { hasEnumConstantWithName(name1, name2) } returns true
+                every { hasEnumConstantWithName(listOf(name1, name2)) } returns true
             }
         val declaration2: KoEnumConstantProvider =
             mockk {
-                every { hasEnumConstantWithName(name1, name2) } returns false
+                every { hasEnumConstantWithName(listOf(name1, name2)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
 
@@ -374,11 +374,11 @@ class KoEnumConstantProviderListExtTest {
         val name2 = "SampleName2"
         val declaration1: KoEnumConstantProvider =
             mockk {
-                every { hasEnumConstantWithName(name1, name2) } returns true
+                every { hasEnumConstantWithName(listOf(name1, name2)) } returns true
             }
         val declaration2: KoEnumConstantProvider =
             mockk {
-                every { hasEnumConstantWithName(name1, name2) } returns false
+                every { hasEnumConstantWithName(listOf(name1, name2)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
         val names = listOf(name1, name2)
@@ -397,11 +397,11 @@ class KoEnumConstantProviderListExtTest {
         val name2 = "SampleName2"
         val declaration1: KoEnumConstantProvider =
             mockk {
-                every { hasEnumConstantWithName(name1, name2) } returns true
+                every { hasEnumConstantWithName(setOf(name1, name2)) } returns true
             }
         val declaration2: KoEnumConstantProvider =
             mockk {
-                every { hasEnumConstantWithName(name1, name2) } returns false
+                every { hasEnumConstantWithName(setOf(name1, name2)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
         val names = setOf(name1, name2)
@@ -419,11 +419,11 @@ class KoEnumConstantProviderListExtTest {
         val name = "SampleName"
         val declaration1: KoEnumConstantProvider =
             mockk {
-                every { hasEnumConstantsWithAllNames(name) } returns true
+                every { hasEnumConstantsWithAllNames(listOf(name)) } returns true
             }
         val declaration2: KoEnumConstantProvider =
             mockk {
-                every { hasEnumConstantsWithAllNames(name) } returns false
+                every { hasEnumConstantsWithAllNames(listOf(name)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
 
@@ -441,11 +441,11 @@ class KoEnumConstantProviderListExtTest {
         val name2 = "SampleName2"
         val declaration1: KoEnumConstantProvider =
             mockk {
-                every { hasEnumConstantsWithAllNames(name1, name2) } returns true
+                every { hasEnumConstantsWithAllNames(listOf(name1, name2)) } returns true
             }
         val declaration2: KoEnumConstantProvider =
             mockk {
-                every { hasEnumConstantsWithAllNames(name1, name2) } returns false
+                every { hasEnumConstantsWithAllNames(listOf(name1, name2)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
 
@@ -463,11 +463,11 @@ class KoEnumConstantProviderListExtTest {
         val name2 = "SampleName2"
         val declaration1: KoEnumConstantProvider =
             mockk {
-                every { hasEnumConstantsWithAllNames(name1, name2) } returns true
+                every { hasEnumConstantsWithAllNames(listOf(name1, name2)) } returns true
             }
         val declaration2: KoEnumConstantProvider =
             mockk {
-                every { hasEnumConstantsWithAllNames(name1, name2) } returns false
+                every { hasEnumConstantsWithAllNames(listOf(name1, name2)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
         val names = listOf(name1, name2)
@@ -486,11 +486,11 @@ class KoEnumConstantProviderListExtTest {
         val name2 = "SampleName2"
         val declaration1: KoEnumConstantProvider =
             mockk {
-                every { hasEnumConstantsWithAllNames(name1, name2) } returns true
+                every { hasEnumConstantsWithAllNames(setOf(name1, name2)) } returns true
             }
         val declaration2: KoEnumConstantProvider =
             mockk {
-                every { hasEnumConstantsWithAllNames(name1, name2) } returns false
+                every { hasEnumConstantsWithAllNames(setOf(name1, name2)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
         val names = setOf(name1, name2)
@@ -508,11 +508,11 @@ class KoEnumConstantProviderListExtTest {
         val name = "SampleName"
         val declaration1: KoEnumConstantProvider =
             mockk {
-                every { hasEnumConstantsWithAllNames(name) } returns true
+                every { hasEnumConstantsWithAllNames(listOf(name)) } returns true
             }
         val declaration2: KoEnumConstantProvider =
             mockk {
-                every { hasEnumConstantsWithAllNames(name) } returns false
+                every { hasEnumConstantsWithAllNames(listOf(name)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
 
@@ -530,11 +530,11 @@ class KoEnumConstantProviderListExtTest {
         val name2 = "SampleName2"
         val declaration1: KoEnumConstantProvider =
             mockk {
-                every { hasEnumConstantsWithAllNames(name1, name2) } returns true
+                every { hasEnumConstantsWithAllNames(listOf(name1, name2)) } returns true
             }
         val declaration2: KoEnumConstantProvider =
             mockk {
-                every { hasEnumConstantsWithAllNames(name1, name2) } returns false
+                every { hasEnumConstantsWithAllNames(listOf(name1, name2)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
 
@@ -552,11 +552,11 @@ class KoEnumConstantProviderListExtTest {
         val name2 = "SampleName2"
         val declaration1: KoEnumConstantProvider =
             mockk {
-                every { hasEnumConstantsWithAllNames(name1, name2) } returns true
+                every { hasEnumConstantsWithAllNames(listOf(name1, name2)) } returns true
             }
         val declaration2: KoEnumConstantProvider =
             mockk {
-                every { hasEnumConstantsWithAllNames(name1, name2) } returns false
+                every { hasEnumConstantsWithAllNames(listOf(name1, name2)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
         val names = listOf(name1, name2)
@@ -575,11 +575,11 @@ class KoEnumConstantProviderListExtTest {
         val name2 = "SampleName2"
         val declaration1: KoEnumConstantProvider =
             mockk {
-                every { hasEnumConstantsWithAllNames(name1, name2) } returns true
+                every { hasEnumConstantsWithAllNames(setOf(name1, name2)) } returns true
             }
         val declaration2: KoEnumConstantProvider =
             mockk {
-                every { hasEnumConstantsWithAllNames(name1, name2) } returns false
+                every { hasEnumConstantsWithAllNames(setOf(name1, name2)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
         val names = setOf(name1, name2)

--- a/lib/src/test/kotlin/com/lemonappdev/konsist/api/ext/list/KoExternalParentProviderListExtTest.kt
+++ b/lib/src/test/kotlin/com/lemonappdev/konsist/api/ext/list/KoExternalParentProviderListExtTest.kt
@@ -244,11 +244,11 @@ class KoExternalParentProviderListExtTest {
         val name = "SampleName"
         val declaration1: KoExternalParentProvider =
             mockk {
-                every { hasExternalParentWithName(name) } returns true
+                every { hasExternalParentWithName(listOf(name)) } returns true
             }
         val declaration2: KoExternalParentProvider =
             mockk {
-                every { hasExternalParentWithName(name) } returns false
+                every { hasExternalParentWithName(listOf(name)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
 
@@ -266,11 +266,11 @@ class KoExternalParentProviderListExtTest {
         val name2 = "SampleName2"
         val declaration1: KoExternalParentProvider =
             mockk {
-                every { hasExternalParentWithName(name1, name2) } returns true
+                every { hasExternalParentWithName(listOf(name1, name2)) } returns true
             }
         val declaration2: KoExternalParentProvider =
             mockk {
-                every { hasExternalParentWithName(name1, name2) } returns false
+                every { hasExternalParentWithName(listOf(name1, name2)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
 
@@ -288,11 +288,11 @@ class KoExternalParentProviderListExtTest {
         val name2 = "SampleName2"
         val declaration1: KoExternalParentProvider =
             mockk {
-                every { hasExternalParentWithName(name1, name2) } returns true
+                every { hasExternalParentWithName(listOf(name1, name2)) } returns true
             }
         val declaration2: KoExternalParentProvider =
             mockk {
-                every { hasExternalParentWithName(name1, name2) } returns false
+                every { hasExternalParentWithName(listOf(name1, name2)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
         val names = listOf(name1, name2)
@@ -311,11 +311,11 @@ class KoExternalParentProviderListExtTest {
         val name2 = "SampleName2"
         val declaration1: KoExternalParentProvider =
             mockk {
-                every { hasExternalParentWithName(name1, name2) } returns true
+                every { hasExternalParentWithName(setOf(name1, name2)) } returns true
             }
         val declaration2: KoExternalParentProvider =
             mockk {
-                every { hasExternalParentWithName(name1, name2) } returns false
+                every { hasExternalParentWithName(setOf(name1, name2)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
         val names = setOf(name1, name2)
@@ -333,11 +333,11 @@ class KoExternalParentProviderListExtTest {
         val name = "SampleName"
         val declaration1: KoExternalParentProvider =
             mockk {
-                every { hasExternalParentWithName(name) } returns true
+                every { hasExternalParentWithName(listOf(name)) } returns true
             }
         val declaration2: KoExternalParentProvider =
             mockk {
-                every { hasExternalParentWithName(name) } returns false
+                every { hasExternalParentWithName(listOf(name)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
 
@@ -355,11 +355,11 @@ class KoExternalParentProviderListExtTest {
         val name2 = "SampleName2"
         val declaration1: KoExternalParentProvider =
             mockk {
-                every { hasExternalParentWithName(name1, name2) } returns true
+                every { hasExternalParentWithName(listOf(name1, name2)) } returns true
             }
         val declaration2: KoExternalParentProvider =
             mockk {
-                every { hasExternalParentWithName(name1, name2) } returns false
+                every { hasExternalParentWithName(listOf(name1, name2)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
 
@@ -377,11 +377,11 @@ class KoExternalParentProviderListExtTest {
         val name2 = "SampleName2"
         val declaration1: KoExternalParentProvider =
             mockk {
-                every { hasExternalParentWithName(name1, name2) } returns true
+                every { hasExternalParentWithName(listOf(name1, name2)) } returns true
             }
         val declaration2: KoExternalParentProvider =
             mockk {
-                every { hasExternalParentWithName(name1, name2) } returns false
+                every { hasExternalParentWithName(listOf(name1, name2)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
         val names = listOf(name1, name2)
@@ -400,11 +400,11 @@ class KoExternalParentProviderListExtTest {
         val name2 = "SampleName2"
         val declaration1: KoExternalParentProvider =
             mockk {
-                every { hasExternalParentWithName(name1, name2) } returns true
+                every { hasExternalParentWithName(setOf(name1, name2)) } returns true
             }
         val declaration2: KoExternalParentProvider =
             mockk {
-                every { hasExternalParentWithName(name1, name2) } returns false
+                every { hasExternalParentWithName(setOf(name1, name2)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
         val names = setOf(name1, name2)
@@ -422,11 +422,11 @@ class KoExternalParentProviderListExtTest {
         val name = "SampleName"
         val declaration1: KoExternalParentProvider =
             mockk {
-                every { hasExternalParentsWithAllNames(name) } returns true
+                every { hasExternalParentsWithAllNames(listOf(name)) } returns true
             }
         val declaration2: KoExternalParentProvider =
             mockk {
-                every { hasExternalParentsWithAllNames(name) } returns false
+                every { hasExternalParentsWithAllNames(listOf(name)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
 
@@ -444,11 +444,11 @@ class KoExternalParentProviderListExtTest {
         val name2 = "SampleName2"
         val declaration1: KoExternalParentProvider =
             mockk {
-                every { hasExternalParentsWithAllNames(name1, name2) } returns true
+                every { hasExternalParentsWithAllNames(listOf(name1, name2)) } returns true
             }
         val declaration2: KoExternalParentProvider =
             mockk {
-                every { hasExternalParentsWithAllNames(name1, name2) } returns false
+                every { hasExternalParentsWithAllNames(listOf(name1, name2)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
 
@@ -466,11 +466,11 @@ class KoExternalParentProviderListExtTest {
         val name2 = "SampleName2"
         val declaration1: KoExternalParentProvider =
             mockk {
-                every { hasExternalParentsWithAllNames(name1, name2) } returns true
+                every { hasExternalParentsWithAllNames(listOf(name1, name2)) } returns true
             }
         val declaration2: KoExternalParentProvider =
             mockk {
-                every { hasExternalParentsWithAllNames(name1, name2) } returns false
+                every { hasExternalParentsWithAllNames(listOf(name1, name2)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
         val names = listOf(name1, name2)
@@ -489,11 +489,11 @@ class KoExternalParentProviderListExtTest {
         val name2 = "SampleName2"
         val declaration1: KoExternalParentProvider =
             mockk {
-                every { hasExternalParentsWithAllNames(name1, name2) } returns true
+                every { hasExternalParentsWithAllNames(setOf(name1, name2)) } returns true
             }
         val declaration2: KoExternalParentProvider =
             mockk {
-                every { hasExternalParentsWithAllNames(name1, name2) } returns false
+                every { hasExternalParentsWithAllNames(setOf(name1, name2)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
         val names = setOf(name1, name2)
@@ -511,11 +511,11 @@ class KoExternalParentProviderListExtTest {
         val name = "SampleName"
         val declaration1: KoExternalParentProvider =
             mockk {
-                every { hasExternalParentsWithAllNames(name) } returns true
+                every { hasExternalParentsWithAllNames(listOf(name)) } returns true
             }
         val declaration2: KoExternalParentProvider =
             mockk {
-                every { hasExternalParentsWithAllNames(name) } returns false
+                every { hasExternalParentsWithAllNames(listOf(name)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
 
@@ -533,11 +533,11 @@ class KoExternalParentProviderListExtTest {
         val name2 = "SampleName2"
         val declaration1: KoExternalParentProvider =
             mockk {
-                every { hasExternalParentsWithAllNames(name1, name2) } returns true
+                every { hasExternalParentsWithAllNames(listOf(name1, name2)) } returns true
             }
         val declaration2: KoExternalParentProvider =
             mockk {
-                every { hasExternalParentsWithAllNames(name1, name2) } returns false
+                every { hasExternalParentsWithAllNames(listOf(name1, name2)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
 
@@ -555,11 +555,11 @@ class KoExternalParentProviderListExtTest {
         val name2 = "SampleName2"
         val declaration1: KoExternalParentProvider =
             mockk {
-                every { hasExternalParentsWithAllNames(name1, name2) } returns true
+                every { hasExternalParentsWithAllNames(listOf(name1, name2)) } returns true
             }
         val declaration2: KoExternalParentProvider =
             mockk {
-                every { hasExternalParentsWithAllNames(name1, name2) } returns false
+                every { hasExternalParentsWithAllNames(listOf(name1, name2)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
         val names = listOf(name1, name2)
@@ -578,11 +578,11 @@ class KoExternalParentProviderListExtTest {
         val name2 = "SampleName2"
         val declaration1: KoExternalParentProvider =
             mockk {
-                every { hasExternalParentsWithAllNames(name1, name2) } returns true
+                every { hasExternalParentsWithAllNames(setOf(name1, name2)) } returns true
             }
         val declaration2: KoExternalParentProvider =
             mockk {
-                every { hasExternalParentsWithAllNames(name1, name2) } returns false
+                every { hasExternalParentsWithAllNames(setOf(name1, name2)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
         val names = setOf(name1, name2)
@@ -917,11 +917,11 @@ class KoExternalParentProviderListExtTest {
         // given
         val declaration1: KoExternalParentProvider =
             mockk {
-                every { hasExternalParentOf(SampleClass::class, SampleInterface::class) } returns true
+                every { hasExternalParentOf(listOf(SampleClass::class, SampleInterface::class)) } returns true
             }
         val declaration2: KoExternalParentProvider =
             mockk {
-                every { hasExternalParentOf(SampleClass::class, SampleInterface::class) } returns false
+                every { hasExternalParentOf(listOf(SampleClass::class, SampleInterface::class)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
 
@@ -937,11 +937,11 @@ class KoExternalParentProviderListExtTest {
         // given
         val declaration1: KoExternalParentProvider =
             mockk {
-                every { hasExternalParentOf(SampleClass::class, SampleInterface::class) } returns true
+                every { hasExternalParentOf(listOf(SampleClass::class, SampleInterface::class)) } returns true
             }
         val declaration2: KoExternalParentProvider =
             mockk {
-                every { hasExternalParentOf(SampleClass::class, SampleInterface::class) } returns false
+                every { hasExternalParentOf(listOf(SampleClass::class, SampleInterface::class)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
         val kClasses = listOf(SampleClass::class, SampleInterface::class)
@@ -958,11 +958,11 @@ class KoExternalParentProviderListExtTest {
         // given
         val declaration1: KoExternalParentProvider =
             mockk {
-                every { hasExternalParentOf(SampleClass::class, SampleInterface::class) } returns true
+                every { hasExternalParentOf(setOf(SampleClass::class, SampleInterface::class)) } returns true
             }
         val declaration2: KoExternalParentProvider =
             mockk {
-                every { hasExternalParentOf(SampleClass::class, SampleInterface::class) } returns false
+                every { hasExternalParentOf(setOf(SampleClass::class, SampleInterface::class)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
         val kClasses = setOf(SampleClass::class, SampleInterface::class)
@@ -979,11 +979,11 @@ class KoExternalParentProviderListExtTest {
         // given
         val declaration1: KoExternalParentProvider =
             mockk {
-                every { hasExternalParentOf(SampleClass::class, SampleInterface::class) } returns true
+                every { hasExternalParentOf(listOf(SampleClass::class, SampleInterface::class)) } returns true
             }
         val declaration2: KoExternalParentProvider =
             mockk {
-                every { hasExternalParentOf(SampleClass::class, SampleInterface::class) } returns false
+                every { hasExternalParentOf(listOf(SampleClass::class, SampleInterface::class)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
 
@@ -999,11 +999,11 @@ class KoExternalParentProviderListExtTest {
         // given
         val declaration1: KoExternalParentProvider =
             mockk {
-                every { hasExternalParentOf(SampleClass::class, SampleInterface::class) } returns true
+                every { hasExternalParentOf(listOf(SampleClass::class, SampleInterface::class)) } returns true
             }
         val declaration2: KoExternalParentProvider =
             mockk {
-                every { hasExternalParentOf(SampleClass::class, SampleInterface::class) } returns false
+                every { hasExternalParentOf(listOf(SampleClass::class, SampleInterface::class)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
         val kClasses = listOf(SampleClass::class, SampleInterface::class)
@@ -1020,11 +1020,11 @@ class KoExternalParentProviderListExtTest {
         // given
         val declaration1: KoExternalParentProvider =
             mockk {
-                every { hasExternalParentOf(SampleClass::class, SampleInterface::class) } returns true
+                every { hasExternalParentOf(setOf(SampleClass::class, SampleInterface::class)) } returns true
             }
         val declaration2: KoExternalParentProvider =
             mockk {
-                every { hasExternalParentOf(SampleClass::class, SampleInterface::class) } returns false
+                every { hasExternalParentOf(setOf(SampleClass::class, SampleInterface::class)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
         val kClasses = setOf(SampleClass::class, SampleInterface::class)
@@ -1041,11 +1041,11 @@ class KoExternalParentProviderListExtTest {
         // given
         val declaration1: KoExternalParentProvider =
             mockk {
-                every { hasAllExternalParentsOf(SampleClass::class, SampleInterface::class) } returns true
+                every { hasAllExternalParentsOf(listOf(SampleClass::class, SampleInterface::class)) } returns true
             }
         val declaration2: KoExternalParentProvider =
             mockk {
-                every { hasAllExternalParentsOf(SampleClass::class, SampleInterface::class) } returns false
+                every { hasAllExternalParentsOf(listOf(SampleClass::class, SampleInterface::class)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
 
@@ -1061,11 +1061,11 @@ class KoExternalParentProviderListExtTest {
         // given
         val declaration1: KoExternalParentProvider =
             mockk {
-                every { hasAllExternalParentsOf(SampleClass::class, SampleInterface::class) } returns true
+                every { hasAllExternalParentsOf(listOf(SampleClass::class, SampleInterface::class)) } returns true
             }
         val declaration2: KoExternalParentProvider =
             mockk {
-                every { hasAllExternalParentsOf(SampleClass::class, SampleInterface::class) } returns false
+                every { hasAllExternalParentsOf(listOf(SampleClass::class, SampleInterface::class)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
         val kClasses = listOf(SampleClass::class, SampleInterface::class)
@@ -1082,11 +1082,11 @@ class KoExternalParentProviderListExtTest {
         // given
         val declaration1: KoExternalParentProvider =
             mockk {
-                every { hasAllExternalParentsOf(SampleClass::class, SampleInterface::class) } returns true
+                every { hasAllExternalParentsOf(setOf(SampleClass::class, SampleInterface::class)) } returns true
             }
         val declaration2: KoExternalParentProvider =
             mockk {
-                every { hasAllExternalParentsOf(SampleClass::class, SampleInterface::class) } returns false
+                every { hasAllExternalParentsOf(setOf(SampleClass::class, SampleInterface::class)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
         val kClasses = setOf(SampleClass::class, SampleInterface::class)
@@ -1103,11 +1103,11 @@ class KoExternalParentProviderListExtTest {
         // given
         val declaration1: KoExternalParentProvider =
             mockk {
-                every { hasAllExternalParentsOf(SampleClass::class, SampleInterface::class) } returns true
+                every { hasAllExternalParentsOf(listOf(SampleClass::class, SampleInterface::class)) } returns true
             }
         val declaration2: KoExternalParentProvider =
             mockk {
-                every { hasAllExternalParentsOf(SampleClass::class, SampleInterface::class) } returns false
+                every { hasAllExternalParentsOf(listOf(SampleClass::class, SampleInterface::class)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
 
@@ -1123,11 +1123,11 @@ class KoExternalParentProviderListExtTest {
         // given
         val declaration1: KoExternalParentProvider =
             mockk {
-                every { hasAllExternalParentsOf(SampleClass::class, SampleInterface::class) } returns true
+                every { hasAllExternalParentsOf(listOf(SampleClass::class, SampleInterface::class)) } returns true
             }
         val declaration2: KoExternalParentProvider =
             mockk {
-                every { hasAllExternalParentsOf(SampleClass::class, SampleInterface::class) } returns false
+                every { hasAllExternalParentsOf(listOf(SampleClass::class, SampleInterface::class)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
         val kClasses = listOf(SampleClass::class, SampleInterface::class)
@@ -1144,11 +1144,11 @@ class KoExternalParentProviderListExtTest {
         // given
         val declaration1: KoExternalParentProvider =
             mockk {
-                every { hasAllExternalParentsOf(SampleClass::class, SampleInterface::class) } returns true
+                every { hasAllExternalParentsOf(setOf(SampleClass::class, SampleInterface::class)) } returns true
             }
         val declaration2: KoExternalParentProvider =
             mockk {
-                every { hasAllExternalParentsOf(SampleClass::class, SampleInterface::class) } returns false
+                every { hasAllExternalParentsOf(setOf(SampleClass::class, SampleInterface::class)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
         val kClasses = setOf(SampleClass::class, SampleInterface::class)

--- a/lib/src/test/kotlin/com/lemonappdev/konsist/api/ext/list/KoFunctionProviderListExtTest.kt
+++ b/lib/src/test/kotlin/com/lemonappdev/konsist/api/ext/list/KoFunctionProviderListExtTest.kt
@@ -246,11 +246,11 @@ class KoFunctionProviderListExtTest {
         val name = "SampleName"
         val declaration1: KoFunctionProvider =
             mockk {
-                every { hasFunctionWithName(name) } returns true
+                every { hasFunctionWithName(listOf(name)) } returns true
             }
         val declaration2: KoFunctionProvider =
             mockk {
-                every { hasFunctionWithName(name) } returns false
+                every { hasFunctionWithName(listOf(name)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
 
@@ -268,11 +268,11 @@ class KoFunctionProviderListExtTest {
         val name2 = "SampleName2"
         val declaration1: KoFunctionProvider =
             mockk {
-                every { hasFunctionWithName(name1, name2) } returns true
+                every { hasFunctionWithName(listOf(name1, name2)) } returns true
             }
         val declaration2: KoFunctionProvider =
             mockk {
-                every { hasFunctionWithName(name1, name2) } returns false
+                every { hasFunctionWithName(listOf(name1, name2)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
 
@@ -290,11 +290,11 @@ class KoFunctionProviderListExtTest {
         val name2 = "SampleName2"
         val declaration1: KoFunctionProvider =
             mockk {
-                every { hasFunctionWithName(name1, name2) } returns true
+                every { hasFunctionWithName(listOf(name1, name2)) } returns true
             }
         val declaration2: KoFunctionProvider =
             mockk {
-                every { hasFunctionWithName(name1, name2) } returns false
+                every { hasFunctionWithName(listOf(name1, name2)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
         val names = listOf(name1, name2)
@@ -313,11 +313,11 @@ class KoFunctionProviderListExtTest {
         val name2 = "SampleName2"
         val declaration1: KoFunctionProvider =
             mockk {
-                every { hasFunctionWithName(name1, name2) } returns true
+                every { hasFunctionWithName(setOf(name1, name2)) } returns true
             }
         val declaration2: KoFunctionProvider =
             mockk {
-                every { hasFunctionWithName(name1, name2) } returns false
+                every { hasFunctionWithName(setOf(name1, name2)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
         val names = setOf(name1, name2)
@@ -335,11 +335,11 @@ class KoFunctionProviderListExtTest {
         val name = "SampleName"
         val declaration1: KoFunctionProvider =
             mockk {
-                every { hasFunctionWithName(name) } returns true
+                every { hasFunctionWithName(listOf(name)) } returns true
             }
         val declaration2: KoFunctionProvider =
             mockk {
-                every { hasFunctionWithName(name) } returns false
+                every { hasFunctionWithName(listOf(name)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
 
@@ -357,11 +357,11 @@ class KoFunctionProviderListExtTest {
         val name2 = "SampleName2"
         val declaration1: KoFunctionProvider =
             mockk {
-                every { hasFunctionWithName(name1, name2) } returns true
+                every { hasFunctionWithName(listOf(name1, name2)) } returns true
             }
         val declaration2: KoFunctionProvider =
             mockk {
-                every { hasFunctionWithName(name1, name2) } returns false
+                every { hasFunctionWithName(listOf(name1, name2)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
 
@@ -379,11 +379,11 @@ class KoFunctionProviderListExtTest {
         val name2 = "SampleName2"
         val declaration1: KoFunctionProvider =
             mockk {
-                every { hasFunctionWithName(name1, name2) } returns true
+                every { hasFunctionWithName(listOf(name1, name2)) } returns true
             }
         val declaration2: KoFunctionProvider =
             mockk {
-                every { hasFunctionWithName(name1, name2) } returns false
+                every { hasFunctionWithName(listOf(name1, name2)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
         val names = listOf(name1, name2)
@@ -402,11 +402,11 @@ class KoFunctionProviderListExtTest {
         val name2 = "SampleName2"
         val declaration1: KoFunctionProvider =
             mockk {
-                every { hasFunctionWithName(name1, name2) } returns true
+                every { hasFunctionWithName(setOf(name1, name2)) } returns true
             }
         val declaration2: KoFunctionProvider =
             mockk {
-                every { hasFunctionWithName(name1, name2) } returns false
+                every { hasFunctionWithName(setOf(name1, name2)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
         val names = setOf(name1, name2)
@@ -424,11 +424,11 @@ class KoFunctionProviderListExtTest {
         val name = "SampleName"
         val declaration1: KoFunctionProvider =
             mockk {
-                every { hasFunctionsWithAllNames(name) } returns true
+                every { hasFunctionsWithAllNames(listOf(name)) } returns true
             }
         val declaration2: KoFunctionProvider =
             mockk {
-                every { hasFunctionsWithAllNames(name) } returns false
+                every { hasFunctionsWithAllNames(listOf(name)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
 
@@ -446,11 +446,11 @@ class KoFunctionProviderListExtTest {
         val name2 = "SampleName2"
         val declaration1: KoFunctionProvider =
             mockk {
-                every { hasFunctionsWithAllNames(name1, name2) } returns true
+                every { hasFunctionsWithAllNames(listOf(name1, name2)) } returns true
             }
         val declaration2: KoFunctionProvider =
             mockk {
-                every { hasFunctionsWithAllNames(name1, name2) } returns false
+                every { hasFunctionsWithAllNames(listOf(name1, name2)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
 
@@ -468,11 +468,11 @@ class KoFunctionProviderListExtTest {
         val name2 = "SampleName2"
         val declaration1: KoFunctionProvider =
             mockk {
-                every { hasFunctionsWithAllNames(name1, name2) } returns true
+                every { hasFunctionsWithAllNames(listOf(name1, name2)) } returns true
             }
         val declaration2: KoFunctionProvider =
             mockk {
-                every { hasFunctionsWithAllNames(name1, name2) } returns false
+                every { hasFunctionsWithAllNames(listOf(name1, name2)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
         val names = listOf(name1, name2)
@@ -491,11 +491,11 @@ class KoFunctionProviderListExtTest {
         val name2 = "SampleName2"
         val declaration1: KoFunctionProvider =
             mockk {
-                every { hasFunctionsWithAllNames(name1, name2) } returns true
+                every { hasFunctionsWithAllNames(setOf(name1, name2)) } returns true
             }
         val declaration2: KoFunctionProvider =
             mockk {
-                every { hasFunctionsWithAllNames(name1, name2) } returns false
+                every { hasFunctionsWithAllNames(setOf(name1, name2)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
         val names = setOf(name1, name2)
@@ -513,11 +513,11 @@ class KoFunctionProviderListExtTest {
         val name = "SampleName"
         val declaration1: KoFunctionProvider =
             mockk {
-                every { hasFunctionsWithAllNames(name) } returns true
+                every { hasFunctionsWithAllNames(listOf(name)) } returns true
             }
         val declaration2: KoFunctionProvider =
             mockk {
-                every { hasFunctionsWithAllNames(name) } returns false
+                every { hasFunctionsWithAllNames(listOf(name)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
 
@@ -535,11 +535,11 @@ class KoFunctionProviderListExtTest {
         val name2 = "SampleName2"
         val declaration1: KoFunctionProvider =
             mockk {
-                every { hasFunctionsWithAllNames(name1, name2) } returns true
+                every { hasFunctionsWithAllNames(listOf(name1, name2)) } returns true
             }
         val declaration2: KoFunctionProvider =
             mockk {
-                every { hasFunctionsWithAllNames(name1, name2) } returns false
+                every { hasFunctionsWithAllNames(listOf(name1, name2)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
 
@@ -557,11 +557,11 @@ class KoFunctionProviderListExtTest {
         val name2 = "SampleName2"
         val declaration1: KoFunctionProvider =
             mockk {
-                every { hasFunctionsWithAllNames(name1, name2) } returns true
+                every { hasFunctionsWithAllNames(listOf(name1, name2)) } returns true
             }
         val declaration2: KoFunctionProvider =
             mockk {
-                every { hasFunctionsWithAllNames(name1, name2) } returns false
+                every { hasFunctionsWithAllNames(listOf(name1, name2)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
         val names = listOf(name1, name2)
@@ -580,11 +580,11 @@ class KoFunctionProviderListExtTest {
         val name2 = "SampleName2"
         val declaration1: KoFunctionProvider =
             mockk {
-                every { hasFunctionsWithAllNames(name1, name2) } returns true
+                every { hasFunctionsWithAllNames(setOf(name1, name2)) } returns true
             }
         val declaration2: KoFunctionProvider =
             mockk {
-                every { hasFunctionsWithAllNames(name1, name2) } returns false
+                every { hasFunctionsWithAllNames(setOf(name1, name2)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
         val names = setOf(name1, name2)

--- a/lib/src/test/kotlin/com/lemonappdev/konsist/api/ext/list/KoImportAliasProviderListExtTest.kt
+++ b/lib/src/test/kotlin/com/lemonappdev/konsist/api/ext/list/KoImportAliasProviderListExtTest.kt
@@ -241,11 +241,11 @@ class KoImportAliasProviderListExtTest {
         val name = "SampleName"
         val declaration1: KoImportAliasProvider =
             mockk {
-                every { hasImportAliasWithName(name) } returns true
+                every { hasImportAliasWithName(listOf(name)) } returns true
             }
         val declaration2: KoImportAliasProvider =
             mockk {
-                every { hasImportAliasWithName(name) } returns false
+                every { hasImportAliasWithName(listOf(name)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
 
@@ -263,11 +263,11 @@ class KoImportAliasProviderListExtTest {
         val name2 = "SampleName2"
         val declaration1: KoImportAliasProvider =
             mockk {
-                every { hasImportAliasWithName(name1, name2) } returns true
+                every { hasImportAliasWithName(listOf(name1, name2)) } returns true
             }
         val declaration2: KoImportAliasProvider =
             mockk {
-                every { hasImportAliasWithName(name1, name2) } returns false
+                every { hasImportAliasWithName(listOf(name1, name2)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
 
@@ -285,11 +285,11 @@ class KoImportAliasProviderListExtTest {
         val name2 = "SampleName2"
         val declaration1: KoImportAliasProvider =
             mockk {
-                every { hasImportAliasWithName(name1, name2) } returns true
+                every { hasImportAliasWithName(listOf(name1, name2)) } returns true
             }
         val declaration2: KoImportAliasProvider =
             mockk {
-                every { hasImportAliasWithName(name1, name2) } returns false
+                every { hasImportAliasWithName(listOf(name1, name2)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
         val names = listOf(name1, name2)
@@ -308,11 +308,11 @@ class KoImportAliasProviderListExtTest {
         val name2 = "SampleName2"
         val declaration1: KoImportAliasProvider =
             mockk {
-                every { hasImportAliasWithName(name1, name2) } returns true
+                every { hasImportAliasWithName(setOf(name1, name2)) } returns true
             }
         val declaration2: KoImportAliasProvider =
             mockk {
-                every { hasImportAliasWithName(name1, name2) } returns false
+                every { hasImportAliasWithName(setOf(name1, name2)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
         val names = setOf(name1, name2)
@@ -330,11 +330,11 @@ class KoImportAliasProviderListExtTest {
         val name = "SampleName"
         val declaration1: KoImportAliasProvider =
             mockk {
-                every { hasImportAliasWithName(name) } returns true
+                every { hasImportAliasWithName(listOf(name)) } returns true
             }
         val declaration2: KoImportAliasProvider =
             mockk {
-                every { hasImportAliasWithName(name) } returns false
+                every { hasImportAliasWithName(listOf(name)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
 
@@ -352,11 +352,11 @@ class KoImportAliasProviderListExtTest {
         val name2 = "SampleName2"
         val declaration1: KoImportAliasProvider =
             mockk {
-                every { hasImportAliasWithName(name1, name2) } returns true
+                every { hasImportAliasWithName(listOf(name1, name2)) } returns true
             }
         val declaration2: KoImportAliasProvider =
             mockk {
-                every { hasImportAliasWithName(name1, name2) } returns false
+                every { hasImportAliasWithName(listOf(name1, name2)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
 
@@ -374,11 +374,11 @@ class KoImportAliasProviderListExtTest {
         val name2 = "SampleName2"
         val declaration1: KoImportAliasProvider =
             mockk {
-                every { hasImportAliasWithName(name1, name2) } returns true
+                every { hasImportAliasWithName(listOf(name1, name2)) } returns true
             }
         val declaration2: KoImportAliasProvider =
             mockk {
-                every { hasImportAliasWithName(name1, name2) } returns false
+                every { hasImportAliasWithName(listOf(name1, name2)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
         val names = listOf(name1, name2)
@@ -397,11 +397,11 @@ class KoImportAliasProviderListExtTest {
         val name2 = "SampleName2"
         val declaration1: KoImportAliasProvider =
             mockk {
-                every { hasImportAliasWithName(name1, name2) } returns true
+                every { hasImportAliasWithName(setOf(name1, name2)) } returns true
             }
         val declaration2: KoImportAliasProvider =
             mockk {
-                every { hasImportAliasWithName(name1, name2) } returns false
+                every { hasImportAliasWithName(setOf(name1, name2)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
         val names = setOf(name1, name2)
@@ -419,11 +419,11 @@ class KoImportAliasProviderListExtTest {
         val name = "SampleName"
         val declaration1: KoImportAliasProvider =
             mockk {
-                every { hasImportAliasesWithAllNames(name) } returns true
+                every { hasImportAliasesWithAllNames(listOf(name)) } returns true
             }
         val declaration2: KoImportAliasProvider =
             mockk {
-                every { hasImportAliasesWithAllNames(name) } returns false
+                every { hasImportAliasesWithAllNames(listOf(name)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
 
@@ -441,11 +441,11 @@ class KoImportAliasProviderListExtTest {
         val name2 = "SampleName2"
         val declaration1: KoImportAliasProvider =
             mockk {
-                every { hasImportAliasesWithAllNames(name1, name2) } returns true
+                every { hasImportAliasesWithAllNames(listOf(name1, name2)) } returns true
             }
         val declaration2: KoImportAliasProvider =
             mockk {
-                every { hasImportAliasesWithAllNames(name1, name2) } returns false
+                every { hasImportAliasesWithAllNames(listOf(name1, name2)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
 
@@ -463,11 +463,11 @@ class KoImportAliasProviderListExtTest {
         val name2 = "SampleName2"
         val declaration1: KoImportAliasProvider =
             mockk {
-                every { hasImportAliasesWithAllNames(name1, name2) } returns true
+                every { hasImportAliasesWithAllNames(listOf(name1, name2)) } returns true
             }
         val declaration2: KoImportAliasProvider =
             mockk {
-                every { hasImportAliasesWithAllNames(name1, name2) } returns false
+                every { hasImportAliasesWithAllNames(listOf(name1, name2)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
         val names = listOf(name1, name2)
@@ -486,11 +486,11 @@ class KoImportAliasProviderListExtTest {
         val name2 = "SampleName2"
         val declaration1: KoImportAliasProvider =
             mockk {
-                every { hasImportAliasesWithAllNames(name1, name2) } returns true
+                every { hasImportAliasesWithAllNames(setOf(name1, name2)) } returns true
             }
         val declaration2: KoImportAliasProvider =
             mockk {
-                every { hasImportAliasesWithAllNames(name1, name2) } returns false
+                every { hasImportAliasesWithAllNames(setOf(name1, name2)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
         val names = setOf(name1, name2)
@@ -508,11 +508,11 @@ class KoImportAliasProviderListExtTest {
         val name = "SampleName"
         val declaration1: KoImportAliasProvider =
             mockk {
-                every { hasImportAliasesWithAllNames(name) } returns true
+                every { hasImportAliasesWithAllNames(listOf(name)) } returns true
             }
         val declaration2: KoImportAliasProvider =
             mockk {
-                every { hasImportAliasesWithAllNames(name) } returns false
+                every { hasImportAliasesWithAllNames(listOf(name)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
 
@@ -530,11 +530,11 @@ class KoImportAliasProviderListExtTest {
         val name2 = "SampleName2"
         val declaration1: KoImportAliasProvider =
             mockk {
-                every { hasImportAliasesWithAllNames(name1, name2) } returns true
+                every { hasImportAliasesWithAllNames(listOf(name1, name2)) } returns true
             }
         val declaration2: KoImportAliasProvider =
             mockk {
-                every { hasImportAliasesWithAllNames(name1, name2) } returns false
+                every { hasImportAliasesWithAllNames(listOf(name1, name2)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
 
@@ -552,11 +552,11 @@ class KoImportAliasProviderListExtTest {
         val name2 = "SampleName2"
         val declaration1: KoImportAliasProvider =
             mockk {
-                every { hasImportAliasesWithAllNames(name1, name2) } returns true
+                every { hasImportAliasesWithAllNames(listOf(name1, name2)) } returns true
             }
         val declaration2: KoImportAliasProvider =
             mockk {
-                every { hasImportAliasesWithAllNames(name1, name2) } returns false
+                every { hasImportAliasesWithAllNames(listOf(name1, name2)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
         val names = listOf(name1, name2)
@@ -575,11 +575,11 @@ class KoImportAliasProviderListExtTest {
         val name2 = "SampleName2"
         val declaration1: KoImportAliasProvider =
             mockk {
-                every { hasImportAliasesWithAllNames(name1, name2) } returns true
+                every { hasImportAliasesWithAllNames(setOf(name1, name2)) } returns true
             }
         val declaration2: KoImportAliasProvider =
             mockk {
-                every { hasImportAliasesWithAllNames(name1, name2) } returns false
+                every { hasImportAliasesWithAllNames(setOf(name1, name2)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
         val names = setOf(name1, name2)

--- a/lib/src/test/kotlin/com/lemonappdev/konsist/api/ext/list/KoImportProviderListExtTest.kt
+++ b/lib/src/test/kotlin/com/lemonappdev/konsist/api/ext/list/KoImportProviderListExtTest.kt
@@ -241,11 +241,11 @@ class KoImportProviderListExtTest {
         val name = "SampleName"
         val declaration1: KoImportProvider =
             mockk {
-                every { hasImportWithName(name) } returns true
+                every { hasImportWithName(listOf(name)) } returns true
             }
         val declaration2: KoImportProvider =
             mockk {
-                every { hasImportWithName(name) } returns false
+                every { hasImportWithName(listOf(name)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
 
@@ -263,11 +263,11 @@ class KoImportProviderListExtTest {
         val name2 = "SampleName2"
         val declaration1: KoImportProvider =
             mockk {
-                every { hasImportWithName(name1, name2) } returns true
+                every { hasImportWithName(listOf(name1, name2)) } returns true
             }
         val declaration2: KoImportProvider =
             mockk {
-                every { hasImportWithName(name1, name2) } returns false
+                every { hasImportWithName(listOf(name1, name2)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
 
@@ -285,11 +285,11 @@ class KoImportProviderListExtTest {
         val name2 = "SampleName2"
         val declaration1: KoImportProvider =
             mockk {
-                every { hasImportWithName(name1, name2) } returns true
+                every { hasImportWithName(listOf(name1, name2)) } returns true
             }
         val declaration2: KoImportProvider =
             mockk {
-                every { hasImportWithName(name1, name2) } returns false
+                every { hasImportWithName(listOf(name1, name2)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
         val names = listOf(name1, name2)
@@ -308,11 +308,11 @@ class KoImportProviderListExtTest {
         val name2 = "SampleName2"
         val declaration1: KoImportProvider =
             mockk {
-                every { hasImportWithName(name1, name2) } returns true
+                every { hasImportWithName(setOf(name1, name2)) } returns true
             }
         val declaration2: KoImportProvider =
             mockk {
-                every { hasImportWithName(name1, name2) } returns false
+                every { hasImportWithName(setOf(name1, name2)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
         val names = setOf(name1, name2)
@@ -330,11 +330,11 @@ class KoImportProviderListExtTest {
         val name = "SampleName"
         val declaration1: KoImportProvider =
             mockk {
-                every { hasImportWithName(name) } returns true
+                every { hasImportWithName(listOf(name)) } returns true
             }
         val declaration2: KoImportProvider =
             mockk {
-                every { hasImportWithName(name) } returns false
+                every { hasImportWithName(listOf(name)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
 
@@ -352,11 +352,11 @@ class KoImportProviderListExtTest {
         val name2 = "SampleName2"
         val declaration1: KoImportProvider =
             mockk {
-                every { hasImportWithName(name1, name2) } returns true
+                every { hasImportWithName(listOf(name1, name2)) } returns true
             }
         val declaration2: KoImportProvider =
             mockk {
-                every { hasImportWithName(name1, name2) } returns false
+                every { hasImportWithName(listOf(name1, name2)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
 
@@ -374,11 +374,11 @@ class KoImportProviderListExtTest {
         val name2 = "SampleName2"
         val declaration1: KoImportProvider =
             mockk {
-                every { hasImportWithName(name1, name2) } returns true
+                every { hasImportWithName(listOf(name1, name2)) } returns true
             }
         val declaration2: KoImportProvider =
             mockk {
-                every { hasImportWithName(name1, name2) } returns false
+                every { hasImportWithName(listOf(name1, name2)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
         val names = listOf(name1, name2)
@@ -397,11 +397,11 @@ class KoImportProviderListExtTest {
         val name2 = "SampleName2"
         val declaration1: KoImportProvider =
             mockk {
-                every { hasImportWithName(name1, name2) } returns true
+                every { hasImportWithName(setOf(name1, name2)) } returns true
             }
         val declaration2: KoImportProvider =
             mockk {
-                every { hasImportWithName(name1, name2) } returns false
+                every { hasImportWithName(setOf(name1, name2)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
         val names = setOf(name1, name2)
@@ -419,11 +419,11 @@ class KoImportProviderListExtTest {
         val name = "SampleName"
         val declaration1: KoImportProvider =
             mockk {
-                every { hasImportsWithAllNames(name) } returns true
+                every { hasImportsWithAllNames(listOf(name)) } returns true
             }
         val declaration2: KoImportProvider =
             mockk {
-                every { hasImportsWithAllNames(name) } returns false
+                every { hasImportsWithAllNames(listOf(name)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
 
@@ -441,11 +441,11 @@ class KoImportProviderListExtTest {
         val name2 = "SampleName2"
         val declaration1: KoImportProvider =
             mockk {
-                every { hasImportsWithAllNames(name1, name2) } returns true
+                every { hasImportsWithAllNames(listOf(name1, name2)) } returns true
             }
         val declaration2: KoImportProvider =
             mockk {
-                every { hasImportsWithAllNames(name1, name2) } returns false
+                every { hasImportsWithAllNames(listOf(name1, name2)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
 
@@ -463,11 +463,11 @@ class KoImportProviderListExtTest {
         val name2 = "SampleName2"
         val declaration1: KoImportProvider =
             mockk {
-                every { hasImportsWithAllNames(name1, name2) } returns true
+                every { hasImportsWithAllNames(listOf(name1, name2)) } returns true
             }
         val declaration2: KoImportProvider =
             mockk {
-                every { hasImportsWithAllNames(name1, name2) } returns false
+                every { hasImportsWithAllNames(listOf(name1, name2)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
         val names = listOf(name1, name2)
@@ -486,11 +486,11 @@ class KoImportProviderListExtTest {
         val name2 = "SampleName2"
         val declaration1: KoImportProvider =
             mockk {
-                every { hasImportsWithAllNames(name1, name2) } returns true
+                every { hasImportsWithAllNames(setOf(name1, name2)) } returns true
             }
         val declaration2: KoImportProvider =
             mockk {
-                every { hasImportsWithAllNames(name1, name2) } returns false
+                every { hasImportsWithAllNames(setOf(name1, name2)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
         val names = setOf(name1, name2)
@@ -508,11 +508,11 @@ class KoImportProviderListExtTest {
         val name = "SampleName"
         val declaration1: KoImportProvider =
             mockk {
-                every { hasImportsWithAllNames(name) } returns true
+                every { hasImportsWithAllNames(listOf(name)) } returns true
             }
         val declaration2: KoImportProvider =
             mockk {
-                every { hasImportsWithAllNames(name) } returns false
+                every { hasImportsWithAllNames(listOf(name)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
 
@@ -530,11 +530,11 @@ class KoImportProviderListExtTest {
         val name2 = "SampleName2"
         val declaration1: KoImportProvider =
             mockk {
-                every { hasImportsWithAllNames(name1, name2) } returns true
+                every { hasImportsWithAllNames(listOf(name1, name2)) } returns true
             }
         val declaration2: KoImportProvider =
             mockk {
-                every { hasImportsWithAllNames(name1, name2) } returns false
+                every { hasImportsWithAllNames(listOf(name1, name2)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
 
@@ -552,11 +552,11 @@ class KoImportProviderListExtTest {
         val name2 = "SampleName2"
         val declaration1: KoImportProvider =
             mockk {
-                every { hasImportsWithAllNames(name1, name2) } returns true
+                every { hasImportsWithAllNames(listOf(name1, name2)) } returns true
             }
         val declaration2: KoImportProvider =
             mockk {
-                every { hasImportsWithAllNames(name1, name2) } returns false
+                every { hasImportsWithAllNames(listOf(name1, name2)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
         val names = listOf(name1, name2)
@@ -575,11 +575,11 @@ class KoImportProviderListExtTest {
         val name2 = "SampleName2"
         val declaration1: KoImportProvider =
             mockk {
-                every { hasImportsWithAllNames(name1, name2) } returns true
+                every { hasImportsWithAllNames(setOf(name1, name2)) } returns true
             }
         val declaration2: KoImportProvider =
             mockk {
-                every { hasImportsWithAllNames(name1, name2) } returns false
+                every { hasImportsWithAllNames(setOf(name1, name2)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
         val names = setOf(name1, name2)

--- a/lib/src/test/kotlin/com/lemonappdev/konsist/api/ext/list/KoInterfaceProviderListExtTest.kt
+++ b/lib/src/test/kotlin/com/lemonappdev/konsist/api/ext/list/KoInterfaceProviderListExtTest.kt
@@ -242,11 +242,11 @@ class KoInterfaceProviderListExtTest {
         val name = "SampleName"
         val declaration1: KoInterfaceProvider =
             mockk {
-                every { hasInterfaceWithName(name) } returns true
+                every { hasInterfaceWithName(listOf(name)) } returns true
             }
         val declaration2: KoInterfaceProvider =
             mockk {
-                every { hasInterfaceWithName(name) } returns false
+                every { hasInterfaceWithName(listOf(name)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
 
@@ -264,11 +264,11 @@ class KoInterfaceProviderListExtTest {
         val name2 = "SampleName2"
         val declaration1: KoInterfaceProvider =
             mockk {
-                every { hasInterfaceWithName(name1, name2) } returns true
+                every { hasInterfaceWithName(listOf(name1, name2)) } returns true
             }
         val declaration2: KoInterfaceProvider =
             mockk {
-                every { hasInterfaceWithName(name1, name2) } returns false
+                every { hasInterfaceWithName(listOf(name1, name2)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
 
@@ -286,11 +286,11 @@ class KoInterfaceProviderListExtTest {
         val name2 = "SampleName2"
         val declaration1: KoInterfaceProvider =
             mockk {
-                every { hasInterfaceWithName(name1, name2) } returns true
+                every { hasInterfaceWithName(listOf(name1, name2)) } returns true
             }
         val declaration2: KoInterfaceProvider =
             mockk {
-                every { hasInterfaceWithName(name1, name2) } returns false
+                every { hasInterfaceWithName(listOf(name1, name2)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
         val names = listOf(name1, name2)
@@ -309,11 +309,11 @@ class KoInterfaceProviderListExtTest {
         val name2 = "SampleName2"
         val declaration1: KoInterfaceProvider =
             mockk {
-                every { hasInterfaceWithName(name1, name2) } returns true
+                every { hasInterfaceWithName(setOf(name1, name2)) } returns true
             }
         val declaration2: KoInterfaceProvider =
             mockk {
-                every { hasInterfaceWithName(name1, name2) } returns false
+                every { hasInterfaceWithName(setOf(name1, name2)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
         val names = setOf(name1, name2)
@@ -331,11 +331,11 @@ class KoInterfaceProviderListExtTest {
         val name = "SampleName"
         val declaration1: KoInterfaceProvider =
             mockk {
-                every { hasInterfaceWithName(name) } returns true
+                every { hasInterfaceWithName(listOf(name)) } returns true
             }
         val declaration2: KoInterfaceProvider =
             mockk {
-                every { hasInterfaceWithName(name) } returns false
+                every { hasInterfaceWithName(listOf(name)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
 
@@ -353,11 +353,11 @@ class KoInterfaceProviderListExtTest {
         val name2 = "SampleName2"
         val declaration1: KoInterfaceProvider =
             mockk {
-                every { hasInterfaceWithName(name1, name2) } returns true
+                every { hasInterfaceWithName(listOf(name1, name2)) } returns true
             }
         val declaration2: KoInterfaceProvider =
             mockk {
-                every { hasInterfaceWithName(name1, name2) } returns false
+                every { hasInterfaceWithName(listOf(name1, name2)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
 
@@ -375,11 +375,11 @@ class KoInterfaceProviderListExtTest {
         val name2 = "SampleName2"
         val declaration1: KoInterfaceProvider =
             mockk {
-                every { hasInterfaceWithName(name1, name2) } returns true
+                every { hasInterfaceWithName(listOf(name1, name2)) } returns true
             }
         val declaration2: KoInterfaceProvider =
             mockk {
-                every { hasInterfaceWithName(name1, name2) } returns false
+                every { hasInterfaceWithName(listOf(name1, name2)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
         val names = listOf(name1, name2)
@@ -398,11 +398,11 @@ class KoInterfaceProviderListExtTest {
         val name2 = "SampleName2"
         val declaration1: KoInterfaceProvider =
             mockk {
-                every { hasInterfaceWithName(name1, name2) } returns true
+                every { hasInterfaceWithName(setOf(name1, name2)) } returns true
             }
         val declaration2: KoInterfaceProvider =
             mockk {
-                every { hasInterfaceWithName(name1, name2) } returns false
+                every { hasInterfaceWithName(setOf(name1, name2)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
         val names = setOf(name1, name2)
@@ -420,11 +420,11 @@ class KoInterfaceProviderListExtTest {
         val name = "SampleName"
         val declaration1: KoInterfaceProvider =
             mockk {
-                every { hasInterfacesWithAllNames(name) } returns true
+                every { hasInterfacesWithAllNames(listOf(name)) } returns true
             }
         val declaration2: KoInterfaceProvider =
             mockk {
-                every { hasInterfacesWithAllNames(name) } returns false
+                every { hasInterfacesWithAllNames(listOf(name)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
 
@@ -442,11 +442,11 @@ class KoInterfaceProviderListExtTest {
         val name2 = "SampleName2"
         val declaration1: KoInterfaceProvider =
             mockk {
-                every { hasInterfacesWithAllNames(name1, name2) } returns true
+                every { hasInterfacesWithAllNames(listOf(name1, name2)) } returns true
             }
         val declaration2: KoInterfaceProvider =
             mockk {
-                every { hasInterfacesWithAllNames(name1, name2) } returns false
+                every { hasInterfacesWithAllNames(listOf(name1, name2)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
 
@@ -464,11 +464,11 @@ class KoInterfaceProviderListExtTest {
         val name2 = "SampleName2"
         val declaration1: KoInterfaceProvider =
             mockk {
-                every { hasInterfacesWithAllNames(name1, name2) } returns true
+                every { hasInterfacesWithAllNames(listOf(name1, name2)) } returns true
             }
         val declaration2: KoInterfaceProvider =
             mockk {
-                every { hasInterfacesWithAllNames(name1, name2) } returns false
+                every { hasInterfacesWithAllNames(listOf(name1, name2)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
         val names = listOf(name1, name2)
@@ -487,11 +487,11 @@ class KoInterfaceProviderListExtTest {
         val name2 = "SampleName2"
         val declaration1: KoInterfaceProvider =
             mockk {
-                every { hasInterfacesWithAllNames(name1, name2) } returns true
+                every { hasInterfacesWithAllNames(setOf(name1, name2)) } returns true
             }
         val declaration2: KoInterfaceProvider =
             mockk {
-                every { hasInterfacesWithAllNames(name1, name2) } returns false
+                every { hasInterfacesWithAllNames(setOf(name1, name2)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
         val names = setOf(name1, name2)
@@ -509,11 +509,11 @@ class KoInterfaceProviderListExtTest {
         val name = "SampleName"
         val declaration1: KoInterfaceProvider =
             mockk {
-                every { hasInterfacesWithAllNames(name) } returns true
+                every { hasInterfacesWithAllNames(listOf(name)) } returns true
             }
         val declaration2: KoInterfaceProvider =
             mockk {
-                every { hasInterfacesWithAllNames(name) } returns false
+                every { hasInterfacesWithAllNames(listOf(name)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
 
@@ -531,11 +531,11 @@ class KoInterfaceProviderListExtTest {
         val name2 = "SampleName2"
         val declaration1: KoInterfaceProvider =
             mockk {
-                every { hasInterfacesWithAllNames(name1, name2) } returns true
+                every { hasInterfacesWithAllNames(listOf(name1, name2)) } returns true
             }
         val declaration2: KoInterfaceProvider =
             mockk {
-                every { hasInterfacesWithAllNames(name1, name2) } returns false
+                every { hasInterfacesWithAllNames(listOf(name1, name2)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
 
@@ -553,11 +553,11 @@ class KoInterfaceProviderListExtTest {
         val name2 = "SampleName2"
         val declaration1: KoInterfaceProvider =
             mockk {
-                every { hasInterfacesWithAllNames(name1, name2) } returns true
+                every { hasInterfacesWithAllNames(listOf(name1, name2)) } returns true
             }
         val declaration2: KoInterfaceProvider =
             mockk {
-                every { hasInterfacesWithAllNames(name1, name2) } returns false
+                every { hasInterfacesWithAllNames(listOf(name1, name2)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
         val names = listOf(name1, name2)
@@ -576,11 +576,11 @@ class KoInterfaceProviderListExtTest {
         val name2 = "SampleName2"
         val declaration1: KoInterfaceProvider =
             mockk {
-                every { hasInterfacesWithAllNames(name1, name2) } returns true
+                every { hasInterfacesWithAllNames(setOf(name1, name2)) } returns true
             }
         val declaration2: KoInterfaceProvider =
             mockk {
-                every { hasInterfacesWithAllNames(name1, name2) } returns false
+                every { hasInterfacesWithAllNames(setOf(name1, name2)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
         val names = setOf(name1, name2)

--- a/lib/src/test/kotlin/com/lemonappdev/konsist/api/ext/list/KoLocalClassProviderListExtTest.kt
+++ b/lib/src/test/kotlin/com/lemonappdev/konsist/api/ext/list/KoLocalClassProviderListExtTest.kt
@@ -241,11 +241,11 @@ class KoLocalClassProviderListExtTest {
         val name = "SampleName"
         val declaration1: KoLocalClassProvider =
             mockk {
-                every { hasLocalClassWithName(name) } returns true
+                every { hasLocalClassWithName(listOf(name)) } returns true
             }
         val declaration2: KoLocalClassProvider =
             mockk {
-                every { hasLocalClassWithName(name) } returns false
+                every { hasLocalClassWithName(listOf(name)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
 
@@ -263,11 +263,11 @@ class KoLocalClassProviderListExtTest {
         val name2 = "SampleName2"
         val declaration1: KoLocalClassProvider =
             mockk {
-                every { hasLocalClassWithName(name1, name2) } returns true
+                every { hasLocalClassWithName(listOf(name1, name2)) } returns true
             }
         val declaration2: KoLocalClassProvider =
             mockk {
-                every { hasLocalClassWithName(name1, name2) } returns false
+                every { hasLocalClassWithName(listOf(name1, name2)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
 
@@ -285,11 +285,11 @@ class KoLocalClassProviderListExtTest {
         val name2 = "SampleName2"
         val declaration1: KoLocalClassProvider =
             mockk {
-                every { hasLocalClassWithName(name1, name2) } returns true
+                every { hasLocalClassWithName(listOf(name1, name2)) } returns true
             }
         val declaration2: KoLocalClassProvider =
             mockk {
-                every { hasLocalClassWithName(name1, name2) } returns false
+                every { hasLocalClassWithName(listOf(name1, name2)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
         val names = listOf(name1, name2)
@@ -308,11 +308,11 @@ class KoLocalClassProviderListExtTest {
         val name2 = "SampleName2"
         val declaration1: KoLocalClassProvider =
             mockk {
-                every { hasLocalClassWithName(name1, name2) } returns true
+                every { hasLocalClassWithName(setOf(name1, name2)) } returns true
             }
         val declaration2: KoLocalClassProvider =
             mockk {
-                every { hasLocalClassWithName(name1, name2) } returns false
+                every { hasLocalClassWithName(setOf(name1, name2)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
         val names = setOf(name1, name2)
@@ -330,11 +330,11 @@ class KoLocalClassProviderListExtTest {
         val name = "SampleName"
         val declaration1: KoLocalClassProvider =
             mockk {
-                every { hasLocalClassWithName(name) } returns true
+                every { hasLocalClassWithName(listOf(name)) } returns true
             }
         val declaration2: KoLocalClassProvider =
             mockk {
-                every { hasLocalClassWithName(name) } returns false
+                every { hasLocalClassWithName(listOf(name)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
 
@@ -352,11 +352,11 @@ class KoLocalClassProviderListExtTest {
         val name2 = "SampleName2"
         val declaration1: KoLocalClassProvider =
             mockk {
-                every { hasLocalClassWithName(name1, name2) } returns true
+                every { hasLocalClassWithName(listOf(name1, name2)) } returns true
             }
         val declaration2: KoLocalClassProvider =
             mockk {
-                every { hasLocalClassWithName(name1, name2) } returns false
+                every { hasLocalClassWithName(listOf(name1, name2)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
 
@@ -374,11 +374,11 @@ class KoLocalClassProviderListExtTest {
         val name2 = "SampleName2"
         val declaration1: KoLocalClassProvider =
             mockk {
-                every { hasLocalClassWithName(name1, name2) } returns true
+                every { hasLocalClassWithName(listOf(name1, name2)) } returns true
             }
         val declaration2: KoLocalClassProvider =
             mockk {
-                every { hasLocalClassWithName(name1, name2) } returns false
+                every { hasLocalClassWithName(listOf(name1, name2)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
         val names = listOf(name1, name2)
@@ -397,11 +397,11 @@ class KoLocalClassProviderListExtTest {
         val name2 = "SampleName2"
         val declaration1: KoLocalClassProvider =
             mockk {
-                every { hasLocalClassWithName(name1, name2) } returns true
+                every { hasLocalClassWithName(setOf(name1, name2)) } returns true
             }
         val declaration2: KoLocalClassProvider =
             mockk {
-                every { hasLocalClassWithName(name1, name2) } returns false
+                every { hasLocalClassWithName(setOf(name1, name2)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
         val names = setOf(name1, name2)
@@ -419,11 +419,11 @@ class KoLocalClassProviderListExtTest {
         val name = "SampleName"
         val declaration1: KoLocalClassProvider =
             mockk {
-                every { hasLocalClassesWithAllNames(name) } returns true
+                every { hasLocalClassesWithAllNames(listOf(name)) } returns true
             }
         val declaration2: KoLocalClassProvider =
             mockk {
-                every { hasLocalClassesWithAllNames(name) } returns false
+                every { hasLocalClassesWithAllNames(listOf(name)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
 
@@ -441,11 +441,11 @@ class KoLocalClassProviderListExtTest {
         val name2 = "SampleName2"
         val declaration1: KoLocalClassProvider =
             mockk {
-                every { hasLocalClassesWithAllNames(name1, name2) } returns true
+                every { hasLocalClassesWithAllNames(listOf(name1, name2)) } returns true
             }
         val declaration2: KoLocalClassProvider =
             mockk {
-                every { hasLocalClassesWithAllNames(name1, name2) } returns false
+                every { hasLocalClassesWithAllNames(listOf(name1, name2)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
 
@@ -463,11 +463,11 @@ class KoLocalClassProviderListExtTest {
         val name2 = "SampleName2"
         val declaration1: KoLocalClassProvider =
             mockk {
-                every { hasLocalClassesWithAllNames(name1, name2) } returns true
+                every { hasLocalClassesWithAllNames(listOf(name1, name2)) } returns true
             }
         val declaration2: KoLocalClassProvider =
             mockk {
-                every { hasLocalClassesWithAllNames(name1, name2) } returns false
+                every { hasLocalClassesWithAllNames(listOf(name1, name2)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
         val names = listOf(name1, name2)
@@ -486,11 +486,11 @@ class KoLocalClassProviderListExtTest {
         val name2 = "SampleName2"
         val declaration1: KoLocalClassProvider =
             mockk {
-                every { hasLocalClassesWithAllNames(name1, name2) } returns true
+                every { hasLocalClassesWithAllNames(setOf(name1, name2)) } returns true
             }
         val declaration2: KoLocalClassProvider =
             mockk {
-                every { hasLocalClassesWithAllNames(name1, name2) } returns false
+                every { hasLocalClassesWithAllNames(setOf(name1, name2)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
         val names = setOf(name1, name2)
@@ -508,11 +508,11 @@ class KoLocalClassProviderListExtTest {
         val name = "SampleName"
         val declaration1: KoLocalClassProvider =
             mockk {
-                every { hasLocalClassesWithAllNames(name) } returns true
+                every { hasLocalClassesWithAllNames(listOf(name)) } returns true
             }
         val declaration2: KoLocalClassProvider =
             mockk {
-                every { hasLocalClassesWithAllNames(name) } returns false
+                every { hasLocalClassesWithAllNames(listOf(name)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
 
@@ -530,11 +530,11 @@ class KoLocalClassProviderListExtTest {
         val name2 = "SampleName2"
         val declaration1: KoLocalClassProvider =
             mockk {
-                every { hasLocalClassesWithAllNames(name1, name2) } returns true
+                every { hasLocalClassesWithAllNames(listOf(name1, name2)) } returns true
             }
         val declaration2: KoLocalClassProvider =
             mockk {
-                every { hasLocalClassesWithAllNames(name1, name2) } returns false
+                every { hasLocalClassesWithAllNames(listOf(name1, name2)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
 
@@ -552,11 +552,11 @@ class KoLocalClassProviderListExtTest {
         val name2 = "SampleName2"
         val declaration1: KoLocalClassProvider =
             mockk {
-                every { hasLocalClassesWithAllNames(name1, name2) } returns true
+                every { hasLocalClassesWithAllNames(listOf(name1, name2)) } returns true
             }
         val declaration2: KoLocalClassProvider =
             mockk {
-                every { hasLocalClassesWithAllNames(name1, name2) } returns false
+                every { hasLocalClassesWithAllNames(listOf(name1, name2)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
         val names = listOf(name1, name2)
@@ -575,11 +575,11 @@ class KoLocalClassProviderListExtTest {
         val name2 = "SampleName2"
         val declaration1: KoLocalClassProvider =
             mockk {
-                every { hasLocalClassesWithAllNames(name1, name2) } returns true
+                every { hasLocalClassesWithAllNames(setOf(name1, name2)) } returns true
             }
         val declaration2: KoLocalClassProvider =
             mockk {
-                every { hasLocalClassesWithAllNames(name1, name2) } returns false
+                every { hasLocalClassesWithAllNames(setOf(name1, name2)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
         val names = setOf(name1, name2)

--- a/lib/src/test/kotlin/com/lemonappdev/konsist/api/ext/list/KoLocalFunctionProviderListExtTest.kt
+++ b/lib/src/test/kotlin/com/lemonappdev/konsist/api/ext/list/KoLocalFunctionProviderListExtTest.kt
@@ -241,11 +241,11 @@ class KoLocalFunctionProviderListExtTest {
         val name = "SampleName"
         val declaration1: KoLocalFunctionProvider =
             mockk {
-                every { hasLocalFunctionWithName(name) } returns true
+                every { hasLocalFunctionWithName(listOf(name)) } returns true
             }
         val declaration2: KoLocalFunctionProvider =
             mockk {
-                every { hasLocalFunctionWithName(name) } returns false
+                every { hasLocalFunctionWithName(listOf(name)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
 
@@ -263,11 +263,11 @@ class KoLocalFunctionProviderListExtTest {
         val name2 = "SampleName2"
         val declaration1: KoLocalFunctionProvider =
             mockk {
-                every { hasLocalFunctionWithName(name1, name2) } returns true
+                every { hasLocalFunctionWithName(listOf(name1, name2)) } returns true
             }
         val declaration2: KoLocalFunctionProvider =
             mockk {
-                every { hasLocalFunctionWithName(name1, name2) } returns false
+                every { hasLocalFunctionWithName(listOf(name1, name2)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
 
@@ -285,11 +285,11 @@ class KoLocalFunctionProviderListExtTest {
         val name2 = "SampleName2"
         val declaration1: KoLocalFunctionProvider =
             mockk {
-                every { hasLocalFunctionWithName(name1, name2) } returns true
+                every { hasLocalFunctionWithName(listOf(name1, name2)) } returns true
             }
         val declaration2: KoLocalFunctionProvider =
             mockk {
-                every { hasLocalFunctionWithName(name1, name2) } returns false
+                every { hasLocalFunctionWithName(listOf(name1, name2)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
         val names = listOf(name1, name2)
@@ -308,11 +308,11 @@ class KoLocalFunctionProviderListExtTest {
         val name2 = "SampleName2"
         val declaration1: KoLocalFunctionProvider =
             mockk {
-                every { hasLocalFunctionWithName(name1, name2) } returns true
+                every { hasLocalFunctionWithName(setOf(name1, name2)) } returns true
             }
         val declaration2: KoLocalFunctionProvider =
             mockk {
-                every { hasLocalFunctionWithName(name1, name2) } returns false
+                every { hasLocalFunctionWithName(setOf(name1, name2)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
         val names = setOf(name1, name2)
@@ -330,11 +330,11 @@ class KoLocalFunctionProviderListExtTest {
         val name = "SampleName"
         val declaration1: KoLocalFunctionProvider =
             mockk {
-                every { hasLocalFunctionWithName(name) } returns true
+                every { hasLocalFunctionWithName(listOf(name)) } returns true
             }
         val declaration2: KoLocalFunctionProvider =
             mockk {
-                every { hasLocalFunctionWithName(name) } returns false
+                every { hasLocalFunctionWithName(listOf(name)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
 
@@ -352,11 +352,11 @@ class KoLocalFunctionProviderListExtTest {
         val name2 = "SampleName2"
         val declaration1: KoLocalFunctionProvider =
             mockk {
-                every { hasLocalFunctionWithName(name1, name2) } returns true
+                every { hasLocalFunctionWithName(listOf(name1, name2)) } returns true
             }
         val declaration2: KoLocalFunctionProvider =
             mockk {
-                every { hasLocalFunctionWithName(name1, name2) } returns false
+                every { hasLocalFunctionWithName(listOf(name1, name2)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
 
@@ -374,11 +374,11 @@ class KoLocalFunctionProviderListExtTest {
         val name2 = "SampleName2"
         val declaration1: KoLocalFunctionProvider =
             mockk {
-                every { hasLocalFunctionWithName(name1, name2) } returns true
+                every { hasLocalFunctionWithName(listOf(name1, name2)) } returns true
             }
         val declaration2: KoLocalFunctionProvider =
             mockk {
-                every { hasLocalFunctionWithName(name1, name2) } returns false
+                every { hasLocalFunctionWithName(listOf(name1, name2)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
         val names = listOf(name1, name2)
@@ -397,11 +397,11 @@ class KoLocalFunctionProviderListExtTest {
         val name2 = "SampleName2"
         val declaration1: KoLocalFunctionProvider =
             mockk {
-                every { hasLocalFunctionWithName(name1, name2) } returns true
+                every { hasLocalFunctionWithName(setOf(name1, name2)) } returns true
             }
         val declaration2: KoLocalFunctionProvider =
             mockk {
-                every { hasLocalFunctionWithName(name1, name2) } returns false
+                every { hasLocalFunctionWithName(setOf(name1, name2)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
         val names = setOf(name1, name2)
@@ -419,11 +419,11 @@ class KoLocalFunctionProviderListExtTest {
         val name = "SampleName"
         val declaration1: KoLocalFunctionProvider =
             mockk {
-                every { hasLocalFunctionsWithAllNames(name) } returns true
+                every { hasLocalFunctionsWithAllNames(listOf(name)) } returns true
             }
         val declaration2: KoLocalFunctionProvider =
             mockk {
-                every { hasLocalFunctionsWithAllNames(name) } returns false
+                every { hasLocalFunctionsWithAllNames(listOf(name)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
 
@@ -441,11 +441,11 @@ class KoLocalFunctionProviderListExtTest {
         val name2 = "SampleName2"
         val declaration1: KoLocalFunctionProvider =
             mockk {
-                every { hasLocalFunctionsWithAllNames(name1, name2) } returns true
+                every { hasLocalFunctionsWithAllNames(listOf(name1, name2)) } returns true
             }
         val declaration2: KoLocalFunctionProvider =
             mockk {
-                every { hasLocalFunctionsWithAllNames(name1, name2) } returns false
+                every { hasLocalFunctionsWithAllNames(listOf(name1, name2)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
 
@@ -463,11 +463,11 @@ class KoLocalFunctionProviderListExtTest {
         val name2 = "SampleName2"
         val declaration1: KoLocalFunctionProvider =
             mockk {
-                every { hasLocalFunctionsWithAllNames(name1, name2) } returns true
+                every { hasLocalFunctionsWithAllNames(listOf(name1, name2)) } returns true
             }
         val declaration2: KoLocalFunctionProvider =
             mockk {
-                every { hasLocalFunctionsWithAllNames(name1, name2) } returns false
+                every { hasLocalFunctionsWithAllNames(listOf(name1, name2)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
         val names = listOf(name1, name2)
@@ -486,11 +486,11 @@ class KoLocalFunctionProviderListExtTest {
         val name2 = "SampleName2"
         val declaration1: KoLocalFunctionProvider =
             mockk {
-                every { hasLocalFunctionsWithAllNames(name1, name2) } returns true
+                every { hasLocalFunctionsWithAllNames(setOf(name1, name2)) } returns true
             }
         val declaration2: KoLocalFunctionProvider =
             mockk {
-                every { hasLocalFunctionsWithAllNames(name1, name2) } returns false
+                every { hasLocalFunctionsWithAllNames(setOf(name1, name2)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
         val names = setOf(name1, name2)
@@ -508,11 +508,11 @@ class KoLocalFunctionProviderListExtTest {
         val name = "SampleName"
         val declaration1: KoLocalFunctionProvider =
             mockk {
-                every { hasLocalFunctionsWithAllNames(name) } returns true
+                every { hasLocalFunctionsWithAllNames(listOf(name)) } returns true
             }
         val declaration2: KoLocalFunctionProvider =
             mockk {
-                every { hasLocalFunctionsWithAllNames(name) } returns false
+                every { hasLocalFunctionsWithAllNames(listOf(name)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
 
@@ -530,11 +530,11 @@ class KoLocalFunctionProviderListExtTest {
         val name2 = "SampleName2"
         val declaration1: KoLocalFunctionProvider =
             mockk {
-                every { hasLocalFunctionsWithAllNames(name1, name2) } returns true
+                every { hasLocalFunctionsWithAllNames(listOf(name1, name2)) } returns true
             }
         val declaration2: KoLocalFunctionProvider =
             mockk {
-                every { hasLocalFunctionsWithAllNames(name1, name2) } returns false
+                every { hasLocalFunctionsWithAllNames(listOf(name1, name2)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
 
@@ -552,11 +552,11 @@ class KoLocalFunctionProviderListExtTest {
         val name2 = "SampleName2"
         val declaration1: KoLocalFunctionProvider =
             mockk {
-                every { hasLocalFunctionsWithAllNames(name1, name2) } returns true
+                every { hasLocalFunctionsWithAllNames(listOf(name1, name2)) } returns true
             }
         val declaration2: KoLocalFunctionProvider =
             mockk {
-                every { hasLocalFunctionsWithAllNames(name1, name2) } returns false
+                every { hasLocalFunctionsWithAllNames(listOf(name1, name2)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
         val names = listOf(name1, name2)
@@ -575,11 +575,11 @@ class KoLocalFunctionProviderListExtTest {
         val name2 = "SampleName2"
         val declaration1: KoLocalFunctionProvider =
             mockk {
-                every { hasLocalFunctionsWithAllNames(name1, name2) } returns true
+                every { hasLocalFunctionsWithAllNames(setOf(name1, name2)) } returns true
             }
         val declaration2: KoLocalFunctionProvider =
             mockk {
-                every { hasLocalFunctionsWithAllNames(name1, name2) } returns false
+                every { hasLocalFunctionsWithAllNames(setOf(name1, name2)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
         val names = setOf(name1, name2)

--- a/lib/src/test/kotlin/com/lemonappdev/konsist/api/ext/list/KoObjectProviderListExtTest.kt
+++ b/lib/src/test/kotlin/com/lemonappdev/konsist/api/ext/list/KoObjectProviderListExtTest.kt
@@ -242,11 +242,11 @@ class KoObjectProviderListExtTest {
         val name = "SampleName"
         val declaration1: KoObjectProvider =
             mockk {
-                every { hasObjectWithName(name) } returns true
+                every { hasObjectWithName(listOf(name)) } returns true
             }
         val declaration2: KoObjectProvider =
             mockk {
-                every { hasObjectWithName(name) } returns false
+                every { hasObjectWithName(listOf(name)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
 
@@ -264,11 +264,11 @@ class KoObjectProviderListExtTest {
         val name2 = "SampleName2"
         val declaration1: KoObjectProvider =
             mockk {
-                every { hasObjectWithName(name1, name2) } returns true
+                every { hasObjectWithName(listOf(name1, name2)) } returns true
             }
         val declaration2: KoObjectProvider =
             mockk {
-                every { hasObjectWithName(name1, name2) } returns false
+                every { hasObjectWithName(listOf(name1, name2)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
 
@@ -286,11 +286,11 @@ class KoObjectProviderListExtTest {
         val name2 = "SampleName2"
         val declaration1: KoObjectProvider =
             mockk {
-                every { hasObjectWithName(name1, name2) } returns true
+                every { hasObjectWithName(listOf(name1, name2)) } returns true
             }
         val declaration2: KoObjectProvider =
             mockk {
-                every { hasObjectWithName(name1, name2) } returns false
+                every { hasObjectWithName(listOf(name1, name2)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
         val names = listOf(name1, name2)
@@ -309,11 +309,11 @@ class KoObjectProviderListExtTest {
         val name2 = "SampleName2"
         val declaration1: KoObjectProvider =
             mockk {
-                every { hasObjectWithName(name1, name2) } returns true
+                every { hasObjectWithName(setOf(name1, name2)) } returns true
             }
         val declaration2: KoObjectProvider =
             mockk {
-                every { hasObjectWithName(name1, name2) } returns false
+                every { hasObjectWithName(setOf(name1, name2)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
         val names = setOf(name1, name2)
@@ -331,11 +331,11 @@ class KoObjectProviderListExtTest {
         val name = "SampleName"
         val declaration1: KoObjectProvider =
             mockk {
-                every { hasObjectWithName(name) } returns true
+                every { hasObjectWithName(listOf(name)) } returns true
             }
         val declaration2: KoObjectProvider =
             mockk {
-                every { hasObjectWithName(name) } returns false
+                every { hasObjectWithName(listOf(name)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
 
@@ -353,11 +353,11 @@ class KoObjectProviderListExtTest {
         val name2 = "SampleName2"
         val declaration1: KoObjectProvider =
             mockk {
-                every { hasObjectWithName(name1, name2) } returns true
+                every { hasObjectWithName(listOf(name1, name2)) } returns true
             }
         val declaration2: KoObjectProvider =
             mockk {
-                every { hasObjectWithName(name1, name2) } returns false
+                every { hasObjectWithName(listOf(name1, name2)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
 
@@ -375,11 +375,11 @@ class KoObjectProviderListExtTest {
         val name2 = "SampleName2"
         val declaration1: KoObjectProvider =
             mockk {
-                every { hasObjectWithName(name1, name2) } returns true
+                every { hasObjectWithName(listOf(name1, name2)) } returns true
             }
         val declaration2: KoObjectProvider =
             mockk {
-                every { hasObjectWithName(name1, name2) } returns false
+                every { hasObjectWithName(listOf(name1, name2)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
         val names = listOf(name1, name2)
@@ -398,11 +398,11 @@ class KoObjectProviderListExtTest {
         val name2 = "SampleName2"
         val declaration1: KoObjectProvider =
             mockk {
-                every { hasObjectWithName(name1, name2) } returns true
+                every { hasObjectWithName(setOf(name1, name2)) } returns true
             }
         val declaration2: KoObjectProvider =
             mockk {
-                every { hasObjectWithName(name1, name2) } returns false
+                every { hasObjectWithName(setOf(name1, name2)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
         val names = setOf(name1, name2)
@@ -420,11 +420,11 @@ class KoObjectProviderListExtTest {
         val name = "SampleName"
         val declaration1: KoObjectProvider =
             mockk {
-                every { hasObjectsWithAllNames(name) } returns true
+                every { hasObjectsWithAllNames(listOf(name)) } returns true
             }
         val declaration2: KoObjectProvider =
             mockk {
-                every { hasObjectsWithAllNames(name) } returns false
+                every { hasObjectsWithAllNames(listOf(name)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
 
@@ -442,11 +442,11 @@ class KoObjectProviderListExtTest {
         val name2 = "SampleName2"
         val declaration1: KoObjectProvider =
             mockk {
-                every { hasObjectsWithAllNames(name1, name2) } returns true
+                every { hasObjectsWithAllNames(listOf(name1, name2)) } returns true
             }
         val declaration2: KoObjectProvider =
             mockk {
-                every { hasObjectsWithAllNames(name1, name2) } returns false
+                every { hasObjectsWithAllNames(listOf(name1, name2)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
 
@@ -464,11 +464,11 @@ class KoObjectProviderListExtTest {
         val name2 = "SampleName2"
         val declaration1: KoObjectProvider =
             mockk {
-                every { hasObjectsWithAllNames(name1, name2) } returns true
+                every { hasObjectsWithAllNames(listOf(name1, name2)) } returns true
             }
         val declaration2: KoObjectProvider =
             mockk {
-                every { hasObjectsWithAllNames(name1, name2) } returns false
+                every { hasObjectsWithAllNames(listOf(name1, name2)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
         val names = listOf(name1, name2)
@@ -487,11 +487,11 @@ class KoObjectProviderListExtTest {
         val name2 = "SampleName2"
         val declaration1: KoObjectProvider =
             mockk {
-                every { hasObjectsWithAllNames(name1, name2) } returns true
+                every { hasObjectsWithAllNames(setOf(name1, name2)) } returns true
             }
         val declaration2: KoObjectProvider =
             mockk {
-                every { hasObjectsWithAllNames(name1, name2) } returns false
+                every { hasObjectsWithAllNames(setOf(name1, name2)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
         val names = setOf(name1, name2)
@@ -509,11 +509,11 @@ class KoObjectProviderListExtTest {
         val name = "SampleName"
         val declaration1: KoObjectProvider =
             mockk {
-                every { hasObjectsWithAllNames(name) } returns true
+                every { hasObjectsWithAllNames(listOf(name)) } returns true
             }
         val declaration2: KoObjectProvider =
             mockk {
-                every { hasObjectsWithAllNames(name) } returns false
+                every { hasObjectsWithAllNames(listOf(name)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
 
@@ -531,11 +531,11 @@ class KoObjectProviderListExtTest {
         val name2 = "SampleName2"
         val declaration1: KoObjectProvider =
             mockk {
-                every { hasObjectsWithAllNames(name1, name2) } returns true
+                every { hasObjectsWithAllNames(listOf(name1, name2)) } returns true
             }
         val declaration2: KoObjectProvider =
             mockk {
-                every { hasObjectsWithAllNames(name1, name2) } returns false
+                every { hasObjectsWithAllNames(listOf(name1, name2)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
 
@@ -553,11 +553,11 @@ class KoObjectProviderListExtTest {
         val name2 = "SampleName2"
         val declaration1: KoObjectProvider =
             mockk {
-                every { hasObjectsWithAllNames(name1, name2) } returns true
+                every { hasObjectsWithAllNames(listOf(name1, name2)) } returns true
             }
         val declaration2: KoObjectProvider =
             mockk {
-                every { hasObjectsWithAllNames(name1, name2) } returns false
+                every { hasObjectsWithAllNames(listOf(name1, name2)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
         val names = listOf(name1, name2)
@@ -576,11 +576,11 @@ class KoObjectProviderListExtTest {
         val name2 = "SampleName2"
         val declaration1: KoObjectProvider =
             mockk {
-                every { hasObjectsWithAllNames(name1, name2) } returns true
+                every { hasObjectsWithAllNames(setOf(name1, name2)) } returns true
             }
         val declaration2: KoObjectProvider =
             mockk {
-                every { hasObjectsWithAllNames(name1, name2) } returns false
+                every { hasObjectsWithAllNames(setOf(name1, name2)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
         val names = setOf(name1, name2)

--- a/lib/src/test/kotlin/com/lemonappdev/konsist/api/ext/list/KoParametersProviderListExtTest.kt
+++ b/lib/src/test/kotlin/com/lemonappdev/konsist/api/ext/list/KoParametersProviderListExtTest.kt
@@ -161,11 +161,11 @@ class KoParametersProviderListExtTest {
         val name = "SampleName"
         val declaration1: KoParametersProvider =
             mockk {
-                every { hasParameterWithName(name) } returns true
+                every { hasParameterWithName(listOf(name)) } returns true
             }
         val declaration2: KoParametersProvider =
             mockk {
-                every { hasParameterWithName(name) } returns false
+                every { hasParameterWithName(listOf(name)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
 
@@ -183,11 +183,11 @@ class KoParametersProviderListExtTest {
         val name2 = "SampleName2"
         val declaration1: KoParametersProvider =
             mockk {
-                every { hasParameterWithName(name1, name2) } returns true
+                every { hasParameterWithName(listOf(name1, name2)) } returns true
             }
         val declaration2: KoParametersProvider =
             mockk {
-                every { hasParameterWithName(name1, name2) } returns false
+                every { hasParameterWithName(listOf(name1, name2)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
 
@@ -205,11 +205,11 @@ class KoParametersProviderListExtTest {
         val name2 = "SampleName2"
         val declaration1: KoParametersProvider =
             mockk {
-                every { hasParameterWithName(name1, name2) } returns true
+                every { hasParameterWithName(listOf(name1, name2)) } returns true
             }
         val declaration2: KoParametersProvider =
             mockk {
-                every { hasParameterWithName(name1, name2) } returns false
+                every { hasParameterWithName(listOf(name1, name2)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
         val names = listOf(name1, name2)
@@ -228,11 +228,11 @@ class KoParametersProviderListExtTest {
         val name2 = "SampleName2"
         val declaration1: KoParametersProvider =
             mockk {
-                every { hasParameterWithName(name1, name2) } returns true
+                every { hasParameterWithName(setOf(name1, name2)) } returns true
             }
         val declaration2: KoParametersProvider =
             mockk {
-                every { hasParameterWithName(name1, name2) } returns false
+                every { hasParameterWithName(setOf(name1, name2)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
         val names = setOf(name1, name2)
@@ -250,11 +250,11 @@ class KoParametersProviderListExtTest {
         val name = "SampleName"
         val declaration1: KoParametersProvider =
             mockk {
-                every { hasParameterWithName(name) } returns true
+                every { hasParameterWithName(listOf(name)) } returns true
             }
         val declaration2: KoParametersProvider =
             mockk {
-                every { hasParameterWithName(name) } returns false
+                every { hasParameterWithName(listOf(name)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
 
@@ -272,11 +272,11 @@ class KoParametersProviderListExtTest {
         val name2 = "SampleName2"
         val declaration1: KoParametersProvider =
             mockk {
-                every { hasParameterWithName(name1, name2) } returns true
+                every { hasParameterWithName(listOf(name1, name2)) } returns true
             }
         val declaration2: KoParametersProvider =
             mockk {
-                every { hasParameterWithName(name1, name2) } returns false
+                every { hasParameterWithName(listOf(name1, name2)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
 
@@ -294,11 +294,11 @@ class KoParametersProviderListExtTest {
         val name2 = "SampleName2"
         val declaration1: KoParametersProvider =
             mockk {
-                every { hasParameterWithName(name1, name2) } returns true
+                every { hasParameterWithName(listOf(name1, name2)) } returns true
             }
         val declaration2: KoParametersProvider =
             mockk {
-                every { hasParameterWithName(name1, name2) } returns false
+                every { hasParameterWithName(listOf(name1, name2)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
         val names = listOf(name1, name2)
@@ -317,11 +317,11 @@ class KoParametersProviderListExtTest {
         val name2 = "SampleName2"
         val declaration1: KoParametersProvider =
             mockk {
-                every { hasParameterWithName(name1, name2) } returns true
+                every { hasParameterWithName(setOf(name1, name2)) } returns true
             }
         val declaration2: KoParametersProvider =
             mockk {
-                every { hasParameterWithName(name1, name2) } returns false
+                every { hasParameterWithName(setOf(name1, name2)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
         val names = setOf(name1, name2)
@@ -339,11 +339,11 @@ class KoParametersProviderListExtTest {
         val name = "SampleName"
         val declaration1: KoParametersProvider =
             mockk {
-                every { hasParametersWithAllNames(name) } returns true
+                every { hasParametersWithAllNames(listOf(name)) } returns true
             }
         val declaration2: KoParametersProvider =
             mockk {
-                every { hasParametersWithAllNames(name) } returns false
+                every { hasParametersWithAllNames(listOf(name)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
 
@@ -361,11 +361,11 @@ class KoParametersProviderListExtTest {
         val name2 = "SampleName2"
         val declaration1: KoParametersProvider =
             mockk {
-                every { hasParametersWithAllNames(name1, name2) } returns true
+                every { hasParametersWithAllNames(listOf(name1, name2)) } returns true
             }
         val declaration2: KoParametersProvider =
             mockk {
-                every { hasParametersWithAllNames(name1, name2) } returns false
+                every { hasParametersWithAllNames(listOf(name1, name2)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
 
@@ -383,11 +383,11 @@ class KoParametersProviderListExtTest {
         val name2 = "SampleName2"
         val declaration1: KoParametersProvider =
             mockk {
-                every { hasParametersWithAllNames(name1, name2) } returns true
+                every { hasParametersWithAllNames(listOf(name1, name2)) } returns true
             }
         val declaration2: KoParametersProvider =
             mockk {
-                every { hasParametersWithAllNames(name1, name2) } returns false
+                every { hasParametersWithAllNames(listOf(name1, name2)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
         val names = listOf(name1, name2)
@@ -406,11 +406,11 @@ class KoParametersProviderListExtTest {
         val name2 = "SampleName2"
         val declaration1: KoParametersProvider =
             mockk {
-                every { hasParametersWithAllNames(name1, name2) } returns true
+                every { hasParametersWithAllNames(setOf(name1, name2)) } returns true
             }
         val declaration2: KoParametersProvider =
             mockk {
-                every { hasParametersWithAllNames(name1, name2) } returns false
+                every { hasParametersWithAllNames(setOf(name1, name2)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
         val names = setOf(name1, name2)
@@ -428,11 +428,11 @@ class KoParametersProviderListExtTest {
         val name = "SampleName"
         val declaration1: KoParametersProvider =
             mockk {
-                every { hasParametersWithAllNames(name) } returns true
+                every { hasParametersWithAllNames(listOf(name)) } returns true
             }
         val declaration2: KoParametersProvider =
             mockk {
-                every { hasParametersWithAllNames(name) } returns false
+                every { hasParametersWithAllNames(listOf(name)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
 
@@ -450,11 +450,11 @@ class KoParametersProviderListExtTest {
         val name2 = "SampleName2"
         val declaration1: KoParametersProvider =
             mockk {
-                every { hasParametersWithAllNames(name1, name2) } returns true
+                every { hasParametersWithAllNames(listOf(name1, name2)) } returns true
             }
         val declaration2: KoParametersProvider =
             mockk {
-                every { hasParametersWithAllNames(name1, name2) } returns false
+                every { hasParametersWithAllNames(listOf(name1, name2)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
 
@@ -472,11 +472,11 @@ class KoParametersProviderListExtTest {
         val name2 = "SampleName2"
         val declaration1: KoParametersProvider =
             mockk {
-                every { hasParametersWithAllNames(name1, name2) } returns true
+                every { hasParametersWithAllNames(listOf(name1, name2)) } returns true
             }
         val declaration2: KoParametersProvider =
             mockk {
-                every { hasParametersWithAllNames(name1, name2) } returns false
+                every { hasParametersWithAllNames(listOf(name1, name2)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
         val names = listOf(name1, name2)
@@ -495,11 +495,11 @@ class KoParametersProviderListExtTest {
         val name2 = "SampleName2"
         val declaration1: KoParametersProvider =
             mockk {
-                every { hasParametersWithAllNames(name1, name2) } returns true
+                every { hasParametersWithAllNames(setOf(name1, name2)) } returns true
             }
         val declaration2: KoParametersProvider =
             mockk {
-                every { hasParametersWithAllNames(name1, name2) } returns false
+                every { hasParametersWithAllNames(setOf(name1, name2)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
         val names = setOf(name1, name2)

--- a/lib/src/test/kotlin/com/lemonappdev/konsist/api/ext/list/KoParentClassProviderListExtTest.kt
+++ b/lib/src/test/kotlin/com/lemonappdev/konsist/api/ext/list/KoParentClassProviderListExtTest.kt
@@ -470,11 +470,11 @@ class KoParentClassProviderListExtTest {
         val name = "SampleName"
         val declaration1: KoParentClassProvider =
             mockk {
-                every { hasParentClassWithName(name) } returns true
+                every { hasParentClassWithName(listOf(name)) } returns true
             }
         val declaration2: KoParentClassProvider =
             mockk {
-                every { hasParentClassWithName(name) } returns false
+                every { hasParentClassWithName(listOf(name)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
 
@@ -492,11 +492,11 @@ class KoParentClassProviderListExtTest {
         val name2 = "SampleName2"
         val declaration1: KoParentClassProvider =
             mockk {
-                every { hasParentClassWithName(name1, name2) } returns true
+                every { hasParentClassWithName(listOf(name1, name2)) } returns true
             }
         val declaration2: KoParentClassProvider =
             mockk {
-                every { hasParentClassWithName(name1, name2) } returns false
+                every { hasParentClassWithName(listOf(name1, name2)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
 
@@ -514,11 +514,11 @@ class KoParentClassProviderListExtTest {
         val name2 = "SampleName2"
         val declaration1: KoParentClassProvider =
             mockk {
-                every { hasParentClassWithName(name1, name2) } returns true
+                every { hasParentClassWithName(listOf(name1, name2)) } returns true
             }
         val declaration2: KoParentClassProvider =
             mockk {
-                every { hasParentClassWithName(name1, name2) } returns false
+                every { hasParentClassWithName(listOf(name1, name2)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
         val names = listOf(name1, name2)
@@ -537,11 +537,11 @@ class KoParentClassProviderListExtTest {
         val name2 = "SampleName2"
         val declaration1: KoParentClassProvider =
             mockk {
-                every { hasParentClassWithName(name1, name2) } returns true
+                every { hasParentClassWithName(setOf(name1, name2)) } returns true
             }
         val declaration2: KoParentClassProvider =
             mockk {
-                every { hasParentClassWithName(name1, name2) } returns false
+                every { hasParentClassWithName(setOf(name1, name2)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
         val names = setOf(name1, name2)
@@ -559,11 +559,11 @@ class KoParentClassProviderListExtTest {
         val name = "SampleName"
         val declaration1: KoParentClassProvider =
             mockk {
-                every { hasParentClassWithName(name) } returns true
+                every { hasParentClassWithName(listOf(name)) } returns true
             }
         val declaration2: KoParentClassProvider =
             mockk {
-                every { hasParentClassWithName(name) } returns false
+                every { hasParentClassWithName(listOf(name)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
 
@@ -581,11 +581,11 @@ class KoParentClassProviderListExtTest {
         val name2 = "SampleName2"
         val declaration1: KoParentClassProvider =
             mockk {
-                every { hasParentClassWithName(name1, name2) } returns true
+                every { hasParentClassWithName(listOf(name1, name2)) } returns true
             }
         val declaration2: KoParentClassProvider =
             mockk {
-                every { hasParentClassWithName(name1, name2) } returns false
+                every { hasParentClassWithName(listOf(name1, name2)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
 
@@ -603,11 +603,11 @@ class KoParentClassProviderListExtTest {
         val name2 = "SampleName2"
         val declaration1: KoParentClassProvider =
             mockk {
-                every { hasParentClassWithName(name1, name2) } returns true
+                every { hasParentClassWithName(listOf(name1, name2)) } returns true
             }
         val declaration2: KoParentClassProvider =
             mockk {
-                every { hasParentClassWithName(name1, name2) } returns false
+                every { hasParentClassWithName(listOf(name1, name2)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
         val names = listOf(name1, name2)
@@ -626,11 +626,11 @@ class KoParentClassProviderListExtTest {
         val name2 = "SampleName2"
         val declaration1: KoParentClassProvider =
             mockk {
-                every { hasParentClassWithName(name1, name2) } returns true
+                every { hasParentClassWithName(setOf(name1, name2)) } returns true
             }
         val declaration2: KoParentClassProvider =
             mockk {
-                every { hasParentClassWithName(name1, name2) } returns false
+                every { hasParentClassWithName(setOf(name1, name2)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
         val names = setOf(name1, name2)
@@ -648,11 +648,11 @@ class KoParentClassProviderListExtTest {
         val name = "SampleName"
         val declaration1: KoParentClassProvider =
             mockk {
-                every { hasParentClassesWithAllNames(name) } returns true
+                every { hasParentClassesWithAllNames(listOf(name)) } returns true
             }
         val declaration2: KoParentClassProvider =
             mockk {
-                every { hasParentClassesWithAllNames(name) } returns false
+                every { hasParentClassesWithAllNames(listOf(name)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
 
@@ -670,11 +670,11 @@ class KoParentClassProviderListExtTest {
         val name2 = "SampleName2"
         val declaration1: KoParentClassProvider =
             mockk {
-                every { hasParentClassesWithAllNames(name1, name2) } returns true
+                every { hasParentClassesWithAllNames(listOf(name1, name2)) } returns true
             }
         val declaration2: KoParentClassProvider =
             mockk {
-                every { hasParentClassesWithAllNames(name1, name2) } returns false
+                every { hasParentClassesWithAllNames(listOf(name1, name2)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
 
@@ -692,11 +692,11 @@ class KoParentClassProviderListExtTest {
         val name2 = "SampleName2"
         val declaration1: KoParentClassProvider =
             mockk {
-                every { hasParentClassesWithAllNames(name1, name2) } returns true
+                every { hasParentClassesWithAllNames(listOf(name1, name2)) } returns true
             }
         val declaration2: KoParentClassProvider =
             mockk {
-                every { hasParentClassesWithAllNames(name1, name2) } returns false
+                every { hasParentClassesWithAllNames(listOf(name1, name2)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
         val names = listOf(name1, name2)
@@ -715,11 +715,11 @@ class KoParentClassProviderListExtTest {
         val name2 = "SampleName2"
         val declaration1: KoParentClassProvider =
             mockk {
-                every { hasParentClassesWithAllNames(name1, name2) } returns true
+                every { hasParentClassesWithAllNames(setOf(name1, name2)) } returns true
             }
         val declaration2: KoParentClassProvider =
             mockk {
-                every { hasParentClassesWithAllNames(name1, name2) } returns false
+                every { hasParentClassesWithAllNames(setOf(name1, name2)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
         val names = setOf(name1, name2)
@@ -737,11 +737,11 @@ class KoParentClassProviderListExtTest {
         val name = "SampleName"
         val declaration1: KoParentClassProvider =
             mockk {
-                every { hasParentClassesWithAllNames(name) } returns true
+                every { hasParentClassesWithAllNames(listOf(name)) } returns true
             }
         val declaration2: KoParentClassProvider =
             mockk {
-                every { hasParentClassesWithAllNames(name) } returns false
+                every { hasParentClassesWithAllNames(listOf(name)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
 
@@ -759,11 +759,11 @@ class KoParentClassProviderListExtTest {
         val name2 = "SampleName2"
         val declaration1: KoParentClassProvider =
             mockk {
-                every { hasParentClassesWithAllNames(name1, name2) } returns true
+                every { hasParentClassesWithAllNames(listOf(name1, name2)) } returns true
             }
         val declaration2: KoParentClassProvider =
             mockk {
-                every { hasParentClassesWithAllNames(name1, name2) } returns false
+                every { hasParentClassesWithAllNames(listOf(name1, name2)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
 
@@ -781,11 +781,11 @@ class KoParentClassProviderListExtTest {
         val name2 = "SampleName2"
         val declaration1: KoParentClassProvider =
             mockk {
-                every { hasParentClassesWithAllNames(name1, name2) } returns true
+                every { hasParentClassesWithAllNames(listOf(name1, name2)) } returns true
             }
         val declaration2: KoParentClassProvider =
             mockk {
-                every { hasParentClassesWithAllNames(name1, name2) } returns false
+                every { hasParentClassesWithAllNames(listOf(name1, name2)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
         val names = listOf(name1, name2)
@@ -804,11 +804,11 @@ class KoParentClassProviderListExtTest {
         val name2 = "SampleName2"
         val declaration1: KoParentClassProvider =
             mockk {
-                every { hasParentClassesWithAllNames(name1, name2) } returns true
+                every { hasParentClassesWithAllNames(setOf(name1, name2)) } returns true
             }
         val declaration2: KoParentClassProvider =
             mockk {
-                every { hasParentClassesWithAllNames(name1, name2) } returns false
+                every { hasParentClassesWithAllNames(setOf(name1, name2)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
         val names = setOf(name1, name2)
@@ -1085,11 +1085,11 @@ class KoParentClassProviderListExtTest {
         // given
         val declaration1: KoParentClassProvider =
             mockk {
-                every { hasParentClassOf(SampleClass1::class) } returns true
+                every { hasParentClassOf(listOf(SampleClass1::class)) } returns true
             }
         val declaration2: KoParentClassProvider =
             mockk {
-                every { hasParentClassOf(SampleClass1::class) } returns false
+                every { hasParentClassOf(listOf(SampleClass1::class)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
 
@@ -1105,11 +1105,11 @@ class KoParentClassProviderListExtTest {
         // given
         val declaration1: KoParentClassProvider =
             mockk {
-                every { hasParentClassOf(SampleClass1::class, SampleClass2::class) } returns true
+                every { hasParentClassOf(listOf(SampleClass1::class, SampleClass2::class)) } returns true
             }
         val declaration2: KoParentClassProvider =
             mockk {
-                every { hasParentClassOf(SampleClass1::class, SampleClass2::class) } returns false
+                every { hasParentClassOf(listOf(SampleClass1::class, SampleClass2::class)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
 
@@ -1125,11 +1125,11 @@ class KoParentClassProviderListExtTest {
         // given
         val declaration1: KoParentClassProvider =
             mockk {
-                every { hasParentClassOf(SampleClass1::class, SampleClass2::class) } returns true
+                every { hasParentClassOf(listOf(SampleClass1::class, SampleClass2::class)) } returns true
             }
         val declaration2: KoParentClassProvider =
             mockk {
-                every { hasParentClassOf(SampleClass1::class, SampleClass2::class) } returns false
+                every { hasParentClassOf(listOf(SampleClass1::class, SampleClass2::class)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
         val kClasses = listOf(SampleClass1::class, SampleClass2::class)
@@ -1146,11 +1146,11 @@ class KoParentClassProviderListExtTest {
         // given
         val declaration1: KoParentClassProvider =
             mockk {
-                every { hasParentClassOf(SampleClass1::class, SampleClass2::class) } returns true
+                every { hasParentClassOf(setOf(SampleClass1::class, SampleClass2::class)) } returns true
             }
         val declaration2: KoParentClassProvider =
             mockk {
-                every { hasParentClassOf(SampleClass1::class, SampleClass2::class) } returns false
+                every { hasParentClassOf(setOf(SampleClass1::class, SampleClass2::class)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
         val kClasses = setOf(SampleClass1::class, SampleClass2::class)
@@ -1167,11 +1167,11 @@ class KoParentClassProviderListExtTest {
         // given
         val declaration1: KoParentClassProvider =
             mockk {
-                every { hasParentClassOf(SampleClass::class) } returns true
+                every { hasParentClassOf(listOf(SampleClass::class)) } returns true
             }
         val declaration2: KoParentClassProvider =
             mockk {
-                every { hasParentClassOf(SampleClass::class) } returns false
+                every { hasParentClassOf(listOf(SampleClass::class)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
 
@@ -1187,11 +1187,11 @@ class KoParentClassProviderListExtTest {
         // given
         val declaration1: KoParentClassProvider =
             mockk {
-                every { hasParentClassOf(SampleClass1::class, SampleClass2::class) } returns true
+                every { hasParentClassOf(listOf(SampleClass1::class, SampleClass2::class)) } returns true
             }
         val declaration2: KoParentClassProvider =
             mockk {
-                every { hasParentClassOf(SampleClass1::class, SampleClass2::class) } returns false
+                every { hasParentClassOf(listOf(SampleClass1::class, SampleClass2::class)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
 
@@ -1207,11 +1207,11 @@ class KoParentClassProviderListExtTest {
         // given
         val declaration1: KoParentClassProvider =
             mockk {
-                every { hasParentClassOf(SampleClass1::class, SampleClass2::class) } returns true
+                every { hasParentClassOf(listOf(SampleClass1::class, SampleClass2::class)) } returns true
             }
         val declaration2: KoParentClassProvider =
             mockk {
-                every { hasParentClassOf(SampleClass1::class, SampleClass2::class) } returns false
+                every { hasParentClassOf(listOf(SampleClass1::class, SampleClass2::class)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
         val kClasses = listOf(SampleClass1::class, SampleClass2::class)
@@ -1228,11 +1228,11 @@ class KoParentClassProviderListExtTest {
         // given
         val declaration1: KoParentClassProvider =
             mockk {
-                every { hasParentClassOf(SampleClass1::class, SampleClass2::class) } returns true
+                every { hasParentClassOf(setOf(SampleClass1::class, SampleClass2::class)) } returns true
             }
         val declaration2: KoParentClassProvider =
             mockk {
-                every { hasParentClassOf(SampleClass1::class, SampleClass2::class) } returns false
+                every { hasParentClassOf(setOf(SampleClass1::class, SampleClass2::class)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
         val kClasses = setOf(SampleClass1::class, SampleClass2::class)
@@ -1249,11 +1249,11 @@ class KoParentClassProviderListExtTest {
         // given
         val declaration1: KoParentClassProvider =
             mockk {
-                every { hasAllParentClassesOf(SampleClass::class, SampleInterface::class) } returns true
+                every { hasAllParentClassesOf(listOf(SampleClass::class, SampleInterface::class)) } returns true
             }
         val declaration2: KoParentClassProvider =
             mockk {
-                every { hasAllParentClassesOf(SampleClass::class, SampleInterface::class) } returns false
+                every { hasAllParentClassesOf(listOf(SampleClass::class, SampleInterface::class)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
 
@@ -1269,11 +1269,11 @@ class KoParentClassProviderListExtTest {
         // given
         val declaration1: KoParentClassProvider =
             mockk {
-                every { hasAllParentClassesOf(SampleClass::class, SampleInterface::class) } returns true
+                every { hasAllParentClassesOf(listOf(SampleClass::class, SampleInterface::class)) } returns true
             }
         val declaration2: KoParentClassProvider =
             mockk {
-                every { hasAllParentClassesOf(SampleClass::class, SampleInterface::class) } returns false
+                every { hasAllParentClassesOf(listOf(SampleClass::class, SampleInterface::class)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
         val kClasses = listOf(SampleClass::class, SampleInterface::class)
@@ -1290,11 +1290,11 @@ class KoParentClassProviderListExtTest {
         // given
         val declaration1: KoParentClassProvider =
             mockk {
-                every { hasAllParentClassesOf(SampleClass::class, SampleInterface::class) } returns true
+                every { hasAllParentClassesOf(setOf(SampleClass::class, SampleInterface::class)) } returns true
             }
         val declaration2: KoParentClassProvider =
             mockk {
-                every { hasAllParentClassesOf(SampleClass::class, SampleInterface::class) } returns false
+                every { hasAllParentClassesOf(setOf(SampleClass::class, SampleInterface::class)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
         val kClasses = setOf(SampleClass::class, SampleInterface::class)
@@ -1311,11 +1311,11 @@ class KoParentClassProviderListExtTest {
         // given
         val declaration1: KoParentClassProvider =
             mockk {
-                every { hasAllParentClassesOf(SampleClass::class, SampleInterface::class) } returns true
+                every { hasAllParentClassesOf(listOf(SampleClass::class, SampleInterface::class)) } returns true
             }
         val declaration2: KoParentClassProvider =
             mockk {
-                every { hasAllParentClassesOf(SampleClass::class, SampleInterface::class) } returns false
+                every { hasAllParentClassesOf(listOf(SampleClass::class, SampleInterface::class)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
 
@@ -1331,11 +1331,11 @@ class KoParentClassProviderListExtTest {
         // given
         val declaration1: KoParentClassProvider =
             mockk {
-                every { hasAllParentClassesOf(SampleClass::class, SampleInterface::class) } returns true
+                every { hasAllParentClassesOf(listOf(SampleClass::class, SampleInterface::class)) } returns true
             }
         val declaration2: KoParentClassProvider =
             mockk {
-                every { hasAllParentClassesOf(SampleClass::class, SampleInterface::class) } returns false
+                every { hasAllParentClassesOf(listOf(SampleClass::class, SampleInterface::class)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
         val kClasses = listOf(SampleClass::class, SampleInterface::class)
@@ -1352,11 +1352,11 @@ class KoParentClassProviderListExtTest {
         // given
         val declaration1: KoParentClassProvider =
             mockk {
-                every { hasAllParentClassesOf(SampleClass::class, SampleInterface::class) } returns true
+                every { hasAllParentClassesOf(setOf(SampleClass::class, SampleInterface::class)) } returns true
             }
         val declaration2: KoParentClassProvider =
             mockk {
-                every { hasAllParentClassesOf(SampleClass::class, SampleInterface::class) } returns false
+                every { hasAllParentClassesOf(setOf(SampleClass::class, SampleInterface::class)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
         val kClasses = setOf(SampleClass::class, SampleInterface::class)

--- a/lib/src/test/kotlin/com/lemonappdev/konsist/api/ext/list/KoParentInterfaceProviderListExtTest.kt
+++ b/lib/src/test/kotlin/com/lemonappdev/konsist/api/ext/list/KoParentInterfaceProviderListExtTest.kt
@@ -271,11 +271,11 @@ class KoParentInterfaceProviderListExtTest {
         val name = "SampleName"
         val declaration1: KoParentInterfaceProvider =
             mockk {
-                every { hasParentInterfaceWithName(name) } returns true
+                every { hasParentInterfaceWithName(listOf(name)) } returns true
             }
         val declaration2: KoParentInterfaceProvider =
             mockk {
-                every { hasParentInterfaceWithName(name) } returns false
+                every { hasParentInterfaceWithName(listOf(name)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
 
@@ -293,11 +293,11 @@ class KoParentInterfaceProviderListExtTest {
         val name2 = "SampleName2"
         val declaration1: KoParentInterfaceProvider =
             mockk {
-                every { hasParentInterfaceWithName(name1, name2) } returns true
+                every { hasParentInterfaceWithName(listOf(name1, name2)) } returns true
             }
         val declaration2: KoParentInterfaceProvider =
             mockk {
-                every { hasParentInterfaceWithName(name1, name2) } returns false
+                every { hasParentInterfaceWithName(listOf(name1, name2)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
 
@@ -315,11 +315,11 @@ class KoParentInterfaceProviderListExtTest {
         val name2 = "SampleName2"
         val declaration1: KoParentInterfaceProvider =
             mockk {
-                every { hasParentInterfaceWithName(name1, name2) } returns true
+                every { hasParentInterfaceWithName(listOf(name1, name2)) } returns true
             }
         val declaration2: KoParentInterfaceProvider =
             mockk {
-                every { hasParentInterfaceWithName(name1, name2) } returns false
+                every { hasParentInterfaceWithName(listOf(name1, name2)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
         val names = listOf(name1, name2)
@@ -338,11 +338,11 @@ class KoParentInterfaceProviderListExtTest {
         val name2 = "SampleName2"
         val declaration1: KoParentInterfaceProvider =
             mockk {
-                every { hasParentInterfaceWithName(name1, name2) } returns true
+                every { hasParentInterfaceWithName(setOf(name1, name2)) } returns true
             }
         val declaration2: KoParentInterfaceProvider =
             mockk {
-                every { hasParentInterfaceWithName(name1, name2) } returns false
+                every { hasParentInterfaceWithName(setOf(name1, name2)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
         val names = setOf(name1, name2)
@@ -360,11 +360,11 @@ class KoParentInterfaceProviderListExtTest {
         val name = "SampleName"
         val declaration1: KoParentInterfaceProvider =
             mockk {
-                every { hasParentInterfaceWithName(name) } returns true
+                every { hasParentInterfaceWithName(listOf(name)) } returns true
             }
         val declaration2: KoParentInterfaceProvider =
             mockk {
-                every { hasParentInterfaceWithName(name) } returns false
+                every { hasParentInterfaceWithName(listOf(name)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
 
@@ -382,11 +382,11 @@ class KoParentInterfaceProviderListExtTest {
         val name2 = "SampleName2"
         val declaration1: KoParentInterfaceProvider =
             mockk {
-                every { hasParentInterfaceWithName(name1, name2) } returns true
+                every { hasParentInterfaceWithName(listOf(name1, name2)) } returns true
             }
         val declaration2: KoParentInterfaceProvider =
             mockk {
-                every { hasParentInterfaceWithName(name1, name2) } returns false
+                every { hasParentInterfaceWithName(listOf(name1, name2)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
 
@@ -404,11 +404,11 @@ class KoParentInterfaceProviderListExtTest {
         val name2 = "SampleName2"
         val declaration1: KoParentInterfaceProvider =
             mockk {
-                every { hasParentInterfaceWithName(name1, name2) } returns true
+                every { hasParentInterfaceWithName(listOf(name1, name2)) } returns true
             }
         val declaration2: KoParentInterfaceProvider =
             mockk {
-                every { hasParentInterfaceWithName(name1, name2) } returns false
+                every { hasParentInterfaceWithName(listOf(name1, name2)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
         val names = listOf(name1, name2)
@@ -427,11 +427,11 @@ class KoParentInterfaceProviderListExtTest {
         val name2 = "SampleName2"
         val declaration1: KoParentInterfaceProvider =
             mockk {
-                every { hasParentInterfaceWithName(name1, name2) } returns true
+                every { hasParentInterfaceWithName(setOf(name1, name2)) } returns true
             }
         val declaration2: KoParentInterfaceProvider =
             mockk {
-                every { hasParentInterfaceWithName(name1, name2) } returns false
+                every { hasParentInterfaceWithName(setOf(name1, name2)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
         val names = setOf(name1, name2)
@@ -449,11 +449,11 @@ class KoParentInterfaceProviderListExtTest {
         val name = "SampleName"
         val declaration1: KoParentInterfaceProvider =
             mockk {
-                every { hasParentInterfacesWithAllNames(name) } returns true
+                every { hasParentInterfacesWithAllNames(listOf(name)) } returns true
             }
         val declaration2: KoParentInterfaceProvider =
             mockk {
-                every { hasParentInterfacesWithAllNames(name) } returns false
+                every { hasParentInterfacesWithAllNames(listOf(name)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
 
@@ -471,11 +471,11 @@ class KoParentInterfaceProviderListExtTest {
         val name2 = "SampleName2"
         val declaration1: KoParentInterfaceProvider =
             mockk {
-                every { hasParentInterfacesWithAllNames(name1, name2) } returns true
+                every { hasParentInterfacesWithAllNames(listOf(name1, name2)) } returns true
             }
         val declaration2: KoParentInterfaceProvider =
             mockk {
-                every { hasParentInterfacesWithAllNames(name1, name2) } returns false
+                every { hasParentInterfacesWithAllNames(listOf(name1, name2)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
 
@@ -493,11 +493,11 @@ class KoParentInterfaceProviderListExtTest {
         val name2 = "SampleName2"
         val declaration1: KoParentInterfaceProvider =
             mockk {
-                every { hasParentInterfacesWithAllNames(name1, name2) } returns true
+                every { hasParentInterfacesWithAllNames(listOf(name1, name2)) } returns true
             }
         val declaration2: KoParentInterfaceProvider =
             mockk {
-                every { hasParentInterfacesWithAllNames(name1, name2) } returns false
+                every { hasParentInterfacesWithAllNames(listOf(name1, name2)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
         val names = listOf(name1, name2)
@@ -516,11 +516,11 @@ class KoParentInterfaceProviderListExtTest {
         val name2 = "SampleName2"
         val declaration1: KoParentInterfaceProvider =
             mockk {
-                every { hasParentInterfacesWithAllNames(name1, name2) } returns true
+                every { hasParentInterfacesWithAllNames(setOf(name1, name2)) } returns true
             }
         val declaration2: KoParentInterfaceProvider =
             mockk {
-                every { hasParentInterfacesWithAllNames(name1, name2) } returns false
+                every { hasParentInterfacesWithAllNames(setOf(name1, name2)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
         val names = setOf(name1, name2)
@@ -538,11 +538,11 @@ class KoParentInterfaceProviderListExtTest {
         val name = "SampleName"
         val declaration1: KoParentInterfaceProvider =
             mockk {
-                every { hasParentInterfacesWithAllNames(name) } returns true
+                every { hasParentInterfacesWithAllNames(listOf(name)) } returns true
             }
         val declaration2: KoParentInterfaceProvider =
             mockk {
-                every { hasParentInterfacesWithAllNames(name) } returns false
+                every { hasParentInterfacesWithAllNames(listOf(name)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
 
@@ -560,11 +560,11 @@ class KoParentInterfaceProviderListExtTest {
         val name2 = "SampleName2"
         val declaration1: KoParentInterfaceProvider =
             mockk {
-                every { hasParentInterfacesWithAllNames(name1, name2) } returns true
+                every { hasParentInterfacesWithAllNames(listOf(name1, name2)) } returns true
             }
         val declaration2: KoParentInterfaceProvider =
             mockk {
-                every { hasParentInterfacesWithAllNames(name1, name2) } returns false
+                every { hasParentInterfacesWithAllNames(listOf(name1, name2)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
 
@@ -582,11 +582,11 @@ class KoParentInterfaceProviderListExtTest {
         val name2 = "SampleName2"
         val declaration1: KoParentInterfaceProvider =
             mockk {
-                every { hasParentInterfacesWithAllNames(name1, name2) } returns true
+                every { hasParentInterfacesWithAllNames(listOf(name1, name2)) } returns true
             }
         val declaration2: KoParentInterfaceProvider =
             mockk {
-                every { hasParentInterfacesWithAllNames(name1, name2) } returns false
+                every { hasParentInterfacesWithAllNames(listOf(name1, name2)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
         val names = listOf(name1, name2)
@@ -605,11 +605,11 @@ class KoParentInterfaceProviderListExtTest {
         val name2 = "SampleName2"
         val declaration1: KoParentInterfaceProvider =
             mockk {
-                every { hasParentInterfacesWithAllNames(name1, name2) } returns true
+                every { hasParentInterfacesWithAllNames(setOf(name1, name2)) } returns true
             }
         val declaration2: KoParentInterfaceProvider =
             mockk {
-                every { hasParentInterfacesWithAllNames(name1, name2) } returns false
+                every { hasParentInterfacesWithAllNames(setOf(name1, name2)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
         val names = setOf(name1, name2)
@@ -1130,11 +1130,11 @@ class KoParentInterfaceProviderListExtTest {
         // given
         val declaration1: KoParentInterfaceProvider =
             mockk {
-                every { hasParentInterfaceOf(SampleClass::class, SampleInterface::class) } returns true
+                every { hasParentInterfaceOf(listOf(SampleClass::class, SampleInterface::class)) } returns true
             }
         val declaration2: KoParentInterfaceProvider =
             mockk {
-                every { hasParentInterfaceOf(SampleClass::class, SampleInterface::class) } returns false
+                every { hasParentInterfaceOf(listOf(SampleClass::class, SampleInterface::class)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
 
@@ -1150,11 +1150,11 @@ class KoParentInterfaceProviderListExtTest {
         // given
         val declaration1: KoParentInterfaceProvider =
             mockk {
-                every { hasParentInterfaceOf(SampleClass::class, SampleInterface::class) } returns true
+                every { hasParentInterfaceOf(listOf(SampleClass::class, SampleInterface::class)) } returns true
             }
         val declaration2: KoParentInterfaceProvider =
             mockk {
-                every { hasParentInterfaceOf(SampleClass::class, SampleInterface::class) } returns false
+                every { hasParentInterfaceOf(listOf(SampleClass::class, SampleInterface::class)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
         val kClasses = listOf(SampleClass::class, SampleInterface::class)
@@ -1171,11 +1171,11 @@ class KoParentInterfaceProviderListExtTest {
         // given
         val declaration1: KoParentInterfaceProvider =
             mockk {
-                every { hasParentInterfaceOf(SampleClass::class, SampleInterface::class) } returns true
+                every { hasParentInterfaceOf(setOf(SampleClass::class, SampleInterface::class)) } returns true
             }
         val declaration2: KoParentInterfaceProvider =
             mockk {
-                every { hasParentInterfaceOf(SampleClass::class, SampleInterface::class) } returns false
+                every { hasParentInterfaceOf(setOf(SampleClass::class, SampleInterface::class)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
         val kClasses = setOf(SampleClass::class, SampleInterface::class)
@@ -1192,11 +1192,11 @@ class KoParentInterfaceProviderListExtTest {
         // given
         val declaration1: KoParentInterfaceProvider =
             mockk {
-                every { hasParentInterfaceOf(SampleClass::class, SampleInterface::class) } returns true
+                every { hasParentInterfaceOf(listOf(SampleClass::class, SampleInterface::class)) } returns true
             }
         val declaration2: KoParentInterfaceProvider =
             mockk {
-                every { hasParentInterfaceOf(SampleClass::class, SampleInterface::class) } returns false
+                every { hasParentInterfaceOf(listOf(SampleClass::class, SampleInterface::class)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
 
@@ -1212,11 +1212,11 @@ class KoParentInterfaceProviderListExtTest {
         // given
         val declaration1: KoParentInterfaceProvider =
             mockk {
-                every { hasParentInterfaceOf(SampleClass::class, SampleInterface::class) } returns true
+                every { hasParentInterfaceOf(listOf(SampleClass::class, SampleInterface::class)) } returns true
             }
         val declaration2: KoParentInterfaceProvider =
             mockk {
-                every { hasParentInterfaceOf(SampleClass::class, SampleInterface::class) } returns false
+                every { hasParentInterfaceOf(listOf(SampleClass::class, SampleInterface::class)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
         val kClasses = listOf(SampleClass::class, SampleInterface::class)
@@ -1233,11 +1233,11 @@ class KoParentInterfaceProviderListExtTest {
         // given
         val declaration1: KoParentInterfaceProvider =
             mockk {
-                every { hasParentInterfaceOf(SampleClass::class, SampleInterface::class) } returns true
+                every { hasParentInterfaceOf(setOf(SampleClass::class, SampleInterface::class)) } returns true
             }
         val declaration2: KoParentInterfaceProvider =
             mockk {
-                every { hasParentInterfaceOf(SampleClass::class, SampleInterface::class) } returns false
+                every { hasParentInterfaceOf(setOf(SampleClass::class, SampleInterface::class)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
         val kClasses = setOf(SampleClass::class, SampleInterface::class)
@@ -1254,11 +1254,11 @@ class KoParentInterfaceProviderListExtTest {
         // given
         val declaration1: KoParentInterfaceProvider =
             mockk {
-                every { hasAllParentInterfacesOf(SampleClass::class, SampleInterface::class) } returns true
+                every { hasAllParentInterfacesOf(listOf(SampleClass::class, SampleInterface::class)) } returns true
             }
         val declaration2: KoParentInterfaceProvider =
             mockk {
-                every { hasAllParentInterfacesOf(SampleClass::class, SampleInterface::class) } returns false
+                every { hasAllParentInterfacesOf(listOf(SampleClass::class, SampleInterface::class)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
 
@@ -1274,11 +1274,11 @@ class KoParentInterfaceProviderListExtTest {
         // given
         val declaration1: KoParentInterfaceProvider =
             mockk {
-                every { hasAllParentInterfacesOf(SampleClass::class, SampleInterface::class) } returns true
+                every { hasAllParentInterfacesOf(listOf(SampleClass::class, SampleInterface::class)) } returns true
             }
         val declaration2: KoParentInterfaceProvider =
             mockk {
-                every { hasAllParentInterfacesOf(SampleClass::class, SampleInterface::class) } returns false
+                every { hasAllParentInterfacesOf(listOf(SampleClass::class, SampleInterface::class)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
         val kClasses = listOf(SampleClass::class, SampleInterface::class)
@@ -1295,11 +1295,11 @@ class KoParentInterfaceProviderListExtTest {
         // given
         val declaration1: KoParentInterfaceProvider =
             mockk {
-                every { hasAllParentInterfacesOf(SampleClass::class, SampleInterface::class) } returns true
+                every { hasAllParentInterfacesOf(setOf(SampleClass::class, SampleInterface::class)) } returns true
             }
         val declaration2: KoParentInterfaceProvider =
             mockk {
-                every { hasAllParentInterfacesOf(SampleClass::class, SampleInterface::class) } returns false
+                every { hasAllParentInterfacesOf(setOf(SampleClass::class, SampleInterface::class)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
         val kClasses = setOf(SampleClass::class, SampleInterface::class)
@@ -1316,11 +1316,11 @@ class KoParentInterfaceProviderListExtTest {
         // given
         val declaration1: KoParentInterfaceProvider =
             mockk {
-                every { hasAllParentInterfacesOf(SampleClass::class, SampleInterface::class) } returns true
+                every { hasAllParentInterfacesOf(listOf(SampleClass::class, SampleInterface::class)) } returns true
             }
         val declaration2: KoParentInterfaceProvider =
             mockk {
-                every { hasAllParentInterfacesOf(SampleClass::class, SampleInterface::class) } returns false
+                every { hasAllParentInterfacesOf(listOf(SampleClass::class, SampleInterface::class)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
 
@@ -1336,11 +1336,11 @@ class KoParentInterfaceProviderListExtTest {
         // given
         val declaration1: KoParentInterfaceProvider =
             mockk {
-                every { hasAllParentInterfacesOf(SampleClass::class, SampleInterface::class) } returns true
+                every { hasAllParentInterfacesOf(listOf(SampleClass::class, SampleInterface::class)) } returns true
             }
         val declaration2: KoParentInterfaceProvider =
             mockk {
-                every { hasAllParentInterfacesOf(SampleClass::class, SampleInterface::class) } returns false
+                every { hasAllParentInterfacesOf(listOf(SampleClass::class, SampleInterface::class)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
         val kClasses = listOf(SampleClass::class, SampleInterface::class)
@@ -1357,11 +1357,11 @@ class KoParentInterfaceProviderListExtTest {
         // given
         val declaration1: KoParentInterfaceProvider =
             mockk {
-                every { hasAllParentInterfacesOf(SampleClass::class, SampleInterface::class) } returns true
+                every { hasAllParentInterfacesOf(setOf(SampleClass::class, SampleInterface::class)) } returns true
             }
         val declaration2: KoParentInterfaceProvider =
             mockk {
-                every { hasAllParentInterfacesOf(SampleClass::class, SampleInterface::class) } returns false
+                every { hasAllParentInterfacesOf(setOf(SampleClass::class, SampleInterface::class)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
         val kClasses = setOf(SampleClass::class, SampleInterface::class)

--- a/lib/src/test/kotlin/com/lemonappdev/konsist/api/ext/list/KoParentProviderListExtTest.kt
+++ b/lib/src/test/kotlin/com/lemonappdev/konsist/api/ext/list/KoParentProviderListExtTest.kt
@@ -271,11 +271,11 @@ class KoParentProviderListExtTest {
         val name = "SampleName"
         val declaration1: KoParentProvider =
             mockk {
-                every { hasParentWithName(name) } returns true
+                every { hasParentWithName(listOf(name)) } returns true
             }
         val declaration2: KoParentProvider =
             mockk {
-                every { hasParentWithName(name) } returns false
+                every { hasParentWithName(listOf(name)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
 
@@ -293,11 +293,11 @@ class KoParentProviderListExtTest {
         val name2 = "SampleName2"
         val declaration1: KoParentProvider =
             mockk {
-                every { hasParentWithName(name1, name2) } returns true
+                every { hasParentWithName(listOf(name1, name2)) } returns true
             }
         val declaration2: KoParentProvider =
             mockk {
-                every { hasParentWithName(name1, name2) } returns false
+                every { hasParentWithName(listOf(name1, name2)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
 
@@ -315,11 +315,11 @@ class KoParentProviderListExtTest {
         val name2 = "SampleName2"
         val declaration1: KoParentProvider =
             mockk {
-                every { hasParentWithName(name1, name2) } returns true
+                every { hasParentWithName(listOf(name1, name2)) } returns true
             }
         val declaration2: KoParentProvider =
             mockk {
-                every { hasParentWithName(name1, name2) } returns false
+                every { hasParentWithName(listOf(name1, name2)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
         val names = listOf(name1, name2)
@@ -338,11 +338,11 @@ class KoParentProviderListExtTest {
         val name2 = "SampleName2"
         val declaration1: KoParentProvider =
             mockk {
-                every { hasParentWithName(name1, name2) } returns true
+                every { hasParentWithName(setOf(name1, name2)) } returns true
             }
         val declaration2: KoParentProvider =
             mockk {
-                every { hasParentWithName(name1, name2) } returns false
+                every { hasParentWithName(setOf(name1, name2)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
         val names = setOf(name1, name2)
@@ -360,11 +360,11 @@ class KoParentProviderListExtTest {
         val name = "SampleName"
         val declaration1: KoParentProvider =
             mockk {
-                every { hasParentWithName(name) } returns true
+                every { hasParentWithName(listOf(name)) } returns true
             }
         val declaration2: KoParentProvider =
             mockk {
-                every { hasParentWithName(name) } returns false
+                every { hasParentWithName(listOf(name)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
 
@@ -382,11 +382,11 @@ class KoParentProviderListExtTest {
         val name2 = "SampleName2"
         val declaration1: KoParentProvider =
             mockk {
-                every { hasParentWithName(name1, name2) } returns true
+                every { hasParentWithName(listOf(name1, name2)) } returns true
             }
         val declaration2: KoParentProvider =
             mockk {
-                every { hasParentWithName(name1, name2) } returns false
+                every { hasParentWithName(listOf(name1, name2)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
 
@@ -404,11 +404,11 @@ class KoParentProviderListExtTest {
         val name2 = "SampleName2"
         val declaration1: KoParentProvider =
             mockk {
-                every { hasParentWithName(name1, name2) } returns true
+                every { hasParentWithName(listOf(name1, name2)) } returns true
             }
         val declaration2: KoParentProvider =
             mockk {
-                every { hasParentWithName(name1, name2) } returns false
+                every { hasParentWithName(listOf(name1, name2)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
         val names = listOf(name1, name2)
@@ -427,11 +427,11 @@ class KoParentProviderListExtTest {
         val name2 = "SampleName2"
         val declaration1: KoParentProvider =
             mockk {
-                every { hasParentWithName(name1, name2) } returns true
+                every { hasParentWithName(setOf(name1, name2)) } returns true
             }
         val declaration2: KoParentProvider =
             mockk {
-                every { hasParentWithName(name1, name2) } returns false
+                every { hasParentWithName(setOf(name1, name2)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
         val names = setOf(name1, name2)
@@ -449,11 +449,11 @@ class KoParentProviderListExtTest {
         val name = "SampleName"
         val declaration1: KoParentProvider =
             mockk {
-                every { hasParentsWithAllNames(name) } returns true
+                every { hasParentsWithAllNames(listOf(name)) } returns true
             }
         val declaration2: KoParentProvider =
             mockk {
-                every { hasParentsWithAllNames(name) } returns false
+                every { hasParentsWithAllNames(listOf(name)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
 
@@ -471,11 +471,11 @@ class KoParentProviderListExtTest {
         val name2 = "SampleName2"
         val declaration1: KoParentProvider =
             mockk {
-                every { hasParentsWithAllNames(name1, name2) } returns true
+                every { hasParentsWithAllNames(listOf(name1, name2)) } returns true
             }
         val declaration2: KoParentProvider =
             mockk {
-                every { hasParentsWithAllNames(name1, name2) } returns false
+                every { hasParentsWithAllNames(listOf(name1, name2)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
 
@@ -493,11 +493,11 @@ class KoParentProviderListExtTest {
         val name2 = "SampleName2"
         val declaration1: KoParentProvider =
             mockk {
-                every { hasParentsWithAllNames(name1, name2) } returns true
+                every { hasParentsWithAllNames(listOf(name1, name2)) } returns true
             }
         val declaration2: KoParentProvider =
             mockk {
-                every { hasParentsWithAllNames(name1, name2) } returns false
+                every { hasParentsWithAllNames(listOf(name1, name2)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
         val names = listOf(name1, name2)
@@ -516,11 +516,11 @@ class KoParentProviderListExtTest {
         val name2 = "SampleName2"
         val declaration1: KoParentProvider =
             mockk {
-                every { hasParentsWithAllNames(name1, name2) } returns true
+                every { hasParentsWithAllNames(setOf(name1, name2)) } returns true
             }
         val declaration2: KoParentProvider =
             mockk {
-                every { hasParentsWithAllNames(name1, name2) } returns false
+                every { hasParentsWithAllNames(setOf(name1, name2)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
         val names = setOf(name1, name2)
@@ -538,11 +538,11 @@ class KoParentProviderListExtTest {
         val name = "SampleName"
         val declaration1: KoParentProvider =
             mockk {
-                every { hasParentsWithAllNames(name) } returns true
+                every { hasParentsWithAllNames(listOf(name)) } returns true
             }
         val declaration2: KoParentProvider =
             mockk {
-                every { hasParentsWithAllNames(name) } returns false
+                every { hasParentsWithAllNames(listOf(name)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
 
@@ -560,11 +560,11 @@ class KoParentProviderListExtTest {
         val name2 = "SampleName2"
         val declaration1: KoParentProvider =
             mockk {
-                every { hasParentsWithAllNames(name1, name2) } returns true
+                every { hasParentsWithAllNames(listOf(name1, name2)) } returns true
             }
         val declaration2: KoParentProvider =
             mockk {
-                every { hasParentsWithAllNames(name1, name2) } returns false
+                every { hasParentsWithAllNames(listOf(name1, name2)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
 
@@ -582,11 +582,11 @@ class KoParentProviderListExtTest {
         val name2 = "SampleName2"
         val declaration1: KoParentProvider =
             mockk {
-                every { hasParentsWithAllNames(name1, name2) } returns true
+                every { hasParentsWithAllNames(listOf(name1, name2)) } returns true
             }
         val declaration2: KoParentProvider =
             mockk {
-                every { hasParentsWithAllNames(name1, name2) } returns false
+                every { hasParentsWithAllNames(listOf(name1, name2)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
         val names = listOf(name1, name2)
@@ -605,11 +605,11 @@ class KoParentProviderListExtTest {
         val name2 = "SampleName2"
         val declaration1: KoParentProvider =
             mockk {
-                every { hasParentsWithAllNames(name1, name2) } returns true
+                every { hasParentsWithAllNames(setOf(name1, name2)) } returns true
             }
         val declaration2: KoParentProvider =
             mockk {
-                every { hasParentsWithAllNames(name1, name2) } returns false
+                every { hasParentsWithAllNames(setOf(name1, name2)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
         val names = setOf(name1, name2)
@@ -1130,11 +1130,11 @@ class KoParentProviderListExtTest {
         // given
         val declaration1: KoParentProvider =
             mockk {
-                every { hasParentOf(SampleClass::class, SampleInterface::class) } returns true
+                every { hasParentOf(listOf(SampleClass::class, SampleInterface::class)) } returns true
             }
         val declaration2: KoParentProvider =
             mockk {
-                every { hasParentOf(SampleClass::class, SampleInterface::class) } returns false
+                every { hasParentOf(listOf(SampleClass::class, SampleInterface::class)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
 
@@ -1150,11 +1150,11 @@ class KoParentProviderListExtTest {
         // given
         val declaration1: KoParentProvider =
             mockk {
-                every { hasParentOf(SampleClass::class, SampleInterface::class) } returns true
+                every { hasParentOf(listOf(SampleClass::class, SampleInterface::class)) } returns true
             }
         val declaration2: KoParentProvider =
             mockk {
-                every { hasParentOf(SampleClass::class, SampleInterface::class) } returns false
+                every { hasParentOf(listOf(SampleClass::class, SampleInterface::class)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
         val kClasses = listOf(SampleClass::class, SampleInterface::class)
@@ -1171,11 +1171,11 @@ class KoParentProviderListExtTest {
         // given
         val declaration1: KoParentProvider =
             mockk {
-                every { hasParentOf(SampleClass::class, SampleInterface::class) } returns true
+                every { hasParentOf(setOf(SampleClass::class, SampleInterface::class)) } returns true
             }
         val declaration2: KoParentProvider =
             mockk {
-                every { hasParentOf(SampleClass::class, SampleInterface::class) } returns false
+                every { hasParentOf(setOf(SampleClass::class, SampleInterface::class)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
         val kClasses = setOf(SampleClass::class, SampleInterface::class)
@@ -1192,11 +1192,11 @@ class KoParentProviderListExtTest {
         // given
         val declaration1: KoParentProvider =
             mockk {
-                every { hasParentOf(SampleClass::class, SampleInterface::class) } returns true
+                every { hasParentOf(listOf(SampleClass::class, SampleInterface::class)) } returns true
             }
         val declaration2: KoParentProvider =
             mockk {
-                every { hasParentOf(SampleClass::class, SampleInterface::class) } returns false
+                every { hasParentOf(listOf(SampleClass::class, SampleInterface::class)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
 
@@ -1212,11 +1212,11 @@ class KoParentProviderListExtTest {
         // given
         val declaration1: KoParentProvider =
             mockk {
-                every { hasParentOf(SampleClass::class, SampleInterface::class) } returns true
+                every { hasParentOf(listOf(SampleClass::class, SampleInterface::class)) } returns true
             }
         val declaration2: KoParentProvider =
             mockk {
-                every { hasParentOf(SampleClass::class, SampleInterface::class) } returns false
+                every { hasParentOf(listOf(SampleClass::class, SampleInterface::class)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
         val kClasses = listOf(SampleClass::class, SampleInterface::class)
@@ -1233,11 +1233,11 @@ class KoParentProviderListExtTest {
         // given
         val declaration1: KoParentProvider =
             mockk {
-                every { hasParentOf(SampleClass::class, SampleInterface::class) } returns true
+                every { hasParentOf(setOf(SampleClass::class, SampleInterface::class)) } returns true
             }
         val declaration2: KoParentProvider =
             mockk {
-                every { hasParentOf(SampleClass::class, SampleInterface::class) } returns false
+                every { hasParentOf(setOf(SampleClass::class, SampleInterface::class)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
         val kClasses = setOf(SampleClass::class, SampleInterface::class)
@@ -1254,11 +1254,11 @@ class KoParentProviderListExtTest {
         // given
         val declaration1: KoParentProvider =
             mockk {
-                every { hasAllParentsOf(SampleClass::class, SampleInterface::class) } returns true
+                every { hasAllParentsOf(listOf(SampleClass::class, SampleInterface::class)) } returns true
             }
         val declaration2: KoParentProvider =
             mockk {
-                every { hasAllParentsOf(SampleClass::class, SampleInterface::class) } returns false
+                every { hasAllParentsOf(listOf(SampleClass::class, SampleInterface::class)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
 
@@ -1274,11 +1274,11 @@ class KoParentProviderListExtTest {
         // given
         val declaration1: KoParentProvider =
             mockk {
-                every { hasAllParentsOf(SampleClass::class, SampleInterface::class) } returns true
+                every { hasAllParentsOf(listOf(SampleClass::class, SampleInterface::class)) } returns true
             }
         val declaration2: KoParentProvider =
             mockk {
-                every { hasAllParentsOf(SampleClass::class, SampleInterface::class) } returns false
+                every { hasAllParentsOf(listOf(SampleClass::class, SampleInterface::class)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
         val kClasses = listOf(SampleClass::class, SampleInterface::class)
@@ -1295,11 +1295,11 @@ class KoParentProviderListExtTest {
         // given
         val declaration1: KoParentProvider =
             mockk {
-                every { hasAllParentsOf(SampleClass::class, SampleInterface::class) } returns true
+                every { hasAllParentsOf(setOf(SampleClass::class, SampleInterface::class)) } returns true
             }
         val declaration2: KoParentProvider =
             mockk {
-                every { hasAllParentsOf(SampleClass::class, SampleInterface::class) } returns false
+                every { hasAllParentsOf(setOf(SampleClass::class, SampleInterface::class)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
         val kClasses = setOf(SampleClass::class, SampleInterface::class)
@@ -1316,11 +1316,11 @@ class KoParentProviderListExtTest {
         // given
         val declaration1: KoParentProvider =
             mockk {
-                every { hasAllParentsOf(SampleClass::class, SampleInterface::class) } returns true
+                every { hasAllParentsOf(listOf(SampleClass::class, SampleInterface::class)) } returns true
             }
         val declaration2: KoParentProvider =
             mockk {
-                every { hasAllParentsOf(SampleClass::class, SampleInterface::class) } returns false
+                every { hasAllParentsOf(listOf(SampleClass::class, SampleInterface::class)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
 
@@ -1336,11 +1336,11 @@ class KoParentProviderListExtTest {
         // given
         val declaration1: KoParentProvider =
             mockk {
-                every { hasAllParentsOf(SampleClass::class, SampleInterface::class) } returns true
+                every { hasAllParentsOf(listOf(SampleClass::class, SampleInterface::class)) } returns true
             }
         val declaration2: KoParentProvider =
             mockk {
-                every { hasAllParentsOf(SampleClass::class, SampleInterface::class) } returns false
+                every { hasAllParentsOf(listOf(SampleClass::class, SampleInterface::class)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
         val kClasses = listOf(SampleClass::class, SampleInterface::class)
@@ -1357,11 +1357,11 @@ class KoParentProviderListExtTest {
         // given
         val declaration1: KoParentProvider =
             mockk {
-                every { hasAllParentsOf(SampleClass::class, SampleInterface::class) } returns true
+                every { hasAllParentsOf(setOf(SampleClass::class, SampleInterface::class)) } returns true
             }
         val declaration2: KoParentProvider =
             mockk {
-                every { hasAllParentsOf(SampleClass::class, SampleInterface::class) } returns false
+                every { hasAllParentsOf(setOf(SampleClass::class, SampleInterface::class)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
         val kClasses = setOf(SampleClass::class, SampleInterface::class)

--- a/lib/src/test/kotlin/com/lemonappdev/konsist/api/ext/list/KoPropertyProviderListExtTest.kt
+++ b/lib/src/test/kotlin/com/lemonappdev/konsist/api/ext/list/KoPropertyProviderListExtTest.kt
@@ -242,11 +242,11 @@ class KoPropertyProviderListExtTest {
         val name = "SampleName"
         val declaration1: KoPropertyProvider =
             mockk {
-                every { hasPropertyWithName(name) } returns true
+                every { hasPropertyWithName(listOf(name)) } returns true
             }
         val declaration2: KoPropertyProvider =
             mockk {
-                every { hasPropertyWithName(name) } returns false
+                every { hasPropertyWithName(listOf(name)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
 
@@ -264,11 +264,11 @@ class KoPropertyProviderListExtTest {
         val name2 = "SampleName2"
         val declaration1: KoPropertyProvider =
             mockk {
-                every { hasPropertyWithName(name1, name2) } returns true
+                every { hasPropertyWithName(listOf(name1, name2)) } returns true
             }
         val declaration2: KoPropertyProvider =
             mockk {
-                every { hasPropertyWithName(name1, name2) } returns false
+                every { hasPropertyWithName(listOf(name1, name2)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
 
@@ -286,11 +286,11 @@ class KoPropertyProviderListExtTest {
         val name2 = "SampleName2"
         val declaration1: KoPropertyProvider =
             mockk {
-                every { hasPropertyWithName(name1, name2) } returns true
+                every { hasPropertyWithName(listOf(name1, name2)) } returns true
             }
         val declaration2: KoPropertyProvider =
             mockk {
-                every { hasPropertyWithName(name1, name2) } returns false
+                every { hasPropertyWithName(listOf(name1, name2)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
         val names = listOf(name1, name2)
@@ -309,11 +309,11 @@ class KoPropertyProviderListExtTest {
         val name2 = "SampleName2"
         val declaration1: KoPropertyProvider =
             mockk {
-                every { hasPropertyWithName(name1, name2) } returns true
+                every { hasPropertyWithName(setOf(name1, name2)) } returns true
             }
         val declaration2: KoPropertyProvider =
             mockk {
-                every { hasPropertyWithName(name1, name2) } returns false
+                every { hasPropertyWithName(setOf(name1, name2)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
         val names = setOf(name1, name2)
@@ -331,11 +331,11 @@ class KoPropertyProviderListExtTest {
         val name = "SampleName"
         val declaration1: KoPropertyProvider =
             mockk {
-                every { hasPropertyWithName(name) } returns true
+                every { hasPropertyWithName(listOf(name)) } returns true
             }
         val declaration2: KoPropertyProvider =
             mockk {
-                every { hasPropertyWithName(name) } returns false
+                every { hasPropertyWithName(listOf(name)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
 
@@ -353,11 +353,11 @@ class KoPropertyProviderListExtTest {
         val name2 = "SampleName2"
         val declaration1: KoPropertyProvider =
             mockk {
-                every { hasPropertyWithName(name1, name2) } returns true
+                every { hasPropertyWithName(listOf(name1, name2)) } returns true
             }
         val declaration2: KoPropertyProvider =
             mockk {
-                every { hasPropertyWithName(name1, name2) } returns false
+                every { hasPropertyWithName(listOf(name1, name2)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
 
@@ -375,11 +375,11 @@ class KoPropertyProviderListExtTest {
         val name2 = "SampleName2"
         val declaration1: KoPropertyProvider =
             mockk {
-                every { hasPropertyWithName(name1, name2) } returns true
+                every { hasPropertyWithName(listOf(name1, name2)) } returns true
             }
         val declaration2: KoPropertyProvider =
             mockk {
-                every { hasPropertyWithName(name1, name2) } returns false
+                every { hasPropertyWithName(listOf(name1, name2)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
         val names = listOf(name1, name2)
@@ -398,11 +398,11 @@ class KoPropertyProviderListExtTest {
         val name2 = "SampleName2"
         val declaration1: KoPropertyProvider =
             mockk {
-                every { hasPropertyWithName(name1, name2) } returns true
+                every { hasPropertyWithName(setOf(name1, name2)) } returns true
             }
         val declaration2: KoPropertyProvider =
             mockk {
-                every { hasPropertyWithName(name1, name2) } returns false
+                every { hasPropertyWithName(setOf(name1, name2)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
         val names = setOf(name1, name2)
@@ -420,11 +420,11 @@ class KoPropertyProviderListExtTest {
         val name = "SampleName"
         val declaration1: KoPropertyProvider =
             mockk {
-                every { hasPropertiesWithAllNames(name) } returns true
+                every { hasPropertiesWithAllNames(listOf(name)) } returns true
             }
         val declaration2: KoPropertyProvider =
             mockk {
-                every { hasPropertiesWithAllNames(name) } returns false
+                every { hasPropertiesWithAllNames(listOf(name)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
 
@@ -442,11 +442,11 @@ class KoPropertyProviderListExtTest {
         val name2 = "SampleName2"
         val declaration1: KoPropertyProvider =
             mockk {
-                every { hasPropertiesWithAllNames(name1, name2) } returns true
+                every { hasPropertiesWithAllNames(listOf(name1, name2)) } returns true
             }
         val declaration2: KoPropertyProvider =
             mockk {
-                every { hasPropertiesWithAllNames(name1, name2) } returns false
+                every { hasPropertiesWithAllNames(listOf(name1, name2)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
 
@@ -464,11 +464,11 @@ class KoPropertyProviderListExtTest {
         val name2 = "SampleName2"
         val declaration1: KoPropertyProvider =
             mockk {
-                every { hasPropertiesWithAllNames(name1, name2) } returns true
+                every { hasPropertiesWithAllNames(listOf(name1, name2)) } returns true
             }
         val declaration2: KoPropertyProvider =
             mockk {
-                every { hasPropertiesWithAllNames(name1, name2) } returns false
+                every { hasPropertiesWithAllNames(listOf(name1, name2)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
         val names = listOf(name1, name2)
@@ -487,11 +487,11 @@ class KoPropertyProviderListExtTest {
         val name2 = "SampleName2"
         val declaration1: KoPropertyProvider =
             mockk {
-                every { hasPropertiesWithAllNames(name1, name2) } returns true
+                every { hasPropertiesWithAllNames(setOf(name1, name2)) } returns true
             }
         val declaration2: KoPropertyProvider =
             mockk {
-                every { hasPropertiesWithAllNames(name1, name2) } returns false
+                every { hasPropertiesWithAllNames(setOf(name1, name2)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
         val names = setOf(name1, name2)
@@ -509,11 +509,11 @@ class KoPropertyProviderListExtTest {
         val name = "SampleName"
         val declaration1: KoPropertyProvider =
             mockk {
-                every { hasPropertiesWithAllNames(name) } returns true
+                every { hasPropertiesWithAllNames(listOf(name)) } returns true
             }
         val declaration2: KoPropertyProvider =
             mockk {
-                every { hasPropertiesWithAllNames(name) } returns false
+                every { hasPropertiesWithAllNames(listOf(name)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
 
@@ -531,11 +531,11 @@ class KoPropertyProviderListExtTest {
         val name2 = "SampleName2"
         val declaration1: KoPropertyProvider =
             mockk {
-                every { hasPropertiesWithAllNames(name1, name2) } returns true
+                every { hasPropertiesWithAllNames(listOf(name1, name2)) } returns true
             }
         val declaration2: KoPropertyProvider =
             mockk {
-                every { hasPropertiesWithAllNames(name1, name2) } returns false
+                every { hasPropertiesWithAllNames(listOf(name1, name2)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
 
@@ -553,11 +553,11 @@ class KoPropertyProviderListExtTest {
         val name2 = "SampleName2"
         val declaration1: KoPropertyProvider =
             mockk {
-                every { hasPropertiesWithAllNames(name1, name2) } returns true
+                every { hasPropertiesWithAllNames(listOf(name1, name2)) } returns true
             }
         val declaration2: KoPropertyProvider =
             mockk {
-                every { hasPropertiesWithAllNames(name1, name2) } returns false
+                every { hasPropertiesWithAllNames(listOf(name1, name2)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
         val names = listOf(name1, name2)
@@ -576,11 +576,11 @@ class KoPropertyProviderListExtTest {
         val name2 = "SampleName2"
         val declaration1: KoPropertyProvider =
             mockk {
-                every { hasPropertiesWithAllNames(name1, name2) } returns true
+                every { hasPropertiesWithAllNames(setOf(name1, name2)) } returns true
             }
         val declaration2: KoPropertyProvider =
             mockk {
-                every { hasPropertiesWithAllNames(name1, name2) } returns false
+                every { hasPropertiesWithAllNames(setOf(name1, name2)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
         val names = setOf(name1, name2)

--- a/lib/src/test/kotlin/com/lemonappdev/konsist/api/ext/list/KoTypeAliasProviderListExtTest.kt
+++ b/lib/src/test/kotlin/com/lemonappdev/konsist/api/ext/list/KoTypeAliasProviderListExtTest.kt
@@ -241,11 +241,11 @@ class KoTypeAliasProviderListExtTest {
         val name = "SampleName"
         val declaration1: KoTypeAliasProvider =
             mockk {
-                every { hasTypeAliasWithName(name) } returns true
+                every { hasTypeAliasWithName(listOf(name)) } returns true
             }
         val declaration2: KoTypeAliasProvider =
             mockk {
-                every { hasTypeAliasWithName(name) } returns false
+                every { hasTypeAliasWithName(listOf(name)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
 
@@ -263,11 +263,11 @@ class KoTypeAliasProviderListExtTest {
         val name2 = "SampleName2"
         val declaration1: KoTypeAliasProvider =
             mockk {
-                every { hasTypeAliasWithName(name1, name2) } returns true
+                every { hasTypeAliasWithName(listOf(name1, name2)) } returns true
             }
         val declaration2: KoTypeAliasProvider =
             mockk {
-                every { hasTypeAliasWithName(name1, name2) } returns false
+                every { hasTypeAliasWithName(listOf(name1, name2)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
 
@@ -285,11 +285,11 @@ class KoTypeAliasProviderListExtTest {
         val name2 = "SampleName2"
         val declaration1: KoTypeAliasProvider =
             mockk {
-                every { hasTypeAliasWithName(name1, name2) } returns true
+                every { hasTypeAliasWithName(listOf(name1, name2)) } returns true
             }
         val declaration2: KoTypeAliasProvider =
             mockk {
-                every { hasTypeAliasWithName(name1, name2) } returns false
+                every { hasTypeAliasWithName(listOf(name1, name2)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
         val names = listOf(name1, name2)
@@ -308,11 +308,11 @@ class KoTypeAliasProviderListExtTest {
         val name2 = "SampleName2"
         val declaration1: KoTypeAliasProvider =
             mockk {
-                every { hasTypeAliasWithName(name1, name2) } returns true
+                every { hasTypeAliasWithName(setOf(name1, name2)) } returns true
             }
         val declaration2: KoTypeAliasProvider =
             mockk {
-                every { hasTypeAliasWithName(name1, name2) } returns false
+                every { hasTypeAliasWithName(setOf(name1, name2)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
         val names = setOf(name1, name2)
@@ -330,11 +330,11 @@ class KoTypeAliasProviderListExtTest {
         val name = "SampleName"
         val declaration1: KoTypeAliasProvider =
             mockk {
-                every { hasTypeAliasWithName(name) } returns true
+                every { hasTypeAliasWithName(listOf(name)) } returns true
             }
         val declaration2: KoTypeAliasProvider =
             mockk {
-                every { hasTypeAliasWithName(name) } returns false
+                every { hasTypeAliasWithName(listOf(name)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
 
@@ -352,11 +352,11 @@ class KoTypeAliasProviderListExtTest {
         val name2 = "SampleName2"
         val declaration1: KoTypeAliasProvider =
             mockk {
-                every { hasTypeAliasWithName(name1, name2) } returns true
+                every { hasTypeAliasWithName(listOf(name1, name2)) } returns true
             }
         val declaration2: KoTypeAliasProvider =
             mockk {
-                every { hasTypeAliasWithName(name1, name2) } returns false
+                every { hasTypeAliasWithName(listOf(name1, name2)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
 
@@ -374,11 +374,11 @@ class KoTypeAliasProviderListExtTest {
         val name2 = "SampleName2"
         val declaration1: KoTypeAliasProvider =
             mockk {
-                every { hasTypeAliasWithName(name1, name2) } returns true
+                every { hasTypeAliasWithName(listOf(name1, name2)) } returns true
             }
         val declaration2: KoTypeAliasProvider =
             mockk {
-                every { hasTypeAliasWithName(name1, name2) } returns false
+                every { hasTypeAliasWithName(listOf(name1, name2)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
         val names = listOf(name1, name2)
@@ -397,11 +397,11 @@ class KoTypeAliasProviderListExtTest {
         val name2 = "SampleName2"
         val declaration1: KoTypeAliasProvider =
             mockk {
-                every { hasTypeAliasWithName(name1, name2) } returns true
+                every { hasTypeAliasWithName(setOf(name1, name2)) } returns true
             }
         val declaration2: KoTypeAliasProvider =
             mockk {
-                every { hasTypeAliasWithName(name1, name2) } returns false
+                every { hasTypeAliasWithName(setOf(name1, name2)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
         val names = setOf(name1, name2)
@@ -419,11 +419,11 @@ class KoTypeAliasProviderListExtTest {
         val name = "SampleName"
         val declaration1: KoTypeAliasProvider =
             mockk {
-                every { hasTypeAliasesWithAllNames(name) } returns true
+                every { hasTypeAliasesWithAllNames(listOf(name)) } returns true
             }
         val declaration2: KoTypeAliasProvider =
             mockk {
-                every { hasTypeAliasesWithAllNames(name) } returns false
+                every { hasTypeAliasesWithAllNames(listOf(name)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
 
@@ -441,11 +441,11 @@ class KoTypeAliasProviderListExtTest {
         val name2 = "SampleName2"
         val declaration1: KoTypeAliasProvider =
             mockk {
-                every { hasTypeAliasesWithAllNames(name1, name2) } returns true
+                every { hasTypeAliasesWithAllNames(listOf(name1, name2)) } returns true
             }
         val declaration2: KoTypeAliasProvider =
             mockk {
-                every { hasTypeAliasesWithAllNames(name1, name2) } returns false
+                every { hasTypeAliasesWithAllNames(listOf(name1, name2)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
 
@@ -463,11 +463,11 @@ class KoTypeAliasProviderListExtTest {
         val name2 = "SampleName2"
         val declaration1: KoTypeAliasProvider =
             mockk {
-                every { hasTypeAliasesWithAllNames(name1, name2) } returns true
+                every { hasTypeAliasesWithAllNames(listOf(name1, name2)) } returns true
             }
         val declaration2: KoTypeAliasProvider =
             mockk {
-                every { hasTypeAliasesWithAllNames(name1, name2) } returns false
+                every { hasTypeAliasesWithAllNames(listOf(name1, name2)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
         val names = listOf(name1, name2)
@@ -486,11 +486,11 @@ class KoTypeAliasProviderListExtTest {
         val name2 = "SampleName2"
         val declaration1: KoTypeAliasProvider =
             mockk {
-                every { hasTypeAliasesWithAllNames(name1, name2) } returns true
+                every { hasTypeAliasesWithAllNames(setOf(name1, name2)) } returns true
             }
         val declaration2: KoTypeAliasProvider =
             mockk {
-                every { hasTypeAliasesWithAllNames(name1, name2) } returns false
+                every { hasTypeAliasesWithAllNames(setOf(name1, name2)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
         val names = setOf(name1, name2)
@@ -508,11 +508,11 @@ class KoTypeAliasProviderListExtTest {
         val name = "SampleName"
         val declaration1: KoTypeAliasProvider =
             mockk {
-                every { hasTypeAliasesWithAllNames(name) } returns true
+                every { hasTypeAliasesWithAllNames(listOf(name)) } returns true
             }
         val declaration2: KoTypeAliasProvider =
             mockk {
-                every { hasTypeAliasesWithAllNames(name) } returns false
+                every { hasTypeAliasesWithAllNames(listOf(name)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
 
@@ -530,11 +530,11 @@ class KoTypeAliasProviderListExtTest {
         val name2 = "SampleName2"
         val declaration1: KoTypeAliasProvider =
             mockk {
-                every { hasTypeAliasesWithAllNames(name1, name2) } returns true
+                every { hasTypeAliasesWithAllNames(listOf(name1, name2)) } returns true
             }
         val declaration2: KoTypeAliasProvider =
             mockk {
-                every { hasTypeAliasesWithAllNames(name1, name2) } returns false
+                every { hasTypeAliasesWithAllNames(listOf(name1, name2)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
 
@@ -552,11 +552,11 @@ class KoTypeAliasProviderListExtTest {
         val name2 = "SampleName2"
         val declaration1: KoTypeAliasProvider =
             mockk {
-                every { hasTypeAliasesWithAllNames(name1, name2) } returns true
+                every { hasTypeAliasesWithAllNames(listOf(name1, name2)) } returns true
             }
         val declaration2: KoTypeAliasProvider =
             mockk {
-                every { hasTypeAliasesWithAllNames(name1, name2) } returns false
+                every { hasTypeAliasesWithAllNames(listOf(name1, name2)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
         val names = listOf(name1, name2)
@@ -575,11 +575,11 @@ class KoTypeAliasProviderListExtTest {
         val name2 = "SampleName2"
         val declaration1: KoTypeAliasProvider =
             mockk {
-                every { hasTypeAliasesWithAllNames(name1, name2) } returns true
+                every { hasTypeAliasesWithAllNames(setOf(name1, name2)) } returns true
             }
         val declaration2: KoTypeAliasProvider =
             mockk {
-                every { hasTypeAliasesWithAllNames(name1, name2) } returns false
+                every { hasTypeAliasesWithAllNames(setOf(name1, name2)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
         val names = setOf(name1, name2)

--- a/lib/src/test/kotlin/com/lemonappdev/konsist/api/ext/list/KoVariableProviderListExtTest.kt
+++ b/lib/src/test/kotlin/com/lemonappdev/konsist/api/ext/list/KoVariableProviderListExtTest.kt
@@ -241,11 +241,11 @@ class KoVariableProviderListExtTest {
         val name = "SampleName"
         val declaration1: KoVariableProvider =
             mockk {
-                every { hasVariableWithName(name) } returns true
+                every { hasVariableWithName(listOf(name)) } returns true
             }
         val declaration2: KoVariableProvider =
             mockk {
-                every { hasVariableWithName(name) } returns false
+                every { hasVariableWithName(listOf(name)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
 
@@ -263,11 +263,11 @@ class KoVariableProviderListExtTest {
         val name2 = "SampleName2"
         val declaration1: KoVariableProvider =
             mockk {
-                every { hasVariableWithName(name1, name2) } returns true
+                every { hasVariableWithName(listOf(name1, name2)) } returns true
             }
         val declaration2: KoVariableProvider =
             mockk {
-                every { hasVariableWithName(name1, name2) } returns false
+                every { hasVariableWithName(listOf(name1, name2)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
 
@@ -285,11 +285,11 @@ class KoVariableProviderListExtTest {
         val name2 = "SampleName2"
         val declaration1: KoVariableProvider =
             mockk {
-                every { hasVariableWithName(name1, name2) } returns true
+                every { hasVariableWithName(listOf(name1, name2)) } returns true
             }
         val declaration2: KoVariableProvider =
             mockk {
-                every { hasVariableWithName(name1, name2) } returns false
+                every { hasVariableWithName(listOf(name1, name2)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
         val names = listOf(name1, name2)
@@ -308,14 +308,14 @@ class KoVariableProviderListExtTest {
         val name2 = "SampleName2"
         val declaration1: KoVariableProvider =
             mockk {
-                every { hasVariableWithName(name1, name2) } returns true
+                every { hasVariableWithName(setOf(name1, name2)) } returns true
             }
         val declaration2: KoVariableProvider =
             mockk {
-                every { hasVariableWithName(name1, name2) } returns false
+                every { hasVariableWithName(setOf(name1, name2)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
-        val names = listOf(name1, name2)
+        val names = setOf(name1, name2)
 
         // when
         val sut = declarations.withVariableNamed(names)
@@ -330,11 +330,11 @@ class KoVariableProviderListExtTest {
         val name = "SampleName"
         val declaration1: KoVariableProvider =
             mockk {
-                every { hasVariableWithName(name) } returns true
+                every { hasVariableWithName(listOf(name)) } returns true
             }
         val declaration2: KoVariableProvider =
             mockk {
-                every { hasVariableWithName(name) } returns false
+                every { hasVariableWithName(listOf(name)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
 
@@ -352,11 +352,11 @@ class KoVariableProviderListExtTest {
         val name2 = "SampleName2"
         val declaration1: KoVariableProvider =
             mockk {
-                every { hasVariableWithName(name1, name2) } returns true
+                every { hasVariableWithName(listOf(name1, name2)) } returns true
             }
         val declaration2: KoVariableProvider =
             mockk {
-                every { hasVariableWithName(name1, name2) } returns false
+                every { hasVariableWithName(listOf(name1, name2)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
 
@@ -374,11 +374,11 @@ class KoVariableProviderListExtTest {
         val name2 = "SampleName2"
         val declaration1: KoVariableProvider =
             mockk {
-                every { hasVariableWithName(name1, name2) } returns true
+                every { hasVariableWithName(listOf(name1, name2)) } returns true
             }
         val declaration2: KoVariableProvider =
             mockk {
-                every { hasVariableWithName(name1, name2) } returns false
+                every { hasVariableWithName(listOf(name1, name2)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
         val names = listOf(name1, name2)
@@ -397,11 +397,11 @@ class KoVariableProviderListExtTest {
         val name2 = "SampleName2"
         val declaration1: KoVariableProvider =
             mockk {
-                every { hasVariableWithName(name1, name2) } returns true
+                every { hasVariableWithName(setOf(name1, name2)) } returns true
             }
         val declaration2: KoVariableProvider =
             mockk {
-                every { hasVariableWithName(name1, name2) } returns false
+                every { hasVariableWithName(setOf(name1, name2)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
         val names = setOf(name1, name2)
@@ -419,11 +419,11 @@ class KoVariableProviderListExtTest {
         val name = "SampleName"
         val declaration1: KoVariableProvider =
             mockk {
-                every { hasVariablesWithAllNames(name) } returns true
+                every { hasVariablesWithAllNames(listOf(name)) } returns true
             }
         val declaration2: KoVariableProvider =
             mockk {
-                every { hasVariablesWithAllNames(name) } returns false
+                every { hasVariablesWithAllNames(listOf(name)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
 
@@ -441,11 +441,11 @@ class KoVariableProviderListExtTest {
         val name2 = "SampleName2"
         val declaration1: KoVariableProvider =
             mockk {
-                every { hasVariablesWithAllNames(name1, name2) } returns true
+                every { hasVariablesWithAllNames(listOf(name1, name2)) } returns true
             }
         val declaration2: KoVariableProvider =
             mockk {
-                every { hasVariablesWithAllNames(name1, name2) } returns false
+                every { hasVariablesWithAllNames(listOf(name1, name2)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
 
@@ -463,11 +463,11 @@ class KoVariableProviderListExtTest {
         val name2 = "SampleName2"
         val declaration1: KoVariableProvider =
             mockk {
-                every { hasVariablesWithAllNames(name1, name2) } returns true
+                every { hasVariablesWithAllNames(listOf(name1, name2)) } returns true
             }
         val declaration2: KoVariableProvider =
             mockk {
-                every { hasVariablesWithAllNames(name1, name2) } returns false
+                every { hasVariablesWithAllNames(listOf(name1, name2)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
         val names = listOf(name1, name2)
@@ -486,14 +486,14 @@ class KoVariableProviderListExtTest {
         val name2 = "SampleName2"
         val declaration1: KoVariableProvider =
             mockk {
-                every { hasVariablesWithAllNames(name1, name2) } returns true
+                every { hasVariablesWithAllNames(setOf(name1, name2)) } returns true
             }
         val declaration2: KoVariableProvider =
             mockk {
-                every { hasVariablesWithAllNames(name1, name2) } returns false
+                every { hasVariablesWithAllNames(setOf(name1, name2)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
-        val names = listOf(name1, name2)
+        val names = setOf(name1, name2)
 
         // when
         val sut = declarations.withAllVariablesNamed(names)
@@ -508,11 +508,11 @@ class KoVariableProviderListExtTest {
         val name = "SampleName"
         val declaration1: KoVariableProvider =
             mockk {
-                every { hasVariablesWithAllNames(name) } returns true
+                every { hasVariablesWithAllNames(listOf(name)) } returns true
             }
         val declaration2: KoVariableProvider =
             mockk {
-                every { hasVariablesWithAllNames(name) } returns false
+                every { hasVariablesWithAllNames(listOf(name)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
 
@@ -530,11 +530,11 @@ class KoVariableProviderListExtTest {
         val name2 = "SampleName2"
         val declaration1: KoVariableProvider =
             mockk {
-                every { hasVariablesWithAllNames(name1, name2) } returns true
+                every { hasVariablesWithAllNames(listOf(name1, name2)) } returns true
             }
         val declaration2: KoVariableProvider =
             mockk {
-                every { hasVariablesWithAllNames(name1, name2) } returns false
+                every { hasVariablesWithAllNames(listOf(name1, name2)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
 
@@ -552,11 +552,11 @@ class KoVariableProviderListExtTest {
         val name2 = "SampleName2"
         val declaration1: KoVariableProvider =
             mockk {
-                every { hasVariablesWithAllNames(name1, name2) } returns true
+                every { hasVariablesWithAllNames(listOf(name1, name2)) } returns true
             }
         val declaration2: KoVariableProvider =
             mockk {
-                every { hasVariablesWithAllNames(name1, name2) } returns false
+                every { hasVariablesWithAllNames(listOf(name1, name2)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
         val names = listOf(name1, name2)
@@ -575,14 +575,14 @@ class KoVariableProviderListExtTest {
         val name2 = "SampleName2"
         val declaration1: KoVariableProvider =
             mockk {
-                every { hasVariablesWithAllNames(name1, name2) } returns true
+                every { hasVariablesWithAllNames(setOf(name1, name2)) } returns true
             }
         val declaration2: KoVariableProvider =
             mockk {
-                every { hasVariablesWithAllNames(name1, name2) } returns false
+                every { hasVariablesWithAllNames(setOf(name1, name2)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
-        val names = listOf(name1, name2)
+        val names = setOf(name1, name2)
 
         // when
         val sut = declarations.withoutAllVariablesNamed(names)

--- a/lib/src/test/kotlin/com/lemonappdev/konsist/api/ext/list/modifierprovider/KoModifierProviderListExtTest.kt
+++ b/lib/src/test/kotlin/com/lemonappdev/konsist/api/ext/list/modifierprovider/KoModifierProviderListExtTest.kt
@@ -244,11 +244,11 @@ class KoModifierProviderListExtTest {
         val modifier2 = OPEN
         val declaration1: KoModifierProvider =
             mockk {
-                every { hasModifier(modifier1, modifier2) } returns true
+                every { hasModifier(listOf(modifier1, modifier2)) } returns true
             }
         val declaration2: KoModifierProvider =
             mockk {
-                every { hasModifier(modifier1, modifier2) } returns false
+                every { hasModifier(listOf(modifier1, modifier2)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
 
@@ -266,11 +266,11 @@ class KoModifierProviderListExtTest {
         val modifier2 = OPEN
         val declaration1: KoModifierProvider =
             mockk {
-                every { hasModifier(modifier1, modifier2) } returns true
+                every { hasModifier(listOf(modifier1, modifier2)) } returns true
             }
         val declaration2: KoModifierProvider =
             mockk {
-                every { hasModifier(modifier1, modifier2) } returns false
+                every { hasModifier(listOf(modifier1, modifier2)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
         val modifiers = listOf(modifier1, modifier2)
@@ -289,11 +289,11 @@ class KoModifierProviderListExtTest {
         val modifier2 = OPEN
         val declaration1: KoModifierProvider =
             mockk {
-                every { hasModifier(modifier1, modifier2) } returns true
+                every { hasModifier(setOf(modifier1, modifier2)) } returns true
             }
         val declaration2: KoModifierProvider =
             mockk {
-                every { hasModifier(modifier1, modifier2) } returns false
+                every { hasModifier(setOf(modifier1, modifier2)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
         val modifiers = setOf(modifier1, modifier2)
@@ -312,11 +312,11 @@ class KoModifierProviderListExtTest {
         val modifier2 = OPEN
         val declaration1: KoModifierProvider =
             mockk {
-                every { hasModifier(modifier1, modifier2) } returns true
+                every { hasModifier(listOf(modifier1, modifier2)) } returns true
             }
         val declaration2: KoModifierProvider =
             mockk {
-                every { hasModifier(modifier1, modifier2) } returns false
+                every { hasModifier(listOf(modifier1, modifier2)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
 
@@ -334,11 +334,11 @@ class KoModifierProviderListExtTest {
         val modifier2 = OPEN
         val declaration1: KoModifierProvider =
             mockk {
-                every { hasModifier(modifier1, modifier2) } returns true
+                every { hasModifier(listOf(modifier1, modifier2)) } returns true
             }
         val declaration2: KoModifierProvider =
             mockk {
-                every { hasModifier(modifier1, modifier2) } returns false
+                every { hasModifier(listOf(modifier1, modifier2)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
         val modifiers = listOf(modifier1, modifier2)
@@ -357,14 +357,14 @@ class KoModifierProviderListExtTest {
         val modifier2 = OPEN
         val declaration1: KoModifierProvider =
             mockk {
-                every { hasModifier(modifier1, modifier2) } returns true
+                every { hasModifier(setOf(modifier1, modifier2)) } returns true
             }
         val declaration2: KoModifierProvider =
             mockk {
-                every { hasModifier(modifier1, modifier2) } returns false
+                every { hasModifier(setOf(modifier1, modifier2)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
-        val modifiers = listOf(modifier1, modifier2)
+        val modifiers = setOf(modifier1, modifier2)
 
         // when
         val sut = declarations.withoutModifier(modifiers)
@@ -380,11 +380,11 @@ class KoModifierProviderListExtTest {
         val modifier2 = OPEN
         val declaration1: KoModifierProvider =
             mockk {
-                every { hasAllModifiers(modifier1, modifier2) } returns true
+                every { hasAllModifiers(listOf(modifier1, modifier2)) } returns true
             }
         val declaration2: KoModifierProvider =
             mockk {
-                every { hasAllModifiers(modifier1, modifier2) } returns false
+                every { hasAllModifiers(listOf(modifier1, modifier2)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
 
@@ -402,11 +402,11 @@ class KoModifierProviderListExtTest {
         val modifier2 = OPEN
         val declaration1: KoModifierProvider =
             mockk {
-                every { hasAllModifiers(modifier1, modifier2) } returns true
+                every { hasAllModifiers(listOf(modifier1, modifier2)) } returns true
             }
         val declaration2: KoModifierProvider =
             mockk {
-                every { hasAllModifiers(modifier1, modifier2) } returns false
+                every { hasAllModifiers(listOf(modifier1, modifier2)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
         val modifiers = listOf(modifier1, modifier2)
@@ -425,11 +425,11 @@ class KoModifierProviderListExtTest {
         val modifier2 = OPEN
         val declaration1: KoModifierProvider =
             mockk {
-                every { hasAllModifiers(modifier1, modifier2) } returns true
+                every { hasAllModifiers(setOf(modifier1, modifier2)) } returns true
             }
         val declaration2: KoModifierProvider =
             mockk {
-                every { hasAllModifiers(modifier1, modifier2) } returns false
+                every { hasAllModifiers(setOf(modifier1, modifier2)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
         val modifiers = setOf(modifier1, modifier2)
@@ -448,11 +448,11 @@ class KoModifierProviderListExtTest {
         val modifier2 = OPEN
         val declaration1: KoModifierProvider =
             mockk {
-                every { hasAllModifiers(modifier1, modifier2) } returns true
+                every { hasAllModifiers(listOf(modifier1, modifier2)) } returns true
             }
         val declaration2: KoModifierProvider =
             mockk {
-                every { hasAllModifiers(modifier1, modifier2) } returns false
+                every { hasAllModifiers(listOf(modifier1, modifier2)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
 
@@ -470,11 +470,11 @@ class KoModifierProviderListExtTest {
         val modifier2 = OPEN
         val declaration1: KoModifierProvider =
             mockk {
-                every { hasAllModifiers(modifier1, modifier2) } returns true
+                every { hasAllModifiers(listOf(modifier1, modifier2)) } returns true
             }
         val declaration2: KoModifierProvider =
             mockk {
-                every { hasAllModifiers(modifier1, modifier2) } returns false
+                every { hasAllModifiers(listOf(modifier1, modifier2)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
         val modifiers = listOf(modifier1, modifier2)
@@ -493,11 +493,11 @@ class KoModifierProviderListExtTest {
         val modifier2 = OPEN
         val declaration1: KoModifierProvider =
             mockk {
-                every { hasAllModifiers(modifier1, modifier2) } returns true
+                every { hasAllModifiers(setOf(modifier1, modifier2)) } returns true
             }
         val declaration2: KoModifierProvider =
             mockk {
-                every { hasAllModifiers(modifier1, modifier2) } returns false
+                every { hasAllModifiers(setOf(modifier1, modifier2)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
         val modifiers = setOf(modifier1, modifier2)

--- a/lib/src/test/kotlin/com/lemonappdev/konsist/api/ext/list/tagprovider/KoKDocTagProviderListExtTest.kt
+++ b/lib/src/test/kotlin/com/lemonappdev/konsist/api/ext/list/tagprovider/KoKDocTagProviderListExtTest.kt
@@ -243,11 +243,11 @@ class KoKDocTagProviderListExtTest {
         val tag2 = KoKDocTag.SEE
         val declaration1: KoKDocTagProvider =
             mockk {
-                every { hasTag(tag1, tag2) } returns true
+                every { hasTag(listOf(tag1, tag2)) } returns true
             }
         val declaration2: KoKDocTagProvider =
             mockk {
-                every { hasTag(tag1, tag2) } returns false
+                every { hasTag(listOf(tag1, tag2)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
 
@@ -265,11 +265,11 @@ class KoKDocTagProviderListExtTest {
         val tag2 = KoKDocTag.SEE
         val declaration1: KoKDocTagProvider =
             mockk {
-                every { hasTag(tag1, tag2) } returns true
+                every { hasTag(listOf(tag1, tag2)) } returns true
             }
         val declaration2: KoKDocTagProvider =
             mockk {
-                every { hasTag(tag1, tag2) } returns false
+                every { hasTag(listOf(tag1, tag2)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
         val tags = listOf(tag1, tag2)
@@ -288,11 +288,11 @@ class KoKDocTagProviderListExtTest {
         val tag2 = KoKDocTag.SEE
         val declaration1: KoKDocTagProvider =
             mockk {
-                every { hasTag(tag1, tag2) } returns true
+                every { hasTag(setOf(tag1, tag2)) } returns true
             }
         val declaration2: KoKDocTagProvider =
             mockk {
-                every { hasTag(tag1, tag2) } returns false
+                every { hasTag(setOf(tag1, tag2)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
         val tags = setOf(tag1, tag2)
@@ -311,11 +311,11 @@ class KoKDocTagProviderListExtTest {
         val tag2 = KoKDocTag.SEE
         val declaration1: KoKDocTagProvider =
             mockk {
-                every { hasTag(tag1, tag2) } returns true
+                every { hasTag(listOf(tag1, tag2)) } returns true
             }
         val declaration2: KoKDocTagProvider =
             mockk {
-                every { hasTag(tag1, tag2) } returns false
+                every { hasTag(listOf(tag1, tag2)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
 
@@ -333,11 +333,11 @@ class KoKDocTagProviderListExtTest {
         val tag2 = KoKDocTag.SEE
         val declaration1: KoKDocTagProvider =
             mockk {
-                every { hasTag(tag1, tag2) } returns true
+                every { hasTag(listOf(tag1, tag2)) } returns true
             }
         val declaration2: KoKDocTagProvider =
             mockk {
-                every { hasTag(tag1, tag2) } returns false
+                every { hasTag(listOf(tag1, tag2)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
         val tags = listOf(tag1, tag2)
@@ -356,11 +356,11 @@ class KoKDocTagProviderListExtTest {
         val tag2 = KoKDocTag.SEE
         val declaration1: KoKDocTagProvider =
             mockk {
-                every { hasTag(tag1, tag2) } returns true
+                every { hasTag(setOf(tag1, tag2)) } returns true
             }
         val declaration2: KoKDocTagProvider =
             mockk {
-                every { hasTag(tag1, tag2) } returns false
+                every { hasTag(setOf(tag1, tag2)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
         val tags = setOf(tag1, tag2)
@@ -379,11 +379,11 @@ class KoKDocTagProviderListExtTest {
         val tag2 = KoKDocTag.SEE
         val declaration1: KoKDocTagProvider =
             mockk {
-                every { hasAllTags(tag1, tag2) } returns true
+                every { hasAllTags(listOf(tag1, tag2)) } returns true
             }
         val declaration2: KoKDocTagProvider =
             mockk {
-                every { hasAllTags(tag1, tag2) } returns false
+                every { hasAllTags(listOf(tag1, tag2)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
 
@@ -401,11 +401,11 @@ class KoKDocTagProviderListExtTest {
         val tag2 = KoKDocTag.SEE
         val declaration1: KoKDocTagProvider =
             mockk {
-                every { hasAllTags(tag1, tag2) } returns true
+                every { hasAllTags(listOf(tag1, tag2)) } returns true
             }
         val declaration2: KoKDocTagProvider =
             mockk {
-                every { hasAllTags(tag1, tag2) } returns false
+                every { hasAllTags(listOf(tag1, tag2)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
         val tags = listOf(tag1, tag2)
@@ -424,11 +424,11 @@ class KoKDocTagProviderListExtTest {
         val tag2 = KoKDocTag.SEE
         val declaration1: KoKDocTagProvider =
             mockk {
-                every { hasAllTags(tag1, tag2) } returns true
+                every { hasAllTags(setOf(tag1, tag2)) } returns true
             }
         val declaration2: KoKDocTagProvider =
             mockk {
-                every { hasAllTags(tag1, tag2) } returns false
+                every { hasAllTags(setOf(tag1, tag2)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
         val tags = setOf(tag1, tag2)
@@ -447,11 +447,11 @@ class KoKDocTagProviderListExtTest {
         val tag2 = KoKDocTag.SEE
         val declaration1: KoKDocTagProvider =
             mockk {
-                every { hasAllTags(tag1, tag2) } returns true
+                every { hasAllTags(listOf(tag1, tag2)) } returns true
             }
         val declaration2: KoKDocTagProvider =
             mockk {
-                every { hasAllTags(tag1, tag2) } returns false
+                every { hasAllTags(listOf(tag1, tag2)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
 
@@ -469,11 +469,11 @@ class KoKDocTagProviderListExtTest {
         val tag2 = KoKDocTag.SEE
         val declaration1: KoKDocTagProvider =
             mockk {
-                every { hasAllTags(tag1, tag2) } returns true
+                every { hasAllTags(listOf(tag1, tag2)) } returns true
             }
         val declaration2: KoKDocTagProvider =
             mockk {
-                every { hasAllTags(tag1, tag2) } returns false
+                every { hasAllTags(listOf(tag1, tag2)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
         val tags = listOf(tag1, tag2)
@@ -492,11 +492,11 @@ class KoKDocTagProviderListExtTest {
         val tag2 = KoKDocTag.SEE
         val declaration1: KoKDocTagProvider =
             mockk {
-                every { hasAllTags(tag1, tag2) } returns true
+                every { hasAllTags(setOf(tag1, tag2)) } returns true
             }
         val declaration2: KoKDocTagProvider =
             mockk {
-                every { hasAllTags(tag1, tag2) } returns false
+                every { hasAllTags(setOf(tag1, tag2)) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
         val tags = setOf(tag1, tag2)

--- a/test-projects/konsist-declaration-tester/app/src/integrationTest/kotlin/com/lemonappdev/konsist/declaration/koclass/KoClassForKoChildProviderTest.kt
+++ b/test-projects/konsist-declaration-tester/app/src/integrationTest/kotlin/com/lemonappdev/konsist/declaration/koclass/KoClassForKoChildProviderTest.kt
@@ -25,8 +25,16 @@ class KoClassForKoChildProviderTest {
             numChildren() shouldBeEqualTo 0
             countChildren { it.hasNameStartingWith("Parent") } shouldBeEqualTo 0
             hasChildren() shouldBeEqualTo false
+            hasChildWithName(emptyList()) shouldBeEqualTo false
+            hasChildWithName(emptySet()) shouldBeEqualTo false
+            hasChildrenWithAllNames(emptyList()) shouldBeEqualTo false
+            hasChildrenWithAllNames(emptySet()) shouldBeEqualTo false
             hasChildWithName("ParentClass") shouldBeEqualTo false
+            hasChildWithName(listOf("ParentClass")) shouldBeEqualTo false
+            hasChildWithName(setOf("ParentClass")) shouldBeEqualTo false
             hasChildrenWithAllNames("ParentClass") shouldBeEqualTo false
+            hasChildrenWithAllNames(listOf("ParentClass")) shouldBeEqualTo false
+            hasChildrenWithAllNames(setOf("ParentClass")) shouldBeEqualTo false
             hasChild { it.hasNameStartingWith("Parent") } shouldBeEqualTo false
             hasAllChildren { it.hasNameStartingWith("Parent") } shouldBeEqualTo true
         }
@@ -48,10 +56,22 @@ class KoClassForKoChildProviderTest {
             countChildren { it.hasNameStartingWith("Parent") } shouldBeEqualTo 1
             countChildren { it.hasNameStartingWith("Other") } shouldBeEqualTo 0
             hasChildren() shouldBeEqualTo true
+            hasChildWithName(emptyList()) shouldBeEqualTo true
+            hasChildWithName(emptySet()) shouldBeEqualTo true
+            hasChildrenWithAllNames(emptyList()) shouldBeEqualTo true
+            hasChildrenWithAllNames(emptySet()) shouldBeEqualTo true
             hasChildWithName("ParentClass") shouldBeEqualTo true
             hasChildWithName("ParentClass", "OtherClass") shouldBeEqualTo true
+            hasChildWithName(listOf("ParentClass")) shouldBeEqualTo true
+            hasChildWithName(listOf("ParentClass", "OtherClass")) shouldBeEqualTo true
+            hasChildWithName(setOf("ParentClass")) shouldBeEqualTo true
+            hasChildWithName(setOf("ParentClass", "OtherClass")) shouldBeEqualTo true
             hasChildrenWithAllNames("ParentClass") shouldBeEqualTo true
             hasChildrenWithAllNames("ParentClass", "OtherClass") shouldBeEqualTo false
+            hasChildrenWithAllNames(listOf("ParentClass")) shouldBeEqualTo true
+            hasChildrenWithAllNames(listOf("ParentClass", "OtherClass")) shouldBeEqualTo false
+            hasChildrenWithAllNames(setOf("ParentClass")) shouldBeEqualTo true
+            hasChildrenWithAllNames(setOf("ParentClass", "OtherClass")) shouldBeEqualTo false
             hasChild { it.hasNameStartingWith("Parent") } shouldBeEqualTo true
             hasChild { it.hasNameStartingWith("Other") } shouldBeEqualTo false
             hasAllChildren { it.hasNameStartingWith("Parent") } shouldBeEqualTo true
@@ -75,11 +95,25 @@ class KoClassForKoChildProviderTest {
             countChildren(indirectChildren = true) { it.hasNameStartingWith("Parent") } shouldBeEqualTo 1
             countChildren(indirectChildren = true) { it.hasNameStartingWith("App") } shouldBeEqualTo 1
             hasChildren(indirectChildren = true) shouldBeEqualTo true
+            hasChildWithName(emptyList(), indirectChildren = true) shouldBeEqualTo true
+            hasChildWithName(emptySet(), indirectChildren = true) shouldBeEqualTo true
+            hasChildrenWithAllNames(emptyList(), indirectChildren = true) shouldBeEqualTo true
+            hasChildrenWithAllNames(emptySet(), indirectChildren = true) shouldBeEqualTo true
             hasChildWithName("ParentClass", indirectChildren = true) shouldBeEqualTo true
             hasChildWithName("ParentClass", "OtherClass", indirectChildren = true) shouldBeEqualTo true
+            hasChildWithName(listOf("ParentClass"), indirectChildren = true) shouldBeEqualTo true
+            hasChildWithName(listOf("ParentClass", "OtherClass"), indirectChildren = true) shouldBeEqualTo true
+            hasChildWithName(setOf("ParentClass"), indirectChildren = true) shouldBeEqualTo true
+            hasChildWithName(setOf("ParentClass", "OtherClass"), indirectChildren = true) shouldBeEqualTo true
             hasChildrenWithAllNames("ParentClass", indirectChildren = true) shouldBeEqualTo true
             hasChildrenWithAllNames("ParentClass", "AppClass", indirectChildren = true) shouldBeEqualTo true
             hasChildrenWithAllNames("ParentClass", "OtherClass", indirectChildren = true) shouldBeEqualTo false
+            hasChildrenWithAllNames(listOf("ParentClass"), indirectChildren = true) shouldBeEqualTo true
+            hasChildrenWithAllNames(listOf("ParentClass", "AppClass"), indirectChildren = true) shouldBeEqualTo true
+            hasChildrenWithAllNames(listOf("ParentClass", "OtherClass"), indirectChildren = true) shouldBeEqualTo false
+            hasChildrenWithAllNames(setOf("ParentClass"), indirectChildren = true) shouldBeEqualTo true
+            hasChildrenWithAllNames(setOf("ParentClass", "AppClass"), indirectChildren = true) shouldBeEqualTo true
+            hasChildrenWithAllNames(setOf("ParentClass", "OtherClass"), indirectChildren = true) shouldBeEqualTo false
             hasChild(indirectChildren = true) { it.hasNameStartingWith("Parent") } shouldBeEqualTo true
             hasChild(indirectChildren = true) { it.hasNameStartingWith("Other") } shouldBeEqualTo false
             hasAllChildren(indirectChildren = true) { it.hasNameStartingWith("Parent") || it.hasNameStartingWith("App") }

--- a/test-projects/konsist-declaration-tester/app/src/integrationTest/kotlin/com/lemonappdev/konsist/declaration/kointerface/KoInterfaceForKoChildProviderTest.kt
+++ b/test-projects/konsist-declaration-tester/app/src/integrationTest/kotlin/com/lemonappdev/konsist/declaration/kointerface/KoInterfaceForKoChildProviderTest.kt
@@ -25,8 +25,16 @@ class KoInterfaceForKoChildProviderTest {
             numChildren() shouldBeEqualTo 0
             countChildren { it.hasNameStartingWith("Parent") } shouldBeEqualTo 0
             hasChildren() shouldBeEqualTo false
+            hasChildWithName(emptyList()) shouldBeEqualTo false
+            hasChildWithName(emptySet()) shouldBeEqualTo false
+            hasChildrenWithAllNames(emptyList()) shouldBeEqualTo false
+            hasChildrenWithAllNames(emptySet()) shouldBeEqualTo false
             hasChildWithName("ParentInterface") shouldBeEqualTo false
+            hasChildWithName(listOf("ParentInterface")) shouldBeEqualTo false
+            hasChildWithName(setOf("ParentInterface")) shouldBeEqualTo false
             hasChildrenWithAllNames("ParentInterface") shouldBeEqualTo false
+            hasChildrenWithAllNames(listOf("ParentInterface")) shouldBeEqualTo false
+            hasChildrenWithAllNames(setOf("ParentInterface")) shouldBeEqualTo false
             hasChild { it.hasNameStartingWith("Parent") } shouldBeEqualTo false
             hasAllChildren { it.hasNameStartingWith("Parent") } shouldBeEqualTo true
         }
@@ -48,10 +56,22 @@ class KoInterfaceForKoChildProviderTest {
             countChildren { it.hasNameStartingWith("Parent") } shouldBeEqualTo 1
             countChildren { it.hasNameStartingWith("Other") } shouldBeEqualTo 0
             hasChildren() shouldBeEqualTo true
+            hasChildWithName(emptyList()) shouldBeEqualTo true
+            hasChildWithName(emptySet()) shouldBeEqualTo true
+            hasChildrenWithAllNames(emptyList()) shouldBeEqualTo true
+            hasChildrenWithAllNames(emptySet()) shouldBeEqualTo true
             hasChildWithName("ParentInterface") shouldBeEqualTo true
             hasChildWithName("ParentInterface", "OtherInterface") shouldBeEqualTo true
+            hasChildWithName(listOf("ParentInterface")) shouldBeEqualTo true
+            hasChildWithName(listOf("ParentInterface", "OtherInterface")) shouldBeEqualTo true
+            hasChildWithName(setOf("ParentInterface")) shouldBeEqualTo true
+            hasChildWithName(setOf("ParentInterface", "OtherInterface")) shouldBeEqualTo true
             hasChildrenWithAllNames("ParentInterface") shouldBeEqualTo true
             hasChildrenWithAllNames("ParentInterface", "OtherInterface") shouldBeEqualTo false
+            hasChildrenWithAllNames(listOf("ParentInterface")) shouldBeEqualTo true
+            hasChildrenWithAllNames(listOf("ParentInterface", "OtherInterface")) shouldBeEqualTo false
+            hasChildrenWithAllNames(setOf("ParentInterface")) shouldBeEqualTo true
+            hasChildrenWithAllNames(setOf("ParentInterface", "OtherInterface")) shouldBeEqualTo false
             hasChild { it.hasNameStartingWith("Parent") } shouldBeEqualTo true
             hasChild { it.hasNameStartingWith("Other") } shouldBeEqualTo false
             hasAllChildren { it.hasNameStartingWith("Parent") } shouldBeEqualTo true
@@ -75,11 +95,25 @@ class KoInterfaceForKoChildProviderTest {
             countChildren(indirectChildren = true) { it.hasNameStartingWith("Parent") } shouldBeEqualTo 1
             countChildren(indirectChildren = true) { it.hasNameStartingWith("App") } shouldBeEqualTo 1
             hasChildren(indirectChildren = true) shouldBeEqualTo true
+            hasChildWithName(emptyList(), indirectChildren = true) shouldBeEqualTo true
+            hasChildWithName(emptySet(), indirectChildren = true) shouldBeEqualTo true
+            hasChildrenWithAllNames(emptyList(), indirectChildren = true) shouldBeEqualTo true
+            hasChildrenWithAllNames(emptySet(), indirectChildren = true) shouldBeEqualTo true
             hasChildWithName("ParentInterface", indirectChildren = true) shouldBeEqualTo true
             hasChildWithName("ParentInterface", "OtherInterface", indirectChildren = true) shouldBeEqualTo true
+            hasChildWithName(listOf("ParentInterface"), indirectChildren = true) shouldBeEqualTo true
+            hasChildWithName(listOf("ParentInterface", "OtherInterface"), indirectChildren = true) shouldBeEqualTo true
+            hasChildWithName(setOf("ParentInterface"), indirectChildren = true) shouldBeEqualTo true
+            hasChildWithName(setOf("ParentInterface", "OtherInterface"), indirectChildren = true) shouldBeEqualTo true
             hasChildrenWithAllNames("ParentInterface", indirectChildren = true) shouldBeEqualTo true
             hasChildrenWithAllNames("ParentInterface", "AppClass", indirectChildren = true) shouldBeEqualTo true
             hasChildrenWithAllNames("ParentInterface", "OtherInterface", indirectChildren = true) shouldBeEqualTo false
+            hasChildrenWithAllNames(listOf("ParentInterface"), indirectChildren = true) shouldBeEqualTo true
+            hasChildrenWithAllNames(listOf("ParentInterface", "AppClass"), indirectChildren = true) shouldBeEqualTo true
+            hasChildrenWithAllNames(listOf("ParentInterface", "OtherInterface"), indirectChildren = true) shouldBeEqualTo false
+            hasChildrenWithAllNames(setOf("ParentInterface"), indirectChildren = true) shouldBeEqualTo true
+            hasChildrenWithAllNames(setOf("ParentInterface", "AppClass"), indirectChildren = true) shouldBeEqualTo true
+            hasChildrenWithAllNames(setOf("ParentInterface", "OtherInterface"), indirectChildren = true) shouldBeEqualTo false
             hasChild(indirectChildren = true) { it.hasNameStartingWith("Parent") } shouldBeEqualTo true
             hasChild(indirectChildren = true) { it.hasNameStartingWith("Other") } shouldBeEqualTo false
             hasAllChildren(indirectChildren = true) { it.hasNameStartingWith("Parent") || it.hasNameStartingWith("App") }

--- a/test-projects/konsist-path-tester/app/src/integrationTest/kotlin/com/lemonappdev/konsist/container/from/KoScopeFromDirectoriesTest.kt
+++ b/test-projects/konsist-path-tester/app/src/integrationTest/kotlin/com/lemonappdev/konsist/container/from/KoScopeFromDirectoriesTest.kt
@@ -14,7 +14,7 @@ import org.junit.jupiter.api.Test
 class KoScopeFromDirectoriesTest {
 
     @Test
-    fun `scopeFromDirectories`() {
+    fun `scopeFromDirectories(set)`() {
         // given
         val paths = setOf(
             "app/src/main/kotlin/com/lemonappdev/sample/".toOsSeparator(),
@@ -36,12 +36,33 @@ class KoScopeFromDirectoriesTest {
     }
 
     @Test
-    fun `scopeFromDirectories throws exception if path does not exist`() {
+    fun `scopeFromDirectories(list)`() {
+        // given
+        val paths = listOf(
+            "app/src/main/kotlin/com/lemonappdev/sample/".toOsSeparator(),
+            "app/src/integrationTest/kotlin/com/lemonappdev/sample/".toOsSeparator(),
+        )
+        val sut = Konsist
+            .scopeFromDirectories(paths)
+            .mapToFilePaths()
+
+        // then
+        sut.shouldBeEqualTo(
+            listOf(
+                "$appIntegrationTestSourceSetDirectory/sample/AppClassTest.kt",
+                "$appIntegrationTestSourceSetDirectory/sample/data/AppDataClassTest.kt",
+                "$appMainSourceSetDirectory/sample/AppClass.kt",
+                "$appMainSourceSetDirectory/sample/data/AppDataClass.kt",
+            ).toOsSeparator(),
+        )
+    }
+
+    @Test
+    fun `scopeFromDirectories(set) throws exception if path does not exist`() {
         // given
         val paths = setOf("app/src/main/kotlin/com/lemonappdev/nonExisting/".toOsSeparator())
 
-        val func =
-            { Konsist.scopeFromDirectories(paths) }
+        val func = { Konsist.scopeFromDirectories(paths) }
 
         // then
         val message = "Directory does not exist: $appMainSourceSetDirectory${fileSeparator}nonExisting$fileSeparator"
@@ -49,14 +70,36 @@ class KoScopeFromDirectoriesTest {
     }
 
     @Test
-    fun `scopeFromDirectories throws exception if path points to file`() {
+    fun `scopeFromDirectories(list) throws exception if path does not exist`() {
+        // given
+        val paths = listOf("app/src/main/kotlin/com/lemonappdev/nonExisting/".toOsSeparator())
+
+        val func = { Konsist.scopeFromDirectories(paths) }
+
+        // then
+        val message = "Directory does not exist: $appMainSourceSetDirectory${fileSeparator}nonExisting$fileSeparator"
+        func shouldThrow IllegalArgumentException::class withMessage message
+    }
+
+    @Test
+    fun `scopeFromDirectories(set) throws exception if path points to file`() {
         // given
         val paths = setOf("app/src/main/kotlin/com/lemonappdev/sample/AppClass.kt".toOsSeparator())
 
-        val func =
-            {
-                Konsist.scopeFromDirectories(paths)
-            }
+        val func = { Konsist.scopeFromDirectories(paths) }
+
+        // then
+        val message =
+            "Path is a file, but should be a directory: $appMainSourceSetDirectory${fileSeparator}sample${fileSeparator}AppClass.kt"
+        func shouldThrow IllegalArgumentException::class withMessage message
+    }
+
+    @Test
+    fun `scopeFromDirectories(list) throws exception if path points to file`() {
+        // given
+        val paths = listOf("app/src/main/kotlin/com/lemonappdev/sample/AppClass.kt".toOsSeparator())
+
+        val func = { Konsist.scopeFromDirectories(paths) }
 
         // then
         val message =

--- a/test-projects/konsist-path-tester/app/src/integrationTest/kotlin/com/lemonappdev/konsist/container/from/KoScopeFromFilesTest.kt
+++ b/test-projects/konsist-path-tester/app/src/integrationTest/kotlin/com/lemonappdev/konsist/container/from/KoScopeFromFilesTest.kt
@@ -13,7 +13,7 @@ import org.junit.jupiter.api.Test
 class KoScopeFromFilesTest {
 
     @Test
-    fun `scopeFromFiles`() {
+    fun `scopeFromFiles(set)`() {
         // given
         val files = setOf(
             "/app/src/main/kotlin/com/lemonappdev/sample/AppClass.kt".toOsSeparator(),
@@ -32,14 +32,32 @@ class KoScopeFromFilesTest {
     }
 
     @Test
-    fun `scopeFromFiles throws exception if path does not exist`() {
+    fun `scopeFromFiles(list)`() {
+        // given
+        val files = listOf(
+            "/app/src/main/kotlin/com/lemonappdev/sample/AppClass.kt".toOsSeparator(),
+            "/app/src/main/kotlin/com/lemonappdev/sample/data/AppDataClass.kt".toOsSeparator()
+        )
+        val sut = Konsist.scopeFromFiles(files)
+            .mapToFilePaths()
+
+        // then
+        sut.shouldBeEqualTo(
+            listOf(
+                "$appMainSourceSetDirectory/sample/AppClass.kt",
+                "$appMainSourceSetDirectory/sample/data/AppDataClass.kt",
+            ).toOsSeparator(),
+        )
+    }
+
+    @Test
+    fun `scopeFromFiles(set) throws exception if path does not exist`() {
         // given
         val files = setOf(
             "app/src/main/kotlin/com/lemonappdev/NonExistingTest.kt".toOsSeparator()
         )
 
-        val func =
-            { Konsist.scopeFromFiles(files) }
+        val func = { Konsist.scopeFromFiles(files) }
 
         // then
         val message = "File does not exist: $appMainSourceSetDirectory${fileSeparator}NonExistingTest.kt"
@@ -47,9 +65,37 @@ class KoScopeFromFilesTest {
     }
 
     @Test
-    fun `scopeFromFiles throws exception if path points to directory`() {
+    fun `scopeFromFiles(list) throws exception if path does not exist`() {
+        // given
+        val files = listOf(
+            "app/src/main/kotlin/com/lemonappdev/NonExistingTest.kt".toOsSeparator()
+        )
+
+        val func = { Konsist.scopeFromFiles(files) }
+
+        // then
+        val message = "File does not exist: $appMainSourceSetDirectory${fileSeparator}NonExistingTest.kt"
+        func shouldThrow IllegalArgumentException::class withMessage message
+    }
+
+    @Test
+    fun `scopeFromFiles(set) throws exception if path points to directory`() {
         // given
         val files = setOf(
+            "app/src/main/kotlin/com/lemonappdev/sample".toOsSeparator()
+        )
+
+        val func = { Konsist.scopeFromFiles(files) }
+
+        // then
+        val message = "Path is a directory, but should be a file: $appMainSourceSetDirectory${fileSeparator}sample"
+        func shouldThrow IllegalArgumentException::class withMessage message
+    }
+
+    @Test
+    fun `scopeFromFiles(list) throws exception if path points to directory`() {
+        // given
+        val files = listOf(
             "app/src/main/kotlin/com/lemonappdev/sample".toOsSeparator()
         )
 

--- a/test-projects/konsist-path-tester/app/src/integrationTest/kotlin/com/lemonappdev/konsist/container/from/KoScopeFromModulesTest.kt
+++ b/test-projects/konsist-path-tester/app/src/integrationTest/kotlin/com/lemonappdev/konsist/container/from/KoScopeFromModulesTest.kt
@@ -14,7 +14,7 @@ import org.junit.jupiter.api.Test
 class KoScopeFromModulesTest {
     @Suppress("detekt.LongMethod")
     @Test
-    fun `scopeFromModules for app module`() {
+    fun `scopeFromModules(set) for app module`() {
         // given
         val moduleNames = setOf("app")
 
@@ -49,8 +49,45 @@ class KoScopeFromModulesTest {
         )
     }
 
+    @Suppress("detekt.LongMethod")
     @Test
-    fun `scopeFromModules for data module`() {
+    fun `scopeFromModules(list) for app module`() {
+        // given
+        val moduleNames = listOf("app")
+
+        val sut = Konsist
+            .scopeFromModules(moduleNames)
+            .mapToFilePaths()
+
+        // then
+        sut.shouldBeEqualTo(
+            listOf(
+                "$appIntegrationTestSourceSetDirectory/konsist/container/KoScopeTest.kt",
+                "$appIntegrationTestSourceSetDirectory/konsist/container/from/KoScopeFromDirectoriesTest.kt",
+                "$appIntegrationTestSourceSetDirectory/konsist/container/from/KoScopeFromDirectoryTest.kt",
+                "$appIntegrationTestSourceSetDirectory/konsist/container/from/KoScopeFromFileTest.kt",
+                "$appIntegrationTestSourceSetDirectory/konsist/container/from/KoScopeFromFilesTest.kt",
+                "$appIntegrationTestSourceSetDirectory/konsist/container/from/KoScopeFromModuleTest.kt",
+                "$appIntegrationTestSourceSetDirectory/konsist/container/from/KoScopeFromModulesTest.kt",
+                "$appIntegrationTestSourceSetDirectory/konsist/container/from/KoScopeFromPackageTest.kt",
+                "$appIntegrationTestSourceSetDirectory/konsist/container/from/KoScopeFromProductionTest.kt",
+                "$appIntegrationTestSourceSetDirectory/konsist/container/from/KoScopeFromProjectTest.kt",
+                "$appIntegrationTestSourceSetDirectory/konsist/container/from/KoScopeFromSourceSetTest.kt",
+                "$appIntegrationTestSourceSetDirectory/konsist/container/from/KoScopeFromSourceSetsTest.kt",
+                "$appIntegrationTestSourceSetDirectory/konsist/container/from/KoScopeFromTest.kt",
+                "$appIntegrationTestSourceSetDirectory/konsist/helper/ext/KoScopeExt.kt",
+                "$appIntegrationTestSourceSetDirectory/konsist/helper/ext/PathExt.kt",
+                "$appIntegrationTestSourceSetDirectory/konsist/helper/util/PathProvider.kt",
+                "$appIntegrationTestSourceSetDirectory/sample/AppClassTest.kt",
+                "$appIntegrationTestSourceSetDirectory/sample/data/AppDataClassTest.kt",
+                "$appMainSourceSetDirectory/sample/AppClass.kt",
+                "$appMainSourceSetDirectory/sample/data/AppDataClass.kt",
+            ).toOsSeparator(),
+        )
+    }
+
+    @Test
+    fun `scopeFromModules(set) for data module`() {
         // given
         val moduleNames = setOf("data")
 
@@ -70,7 +107,28 @@ class KoScopeFromModulesTest {
     }
 
     @Test
-    fun `scopeFromModules for root module`() {
+    fun `scopeFromModules(list) for data module`() {
+        // given
+        val moduleNames = listOf("data")
+
+        val sut = Konsist
+            .scopeFromModules(moduleNames)
+            .mapToFilePaths()
+
+        // then
+        sut.shouldBeEqualTo(
+            listOf(
+                "$dataMainSourceSetDirectory/sample/LibClass.kt",
+                "$dataMainSourceSetDirectory/sample/data/LibDataClass.kt",
+                "$dataTestSourceSetDirectory/sample/LibClassSpec.kt",
+                "$dataTestSourceSetDirectory/sample/data/LibDataClassTest.kt",
+            ).toOsSeparator(),
+        )
+    }
+
+
+    @Test
+    fun `scopeFromModules(set) for root module`() {
         // given
         val moduleNames = setOf("root")
 
@@ -88,11 +146,71 @@ class KoScopeFromModulesTest {
         )
     }
 
+    @Test
+    fun `scopeFromModules(list) for root module`() {
+        // given
+        val moduleNames = listOf("root")
+
+        val sut = Konsist
+            .scopeFromModules(moduleNames)
+            .mapToFilePaths()
+
+        // then
+        sut.shouldBeEqualTo(
+            listOf(
+                "$rootMainSourceSetDirectory/sample/RootClass.kt",
+                "$rootMainSourceSetDirectory/sample/data/RootDataClass.kt",
+                "$rootMainSourceSetDirectory/sample/src/RootSrcClass.kt",
+            ).toOsSeparator(),
+        )
+    }
+
     @Suppress("detekt.LongMethod")
     @Test
-    fun `scopeFromModules for app and data modules`() {
+    fun `scopeFromModules(set) for app and data modules`() {
         // given
         val moduleNames = setOf("app", "data")
+
+        val sut = Konsist
+            .scopeFromModules(moduleNames)
+            .mapToFilePaths()
+
+        // then
+        sut.shouldBeEqualTo(
+            listOf(
+                "$appIntegrationTestSourceSetDirectory/konsist/container/KoScopeTest.kt",
+                "$appIntegrationTestSourceSetDirectory/konsist/container/from/KoScopeFromDirectoriesTest.kt",
+                "$appIntegrationTestSourceSetDirectory/konsist/container/from/KoScopeFromDirectoryTest.kt",
+                "$appIntegrationTestSourceSetDirectory/konsist/container/from/KoScopeFromFileTest.kt",
+                "$appIntegrationTestSourceSetDirectory/konsist/container/from/KoScopeFromFilesTest.kt",
+                "$appIntegrationTestSourceSetDirectory/konsist/container/from/KoScopeFromModuleTest.kt",
+                "$appIntegrationTestSourceSetDirectory/konsist/container/from/KoScopeFromModulesTest.kt",
+                "$appIntegrationTestSourceSetDirectory/konsist/container/from/KoScopeFromPackageTest.kt",
+                "$appIntegrationTestSourceSetDirectory/konsist/container/from/KoScopeFromProductionTest.kt",
+                "$appIntegrationTestSourceSetDirectory/konsist/container/from/KoScopeFromProjectTest.kt",
+                "$appIntegrationTestSourceSetDirectory/konsist/container/from/KoScopeFromSourceSetTest.kt",
+                "$appIntegrationTestSourceSetDirectory/konsist/container/from/KoScopeFromSourceSetsTest.kt",
+                "$appIntegrationTestSourceSetDirectory/konsist/container/from/KoScopeFromTest.kt",
+                "$appIntegrationTestSourceSetDirectory/konsist/helper/ext/KoScopeExt.kt",
+                "$appIntegrationTestSourceSetDirectory/konsist/helper/ext/PathExt.kt",
+                "$appIntegrationTestSourceSetDirectory/konsist/helper/util/PathProvider.kt",
+                "$appIntegrationTestSourceSetDirectory/sample/AppClassTest.kt",
+                "$appIntegrationTestSourceSetDirectory/sample/data/AppDataClassTest.kt",
+                "$appMainSourceSetDirectory/sample/AppClass.kt",
+                "$appMainSourceSetDirectory/sample/data/AppDataClass.kt",
+                "$dataMainSourceSetDirectory/sample/LibClass.kt",
+                "$dataMainSourceSetDirectory/sample/data/LibDataClass.kt",
+                "$dataTestSourceSetDirectory/sample/LibClassSpec.kt",
+                "$dataTestSourceSetDirectory/sample/data/LibDataClassTest.kt",
+            ).toOsSeparator(),
+        )
+    }
+
+    @Suppress("detekt.LongMethod")
+    @Test
+    fun `scopeFromModules(list) for app and data modules`() {
+        // given
+        val moduleNames = listOf("app", "data")
 
         val sut = Konsist
             .scopeFromModules(moduleNames)

--- a/test-projects/konsist-path-tester/app/src/integrationTest/kotlin/com/lemonappdev/konsist/container/from/KoScopeFromSourceSetsTest.kt
+++ b/test-projects/konsist-path-tester/app/src/integrationTest/kotlin/com/lemonappdev/konsist/container/from/KoScopeFromSourceSetsTest.kt
@@ -14,7 +14,7 @@ import org.junit.jupiter.api.Test
 
 class KoScopeFromSourceSetsTest {
     @Test
-    fun `scopeFromSourceSets for main source set`() {
+    fun `scopeFromSourceSets(set) for main source set`() {
         // given
         val sourceSetNames = setOf("main")
 
@@ -36,9 +36,32 @@ class KoScopeFromSourceSetsTest {
         )
     }
 
+    @Test
+    fun `scopeFromSourceSets(list) for main source set`() {
+        // given
+        val sourceSetNames = listOf("main")
+
+        val sut = Konsist
+            .scopeFromSourceSets(sourceSetNames)
+            .mapToFilePaths()
+
+        // then
+        sut.shouldBeEqualTo(
+            listOf(
+                "$appMainSourceSetDirectory/sample/AppClass.kt",
+                "$appMainSourceSetDirectory/sample/data/AppDataClass.kt",
+                "$dataMainSourceSetDirectory/sample/LibClass.kt",
+                "$dataMainSourceSetDirectory/sample/data/LibDataClass.kt",
+                "$rootMainSourceSetDirectory/sample/RootClass.kt",
+                "$rootMainSourceSetDirectory/sample/data/RootDataClass.kt",
+                "$rootMainSourceSetDirectory/sample/src/RootSrcClass.kt",
+            ).toOsSeparator(),
+        )
+    }
+
     @Suppress("detekt.LongMethod")
     @Test
-    fun `scopeFromSourceSets for integrationTest source set`() {
+    fun `scopeFromSourceSets(set) for integrationTest source set`() {
         // given
         val sourceSetNames = setOf("integrationTest")
 
@@ -71,8 +94,43 @@ class KoScopeFromSourceSetsTest {
         )
     }
 
+    @Suppress("detekt.LongMethod")
     @Test
-    fun `scopeFromSourceSets for test source set`() {
+    fun `scopeFromSourceSets(list) for integrationTest source set`() {
+        // given
+        val sourceSetNames = listOf("integrationTest")
+
+        val sut = Konsist
+            .scopeFromSourceSets(sourceSetNames)
+            .mapToFilePaths()
+
+        // then
+        sut.shouldBeEqualTo(
+            listOf(
+                "$appIntegrationTestSourceSetDirectory/konsist/container/KoScopeTest.kt",
+                "$appIntegrationTestSourceSetDirectory/konsist/container/from/KoScopeFromDirectoriesTest.kt",
+                "$appIntegrationTestSourceSetDirectory/konsist/container/from/KoScopeFromDirectoryTest.kt",
+                "$appIntegrationTestSourceSetDirectory/konsist/container/from/KoScopeFromFileTest.kt",
+                "$appIntegrationTestSourceSetDirectory/konsist/container/from/KoScopeFromFilesTest.kt",
+                "$appIntegrationTestSourceSetDirectory/konsist/container/from/KoScopeFromModuleTest.kt",
+                "$appIntegrationTestSourceSetDirectory/konsist/container/from/KoScopeFromModulesTest.kt",
+                "$appIntegrationTestSourceSetDirectory/konsist/container/from/KoScopeFromPackageTest.kt",
+                "$appIntegrationTestSourceSetDirectory/konsist/container/from/KoScopeFromProductionTest.kt",
+                "$appIntegrationTestSourceSetDirectory/konsist/container/from/KoScopeFromProjectTest.kt",
+                "$appIntegrationTestSourceSetDirectory/konsist/container/from/KoScopeFromSourceSetTest.kt",
+                "$appIntegrationTestSourceSetDirectory/konsist/container/from/KoScopeFromSourceSetsTest.kt",
+                "$appIntegrationTestSourceSetDirectory/konsist/container/from/KoScopeFromTest.kt",
+                "$appIntegrationTestSourceSetDirectory/konsist/helper/ext/KoScopeExt.kt",
+                "$appIntegrationTestSourceSetDirectory/konsist/helper/ext/PathExt.kt",
+                "$appIntegrationTestSourceSetDirectory/konsist/helper/util/PathProvider.kt",
+                "$appIntegrationTestSourceSetDirectory/sample/AppClassTest.kt",
+                "$appIntegrationTestSourceSetDirectory/sample/data/AppDataClassTest.kt",
+            ).toOsSeparator(),
+        )
+    }
+
+    @Test
+    fun `scopeFromSourceSets(set) for test source set`() {
         // given
         val sourceSetNames = setOf("test")
 
@@ -90,9 +148,52 @@ class KoScopeFromSourceSetsTest {
     }
 
     @Test
-    fun `scopeFromSourceSets for main and test source sets`() {
+    fun `scopeFromSourceSets(list) for test source set`() {
+        // given
+        val sourceSetNames = listOf("test")
+
+        val sut = Konsist
+            .scopeFromSourceSets(sourceSetNames)
+            .mapToFilePaths()
+
+        // then
+        sut.shouldBeEqualTo(
+            listOf(
+                "$dataTestSourceSetDirectory/sample/LibClassSpec.kt",
+                "$dataTestSourceSetDirectory/sample/data/LibDataClassTest.kt",
+            ).toOsSeparator(),
+        )
+    }
+
+    @Test
+    fun `scopeFromSourceSets(set) for main and test source sets`() {
         // given
         val sourceSetNames = setOf("main", "test")
+
+        val sut = Konsist
+            .scopeFromSourceSets(sourceSetNames)
+            .mapToFilePaths()
+
+        // then
+        sut.shouldBeEqualTo(
+            listOf(
+                "$appMainSourceSetDirectory/sample/AppClass.kt",
+                "$appMainSourceSetDirectory/sample/data/AppDataClass.kt",
+                "$dataMainSourceSetDirectory/sample/LibClass.kt",
+                "$dataMainSourceSetDirectory/sample/data/LibDataClass.kt",
+                "$dataTestSourceSetDirectory/sample/LibClassSpec.kt",
+                "$dataTestSourceSetDirectory/sample/data/LibDataClassTest.kt",
+                "$rootMainSourceSetDirectory/sample/RootClass.kt",
+                "$rootMainSourceSetDirectory/sample/data/RootDataClass.kt",
+                "$rootMainSourceSetDirectory/sample/src/RootSrcClass.kt",
+            ).toOsSeparator(),
+        )
+    }
+
+    @Test
+    fun `scopeFromSourceSets(list) for main and test source sets`() {
+        // given
+        val sourceSetNames = listOf("main", "test")
 
         val sut = Konsist
             .scopeFromSourceSets(sourceSetNames)


### PR DESCRIPTION
**Added:**
1.  Possibility to create scope passing any collection of items

	**Before**
	```kotlin
	// Option 1
	Konsist
		.scopeFromFiles(path1, path2, path3)
		...

	// Option 2
	val paths = setOf(path1, path2, path3)
	Konsist
		.scopeFromFiles(paths)
		...
	```

	**After - you additionally may pass any collection of items**:
	```kotlin
	// Option 1 and Option 2 still works

	// Option 3
	val paths = listOf(path1, path2, path3)
	Konsist
		.scopeFromFiles(paths)
		...
	```

2.  Possibility to pass any collection of items in provider methods where few parameters could be passed using the `vararg` modifier

	**Before**
	```kotlin
	// Option 1
	Konsist
		.scopeFromProject()
		.classes()
		.hasAnnotationWithName(name1, name2, name3)
		...
	```

	**After - you additionally may pass any collection of items**:
	```kotlin
	// Option 1 still works

	// Option 2
	val names = setOf(name1, name2, name3)
	Konsist
		.scopeFromProject()
		.classes()
		.hasAnnotationWithName(names)
		...

	// Option 3
	val names = listOf(name1, name2, name3)
	Konsist
		.scopeFromProject()
		.classes()
		.hasAnnotationWithName(names)
		...
	```