### PR TITLE
KON-622 Add KoAnnotationProvider for type declarations

### DIFF
--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/type/kotype/KoTypeDeclarationForKoAnnotationProviderTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/type/kotype/KoTypeDeclarationForKoAnnotationProviderTest.kt
@@ -1,0 +1,320 @@
+package com.lemonappdev.konsist.core.declaration.type.kotype
+
+import com.lemonappdev.konsist.TestSnippetProvider
+import com.lemonappdev.konsist.testdata.NonExistingAnnotation
+import com.lemonappdev.konsist.testdata.SampleAnnotation
+import com.lemonappdev.konsist.testdata.SampleAnnotation1
+import com.lemonappdev.konsist.testdata.SampleAnnotation2
+import org.amshove.kluent.assertSoftly
+import org.amshove.kluent.shouldBeEqualTo
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.Arguments.arguments
+import org.junit.jupiter.params.provider.MethodSource
+
+class KoTypeDeclarationForKoAnnotationProviderTest {
+    @ParameterizedTest
+    @MethodSource("provideValuesForNoAnnotation")
+    fun `type-has-no-annotation`(fileName: String) {
+        // given
+        val sut =
+            getSnippetFile(fileName)
+                .classes()
+                .first()
+                .primaryConstructor
+                ?.parameters
+                ?.first()
+                ?.type
+
+        // then
+        assertSoftly(sut) {
+            it?.annotations shouldBeEqualTo emptyList()
+            it?.numAnnotations shouldBeEqualTo 0
+            it?.countAnnotations { type -> type.name == "NonExistingAnnotation" } shouldBeEqualTo 0
+            it?.hasAnnotations() shouldBeEqualTo false
+            it?.hasAnnotationWithName(emptyList()) shouldBeEqualTo false
+            it?.hasAnnotationWithName(emptySet()) shouldBeEqualTo false
+            it?.hasAnnotationsWithAllNames(emptyList()) shouldBeEqualTo false
+            it?.hasAnnotationsWithAllNames(emptySet()) shouldBeEqualTo false
+            it?.hasAnnotationWithName("SampleAnnotation") shouldBeEqualTo false
+            it?.hasAnnotationWithName(listOf("SampleAnnotation")) shouldBeEqualTo false
+            it?.hasAnnotationWithName(setOf("SampleAnnotation")) shouldBeEqualTo false
+            it?.hasAnnotationsWithAllNames("SampleAnnotation1", "SampleAnnotation2") shouldBeEqualTo false
+            it?.hasAnnotationsWithAllNames(listOf("SampleAnnotation1", "SampleAnnotation2")) shouldBeEqualTo false
+            it?.hasAnnotationsWithAllNames(setOf("SampleAnnotation1", "SampleAnnotation2")) shouldBeEqualTo false
+            it?.hasAnnotation { type -> type.hasArguments() } shouldBeEqualTo false
+            it?.hasAllAnnotations { type -> type.hasArguments() } shouldBeEqualTo true
+            it?.hasAnnotationOf(emptyList()) shouldBeEqualTo false
+            it?.hasAnnotationOf(emptySet()) shouldBeEqualTo false
+            it?.hasAllAnnotationsOf(emptyList()) shouldBeEqualTo false
+            it?.hasAllAnnotationsOf(emptySet()) shouldBeEqualTo false
+            it?.hasAnnotationOf(SampleAnnotation::class) shouldBeEqualTo false
+            it?.hasAnnotationOf(listOf(SampleAnnotation::class)) shouldBeEqualTo false
+            it?.hasAnnotationOf(setOf(SampleAnnotation::class)) shouldBeEqualTo false
+            it?.hasAllAnnotationsOf(SampleAnnotation1::class, SampleAnnotation2::class) shouldBeEqualTo false
+            it?.hasAllAnnotationsOf(listOf(SampleAnnotation1::class, SampleAnnotation2::class)) shouldBeEqualTo false
+            it?.hasAllAnnotationsOf(setOf(SampleAnnotation1::class, SampleAnnotation2::class)) shouldBeEqualTo false
+        }
+    }
+
+    @ParameterizedTest
+    @MethodSource("provideValuesForOneAnnotation")
+    @Suppress("detekt.LongMethod")
+    fun `type-has-annotation`(fileName: String) {
+        // given
+        val sut =
+            getSnippetFile(fileName)
+                .classes()
+                .first()
+                .primaryConstructor
+                ?.parameters
+                ?.first()
+                ?.type
+
+        // then
+        assertSoftly(sut) {
+            it?.numAnnotations shouldBeEqualTo 1
+            it?.countAnnotations { type -> type.name == "SampleAnnotation" } shouldBeEqualTo 1
+            it?.countAnnotations { type -> type.name == "NonExistingAnnotation" } shouldBeEqualTo 0
+            it?.hasAnnotations() shouldBeEqualTo true
+            it?.hasAnnotationWithName(emptyList()) shouldBeEqualTo true
+            it?.hasAnnotationWithName(emptySet()) shouldBeEqualTo true
+            it?.hasAnnotationsWithAllNames(emptyList()) shouldBeEqualTo true
+            it?.hasAnnotationsWithAllNames(emptySet()) shouldBeEqualTo true
+            it?.hasAnnotationWithName("SampleAnnotation") shouldBeEqualTo true
+            it?.hasAnnotationWithName("OtherAnnotation") shouldBeEqualTo false
+            it?.hasAnnotationWithName("SampleAnnotation", "OtherAnnotation") shouldBeEqualTo true
+            it?.hasAnnotationWithName("com.lemonappdev.konsist.testdata.SampleAnnotation") shouldBeEqualTo true
+            it?.hasAnnotationWithName("com.lemonappdev.konsist.testdata.NonExistingAnnotation") shouldBeEqualTo false
+            it?.hasAnnotationWithName(
+                "com.lemonappdev.konsist.testdata.SampleAnnotation",
+                "com.lemonappdev.konsist.testdata.NonExistingAnnotation",
+            ).shouldBeEqualTo(true)
+            it?.hasAnnotationWithName(listOf("SampleAnnotation")) shouldBeEqualTo true
+            it?.hasAnnotationWithName(listOf("OtherAnnotation")) shouldBeEqualTo false
+            it?.hasAnnotationWithName(listOf("SampleAnnotation", "OtherAnnotation")) shouldBeEqualTo true
+            it?.hasAnnotationWithName(listOf("com.lemonappdev.konsist.testdata.SampleAnnotation")) shouldBeEqualTo true
+            it?.hasAnnotationWithName(listOf("com.lemonappdev.konsist.testdata.NonExistingAnnotation")) shouldBeEqualTo false
+            it?.hasAnnotationWithName(
+                listOf(
+                    "com.lemonappdev.konsist.testdata.SampleAnnotation",
+                    "com.lemonappdev.konsist.testdata.NonExistingAnnotation",
+                ),
+            ).shouldBeEqualTo(true)
+            it?.hasAnnotationWithName(setOf("SampleAnnotation")) shouldBeEqualTo true
+            it?.hasAnnotationWithName(setOf("OtherAnnotation")) shouldBeEqualTo false
+            it?.hasAnnotationWithName(setOf("SampleAnnotation", "OtherAnnotation")) shouldBeEqualTo true
+            it?.hasAnnotationWithName(setOf("com.lemonappdev.konsist.testdata.SampleAnnotation")) shouldBeEqualTo true
+            it?.hasAnnotationWithName(setOf("com.lemonappdev.konsist.testdata.NonExistingAnnotation")) shouldBeEqualTo false
+            it?.hasAnnotationWithName(
+                setOf(
+                    "com.lemonappdev.konsist.testdata.SampleAnnotation",
+                    "com.lemonappdev.konsist.testdata.NonExistingAnnotation",
+                ),
+            ).shouldBeEqualTo(true)
+            it?.hasAnnotationsWithAllNames("SampleAnnotation") shouldBeEqualTo true
+            it?.hasAnnotationsWithAllNames("SampleAnnotation", "OtherAnnotation") shouldBeEqualTo false
+            it?.hasAnnotationsWithAllNames("com.lemonappdev.konsist.testdata.SampleAnnotation") shouldBeEqualTo true
+            it?.hasAnnotationsWithAllNames(
+                "com.lemonappdev.konsist.testdata.SampleAnnotation",
+                "com.lemonappdev.konsist.testdata.NonExistingAnnotation",
+            ).shouldBeEqualTo(false)
+            it?.hasAnnotationsWithAllNames(listOf("SampleAnnotation")) shouldBeEqualTo true
+            it?.hasAnnotationsWithAllNames(listOf("SampleAnnotation", "OtherAnnotation")) shouldBeEqualTo false
+            it?.hasAnnotationsWithAllNames(listOf("com.lemonappdev.konsist.testdata.SampleAnnotation")) shouldBeEqualTo true
+            it?.hasAnnotationsWithAllNames(
+                listOf(
+                    "com.lemonappdev.konsist.testdata.SampleAnnotation",
+                    "com.lemonappdev.konsist.testdata.NonExistingAnnotation",
+                ),
+            ).shouldBeEqualTo(false)
+            it?.hasAnnotation { type -> type.hasNameStartingWith("Sample") } shouldBeEqualTo true
+            it?.hasAnnotation { type -> type.hasNameStartingWith("Other") } shouldBeEqualTo false
+            it?.hasAllAnnotations { type -> type.hasNameStartingWith("Sample") } shouldBeEqualTo true
+            it?.hasAnnotationOf(emptyList()) shouldBeEqualTo true
+            it?.hasAnnotationOf(emptySet()) shouldBeEqualTo true
+            it?.hasAllAnnotationsOf(emptyList()) shouldBeEqualTo true
+            it?.hasAllAnnotationsOf(emptySet()) shouldBeEqualTo true
+            it?.hasAnnotationOf(listOf(SampleAnnotation::class)) shouldBeEqualTo true
+            it?.hasAnnotationOf(listOf(NonExistingAnnotation::class)) shouldBeEqualTo false
+            it?.hasAnnotationOf(listOf(SampleAnnotation::class, NonExistingAnnotation::class)) shouldBeEqualTo true
+            it?.hasAnnotationOf(setOf(SampleAnnotation::class)) shouldBeEqualTo true
+            it?.hasAnnotationOf(setOf(NonExistingAnnotation::class)) shouldBeEqualTo false
+            it?.hasAnnotationOf(setOf(SampleAnnotation::class, NonExistingAnnotation::class)) shouldBeEqualTo true
+            it?.hasAllAnnotationsOf(SampleAnnotation::class) shouldBeEqualTo true
+            it?.hasAllAnnotationsOf(NonExistingAnnotation::class) shouldBeEqualTo false
+            it?.hasAllAnnotationsOf(SampleAnnotation::class, NonExistingAnnotation::class) shouldBeEqualTo false
+            it?.hasAllAnnotationsOf(listOf(SampleAnnotation::class)) shouldBeEqualTo true
+            it?.hasAllAnnotationsOf(listOf(NonExistingAnnotation::class)) shouldBeEqualTo false
+            it?.hasAllAnnotationsOf(listOf(SampleAnnotation::class, NonExistingAnnotation::class)) shouldBeEqualTo false
+            it?.hasAllAnnotationsOf(setOf(SampleAnnotation::class)) shouldBeEqualTo true
+            it?.hasAllAnnotationsOf(setOf(NonExistingAnnotation::class)) shouldBeEqualTo false
+            it?.hasAllAnnotationsOf(setOf(SampleAnnotation::class, NonExistingAnnotation::class)) shouldBeEqualTo false
+        }
+    }
+
+    @ParameterizedTest
+    @MethodSource("provideValuesForTwoAnnotations")
+    @Suppress("detekt.LongMethod")
+    fun `type-has-two-annotations`(fileName: String) {
+        // given
+        val sut =
+            getSnippetFile(fileName)
+                .classes()
+                .first()
+                .primaryConstructor
+                ?.parameters
+                ?.first()
+                ?.type
+
+        // then
+        assertSoftly(sut) {
+            it?.numAnnotations shouldBeEqualTo 2
+            it?.countAnnotations { type -> type.hasNameStartingWith("Sample") } shouldBeEqualTo 2
+            it?.countAnnotations { type -> type.name == "SampleAnnotation1" } shouldBeEqualTo 1
+            it?.hasAnnotations() shouldBeEqualTo true
+            it?.hasAnnotationOf(emptyList()) shouldBeEqualTo true
+            it?.hasAnnotationOf(emptySet()) shouldBeEqualTo true
+            it?.hasAllAnnotationsOf(emptyList()) shouldBeEqualTo true
+            it?.hasAllAnnotationsOf(emptySet()) shouldBeEqualTo true
+            it?.hasAnnotationWithName("SampleAnnotation1") shouldBeEqualTo true
+            it?.hasAnnotationWithName("OtherAnnotation") shouldBeEqualTo false
+            it?.hasAnnotationWithName("SampleAnnotation1", "OtherAnnotation") shouldBeEqualTo true
+            it?.hasAnnotationWithName("com.lemonappdev.konsist.testdata.SampleAnnotation1") shouldBeEqualTo true
+            it?.hasAnnotationWithName("com.lemonappdev.konsist.testdata.NonExistingAnnotation") shouldBeEqualTo false
+            it?.hasAnnotationWithName(
+                "com.lemonappdev.konsist.testdata.SampleAnnotation1",
+                "com.lemonappdev.konsist.testdata.NonExistingAnnotation",
+            ).shouldBeEqualTo(true)
+            it?.hasAnnotationWithName(listOf("SampleAnnotation1")) shouldBeEqualTo true
+            it?.hasAnnotationWithName(listOf("OtherAnnotation")) shouldBeEqualTo false
+            it?.hasAnnotationWithName(listOf("SampleAnnotation1", "OtherAnnotation")) shouldBeEqualTo true
+            it?.hasAnnotationWithName(listOf("com.lemonappdev.konsist.testdata.SampleAnnotation1")) shouldBeEqualTo true
+            it?.hasAnnotationWithName(listOf("com.lemonappdev.konsist.testdata.NonExistingAnnotation")) shouldBeEqualTo false
+            it?.hasAnnotationWithName(
+                listOf(
+                    "com.lemonappdev.konsist.testdata.SampleAnnotation1",
+                    "com.lemonappdev.konsist.testdata.NonExistingAnnotation",
+                ),
+            ).shouldBeEqualTo(true)
+            it?.hasAnnotationWithName(setOf("SampleAnnotation1")) shouldBeEqualTo true
+            it?.hasAnnotationWithName(setOf("OtherAnnotation")) shouldBeEqualTo false
+            it?.hasAnnotationWithName(setOf("SampleAnnotation1", "OtherAnnotation")) shouldBeEqualTo true
+            it?.hasAnnotationWithName(setOf("com.lemonappdev.konsist.testdata.SampleAnnotation1")) shouldBeEqualTo true
+            it?.hasAnnotationWithName(setOf("com.lemonappdev.konsist.testdata.NonExistingAnnotation")) shouldBeEqualTo false
+            it?.hasAnnotationWithName(
+                setOf(
+                    "com.lemonappdev.konsist.testdata.SampleAnnotation1",
+                    "com.lemonappdev.konsist.testdata.NonExistingAnnotation",
+                ),
+            ).shouldBeEqualTo(true)
+            it?.hasAnnotationsWithAllNames("SampleAnnotation1") shouldBeEqualTo true
+            it?.hasAnnotationsWithAllNames("SampleAnnotation1", "SampleAnnotation2") shouldBeEqualTo true
+            it?.hasAnnotationsWithAllNames("SampleAnnotation1", "OtherAnnotation") shouldBeEqualTo false
+            it?.hasAnnotationsWithAllNames("com.lemonappdev.konsist.testdata.SampleAnnotation1") shouldBeEqualTo true
+            it?.hasAnnotationsWithAllNames(
+                "com.lemonappdev.konsist.testdata.SampleAnnotation1",
+                "com.lemonappdev.konsist.testdata.NonExistingAnnotation",
+            ).shouldBeEqualTo(false)
+            it?.hasAnnotationsWithAllNames(
+                "com.lemonappdev.konsist.testdata.SampleAnnotation1",
+                "com.lemonappdev.konsist.testdata.SampleAnnotation2",
+            ).shouldBeEqualTo(true)
+
+            it?.hasAnnotationsWithAllNames(listOf("SampleAnnotation1")) shouldBeEqualTo true
+            it?.hasAnnotationsWithAllNames(listOf("SampleAnnotation1", "SampleAnnotation2")) shouldBeEqualTo true
+            it?.hasAnnotationsWithAllNames(listOf("SampleAnnotation1", "OtherAnnotation")) shouldBeEqualTo false
+            it?.hasAnnotationsWithAllNames(listOf("com.lemonappdev.konsist.testdata.SampleAnnotation1")) shouldBeEqualTo true
+            it?.hasAnnotationsWithAllNames(
+                listOf(
+                    "com.lemonappdev.konsist.testdata.SampleAnnotation1",
+                    "com.lemonappdev.konsist.testdata.NonExistingAnnotation",
+                ),
+            ).shouldBeEqualTo(false)
+            it?.hasAnnotationsWithAllNames(
+                listOf(
+                    "com.lemonappdev.konsist.testdata.SampleAnnotation1",
+                    "com.lemonappdev.konsist.testdata.SampleAnnotation2",
+                ),
+            ).shouldBeEqualTo(true)
+            it?.hasAnnotation { type -> type.name == "SampleAnnotation1" } shouldBeEqualTo true
+            it?.hasAnnotation { type -> type.name == "OtherAnnotation1" } shouldBeEqualTo false
+            it?.hasAllAnnotations { type -> !type.hasArguments() } shouldBeEqualTo true
+            it?.hasAllAnnotations { type -> type.hasNameEndingWith("tion1") } shouldBeEqualTo false
+            it?.hasAnnotationOf(emptyList()) shouldBeEqualTo true
+            it?.hasAnnotationOf(emptySet()) shouldBeEqualTo true
+            it?.hasAllAnnotationsOf(emptyList()) shouldBeEqualTo true
+            it?.hasAllAnnotationsOf(emptySet()) shouldBeEqualTo true
+            it?.hasAnnotationOf(SampleAnnotation1::class) shouldBeEqualTo true
+            it?.hasAnnotationOf(NonExistingAnnotation::class) shouldBeEqualTo false
+            it?.hasAnnotationOf(SampleAnnotation1::class, NonExistingAnnotation::class) shouldBeEqualTo true
+            it?.hasAnnotationOf(listOf(SampleAnnotation1::class)) shouldBeEqualTo true
+            it?.hasAnnotationOf(listOf(NonExistingAnnotation::class)) shouldBeEqualTo false
+            it?.hasAnnotationOf(listOf(SampleAnnotation1::class, NonExistingAnnotation::class)) shouldBeEqualTo true
+            it?.hasAnnotationOf(setOf(SampleAnnotation1::class)) shouldBeEqualTo true
+            it?.hasAnnotationOf(setOf(NonExistingAnnotation::class)) shouldBeEqualTo false
+            it?.hasAnnotationOf(setOf(SampleAnnotation1::class, NonExistingAnnotation::class)) shouldBeEqualTo true
+            it?.hasAllAnnotationsOf(SampleAnnotation1::class) shouldBeEqualTo true
+            it?.hasAllAnnotationsOf(NonExistingAnnotation::class) shouldBeEqualTo false
+            it?.hasAllAnnotationsOf(SampleAnnotation1::class, SampleAnnotation2::class) shouldBeEqualTo true
+            it?.hasAllAnnotationsOf(SampleAnnotation1::class, NonExistingAnnotation::class) shouldBeEqualTo false
+            it?.hasAllAnnotationsOf(listOf(SampleAnnotation1::class)) shouldBeEqualTo true
+            it?.hasAllAnnotationsOf(listOf(NonExistingAnnotation::class)) shouldBeEqualTo false
+            it?.hasAllAnnotationsOf(listOf(SampleAnnotation1::class, SampleAnnotation2::class)) shouldBeEqualTo true
+            it?.hasAllAnnotationsOf(listOf(SampleAnnotation1::class, NonExistingAnnotation::class)) shouldBeEqualTo false
+            it?.hasAllAnnotationsOf(setOf(SampleAnnotation1::class)) shouldBeEqualTo true
+            it?.hasAllAnnotationsOf(setOf(NonExistingAnnotation::class)) shouldBeEqualTo false
+            it?.hasAllAnnotationsOf(setOf(SampleAnnotation1::class, SampleAnnotation2::class)) shouldBeEqualTo true
+            it?.hasAllAnnotationsOf(setOf(SampleAnnotation1::class, NonExistingAnnotation::class)) shouldBeEqualTo false
+        }
+    }
+
+    private fun getSnippetFile(fileName: String) =
+        TestSnippetProvider.getSnippetKoScope("core/declaration/type/kotype/snippet/forkoannotationrovider/", fileName)
+
+    companion object {
+        @Suppress("unused")
+        @JvmStatic
+        fun provideValuesForNoAnnotation() =
+            listOf(
+                arguments("kotlin-basic-type-has-no-annotation"),
+                arguments("kotlin-collection-type-has-no-annotation"),
+                arguments("class-type-has-no-annotation"),
+                arguments("interface-type-has-no-annotation"),
+                arguments("object-type-has-no-annotation"),
+                arguments("function-type-has-no-annotation"),
+                arguments("import-alias-type-has-no-annotation"),
+                arguments("typealias-type-has-no-annotation"),
+                arguments("external-type-has-no-annotation"),
+            )
+
+        @Suppress("unused")
+        @JvmStatic
+        fun provideValuesForOneAnnotation() =
+            listOf(
+                arguments("kotlin-basic-type-has-annotation"),
+                arguments("kotlin-collection-type-has-annotation"),
+                arguments("class-type-has-annotation"),
+                arguments("interface-type-has-annotation"),
+                arguments("object-type-has-annotation"),
+                arguments("function-type-has-annotation"),
+                arguments("import-alias-type-has-annotation"),
+                arguments("typealias-type-has-annotation"),
+                arguments("external-type-has-annotation"),
+            )
+
+        @Suppress("unused")
+        @JvmStatic
+        fun provideValuesForTwoAnnotations() =
+            listOf(
+                arguments("kotlin-basic-type-has-two-annotations"),
+                arguments("kotlin-collection-type-has-two-annotations"),
+                arguments("class-type-has-two-annotations"),
+                arguments("interface-type-has-two-annotations"),
+                arguments("object-type-has-two-annotations"),
+                arguments("function-type-has-two-annotations"),
+                arguments("import-alias-type-has-two-annotations"),
+                arguments("typealias-type-has-two-annotations"),
+                arguments("external-type-has-two-annotations"),
+            )
+    }
+}

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/type/kotype/snippet/forkoannotationrovider/class-type-has-annotation.kttxt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/type/kotype/snippet/forkoannotationrovider/class-type-has-annotation.kttxt
@@ -1,0 +1,4 @@
+import com.lemonappdev.konsist.testdata.SampleAnnotation
+import com.lemonappdev.konsist.testdata.SampleType
+
+class SampleClass1(val sampleProperty1: @SampleAnnotation SampleType)

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/type/kotype/snippet/forkoannotationrovider/class-type-has-no-annotation.kttxt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/type/kotype/snippet/forkoannotationrovider/class-type-has-no-annotation.kttxt
@@ -1,0 +1,3 @@
+import com.lemonappdev.konsist.testdata.SampleType
+
+class SampleClass1(val sampleProperty1: SampleType)

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/type/kotype/snippet/forkoannotationrovider/class-type-has-two-annotations.kttxt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/type/kotype/snippet/forkoannotationrovider/class-type-has-two-annotations.kttxt
@@ -1,0 +1,5 @@
+import com.lemonappdev.konsist.testdata.SampleAnnotation1
+import com.lemonappdev.konsist.testdata.SampleAnnotation2
+import com.lemonappdev.konsist.testdata.SampleType
+
+class SampleClass1(val sampleProperty1: @SampleAnnotation1 @SampleAnnotation2 SampleType)

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/type/kotype/snippet/forkoannotationrovider/external-type-has-annotation.kttxt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/type/kotype/snippet/forkoannotationrovider/external-type-has-annotation.kttxt
@@ -1,0 +1,4 @@
+import com.lemonappdev.konsist.testdata.SampleAnnotation
+import com.lemonappdev.konsist.externalsample.SampleExternalClass
+
+class SampleClass1(val sampleProperty1: @SampleAnnotation SampleExternalClass)

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/type/kotype/snippet/forkoannotationrovider/external-type-has-no-annotation.kttxt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/type/kotype/snippet/forkoannotationrovider/external-type-has-no-annotation.kttxt
@@ -1,0 +1,3 @@
+import com.lemonappdev.konsist.externalsample.SampleExternalClass
+
+class SampleClass1(val sampleProperty1: SampleExternalClass)

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/type/kotype/snippet/forkoannotationrovider/external-type-has-two-annotations.kttxt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/type/kotype/snippet/forkoannotationrovider/external-type-has-two-annotations.kttxt
@@ -1,0 +1,5 @@
+import com.lemonappdev.konsist.testdata.SampleAnnotation1
+import com.lemonappdev.konsist.testdata.SampleAnnotation2
+import com.lemonappdev.konsist.externalsample.SampleExternalClass
+
+class SampleClass1(val sampleProperty1: @SampleAnnotation1 @SampleAnnotation2 SampleExternalClass)

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/type/kotype/snippet/forkoannotationrovider/function-type-has-annotation.kttxt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/type/kotype/snippet/forkoannotationrovider/function-type-has-annotation.kttxt
@@ -1,0 +1,4 @@
+import com.lemonappdev.konsist.testdata.SampleAnnotation
+import com.lemonappdev.konsist.testdata.SampleObject
+
+class SampleClass1(val sampleProperty1: @SampleAnnotation (SampleObject) -> Unit)

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/type/kotype/snippet/forkoannotationrovider/function-type-has-no-annotation.kttxt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/type/kotype/snippet/forkoannotationrovider/function-type-has-no-annotation.kttxt
@@ -1,0 +1,3 @@
+import com.lemonappdev.konsist.testdata.SampleObject
+
+class SampleClass1(val sampleProperty1: (SampleObject) -> Unit)

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/type/kotype/snippet/forkoannotationrovider/function-type-has-two-annotations.kttxt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/type/kotype/snippet/forkoannotationrovider/function-type-has-two-annotations.kttxt
@@ -1,0 +1,5 @@
+import com.lemonappdev.konsist.testdata.SampleAnnotation1
+import com.lemonappdev.konsist.testdata.SampleAnnotation2
+import com.lemonappdev.konsist.testdata.SampleObject
+
+class SampleClass1(val sampleProperty1: @SampleAnnotation1 @SampleAnnotation2 (SampleObject) -> Unit)

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/type/kotype/snippet/forkoannotationrovider/import-alias-type-has-annotation.kttxt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/type/kotype/snippet/forkoannotationrovider/import-alias-type-has-annotation.kttxt
@@ -1,0 +1,4 @@
+import com.lemonappdev.konsist.testdata.SampleAnnotation
+import com.lemonappdev.konsist.testdata.SampleObject as ImportAlias
+
+class SampleClass1(val sampleProperty1: @SampleAnnotation ImportAlias)

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/type/kotype/snippet/forkoannotationrovider/import-alias-type-has-no-annotation.kttxt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/type/kotype/snippet/forkoannotationrovider/import-alias-type-has-no-annotation.kttxt
@@ -1,0 +1,3 @@
+import com.lemonappdev.konsist.testdata.SampleObject as ImportAlias
+
+class SampleClass1(val sampleProperty1: ImportAlias)

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/type/kotype/snippet/forkoannotationrovider/import-alias-type-has-two-annotations.kttxt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/type/kotype/snippet/forkoannotationrovider/import-alias-type-has-two-annotations.kttxt
@@ -1,0 +1,5 @@
+import com.lemonappdev.konsist.testdata.SampleAnnotation1
+import com.lemonappdev.konsist.testdata.SampleAnnotation2
+import com.lemonappdev.konsist.testdata.SampleObject as ImportAlias
+
+class SampleClass1(val sampleProperty1: @SampleAnnotation1 @SampleAnnotation2 ImportAlias)

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/type/kotype/snippet/forkoannotationrovider/interface-type-has-annotation.kttxt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/type/kotype/snippet/forkoannotationrovider/interface-type-has-annotation.kttxt
@@ -1,0 +1,4 @@
+import com.lemonappdev.konsist.testdata.SampleAnnotation
+import com.lemonappdev.konsist.testdata.SampleInterface
+
+class SampleClass1(val sampleProperty1: @SampleAnnotation SampleInterface)

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/type/kotype/snippet/forkoannotationrovider/interface-type-has-no-annotation.kttxt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/type/kotype/snippet/forkoannotationrovider/interface-type-has-no-annotation.kttxt
@@ -1,0 +1,3 @@
+import com.lemonappdev.konsist.testdata.SampleInterface
+
+class SampleClass1(val sampleProperty1: SampleInterface)

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/type/kotype/snippet/forkoannotationrovider/interface-type-has-two-annotations.kttxt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/type/kotype/snippet/forkoannotationrovider/interface-type-has-two-annotations.kttxt
@@ -1,0 +1,5 @@
+import com.lemonappdev.konsist.testdata.SampleAnnotation1
+import com.lemonappdev.konsist.testdata.SampleAnnotation2
+import com.lemonappdev.konsist.testdata.SampleInterface
+
+class SampleClass1(val sampleProperty1: @SampleAnnotation1 @SampleAnnotation2 SampleInterface)

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/type/kotype/snippet/forkoannotationrovider/kotlin-basic-type-has-annotation.kttxt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/type/kotype/snippet/forkoannotationrovider/kotlin-basic-type-has-annotation.kttxt
@@ -1,0 +1,3 @@
+import com.lemonappdev.konsist.testdata.SampleAnnotation
+
+class SampleClass1(val sampleProperty1: @SampleAnnotation String)

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/type/kotype/snippet/forkoannotationrovider/kotlin-basic-type-has-no-annotation.kttxt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/type/kotype/snippet/forkoannotationrovider/kotlin-basic-type-has-no-annotation.kttxt
@@ -1,0 +1,1 @@
+class SampleClass1(val sampleProperty1: String)

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/type/kotype/snippet/forkoannotationrovider/kotlin-basic-type-has-two-annotations.kttxt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/type/kotype/snippet/forkoannotationrovider/kotlin-basic-type-has-two-annotations.kttxt
@@ -1,0 +1,4 @@
+import com.lemonappdev.konsist.testdata.SampleAnnotation1
+import com.lemonappdev.konsist.testdata.SampleAnnotation2
+
+class SampleClass1(val sampleProperty1: @SampleAnnotation1 @SampleAnnotation2 String)

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/type/kotype/snippet/forkoannotationrovider/kotlin-collection-type-has-annotation.kttxt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/type/kotype/snippet/forkoannotationrovider/kotlin-collection-type-has-annotation.kttxt
@@ -1,0 +1,3 @@
+import com.lemonappdev.konsist.testdata.SampleAnnotation
+
+class SampleClass1(val sampleProperty1: @SampleAnnotation List<String>)

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/type/kotype/snippet/forkoannotationrovider/kotlin-collection-type-has-no-annotation.kttxt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/type/kotype/snippet/forkoannotationrovider/kotlin-collection-type-has-no-annotation.kttxt
@@ -1,0 +1,1 @@
+class SampleClass1(val sampleProperty1: List<String>)

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/type/kotype/snippet/forkoannotationrovider/kotlin-collection-type-has-two-annotations.kttxt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/type/kotype/snippet/forkoannotationrovider/kotlin-collection-type-has-two-annotations.kttxt
@@ -1,0 +1,4 @@
+import com.lemonappdev.konsist.testdata.SampleAnnotation1
+import com.lemonappdev.konsist.testdata.SampleAnnotation2
+
+class SampleClass1(val sampleProperty1: @SampleAnnotation1 @SampleAnnotation2 List<String>)

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/type/kotype/snippet/forkoannotationrovider/object-type-has-annotation.kttxt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/type/kotype/snippet/forkoannotationrovider/object-type-has-annotation.kttxt
@@ -1,0 +1,4 @@
+import com.lemonappdev.konsist.testdata.SampleAnnotation
+import com.lemonappdev.konsist.testdata.SampleObject
+
+class SampleClass1(val sampleProperty1: @SampleAnnotation SampleObject)

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/type/kotype/snippet/forkoannotationrovider/object-type-has-no-annotation.kttxt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/type/kotype/snippet/forkoannotationrovider/object-type-has-no-annotation.kttxt
@@ -1,0 +1,3 @@
+import com.lemonappdev.konsist.testdata.SampleObject
+
+class SampleClass1(val sampleProperty1: SampleObject)

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/type/kotype/snippet/forkoannotationrovider/object-type-has-two-annotations.kttxt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/type/kotype/snippet/forkoannotationrovider/object-type-has-two-annotations.kttxt
@@ -1,0 +1,5 @@
+import com.lemonappdev.konsist.testdata.SampleAnnotation1
+import com.lemonappdev.konsist.testdata.SampleAnnotation2
+import com.lemonappdev.konsist.testdata.SampleObject
+
+class SampleClass1(val sampleProperty1: @SampleAnnotation1 @SampleAnnotation2 SampleObject)

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/type/kotype/snippet/forkoannotationrovider/typealias-type-has-annotation.kttxt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/type/kotype/snippet/forkoannotationrovider/typealias-type-has-annotation.kttxt
@@ -1,0 +1,6 @@
+import com.lemonappdev.konsist.testdata.SampleAnnotation
+import com.lemonappdev.konsist.testdata.SampleObject
+
+class SampleClass1(val sampleProperty1: @SampleAnnotation SampleTypeAlias)
+
+typealias SampleTypeAlias = (SampleObject) -> Unit

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/type/kotype/snippet/forkoannotationrovider/typealias-type-has-no-annotation.kttxt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/type/kotype/snippet/forkoannotationrovider/typealias-type-has-no-annotation.kttxt
@@ -1,0 +1,5 @@
+import com.lemonappdev.konsist.testdata.SampleObject
+
+class SampleClass1(val sampleProperty1: SampleTypeAlias)
+
+typealias SampleTypeAlias = (SampleObject) -> Unit

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/type/kotype/snippet/forkoannotationrovider/typealias-type-has-two-annotations.kttxt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/type/kotype/snippet/forkoannotationrovider/typealias-type-has-two-annotations.kttxt
@@ -1,0 +1,7 @@
+import com.lemonappdev.konsist.testdata.SampleAnnotation1
+import com.lemonappdev.konsist.testdata.SampleAnnotation2
+import com.lemonappdev.konsist.testdata.SampleObject
+
+class SampleClass1(val sampleProperty1: @SampleAnnotation1 @SampleAnnotation2 SampleTypeAlias)
+
+typealias SampleTypeAlias = (SampleObject) -> Unit

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/testdata/TestData.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/testdata/TestData.kt
@@ -92,6 +92,7 @@ annotation class SampleAnnotation
     AnnotationTarget.CONSTRUCTOR,
     AnnotationTarget.TYPEALIAS,
     AnnotationTarget.LOCAL_VARIABLE,
+    AnnotationTarget.TYPE,
 )
 annotation class SampleAnnotation1
 
@@ -103,6 +104,7 @@ annotation class SampleAnnotation1
     AnnotationTarget.CONSTRUCTOR,
     AnnotationTarget.TYPEALIAS,
     AnnotationTarget.LOCAL_VARIABLE,
+    AnnotationTarget.TYPE,
 )
 annotation class SampleAnnotation2
 

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/api/declaration/type/KoTypeDeclaration.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/api/declaration/type/KoTypeDeclaration.kt
@@ -1,6 +1,7 @@
 package com.lemonappdev.konsist.api.declaration.type
 
 import com.lemonappdev.konsist.api.declaration.KoBaseDeclaration
+import com.lemonappdev.konsist.api.provider.KoAnnotationProvider
 import com.lemonappdev.konsist.api.provider.KoBaseProvider
 import com.lemonappdev.konsist.api.provider.KoContainingDeclarationProvider
 import com.lemonappdev.konsist.api.provider.KoContainingFileProvider
@@ -38,4 +39,5 @@ interface KoTypeDeclaration :
     KoSourceAndAliasTypeProvider,
     KoPackageProvider,
     KoResideInPackageProvider,
+    KoAnnotationProvider,
     KoTypeDeclarationProvider

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/core/declaration/type/KoTypeDeclarationCore.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/core/declaration/type/KoTypeDeclarationCore.kt
@@ -4,6 +4,7 @@ import com.lemonappdev.konsist.api.declaration.KoBaseDeclaration
 import com.lemonappdev.konsist.api.declaration.KoPackageDeclaration
 import com.lemonappdev.konsist.api.declaration.type.KoTypeDeclaration
 import com.lemonappdev.konsist.core.cache.KoDeclarationCache
+import com.lemonappdev.konsist.core.provider.KoAnnotationProviderCore
 import com.lemonappdev.konsist.core.provider.KoBaseProviderCore
 import com.lemonappdev.konsist.core.provider.KoContainingDeclarationProviderCore
 import com.lemonappdev.konsist.core.provider.KoContainingFileProviderCore
@@ -21,6 +22,7 @@ import com.lemonappdev.konsist.core.provider.KoTypeDeclarationProviderCore
 import com.lemonappdev.konsist.core.provider.KoTypeProviderCore
 import com.lemonappdev.konsist.core.provider.packagee.KoPackageProviderCore
 import org.jetbrains.kotlin.com.intellij.psi.PsiElement
+import org.jetbrains.kotlin.psi.KtAnnotated
 import org.jetbrains.kotlin.psi.KtElement
 import org.jetbrains.kotlin.psi.KtNullableType
 import org.jetbrains.kotlin.psi.KtTypeReference
@@ -45,10 +47,13 @@ internal class KoTypeDeclarationCore private constructor(
         KoGenericTypeProviderCore,
         KoPackageProviderCore,
         KoResideInPackageProviderCore,
+        KoAnnotationProviderCore,
         KoTypeDeclarationProviderCore {
         override val psiElement: PsiElement by lazy { ktTypeReference }
 
         override val ktElement: KtElement by lazy { ktTypeReference }
+
+        override val ktAnnotated: KtAnnotated by lazy { ktTypeReference }
 
         override val name: String by lazy {
             val typeReference =


### PR DESCRIPTION
After these changes, it is possible to retrieve type annotations, eg. it is possible to write Konsist test:

```kotlin
Konsist
	.scopeFromProject()
	.classes()
    .first()
    .primaryConstructor
	?.parameters
	?.types
	?.assertTrue { it?.hasAnnotationWithName("SampleAnnotation") }
```

which passes for classes like this:
```kotlin
import com.samplepackage.SampleAnnotation
import com.samplepackage.SampleInterface

class SampleClass1(val sampleProperty1: @SampleAnnotation SampleInterface)
```

and fails for classes like below:
```kotlin
import com.samplepackage.SampleInterface

class SampleClass1(val sampleProperty1: SampleInterface)
```
