### PR TITLE
Fix CI jobs on macos-latest after github actions image migration

### DIFF
--- a/.github/workflows/check-path.yml
+++ b/.github/workflows/check-path.yml
@@ -50,6 +50,12 @@ jobs:
       - name: Set up JDK
         uses: actions/setup-java@v4
         with:
+          java-version: 8
+          distribution: 'corretto'
+
+      - name: Set up JDK
+        uses: actions/setup-java@v4
+        with:
           java-version: 21
           distribution: 'corretto'
 
@@ -136,6 +142,12 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+
+      - name: Set up JDK
+        uses: actions/setup-java@v4
+        with:
+          java-version: 8
+          distribution: 'corretto'
 
       - name: Set up JDK
         uses: actions/setup-java@v4

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -158,6 +158,12 @@ jobs:
       - name: Set up JDK
         uses: actions/setup-java@v4
         with:
+          java-version: 8
+          distribution: 'corretto'
+
+      - name: Set up JDK
+        uses: actions/setup-java@v4
+        with:
           java-version: 21
           distribution: 'corretto'
 


### PR DESCRIPTION
`macos-latest` image from github actions was migrated from [macos-14](https://github.com/actions/runner-images/blob/main/images/macos/macos-14-Readme.md) to [macos-14-arm64](https://github.com/actions/runner-images/blob/main/images/macos/macos-14-arm64-Readme.md) (see [README of github actions
runner-images](https://github.com/actions/runner-images/commit/84c158e8b8f516478f045f9712856e6c65c526b3) and [github blog](https://github.blog/changelog/2024-04-01-macos-14-sonoma-is-generally-available-and-the-latest-macos-runner-image/)).

Java `8` is installed in `macos-14`, but not in `macos-14-arm64`, and all jobs on macos images require java `8` and java `21`.