### PR TITLE
KON-623 Add `doesNotDependOn` to layer verification

### DIFF
--- a/lib/src/apiTest/kotlin/com/lemonappdev/konsist/architecture/assertarchitecture/architecture1/Architecture1Test.kt
+++ b/lib/src/apiTest/kotlin/com/lemonappdev/konsist/architecture/assertarchitecture/architecture1/Architecture1Test.kt
@@ -61,4 +61,53 @@ class Architecture1Test {
             .files
             .assertArchitecture(koArchitecture)
     }
+
+    @Test
+    fun `passes when dependency is set that Domain not depends on Presentation (scope)`() {
+        // then
+        scope
+            .assertArchitecture {
+                domain.doesNotDependOn(presentation)
+                presentation.dependsOnNothing()
+            }
+    }
+
+    @Test
+    fun `passes when dependency is set that Domain not depends on Presentation (files)`() {
+        // then
+        scope
+            .files
+            .assertArchitecture {
+                domain.doesNotDependOn(presentation)
+                presentation.dependsOnNothing()
+            }
+    }
+
+    @Test
+    fun `passes when dependency is set that Domain not depends on Presentation when architecture is passed as parameter (scope)`() {
+        // given
+        val koArchitecture =
+            architecture {
+                domain.dependsOnNothing()
+                presentation.dependsOnNothing()
+            }
+
+        // then
+        scope.assertArchitecture(koArchitecture)
+    }
+
+    @Test
+    fun `passes when dependency is set that Domain not depends on Presentation when architecture is passed as parameter (files)`() {
+        // given
+        val koArchitecture =
+            architecture {
+                domain.dependsOnNothing()
+                presentation.dependsOnNothing()
+            }
+
+        // then
+        scope
+            .files
+            .assertArchitecture(koArchitecture)
+    }
 }

--- a/lib/src/apiTest/kotlin/com/lemonappdev/konsist/architecture/assertarchitecture/architecture2/Architecture2Test.kt
+++ b/lib/src/apiTest/kotlin/com/lemonappdev/konsist/architecture/assertarchitecture/architecture2/Architecture2Test.kt
@@ -77,6 +77,41 @@ class Architecture2Test {
     }
 
     @Test
+    fun `passes when dependency is set that domain layer not depends on presentation one (scope)`() {
+        // then
+        scope
+            .assertArchitecture { domain.doesNotDependOn(presentation) }
+    }
+
+    @Test
+    fun `passes when dependency is set that domain layer not depends on presentation one (files)`() {
+        // then
+        scope
+            .files
+            .assertArchitecture { domain.doesNotDependOn(presentation) }
+    }
+
+    @Test
+    fun `passes when dependency is set that domain layer not depends on presentation one and arch is passed as parameter (scope)`() {
+        // given
+        val architecture = architecture { domain.doesNotDependOn(presentation) }
+
+        // then
+        scope.assertArchitecture(architecture)
+    }
+
+    @Test
+    fun `passes when dependency is set that domain layer not depends on presentation one and arch is passed as parameter (files)`() {
+        // given
+        val architecture = architecture { domain.doesNotDependOn(presentation) }
+
+        // then
+        scope
+            .files
+            .assertArchitecture(architecture)
+    }
+
+    @Test
     fun `fails when dependency is set that domain layer is depend on presentation layer (scope)`() {
         // when
         val sut =
@@ -92,14 +127,14 @@ class Architecture2Test {
             .message
             .shouldBeEqualTo(
                 "'fails when dependency is set that domain layer is depend on presentation layer (scope)' " +
-                    "test has failed.\n" +
-                    "Presentation depends on nothing assertion failure:\n" +
-                    "A file $rootPath/lib/src/apiTest/kotlin/com/lemonappdev/konsist/architecture/assertarchitecture" +
-                    "/architecture2/project/presentation/sample/PresentationThirdClass.kt in a Presentation layer " +
-                    "depends on Domain layer, imports:\n" +
-                    "\tcom.lemonappdev.konsist.architecture.assertarchitecture.architecture2.project.domain." +
-                    "DomainFirstClass ($rootPath/lib/src/apiTest/kotlin/com/lemonappdev/konsist/architecture/" +
-                    "assertarchitecture/architecture2/project/presentation/sample/PresentationThirdClass.kt:3:1)",
+                        "test has failed.\n" +
+                        "Presentation depends on nothing assertion failure:\n" +
+                        "A file $rootPath/lib/src/apiTest/kotlin/com/lemonappdev/konsist/architecture/assertarchitecture" +
+                        "/architecture2/project/presentation/sample/PresentationThirdClass.kt in a Presentation layer " +
+                        "depends on Domain layer, imports:\n" +
+                        "\tcom.lemonappdev.konsist.architecture.assertarchitecture.architecture2.project.domain." +
+                        "DomainFirstClass ($rootPath/lib/src/apiTest/kotlin/com/lemonappdev/konsist/architecture/" +
+                        "assertarchitecture/architecture2/project/presentation/sample/PresentationThirdClass.kt:3:1)",
             )
     }
 
@@ -121,14 +156,14 @@ class Architecture2Test {
             .message
             .shouldBeEqualTo(
                 "'fails when dependency is set that domain layer is depend on presentation layer (files)' " +
-                    "test has failed.\n" +
-                    "Presentation depends on nothing assertion failure:\n" +
-                    "A file $rootPath/lib/src/apiTest/kotlin/com/lemonappdev/konsist/architecture/assertarchitecture" +
-                    "/architecture2/project/presentation/sample/PresentationThirdClass.kt in a Presentation layer " +
-                    "depends on Domain layer, imports:\n" +
-                    "\tcom.lemonappdev.konsist.architecture.assertarchitecture.architecture2.project.domain." +
-                    "DomainFirstClass ($rootPath/lib/src/apiTest/kotlin/com/lemonappdev/konsist/architecture/" +
-                    "assertarchitecture/architecture2/project/presentation/sample/PresentationThirdClass.kt:3:1)",
+                        "test has failed.\n" +
+                        "Presentation depends on nothing assertion failure:\n" +
+                        "A file $rootPath/lib/src/apiTest/kotlin/com/lemonappdev/konsist/architecture/assertarchitecture" +
+                        "/architecture2/project/presentation/sample/PresentationThirdClass.kt in a Presentation layer " +
+                        "depends on Domain layer, imports:\n" +
+                        "\tcom.lemonappdev.konsist.architecture.assertarchitecture.architecture2.project.domain." +
+                        "DomainFirstClass ($rootPath/lib/src/apiTest/kotlin/com/lemonappdev/konsist/architecture/" +
+                        "assertarchitecture/architecture2/project/presentation/sample/PresentationThirdClass.kt:3:1)",
             )
     }
 
@@ -153,14 +188,14 @@ class Architecture2Test {
             .message
             .shouldBeEqualTo(
                 "'fails when dependency is set that domain layer is depend on presentation layer and architecture " +
-                    "is passed as parameter (scope)' test has failed.\n" +
-                    "Presentation depends on nothing assertion failure:\n" +
-                    "A file $rootPath/lib/src/apiTest/kotlin/com/lemonappdev/konsist/architecture/assertarchitecture" +
-                    "/architecture2/project/presentation/sample/PresentationThirdClass.kt in a Presentation layer " +
-                    "depends on Domain layer, imports:\n" +
-                    "\tcom.lemonappdev.konsist.architecture.assertarchitecture.architecture2.project.domain." +
-                    "DomainFirstClass ($rootPath/lib/src/apiTest/kotlin/com/lemonappdev/konsist/architecture/" +
-                    "assertarchitecture/architecture2/project/presentation/sample/PresentationThirdClass.kt:3:1)",
+                        "is passed as parameter (scope)' test has failed.\n" +
+                        "Presentation depends on nothing assertion failure:\n" +
+                        "A file $rootPath/lib/src/apiTest/kotlin/com/lemonappdev/konsist/architecture/assertarchitecture" +
+                        "/architecture2/project/presentation/sample/PresentationThirdClass.kt in a Presentation layer " +
+                        "depends on Domain layer, imports:\n" +
+                        "\tcom.lemonappdev.konsist.architecture.assertarchitecture.architecture2.project.domain." +
+                        "DomainFirstClass ($rootPath/lib/src/apiTest/kotlin/com/lemonappdev/konsist/architecture/" +
+                        "assertarchitecture/architecture2/project/presentation/sample/PresentationThirdClass.kt:3:1)",
             )
     }
 
@@ -187,14 +222,136 @@ class Architecture2Test {
             .message
             .shouldBeEqualTo(
                 "'fails when dependency is set that domain layer is depend on presentation layer and architecture " +
-                    "is passed as parameter (files)' test has failed.\n" +
-                    "Presentation depends on nothing assertion failure:\n" +
-                    "A file $rootPath/lib/src/apiTest/kotlin/com/lemonappdev/konsist/architecture/assertarchitecture" +
-                    "/architecture2/project/presentation/sample/PresentationThirdClass.kt in a Presentation layer " +
-                    "depends on Domain layer, imports:\n" +
-                    "\tcom.lemonappdev.konsist.architecture.assertarchitecture.architecture2.project.domain." +
-                    "DomainFirstClass ($rootPath/lib/src/apiTest/kotlin/com/lemonappdev/konsist/architecture/" +
-                    "assertarchitecture/architecture2/project/presentation/sample/PresentationThirdClass.kt:3:1)",
+                        "is passed as parameter (files)' test has failed.\n" +
+                        "Presentation depends on nothing assertion failure:\n" +
+                        "A file $rootPath/lib/src/apiTest/kotlin/com/lemonappdev/konsist/architecture/assertarchitecture" +
+                        "/architecture2/project/presentation/sample/PresentationThirdClass.kt in a Presentation layer " +
+                        "depends on Domain layer, imports:\n" +
+                        "\tcom.lemonappdev.konsist.architecture.assertarchitecture.architecture2.project.domain." +
+                        "DomainFirstClass ($rootPath/lib/src/apiTest/kotlin/com/lemonappdev/konsist/architecture/" +
+                        "assertarchitecture/architecture2/project/presentation/sample/PresentationThirdClass.kt:3:1)",
+            )
+    }
+
+    @Test
+    fun `fails when dependency is set that presentation layer not depends on domain (scope)`() {
+        // when
+        val sut =
+            shouldThrow<KoAssertionFailedException> {
+                scope.assertArchitecture {
+                    presentation.doesNotDependOn(domain)
+                    domain.dependsOnNothing()
+                }
+            }
+
+        // then
+        sut
+            .message
+            .shouldBeEqualTo(
+                "'fails when dependency is set that presentation layer not depends on domain (scope)' " +
+                        "test has failed.\n" +
+                        "Presentation depends on nothing assertion failure:\n" +
+                        "A file $rootPath/lib/src/apiTest/kotlin/com/lemonappdev/konsist/architecture/assertarchitecture" +
+                        "/architecture2/project/presentation/sample/PresentationThirdClass.kt in a Presentation layer " +
+                        "depends on Domain layer, imports:\n" +
+                        "\tcom.lemonappdev.konsist.architecture.assertarchitecture.architecture2.project.domain." +
+                        "DomainFirstClass ($rootPath/lib/src/apiTest/kotlin/com/lemonappdev/konsist/architecture/" +
+                        "assertarchitecture/architecture2/project/presentation/sample/PresentationThirdClass.kt:3:1)",
+            )
+    }
+
+    @Test
+    fun `fails when dependency is set that presentation layer not depends on domain (files)`() {
+        // when
+        val sut =
+            shouldThrow<KoAssertionFailedException> {
+                scope
+                    .files
+                    .assertArchitecture {
+                        presentation.doesNotDependOn(domain)
+                        domain.dependsOnNothing()
+                    }
+            }
+
+        // then
+        sut
+            .message
+            .shouldBeEqualTo(
+                "'fails when dependency is set that presentation layer not depends on domain (files)' " +
+                        "test has failed.\n" +
+                        "Presentation depends on nothing assertion failure:\n" +
+                        "A file $rootPath/lib/src/apiTest/kotlin/com/lemonappdev/konsist/architecture/assertarchitecture" +
+                        "/architecture2/project/presentation/sample/PresentationThirdClass.kt in a Presentation layer " +
+                        "depends on Domain layer, imports:\n" +
+                        "\tcom.lemonappdev.konsist.architecture.assertarchitecture.architecture2.project.domain." +
+                        "DomainFirstClass ($rootPath/lib/src/apiTest/kotlin/com/lemonappdev/konsist/architecture/" +
+                        "assertarchitecture/architecture2/project/presentation/sample/PresentationThirdClass.kt:3:1)",
+            )
+    }
+
+    @Suppress("detekt.MaxLineLength")
+    @Test
+    fun `fails when dependency is set that presentation layer not depends on domain and architecture is passed as parameter (scope)`() {
+        // given
+        val architecture =
+            architecture {
+                presentation.doesNotDependOn(domain)
+                domain.dependsOnNothing()
+            }
+
+        // when
+        val sut =
+            shouldThrow<KoAssertionFailedException> {
+                scope.assertArchitecture(architecture)
+            }
+
+        // then
+        sut
+            .message
+            .shouldBeEqualTo(
+                "'fails when dependency is set that presentation layer not depends on domain and architecture " +
+                        "is passed as parameter (scope)' test has failed.\n" +
+                        "Presentation depends on nothing assertion failure:\n" +
+                        "A file $rootPath/lib/src/apiTest/kotlin/com/lemonappdev/konsist/architecture/assertarchitecture" +
+                        "/architecture2/project/presentation/sample/PresentationThirdClass.kt in a Presentation layer " +
+                        "depends on Domain layer, imports:\n" +
+                        "\tcom.lemonappdev.konsist.architecture.assertarchitecture.architecture2.project.domain." +
+                        "DomainFirstClass ($rootPath/lib/src/apiTest/kotlin/com/lemonappdev/konsist/architecture/" +
+                        "assertarchitecture/architecture2/project/presentation/sample/PresentationThirdClass.kt:3:1)",
+            )
+    }
+
+    @Suppress("detekt.MaxLineLength")
+    @Test
+    fun `fails when dependency is set that presentation layer not depends on domain and architecture is passed as parameter (files)`() {
+        // given
+        val architecture =
+            architecture {
+                presentation.doesNotDependOn(domain)
+                domain.dependsOnNothing()
+            }
+
+        // when
+        val sut =
+            shouldThrow<KoAssertionFailedException> {
+                scope
+                    .files
+                    .assertArchitecture(architecture)
+            }
+
+        // then
+        sut
+            .message
+            .shouldBeEqualTo(
+                "'fails when dependency is set that presentation layer not depends on domain and architecture " +
+                        "is passed as parameter (files)' test has failed.\n" +
+                        "Presentation depends on nothing assertion failure:\n" +
+                        "A file $rootPath/lib/src/apiTest/kotlin/com/lemonappdev/konsist/architecture/assertarchitecture" +
+                        "/architecture2/project/presentation/sample/PresentationThirdClass.kt in a Presentation layer " +
+                        "depends on Domain layer, imports:\n" +
+                        "\tcom.lemonappdev.konsist.architecture.assertarchitecture.architecture2.project.domain." +
+                        "DomainFirstClass ($rootPath/lib/src/apiTest/kotlin/com/lemonappdev/konsist/architecture/" +
+                        "assertarchitecture/architecture2/project/presentation/sample/PresentationThirdClass.kt:3:1)",
             )
     }
 }

--- a/lib/src/apiTest/kotlin/com/lemonappdev/konsist/architecture/assertarchitecture/architecture2/Architecture2Test.kt
+++ b/lib/src/apiTest/kotlin/com/lemonappdev/konsist/architecture/assertarchitecture/architecture2/Architecture2Test.kt
@@ -250,7 +250,7 @@ class Architecture2Test {
             .shouldBeEqualTo(
                 "'fails when dependency is set that presentation layer not depends on domain (scope)' " +
                         "test has failed.\n" +
-                        "Presentation depends on nothing assertion failure:\n" +
+                        "Presentation does not depend on Domain assertion failure:\n" +
                         "A file $rootPath/lib/src/apiTest/kotlin/com/lemonappdev/konsist/architecture/assertarchitecture" +
                         "/architecture2/project/presentation/sample/PresentationThirdClass.kt in a Presentation layer " +
                         "depends on Domain layer, imports:\n" +
@@ -279,7 +279,7 @@ class Architecture2Test {
             .shouldBeEqualTo(
                 "'fails when dependency is set that presentation layer not depends on domain (files)' " +
                         "test has failed.\n" +
-                        "Presentation depends on nothing assertion failure:\n" +
+                        "Presentation does not depend on Domain assertion failure:\n" +
                         "A file $rootPath/lib/src/apiTest/kotlin/com/lemonappdev/konsist/architecture/assertarchitecture" +
                         "/architecture2/project/presentation/sample/PresentationThirdClass.kt in a Presentation layer " +
                         "depends on Domain layer, imports:\n" +
@@ -311,7 +311,7 @@ class Architecture2Test {
             .shouldBeEqualTo(
                 "'fails when dependency is set that presentation layer not depends on domain and architecture " +
                         "is passed as parameter (scope)' test has failed.\n" +
-                        "Presentation depends on nothing assertion failure:\n" +
+                        "Presentation does not depend on Domain assertion failure:\n" +
                         "A file $rootPath/lib/src/apiTest/kotlin/com/lemonappdev/konsist/architecture/assertarchitecture" +
                         "/architecture2/project/presentation/sample/PresentationThirdClass.kt in a Presentation layer " +
                         "depends on Domain layer, imports:\n" +
@@ -345,7 +345,7 @@ class Architecture2Test {
             .shouldBeEqualTo(
                 "'fails when dependency is set that presentation layer not depends on domain and architecture " +
                         "is passed as parameter (files)' test has failed.\n" +
-                        "Presentation depends on nothing assertion failure:\n" +
+                        "Presentation does not depend on Domain assertion failure:\n" +
                         "A file $rootPath/lib/src/apiTest/kotlin/com/lemonappdev/konsist/architecture/assertarchitecture" +
                         "/architecture2/project/presentation/sample/PresentationThirdClass.kt in a Presentation layer " +
                         "depends on Domain layer, imports:\n" +

--- a/lib/src/apiTest/kotlin/com/lemonappdev/konsist/architecture/assertarchitecture/architecture2/Architecture2Test.kt
+++ b/lib/src/apiTest/kotlin/com/lemonappdev/konsist/architecture/assertarchitecture/architecture2/Architecture2Test.kt
@@ -127,14 +127,14 @@ class Architecture2Test {
             .message
             .shouldBeEqualTo(
                 "'fails when dependency is set that domain layer is depend on presentation layer (scope)' " +
-                        "test has failed.\n" +
-                        "Presentation depends on nothing assertion failure:\n" +
-                        "A file $rootPath/lib/src/apiTest/kotlin/com/lemonappdev/konsist/architecture/assertarchitecture" +
-                        "/architecture2/project/presentation/sample/PresentationThirdClass.kt in a Presentation layer " +
-                        "depends on Domain layer, imports:\n" +
-                        "\tcom.lemonappdev.konsist.architecture.assertarchitecture.architecture2.project.domain." +
-                        "DomainFirstClass ($rootPath/lib/src/apiTest/kotlin/com/lemonappdev/konsist/architecture/" +
-                        "assertarchitecture/architecture2/project/presentation/sample/PresentationThirdClass.kt:3:1)",
+                    "test has failed.\n" +
+                    "Presentation depends on nothing assertion failure:\n" +
+                    "A file $rootPath/lib/src/apiTest/kotlin/com/lemonappdev/konsist/architecture/assertarchitecture" +
+                    "/architecture2/project/presentation/sample/PresentationThirdClass.kt in a Presentation layer " +
+                    "depends on Domain layer, imports:\n" +
+                    "\tcom.lemonappdev.konsist.architecture.assertarchitecture.architecture2.project.domain." +
+                    "DomainFirstClass ($rootPath/lib/src/apiTest/kotlin/com/lemonappdev/konsist/architecture/" +
+                    "assertarchitecture/architecture2/project/presentation/sample/PresentationThirdClass.kt:3:1)",
             )
     }
 
@@ -156,14 +156,14 @@ class Architecture2Test {
             .message
             .shouldBeEqualTo(
                 "'fails when dependency is set that domain layer is depend on presentation layer (files)' " +
-                        "test has failed.\n" +
-                        "Presentation depends on nothing assertion failure:\n" +
-                        "A file $rootPath/lib/src/apiTest/kotlin/com/lemonappdev/konsist/architecture/assertarchitecture" +
-                        "/architecture2/project/presentation/sample/PresentationThirdClass.kt in a Presentation layer " +
-                        "depends on Domain layer, imports:\n" +
-                        "\tcom.lemonappdev.konsist.architecture.assertarchitecture.architecture2.project.domain." +
-                        "DomainFirstClass ($rootPath/lib/src/apiTest/kotlin/com/lemonappdev/konsist/architecture/" +
-                        "assertarchitecture/architecture2/project/presentation/sample/PresentationThirdClass.kt:3:1)",
+                    "test has failed.\n" +
+                    "Presentation depends on nothing assertion failure:\n" +
+                    "A file $rootPath/lib/src/apiTest/kotlin/com/lemonappdev/konsist/architecture/assertarchitecture" +
+                    "/architecture2/project/presentation/sample/PresentationThirdClass.kt in a Presentation layer " +
+                    "depends on Domain layer, imports:\n" +
+                    "\tcom.lemonappdev.konsist.architecture.assertarchitecture.architecture2.project.domain." +
+                    "DomainFirstClass ($rootPath/lib/src/apiTest/kotlin/com/lemonappdev/konsist/architecture/" +
+                    "assertarchitecture/architecture2/project/presentation/sample/PresentationThirdClass.kt:3:1)",
             )
     }
 
@@ -188,14 +188,14 @@ class Architecture2Test {
             .message
             .shouldBeEqualTo(
                 "'fails when dependency is set that domain layer is depend on presentation layer and architecture " +
-                        "is passed as parameter (scope)' test has failed.\n" +
-                        "Presentation depends on nothing assertion failure:\n" +
-                        "A file $rootPath/lib/src/apiTest/kotlin/com/lemonappdev/konsist/architecture/assertarchitecture" +
-                        "/architecture2/project/presentation/sample/PresentationThirdClass.kt in a Presentation layer " +
-                        "depends on Domain layer, imports:\n" +
-                        "\tcom.lemonappdev.konsist.architecture.assertarchitecture.architecture2.project.domain." +
-                        "DomainFirstClass ($rootPath/lib/src/apiTest/kotlin/com/lemonappdev/konsist/architecture/" +
-                        "assertarchitecture/architecture2/project/presentation/sample/PresentationThirdClass.kt:3:1)",
+                    "is passed as parameter (scope)' test has failed.\n" +
+                    "Presentation depends on nothing assertion failure:\n" +
+                    "A file $rootPath/lib/src/apiTest/kotlin/com/lemonappdev/konsist/architecture/assertarchitecture" +
+                    "/architecture2/project/presentation/sample/PresentationThirdClass.kt in a Presentation layer " +
+                    "depends on Domain layer, imports:\n" +
+                    "\tcom.lemonappdev.konsist.architecture.assertarchitecture.architecture2.project.domain." +
+                    "DomainFirstClass ($rootPath/lib/src/apiTest/kotlin/com/lemonappdev/konsist/architecture/" +
+                    "assertarchitecture/architecture2/project/presentation/sample/PresentationThirdClass.kt:3:1)",
             )
     }
 
@@ -222,14 +222,14 @@ class Architecture2Test {
             .message
             .shouldBeEqualTo(
                 "'fails when dependency is set that domain layer is depend on presentation layer and architecture " +
-                        "is passed as parameter (files)' test has failed.\n" +
-                        "Presentation depends on nothing assertion failure:\n" +
-                        "A file $rootPath/lib/src/apiTest/kotlin/com/lemonappdev/konsist/architecture/assertarchitecture" +
-                        "/architecture2/project/presentation/sample/PresentationThirdClass.kt in a Presentation layer " +
-                        "depends on Domain layer, imports:\n" +
-                        "\tcom.lemonappdev.konsist.architecture.assertarchitecture.architecture2.project.domain." +
-                        "DomainFirstClass ($rootPath/lib/src/apiTest/kotlin/com/lemonappdev/konsist/architecture/" +
-                        "assertarchitecture/architecture2/project/presentation/sample/PresentationThirdClass.kt:3:1)",
+                    "is passed as parameter (files)' test has failed.\n" +
+                    "Presentation depends on nothing assertion failure:\n" +
+                    "A file $rootPath/lib/src/apiTest/kotlin/com/lemonappdev/konsist/architecture/assertarchitecture" +
+                    "/architecture2/project/presentation/sample/PresentationThirdClass.kt in a Presentation layer " +
+                    "depends on Domain layer, imports:\n" +
+                    "\tcom.lemonappdev.konsist.architecture.assertarchitecture.architecture2.project.domain." +
+                    "DomainFirstClass ($rootPath/lib/src/apiTest/kotlin/com/lemonappdev/konsist/architecture/" +
+                    "assertarchitecture/architecture2/project/presentation/sample/PresentationThirdClass.kt:3:1)",
             )
     }
 
@@ -249,14 +249,14 @@ class Architecture2Test {
             .message
             .shouldBeEqualTo(
                 "'fails when dependency is set that presentation layer not depends on domain (scope)' " +
-                        "test has failed.\n" +
-                        "Presentation does not depend on Domain assertion failure:\n" +
-                        "A file $rootPath/lib/src/apiTest/kotlin/com/lemonappdev/konsist/architecture/assertarchitecture" +
-                        "/architecture2/project/presentation/sample/PresentationThirdClass.kt in a Presentation layer " +
-                        "depends on Domain layer, imports:\n" +
-                        "\tcom.lemonappdev.konsist.architecture.assertarchitecture.architecture2.project.domain." +
-                        "DomainFirstClass ($rootPath/lib/src/apiTest/kotlin/com/lemonappdev/konsist/architecture/" +
-                        "assertarchitecture/architecture2/project/presentation/sample/PresentationThirdClass.kt:3:1)",
+                    "test has failed.\n" +
+                    "Presentation does not depend on Domain assertion failure:\n" +
+                    "A file $rootPath/lib/src/apiTest/kotlin/com/lemonappdev/konsist/architecture/assertarchitecture" +
+                    "/architecture2/project/presentation/sample/PresentationThirdClass.kt in a Presentation layer " +
+                    "depends on Domain layer, imports:\n" +
+                    "\tcom.lemonappdev.konsist.architecture.assertarchitecture.architecture2.project.domain." +
+                    "DomainFirstClass ($rootPath/lib/src/apiTest/kotlin/com/lemonappdev/konsist/architecture/" +
+                    "assertarchitecture/architecture2/project/presentation/sample/PresentationThirdClass.kt:3:1)",
             )
     }
 
@@ -278,14 +278,14 @@ class Architecture2Test {
             .message
             .shouldBeEqualTo(
                 "'fails when dependency is set that presentation layer not depends on domain (files)' " +
-                        "test has failed.\n" +
-                        "Presentation does not depend on Domain assertion failure:\n" +
-                        "A file $rootPath/lib/src/apiTest/kotlin/com/lemonappdev/konsist/architecture/assertarchitecture" +
-                        "/architecture2/project/presentation/sample/PresentationThirdClass.kt in a Presentation layer " +
-                        "depends on Domain layer, imports:\n" +
-                        "\tcom.lemonappdev.konsist.architecture.assertarchitecture.architecture2.project.domain." +
-                        "DomainFirstClass ($rootPath/lib/src/apiTest/kotlin/com/lemonappdev/konsist/architecture/" +
-                        "assertarchitecture/architecture2/project/presentation/sample/PresentationThirdClass.kt:3:1)",
+                    "test has failed.\n" +
+                    "Presentation does not depend on Domain assertion failure:\n" +
+                    "A file $rootPath/lib/src/apiTest/kotlin/com/lemonappdev/konsist/architecture/assertarchitecture" +
+                    "/architecture2/project/presentation/sample/PresentationThirdClass.kt in a Presentation layer " +
+                    "depends on Domain layer, imports:\n" +
+                    "\tcom.lemonappdev.konsist.architecture.assertarchitecture.architecture2.project.domain." +
+                    "DomainFirstClass ($rootPath/lib/src/apiTest/kotlin/com/lemonappdev/konsist/architecture/" +
+                    "assertarchitecture/architecture2/project/presentation/sample/PresentationThirdClass.kt:3:1)",
             )
     }
 
@@ -310,14 +310,14 @@ class Architecture2Test {
             .message
             .shouldBeEqualTo(
                 "'fails when dependency is set that presentation layer not depends on domain and architecture " +
-                        "is passed as parameter (scope)' test has failed.\n" +
-                        "Presentation does not depend on Domain assertion failure:\n" +
-                        "A file $rootPath/lib/src/apiTest/kotlin/com/lemonappdev/konsist/architecture/assertarchitecture" +
-                        "/architecture2/project/presentation/sample/PresentationThirdClass.kt in a Presentation layer " +
-                        "depends on Domain layer, imports:\n" +
-                        "\tcom.lemonappdev.konsist.architecture.assertarchitecture.architecture2.project.domain." +
-                        "DomainFirstClass ($rootPath/lib/src/apiTest/kotlin/com/lemonappdev/konsist/architecture/" +
-                        "assertarchitecture/architecture2/project/presentation/sample/PresentationThirdClass.kt:3:1)",
+                    "is passed as parameter (scope)' test has failed.\n" +
+                    "Presentation does not depend on Domain assertion failure:\n" +
+                    "A file $rootPath/lib/src/apiTest/kotlin/com/lemonappdev/konsist/architecture/assertarchitecture" +
+                    "/architecture2/project/presentation/sample/PresentationThirdClass.kt in a Presentation layer " +
+                    "depends on Domain layer, imports:\n" +
+                    "\tcom.lemonappdev.konsist.architecture.assertarchitecture.architecture2.project.domain." +
+                    "DomainFirstClass ($rootPath/lib/src/apiTest/kotlin/com/lemonappdev/konsist/architecture/" +
+                    "assertarchitecture/architecture2/project/presentation/sample/PresentationThirdClass.kt:3:1)",
             )
     }
 
@@ -344,14 +344,14 @@ class Architecture2Test {
             .message
             .shouldBeEqualTo(
                 "'fails when dependency is set that presentation layer not depends on domain and architecture " +
-                        "is passed as parameter (files)' test has failed.\n" +
-                        "Presentation does not depend on Domain assertion failure:\n" +
-                        "A file $rootPath/lib/src/apiTest/kotlin/com/lemonappdev/konsist/architecture/assertarchitecture" +
-                        "/architecture2/project/presentation/sample/PresentationThirdClass.kt in a Presentation layer " +
-                        "depends on Domain layer, imports:\n" +
-                        "\tcom.lemonappdev.konsist.architecture.assertarchitecture.architecture2.project.domain." +
-                        "DomainFirstClass ($rootPath/lib/src/apiTest/kotlin/com/lemonappdev/konsist/architecture/" +
-                        "assertarchitecture/architecture2/project/presentation/sample/PresentationThirdClass.kt:3:1)",
+                    "is passed as parameter (files)' test has failed.\n" +
+                    "Presentation does not depend on Domain assertion failure:\n" +
+                    "A file $rootPath/lib/src/apiTest/kotlin/com/lemonappdev/konsist/architecture/assertarchitecture" +
+                    "/architecture2/project/presentation/sample/PresentationThirdClass.kt in a Presentation layer " +
+                    "depends on Domain layer, imports:\n" +
+                    "\tcom.lemonappdev.konsist.architecture.assertarchitecture.architecture2.project.domain." +
+                    "DomainFirstClass ($rootPath/lib/src/apiTest/kotlin/com/lemonappdev/konsist/architecture/" +
+                    "assertarchitecture/architecture2/project/presentation/sample/PresentationThirdClass.kt:3:1)",
             )
     }
 }

--- a/lib/src/apiTest/kotlin/com/lemonappdev/konsist/architecture/assertarchitecture/architecture3/Architecture3Test.kt
+++ b/lib/src/apiTest/kotlin/com/lemonappdev/konsist/architecture/assertarchitecture/architecture3/Architecture3Test.kt
@@ -86,14 +86,14 @@ class Architecture3Test {
             .message
             .shouldBeEqualTo(
                 "'fails when dependency is set that presentation layer not depends on domain (scope)' " +
-                        "test has failed.\n" +
-                        "Presentation does not depend on Domain assertion failure:\n" +
-                        "A file $rootPath/lib/src/apiTest/kotlin/com/lemonappdev/konsist/architecture/assertarchitecture" +
-                        "/architecture3/project/presentation/sample/PresentationThirdClass.kt in a Presentation layer " +
-                        "depends on Domain layer, imports:\n" +
-                        "\tcom.lemonappdev.konsist.architecture.assertarchitecture.architecture3.project.domain." +
-                        "DomainFirstClass ($rootPath/lib/src/apiTest/kotlin/com/lemonappdev/konsist/architecture/" +
-                        "assertarchitecture/architecture3/project/presentation/sample/PresentationThirdClass.kt:3:1)",
+                    "test has failed.\n" +
+                    "Presentation does not depend on Domain assertion failure:\n" +
+                    "A file $rootPath/lib/src/apiTest/kotlin/com/lemonappdev/konsist/architecture/assertarchitecture" +
+                    "/architecture3/project/presentation/sample/PresentationThirdClass.kt in a Presentation layer " +
+                    "depends on Domain layer, imports:\n" +
+                    "\tcom.lemonappdev.konsist.architecture.assertarchitecture.architecture3.project.domain." +
+                    "DomainFirstClass ($rootPath/lib/src/apiTest/kotlin/com/lemonappdev/konsist/architecture/" +
+                    "assertarchitecture/architecture3/project/presentation/sample/PresentationThirdClass.kt:3:1)",
             )
     }
 
@@ -112,14 +112,14 @@ class Architecture3Test {
             .message
             .shouldBeEqualTo(
                 "'fails when dependency is set that presentation layer not depends on domain (files)' " +
-                        "test has failed.\n" +
-                        "Presentation does not depend on Domain assertion failure:\n" +
-                        "A file $rootPath/lib/src/apiTest/kotlin/com/lemonappdev/konsist/architecture/assertarchitecture" +
-                        "/architecture3/project/presentation/sample/PresentationThirdClass.kt in a Presentation layer " +
-                        "depends on Domain layer, imports:\n" +
-                        "\tcom.lemonappdev.konsist.architecture.assertarchitecture.architecture3.project.domain." +
-                        "DomainFirstClass ($rootPath/lib/src/apiTest/kotlin/com/lemonappdev/konsist/architecture/" +
-                        "assertarchitecture/architecture3/project/presentation/sample/PresentationThirdClass.kt:3:1)",
+                    "test has failed.\n" +
+                    "Presentation does not depend on Domain assertion failure:\n" +
+                    "A file $rootPath/lib/src/apiTest/kotlin/com/lemonappdev/konsist/architecture/assertarchitecture" +
+                    "/architecture3/project/presentation/sample/PresentationThirdClass.kt in a Presentation layer " +
+                    "depends on Domain layer, imports:\n" +
+                    "\tcom.lemonappdev.konsist.architecture.assertarchitecture.architecture3.project.domain." +
+                    "DomainFirstClass ($rootPath/lib/src/apiTest/kotlin/com/lemonappdev/konsist/architecture/" +
+                    "assertarchitecture/architecture3/project/presentation/sample/PresentationThirdClass.kt:3:1)",
             )
     }
 
@@ -141,14 +141,14 @@ class Architecture3Test {
             .message
             .shouldBeEqualTo(
                 "'fails when dependency is set that presentation layer not depends on domain and architecture " +
-                        "is passed as parameter (scope)' test has failed.\n" +
-                        "Presentation does not depend on Domain assertion failure:\n" +
-                        "A file $rootPath/lib/src/apiTest/kotlin/com/lemonappdev/konsist/architecture/assertarchitecture" +
-                        "/architecture3/project/presentation/sample/PresentationThirdClass.kt in a Presentation layer " +
-                        "depends on Domain layer, imports:\n" +
-                        "\tcom.lemonappdev.konsist.architecture.assertarchitecture.architecture3.project.domain." +
-                        "DomainFirstClass ($rootPath/lib/src/apiTest/kotlin/com/lemonappdev/konsist/architecture/" +
-                        "assertarchitecture/architecture3/project/presentation/sample/PresentationThirdClass.kt:3:1)",
+                    "is passed as parameter (scope)' test has failed.\n" +
+                    "Presentation does not depend on Domain assertion failure:\n" +
+                    "A file $rootPath/lib/src/apiTest/kotlin/com/lemonappdev/konsist/architecture/assertarchitecture" +
+                    "/architecture3/project/presentation/sample/PresentationThirdClass.kt in a Presentation layer " +
+                    "depends on Domain layer, imports:\n" +
+                    "\tcom.lemonappdev.konsist.architecture.assertarchitecture.architecture3.project.domain." +
+                    "DomainFirstClass ($rootPath/lib/src/apiTest/kotlin/com/lemonappdev/konsist/architecture/" +
+                    "assertarchitecture/architecture3/project/presentation/sample/PresentationThirdClass.kt:3:1)",
             )
     }
 
@@ -172,14 +172,14 @@ class Architecture3Test {
             .message
             .shouldBeEqualTo(
                 "'fails when dependency is set that presentation layer not depends on domain and architecture " +
-                        "is passed as parameter (files)' test has failed.\n" +
-                        "Presentation does not depend on Domain assertion failure:\n" +
-                        "A file $rootPath/lib/src/apiTest/kotlin/com/lemonappdev/konsist/architecture/assertarchitecture" +
-                        "/architecture3/project/presentation/sample/PresentationThirdClass.kt in a Presentation layer " +
-                        "depends on Domain layer, imports:\n" +
-                        "\tcom.lemonappdev.konsist.architecture.assertarchitecture.architecture3.project.domain." +
-                        "DomainFirstClass ($rootPath/lib/src/apiTest/kotlin/com/lemonappdev/konsist/architecture/" +
-                        "assertarchitecture/architecture3/project/presentation/sample/PresentationThirdClass.kt:3:1)",
+                    "is passed as parameter (files)' test has failed.\n" +
+                    "Presentation does not depend on Domain assertion failure:\n" +
+                    "A file $rootPath/lib/src/apiTest/kotlin/com/lemonappdev/konsist/architecture/assertarchitecture" +
+                    "/architecture3/project/presentation/sample/PresentationThirdClass.kt in a Presentation layer " +
+                    "depends on Domain layer, imports:\n" +
+                    "\tcom.lemonappdev.konsist.architecture.assertarchitecture.architecture3.project.domain." +
+                    "DomainFirstClass ($rootPath/lib/src/apiTest/kotlin/com/lemonappdev/konsist/architecture/" +
+                    "assertarchitecture/architecture3/project/presentation/sample/PresentationThirdClass.kt:3:1)",
             )
     }
 }

--- a/lib/src/apiTest/kotlin/com/lemonappdev/konsist/architecture/assertarchitecture/architecture3/Architecture3Test.kt
+++ b/lib/src/apiTest/kotlin/com/lemonappdev/konsist/architecture/assertarchitecture/architecture3/Architecture3Test.kt
@@ -4,9 +4,14 @@ import com.lemonappdev.konsist.api.Konsist
 import com.lemonappdev.konsist.api.architecture.KoArchitectureCreator.architecture
 import com.lemonappdev.konsist.api.architecture.KoArchitectureCreator.assertArchitecture
 import com.lemonappdev.konsist.api.architecture.Layer
+import com.lemonappdev.konsist.core.exception.KoAssertionFailedException
+import com.lemonappdev.konsist.core.filesystem.PathProvider
+import io.kotest.assertions.throwables.shouldThrow
+import org.amshove.kluent.shouldBeEqualTo
 import org.junit.jupiter.api.Test
 
 class Architecture3Test {
+    private val rootPath = PathProvider.rootProjectPath
     private val domain =
         Layer("Domain", "com.lemonappdev.konsist.architecture.assertarchitecture.architecture3.project.domain..")
     private val presentation =
@@ -66,5 +71,115 @@ class Architecture3Test {
         scope
             .files
             .assertArchitecture(architecture)
+    }
+
+    @Test
+    fun `fails when dependency is set that presentation layer not depends on domain (scope)`() {
+        // when
+        val sut =
+            shouldThrow<KoAssertionFailedException> {
+                scope.assertArchitecture { presentation.doesNotDependOn(domain) }
+            }
+
+        // then
+        sut
+            .message
+            .shouldBeEqualTo(
+                "'fails when dependency is set that presentation layer not depends on domain (scope)' " +
+                        "test has failed.\n" +
+                        "Presentation does not depend on Domain assertion failure:\n" +
+                        "A file $rootPath/lib/src/apiTest/kotlin/com/lemonappdev/konsist/architecture/assertarchitecture" +
+                        "/architecture3/project/presentation/sample/PresentationThirdClass.kt in a Presentation layer " +
+                        "depends on Domain layer, imports:\n" +
+                        "\tcom.lemonappdev.konsist.architecture.assertarchitecture.architecture3.project.domain." +
+                        "DomainFirstClass ($rootPath/lib/src/apiTest/kotlin/com/lemonappdev/konsist/architecture/" +
+                        "assertarchitecture/architecture3/project/presentation/sample/PresentationThirdClass.kt:3:1)",
+            )
+    }
+
+    @Test
+    fun `fails when dependency is set that presentation layer not depends on domain (files)`() {
+        // when
+        val sut =
+            shouldThrow<KoAssertionFailedException> {
+                scope
+                    .files
+                    .assertArchitecture { presentation.doesNotDependOn(domain) }
+            }
+
+        // then
+        sut
+            .message
+            .shouldBeEqualTo(
+                "'fails when dependency is set that presentation layer not depends on domain (files)' " +
+                        "test has failed.\n" +
+                        "Presentation does not depend on Domain assertion failure:\n" +
+                        "A file $rootPath/lib/src/apiTest/kotlin/com/lemonappdev/konsist/architecture/assertarchitecture" +
+                        "/architecture3/project/presentation/sample/PresentationThirdClass.kt in a Presentation layer " +
+                        "depends on Domain layer, imports:\n" +
+                        "\tcom.lemonappdev.konsist.architecture.assertarchitecture.architecture3.project.domain." +
+                        "DomainFirstClass ($rootPath/lib/src/apiTest/kotlin/com/lemonappdev/konsist/architecture/" +
+                        "assertarchitecture/architecture3/project/presentation/sample/PresentationThirdClass.kt:3:1)",
+            )
+    }
+
+    @Suppress("detekt.MaxLineLength")
+    @Test
+    fun `fails when dependency is set that presentation layer not depends on domain and architecture is passed as parameter (scope)`() {
+        // given
+        val architecture =
+            architecture { presentation.doesNotDependOn(domain) }
+
+        // when
+        val sut =
+            shouldThrow<KoAssertionFailedException> {
+                scope.assertArchitecture(architecture)
+            }
+
+        // then
+        sut
+            .message
+            .shouldBeEqualTo(
+                "'fails when dependency is set that presentation layer not depends on domain and architecture " +
+                        "is passed as parameter (scope)' test has failed.\n" +
+                        "Presentation does not depend on Domain assertion failure:\n" +
+                        "A file $rootPath/lib/src/apiTest/kotlin/com/lemonappdev/konsist/architecture/assertarchitecture" +
+                        "/architecture3/project/presentation/sample/PresentationThirdClass.kt in a Presentation layer " +
+                        "depends on Domain layer, imports:\n" +
+                        "\tcom.lemonappdev.konsist.architecture.assertarchitecture.architecture3.project.domain." +
+                        "DomainFirstClass ($rootPath/lib/src/apiTest/kotlin/com/lemonappdev/konsist/architecture/" +
+                        "assertarchitecture/architecture3/project/presentation/sample/PresentationThirdClass.kt:3:1)",
+            )
+    }
+
+    @Suppress("detekt.MaxLineLength")
+    @Test
+    fun `fails when dependency is set that presentation layer not depends on domain and architecture is passed as parameter (files)`() {
+        // given
+        val architecture =
+            architecture { presentation.doesNotDependOn(domain) }
+
+        // when
+        val sut =
+            shouldThrow<KoAssertionFailedException> {
+                scope
+                    .files
+                    .assertArchitecture(architecture)
+            }
+
+        // then
+        sut
+            .message
+            .shouldBeEqualTo(
+                "'fails when dependency is set that presentation layer not depends on domain and architecture " +
+                        "is passed as parameter (files)' test has failed.\n" +
+                        "Presentation does not depend on Domain assertion failure:\n" +
+                        "A file $rootPath/lib/src/apiTest/kotlin/com/lemonappdev/konsist/architecture/assertarchitecture" +
+                        "/architecture3/project/presentation/sample/PresentationThirdClass.kt in a Presentation layer " +
+                        "depends on Domain layer, imports:\n" +
+                        "\tcom.lemonappdev.konsist.architecture.assertarchitecture.architecture3.project.domain." +
+                        "DomainFirstClass ($rootPath/lib/src/apiTest/kotlin/com/lemonappdev/konsist/architecture/" +
+                        "assertarchitecture/architecture3/project/presentation/sample/PresentationThirdClass.kt:3:1)",
+            )
     }
 }

--- a/lib/src/apiTest/kotlin/com/lemonappdev/konsist/architecture/assertarchitecture/architecture4/Architecture4Test.kt
+++ b/lib/src/apiTest/kotlin/com/lemonappdev/konsist/architecture/assertarchitecture/architecture4/Architecture4Test.kt
@@ -79,6 +79,40 @@ class Architecture4Test {
     }
 
     @Test
+    fun `passes when dependency is set correctly using doesNotDependsOn (scope)`() {
+        // then
+        scope.assertArchitecture { domain.doesNotDependOn(data, presentation) }
+    }
+
+    @Test
+    fun `passes when dependency is set correctly using doesNotDependsOn (files)`() {
+        // then
+        scope
+            .files
+            .assertArchitecture { domain.doesNotDependOn(data, presentation) }
+    }
+
+    @Test
+    fun `passes when dependency is set correctly using doesNotDependsOn and architecture is passed as parameter (scope)`() {
+        // given
+        val architecture = architecture { domain.doesNotDependOn(data, presentation) }
+
+        // then
+        scope.assertArchitecture(architecture)
+    }
+
+    @Test
+    fun `passes when dependency is set correctly using doesNotDependsOn and architecture is passed as parameter (files)`() {
+        // given
+        val architecture = architecture { domain.doesNotDependOn(data, presentation) }
+
+        // then
+        scope
+            .files
+            .assertArchitecture(architecture)
+    }
+
+    @Test
     fun `fails when bad dependency is set (scope)`() {
         // when
         val sut =
@@ -169,6 +203,81 @@ class Architecture4Test {
                 "'fails when bad dependency is set and architecture is passed as parameter (files)' test has failed.\n",
             )
             message?.shouldContain("Presentation depends on Data assertion failure:\n")
+        }
+    }
+
+    @Test
+    fun `fails when bad dependency is set using doesNotDependsOn (scope)`() {
+        // when
+        val sut =
+            shouldThrow<KoAssertionFailedException> {
+                scope.assertArchitecture { presentation.doesNotDependOn(data, domain) }
+            }
+
+        // then
+        assertSoftly(sut) {
+            message?.shouldContain("'fails when bad dependency is set using doesNotDependsOn (scope)' test has failed.\n")
+            message?.shouldContain("Presentation does not depend on Data, Domain assertion failure:\n")
+        }
+    }
+
+    @Test
+    fun `fails when bad dependency is set using doesNotDependsOn (files)`() {
+        // when
+        val sut =
+            shouldThrow<KoAssertionFailedException> {
+                scope
+                    .files
+                    .assertArchitecture { presentation.doesNotDependOn(data, domain) }
+            }
+
+        // then
+        assertSoftly(sut) {
+            message?.shouldContain("'fails when bad dependency is set using doesNotDependsOn (files)' test has failed.\n")
+            message?.shouldContain("Presentation does not depend on Data, Domain assertion failure:\n")
+        }
+    }
+
+    @Test
+    fun `fails when bad dependency is set using doesNotDependsOn and architecture is passed as parameter (scope)`() {
+        // given
+        val architecture = architecture { presentation.doesNotDependOn(data, domain) }
+
+        // when
+        val sut =
+            shouldThrow<KoAssertionFailedException> {
+                scope
+                    .assertArchitecture(architecture)
+            }
+
+        // then
+        assertSoftly(sut) {
+            message?.shouldContain(
+                "'fails when bad dependency is set using doesNotDependsOn and architecture is passed as parameter (scope)' test has failed.\n",
+            )
+            message?.shouldContain("Presentation does not depend on Data, Domain assertion failure:\n")
+        }
+    }
+
+    @Test
+    fun `fails when bad dependency is set using doesNotDependsOn and architecture is passed as parameter (files)`() {
+        // given
+        val architecture = architecture { presentation.doesNotDependOn(data, domain) }
+
+        // when
+        val sut =
+            shouldThrow<KoAssertionFailedException> {
+                scope
+                    .files
+                    .assertArchitecture(architecture)
+            }
+
+        // then
+        assertSoftly(sut) {
+            message?.shouldContain(
+                "'fails when bad dependency is set using doesNotDependsOn and architecture is passed as parameter (files)' test has failed.\n",
+            )
+            message?.shouldContain("Presentation does not depend on Data, Domain assertion failure:\n")
         }
     }
 }

--- a/lib/src/apiTest/kotlin/com/lemonappdev/konsist/architecture/assertarchitecture/architecture4/Architecture4Test.kt
+++ b/lib/src/apiTest/kotlin/com/lemonappdev/konsist/architecture/assertarchitecture/architecture4/Architecture4Test.kt
@@ -253,7 +253,8 @@ class Architecture4Test {
         // then
         assertSoftly(sut) {
             message?.shouldContain(
-                "'fails when bad dependency is set using doesNotDependsOn and architecture is passed as parameter (scope)' test has failed.\n",
+                "'fails when bad dependency is set using doesNotDependsOn and architecture is passed as" +
+                    " parameter (scope)' test has failed.\n",
             )
             message?.shouldContain("Presentation does not depend on Data, Domain assertion failure:\n")
         }
@@ -275,7 +276,8 @@ class Architecture4Test {
         // then
         assertSoftly(sut) {
             message?.shouldContain(
-                "'fails when bad dependency is set using doesNotDependsOn and architecture is passed as parameter (files)' test has failed.\n",
+                "'fails when bad dependency is set using doesNotDependsOn and architecture is passed as" +
+                    " parameter (files)' test has failed.\n",
             )
             message?.shouldContain("Presentation does not depend on Data, Domain assertion failure:\n")
         }

--- a/lib/src/apiTest/kotlin/com/lemonappdev/konsist/architecture/assertarchitecture/architecture5/Architecture5Test.kt
+++ b/lib/src/apiTest/kotlin/com/lemonappdev/konsist/architecture/assertarchitecture/architecture5/Architecture5Test.kt
@@ -214,7 +214,7 @@ class Architecture5Test {
     fun `fails when bad dependency using doesNotDependsOn is set (scope)`() {
         // given
         val sut = {
-            scope.assertArchitecture { infrastructure.doesNotDependOn(application) }
+            scope.assertArchitecture { application.doesNotDependOn(infrastructure) }
         }
 
         // then
@@ -227,7 +227,7 @@ class Architecture5Test {
         val sut = {
             scope
                 .files
-                .assertArchitecture { infrastructure.doesNotDependOn(application) }
+                .assertArchitecture { application.doesNotDependOn(infrastructure) }
         }
 
         // then
@@ -237,7 +237,7 @@ class Architecture5Test {
     @Test
     fun `fails when bad dependency using doesNotDependsOn is set and architecture is passed as parameter (scope)`() {
         // given
-        val architecture = architecture { infrastructure.doesNotDependOn(application) }
+        val architecture = architecture { application.doesNotDependOn(infrastructure) }
 
         val sut = {
             scope.assertArchitecture(architecture)
@@ -250,7 +250,7 @@ class Architecture5Test {
     @Test
     fun `fails when bad dependency using doesNotDependsOn is set and architecture is passed as parameter (files)`() {
         // given
-        val architecture = architecture { infrastructure.doesNotDependOn(application) }
+        val architecture = architecture { application.doesNotDependOn(infrastructure) }
 
         val sut = {
             scope

--- a/lib/src/apiTest/kotlin/com/lemonappdev/konsist/architecture/assertarchitecture/architecture5/Architecture5Test.kt
+++ b/lib/src/apiTest/kotlin/com/lemonappdev/konsist/architecture/assertarchitecture/architecture5/Architecture5Test.kt
@@ -92,10 +92,7 @@ class Architecture5Test {
     @Test
     fun `passes when good dependency is set using doesNotDependsOn (scope)`() {
         // then
-        scope
-            .assertArchitecture {
-                infrastructure.doesNotDependOn(presentation)
-            }
+        scope.assertArchitecture { presentation.doesNotDependOn(domain, infrastructure) }
     }
 
     @Test
@@ -103,31 +100,22 @@ class Architecture5Test {
         // then
         scope
             .files
-            .assertArchitecture {
-                infrastructure.doesNotDependOn(presentation)
-            }
+            .assertArchitecture { presentation.doesNotDependOn(domain, infrastructure) }
     }
 
     @Test
     fun `passes when good dependency is set using doesNotDependsOn and architecture is passed as parameter (scope)`() {
         // given
-        val architecture =
-            architecture {
-                infrastructure.doesNotDependOn(presentation)
-            }
+        val architecture = architecture { presentation.doesNotDependOn(domain, infrastructure) }
 
         // then
-        scope
-            .assertArchitecture(architecture)
+        scope.assertArchitecture(architecture)
     }
 
     @Test
     fun `passes when good dependency is set using doesNotDependsOn and architecture is passed as parameter (files)`() {
         // given
-        val architecture =
-            architecture {
-                infrastructure.doesNotDependOn(presentation)
-            }
+        val architecture = architecture { presentation.doesNotDependOn(domain, infrastructure) }
 
         // then
         scope
@@ -213,9 +201,7 @@ class Architecture5Test {
     @Test
     fun `fails when bad dependency using doesNotDependsOn is set (scope)`() {
         // given
-        val sut = {
-            scope.assertArchitecture { application.doesNotDependOn(infrastructure) }
-        }
+        val sut = { scope.assertArchitecture { application.doesNotDependOn(infrastructure) } }
 
         // then
         sut shouldThrow KoAssertionFailedException::class
@@ -239,9 +225,7 @@ class Architecture5Test {
         // given
         val architecture = architecture { application.doesNotDependOn(infrastructure) }
 
-        val sut = {
-            scope.assertArchitecture(architecture)
-        }
+        val sut = { scope.assertArchitecture(architecture) }
 
         // then
         sut shouldThrow KoAssertionFailedException::class

--- a/lib/src/apiTest/kotlin/com/lemonappdev/konsist/architecture/assertarchitecture/architecture5/Architecture5Test.kt
+++ b/lib/src/apiTest/kotlin/com/lemonappdev/konsist/architecture/assertarchitecture/architecture5/Architecture5Test.kt
@@ -10,12 +10,22 @@ import org.junit.jupiter.api.Test
 
 class Architecture5Test {
     private val presentation =
-        Layer("Presentation", "com.lemonappdev.konsist.architecture.assertarchitecture.architecture5.project.presentation..")
+        Layer(
+            "Presentation",
+            "com.lemonappdev.konsist.architecture.assertarchitecture.architecture5.project.presentation.."
+        )
     private val application =
-        Layer("Application", "com.lemonappdev.konsist.architecture.assertarchitecture.architecture5.project.application..")
-    private val domain = Layer("Domain", "com.lemonappdev.konsist.architecture.assertarchitecture.architecture5.project.domain..")
+        Layer(
+            "Application",
+            "com.lemonappdev.konsist.architecture.assertarchitecture.architecture5.project.application.."
+        )
+    private val domain =
+        Layer("Domain", "com.lemonappdev.konsist.architecture.assertarchitecture.architecture5.project.domain..")
     private val infrastructure =
-        Layer("Infrastructure", "com.lemonappdev.konsist.architecture.assertarchitecture.architecture5.project.infrastructure..")
+        Layer(
+            "Infrastructure",
+            "com.lemonappdev.konsist.architecture.assertarchitecture.architecture5.project.infrastructure.."
+        )
     private val scope =
         Konsist.scopeFromDirectory(
             "lib/src/apiTest/kotlin/com/lemonappdev/konsist/architecture/assertarchitecture/architecture5/project",
@@ -71,6 +81,52 @@ class Architecture5Test {
                 application.dependsOn(domain, infrastructure)
                 domain.dependsOn(infrastructure)
                 infrastructure.dependsOnNothing()
+            }
+
+        // then
+        scope
+            .files
+            .assertArchitecture(architecture)
+    }
+
+    @Test
+    fun `passes when good dependency is set using doesNotDependsOn (scope)`() {
+        // then
+        scope
+            .assertArchitecture {
+                infrastructure.doesNotDependOn(presentation)
+            }
+    }
+
+    @Test
+    fun `passes when good dependency is set using doesNotDependsOn (files)`() {
+        // then
+        scope
+            .files
+            .assertArchitecture {
+                infrastructure.doesNotDependOn(presentation)
+            }
+    }
+
+    @Test
+    fun `passes when good dependency is set using doesNotDependsOn and architecture is passed as parameter (scope)`() {
+        // given
+        val architecture =
+            architecture {
+                infrastructure.doesNotDependOn(presentation)
+            }
+
+        // then
+        scope
+            .assertArchitecture(architecture)
+    }
+
+    @Test
+    fun `passes when good dependency is set using doesNotDependsOn and architecture is passed as parameter (files)`() {
+        // given
+        val architecture =
+            architecture {
+                infrastructure.doesNotDependOn(presentation)
             }
 
         // then
@@ -143,6 +199,58 @@ class Architecture5Test {
                 domain.dependsOn(infrastructure)
                 infrastructure.dependsOnNothing()
             }
+
+        val sut = {
+            scope
+                .files
+                .assertArchitecture(architecture)
+        }
+
+        // then
+        sut shouldThrow KoAssertionFailedException::class
+    }
+
+    @Test
+    fun `fails when bad dependency using doesNotDependsOn is set (scope)`() {
+        // given
+        val sut = {
+            scope.assertArchitecture { infrastructure.doesNotDependOn(application) }
+        }
+
+        // then
+        sut shouldThrow KoAssertionFailedException::class
+    }
+
+    @Test
+    fun `fails when bad dependency using doesNotDependsOn is set (files)`() {
+        // given
+        val sut = {
+            scope
+                .files
+                .assertArchitecture { infrastructure.doesNotDependOn(application) }
+        }
+
+        // then
+        sut shouldThrow KoAssertionFailedException::class
+    }
+
+    @Test
+    fun `fails when bad dependency using doesNotDependsOn is set and architecture is passed as parameter (scope)`() {
+        // given
+        val architecture = architecture { infrastructure.doesNotDependOn(application) }
+
+        val sut = {
+            scope.assertArchitecture(architecture)
+        }
+
+        // then
+        sut shouldThrow KoAssertionFailedException::class
+    }
+
+    @Test
+    fun `fails when bad dependency using doesNotDependsOn is set and architecture is passed as parameter (files)`() {
+        // given
+        val architecture = architecture { infrastructure.doesNotDependOn(application) }
 
         val sut = {
             scope

--- a/lib/src/apiTest/kotlin/com/lemonappdev/konsist/architecture/assertarchitecture/architecture5/Architecture5Test.kt
+++ b/lib/src/apiTest/kotlin/com/lemonappdev/konsist/architecture/assertarchitecture/architecture5/Architecture5Test.kt
@@ -12,19 +12,19 @@ class Architecture5Test {
     private val presentation =
         Layer(
             "Presentation",
-            "com.lemonappdev.konsist.architecture.assertarchitecture.architecture5.project.presentation.."
+            "com.lemonappdev.konsist.architecture.assertarchitecture.architecture5.project.presentation..",
         )
     private val application =
         Layer(
             "Application",
-            "com.lemonappdev.konsist.architecture.assertarchitecture.architecture5.project.application.."
+            "com.lemonappdev.konsist.architecture.assertarchitecture.architecture5.project.application..",
         )
     private val domain =
         Layer("Domain", "com.lemonappdev.konsist.architecture.assertarchitecture.architecture5.project.domain..")
     private val infrastructure =
         Layer(
             "Infrastructure",
-            "com.lemonappdev.konsist.architecture.assertarchitecture.architecture5.project.infrastructure.."
+            "com.lemonappdev.konsist.architecture.assertarchitecture.architecture5.project.infrastructure..",
         )
     private val scope =
         Konsist.scopeFromDirectory(

--- a/lib/src/apiTest/kotlin/com/lemonappdev/konsist/architecture/assertarchitecture/architecture7/Architecture7Test.kt
+++ b/lib/src/apiTest/kotlin/com/lemonappdev/konsist/architecture/assertarchitecture/architecture7/Architecture7Test.kt
@@ -86,7 +86,7 @@ class Architecture7Test {
     fun `passes when good dependency is set using doesNotDependsOn (scope)`() {
         // then
         scope
-            .assertArchitecture { domain.doesNotDependOn(adapter) }
+            .assertArchitecture { domain.doesNotDependOn(adapter, port) }
     }
 
     @Test
@@ -94,13 +94,13 @@ class Architecture7Test {
         // then
         scope
             .files
-            .assertArchitecture { domain.doesNotDependOn(adapter) }
+            .assertArchitecture { domain.doesNotDependOn(adapter, port) }
     }
 
     @Test
     fun `passes when good dependency is set using doesNotDependsOn and architecture is passed as parameter (scope)`() {
         // then
-        val architecture = architecture { domain.doesNotDependOn(adapter) }
+        val architecture = architecture { domain.doesNotDependOn(adapter, port) }
 
         scope.assertArchitecture(architecture)
     }
@@ -108,7 +108,7 @@ class Architecture7Test {
     @Test
     fun `passes when good dependency is set using doesNotDependsOn and architecture is passed as parameter (files)`() {
         // then
-        val architecture = architecture { domain.doesNotDependOn(adapter) }
+        val architecture = architecture { domain.doesNotDependOn(adapter, port) }
 
         scope
             .files

--- a/lib/src/apiTest/kotlin/com/lemonappdev/konsist/architecture/assertarchitecture/architecture7/Architecture7Test.kt
+++ b/lib/src/apiTest/kotlin/com/lemonappdev/konsist/architecture/assertarchitecture/architecture7/Architecture7Test.kt
@@ -1,8 +1,12 @@
 package com.lemonappdev.konsist.architecture.assertarchitecture.architecture7
 
 import com.lemonappdev.konsist.api.Konsist
+import com.lemonappdev.konsist.api.architecture.KoArchitectureCreator
+import com.lemonappdev.konsist.api.architecture.KoArchitectureCreator.architecture
 import com.lemonappdev.konsist.api.architecture.KoArchitectureCreator.assertArchitecture
 import com.lemonappdev.konsist.api.architecture.Layer
+import com.lemonappdev.konsist.core.exception.KoAssertionFailedException
+import org.amshove.kluent.shouldThrow
 import org.junit.jupiter.api.Test
 
 class Architecture7Test {
@@ -11,19 +15,20 @@ class Architecture7Test {
             "lib/src/apiTest/kotlin/com/lemonappdev/konsist/architecture/assertarchitecture/architecture7/project",
         )
 
+    private val adapter =
+        Layer("Adapter", "com.lemonappdev.konsist.architecture.assertarchitecture.architecture7.project.adapter..")
+    private val common =
+        Layer("Common", "com.lemonappdev.konsist.architecture.assertarchitecture.architecture7.project.common..")
+    private val domain =
+        Layer("Domain", "com.lemonappdev.konsist.architecture.assertarchitecture.architecture7.project.domain..")
+    private val port =
+        Layer("Port", "com.lemonappdev.konsist.architecture.assertarchitecture.architecture7.project.port..")
+
     @Test
     fun `passes when good dependency is set (scope)`() {
         // then
         scope
             .assertArchitecture {
-                val adapter =
-                    Layer("Adapter", "com.lemonappdev.konsist.architecture.assertarchitecture.architecture7.project.adapter..")
-                val common =
-                    Layer("Common", "com.lemonappdev.konsist.architecture.assertarchitecture.architecture7.project.common..")
-                val domain = Layer("Domain", "com.lemonappdev.konsist.architecture.assertarchitecture.architecture7.project.domain..")
-                val port =
-                    Layer("Port", "com.lemonappdev.konsist.architecture.assertarchitecture.architecture7.project.port..")
-
                 domain.dependsOn(common)
                 adapter.dependsOn(common)
                 port.dependsOn(domain, common)
@@ -38,19 +43,126 @@ class Architecture7Test {
         scope
             .files
             .assertArchitecture {
-                val adapter =
-                    Layer("Adapter", "com.lemonappdev.konsist.architecture.assertarchitecture.architecture7.project.adapter..")
-                val common =
-                    Layer("Common", "com.lemonappdev.konsist.architecture.assertarchitecture.architecture7.project.common..")
-                val domain = Layer("Domain", "com.lemonappdev.konsist.architecture.assertarchitecture.architecture7.project.domain..")
-                val port =
-                    Layer("Port", "com.lemonappdev.konsist.architecture.assertarchitecture.architecture7.project.port..")
-
                 domain.dependsOn(common)
                 adapter.dependsOn(common)
                 port.dependsOn(domain, common)
                 adapter.dependsOn(port)
                 common.dependsOnNothing()
             }
+    }
+
+    @Test
+    fun `passes when good dependency is set and architecture is passed as parameter (scope)`() {
+        // then
+        val architecture = architecture {
+            domain.dependsOn(common)
+            adapter.dependsOn(common)
+            port.dependsOn(domain, common)
+            adapter.dependsOn(port)
+            common.dependsOnNothing()
+        }
+
+        scope.assertArchitecture(architecture)
+    }
+
+    @Test
+    fun `passes when good dependency is set and architecture is passed as parameter (files)`() {
+        // then
+        val architecture = architecture {
+            domain.dependsOn(common)
+            adapter.dependsOn(common)
+            port.dependsOn(domain, common)
+            adapter.dependsOn(port)
+            common.dependsOnNothing()
+        }
+
+        scope
+            .files
+            .assertArchitecture(architecture)
+    }
+
+    @Test
+    fun `passes when good dependency is set using doesNotDependsOn (scope)`() {
+        // then
+        scope
+            .assertArchitecture { domain.doesNotDependOn(adapter) }
+    }
+
+    @Test
+    fun `passes when good dependency is set using doesNotDependsOn (files)`() {
+        // then
+        scope
+            .files
+            .assertArchitecture { domain.doesNotDependOn(adapter) }
+    }
+
+    @Test
+    fun `passes when good dependency is set using doesNotDependsOn and architecture is passed as parameter (scope)`() {
+        // then
+        val architecture = architecture { domain.doesNotDependOn(adapter) }
+
+        scope.assertArchitecture(architecture)
+    }
+
+    @Test
+    fun `passes when good dependency is set using doesNotDependsOn and architecture is passed as parameter (files)`() {
+        // then
+        val architecture = architecture { domain.doesNotDependOn(adapter) }
+
+        scope
+            .files
+            .assertArchitecture(architecture)
+    }
+
+    @Test
+    fun `fails when bad dependency using doesNotDependsOn is set (scope)`() {
+        // given
+        val sut = {
+            scope.assertArchitecture { domain.doesNotDependOn(adapter, port) }
+        }
+
+        // then
+        sut shouldThrow KoAssertionFailedException::class
+    }
+
+    @Test
+    fun `fails when bad dependency using doesNotDependsOn is set (files)`() {
+        // given
+        val sut = {
+            scope
+                .files
+                .assertArchitecture { domain.doesNotDependOn(adapter, port) }
+        }
+
+        // then
+        sut shouldThrow KoAssertionFailedException::class
+    }
+
+    @Test
+    fun `fails when bad dependency using doesNotDependsOn is set and architecture is passed as parameter (scope)`() {
+        // given
+        val architecture = architecture { domain.doesNotDependOn(adapter, port) }
+
+        val sut = {
+            scope.assertArchitecture(architecture)
+        }
+
+        // then
+        sut shouldThrow KoAssertionFailedException::class
+    }
+
+    @Test
+    fun `fails when bad dependency using doesNotDependsOn is set and architecture is passed as parameter (files)`() {
+        // given
+        val architecture = architecture { domain.doesNotDependOn(adapter, port) }
+
+        val sut = {
+            scope
+                .files
+                .assertArchitecture(architecture)
+        }
+
+        // then
+        sut shouldThrow KoAssertionFailedException::class
     }
 }

--- a/lib/src/apiTest/kotlin/com/lemonappdev/konsist/architecture/assertarchitecture/architecture7/Architecture7Test.kt
+++ b/lib/src/apiTest/kotlin/com/lemonappdev/konsist/architecture/assertarchitecture/architecture7/Architecture7Test.kt
@@ -1,7 +1,6 @@
 package com.lemonappdev.konsist.architecture.assertarchitecture.architecture7
 
 import com.lemonappdev.konsist.api.Konsist
-import com.lemonappdev.konsist.api.architecture.KoArchitectureCreator
 import com.lemonappdev.konsist.api.architecture.KoArchitectureCreator.architecture
 import com.lemonappdev.konsist.api.architecture.KoArchitectureCreator.assertArchitecture
 import com.lemonappdev.konsist.api.architecture.Layer
@@ -54,13 +53,14 @@ class Architecture7Test {
     @Test
     fun `passes when good dependency is set and architecture is passed as parameter (scope)`() {
         // then
-        val architecture = architecture {
-            domain.dependsOn(common)
-            adapter.dependsOn(common)
-            port.dependsOn(domain, common)
-            adapter.dependsOn(port)
-            common.dependsOnNothing()
-        }
+        val architecture =
+            architecture {
+                domain.dependsOn(common)
+                adapter.dependsOn(common)
+                port.dependsOn(domain, common)
+                adapter.dependsOn(port)
+                common.dependsOnNothing()
+            }
 
         scope.assertArchitecture(architecture)
     }
@@ -68,13 +68,14 @@ class Architecture7Test {
     @Test
     fun `passes when good dependency is set and architecture is passed as parameter (files)`() {
         // then
-        val architecture = architecture {
-            domain.dependsOn(common)
-            adapter.dependsOn(common)
-            port.dependsOn(domain, common)
-            adapter.dependsOn(port)
-            common.dependsOnNothing()
-        }
+        val architecture =
+            architecture {
+                domain.dependsOn(common)
+                adapter.dependsOn(common)
+                port.dependsOn(domain, common)
+                adapter.dependsOn(port)
+                common.dependsOnNothing()
+            }
 
         scope
             .files

--- a/lib/src/apiTest/kotlin/com/lemonappdev/konsist/architecture/assertarchitecture/architecture7/Architecture7Test.kt
+++ b/lib/src/apiTest/kotlin/com/lemonappdev/konsist/architecture/assertarchitecture/architecture7/Architecture7Test.kt
@@ -118,7 +118,7 @@ class Architecture7Test {
     fun `fails when bad dependency using doesNotDependsOn is set (scope)`() {
         // given
         val sut = {
-            scope.assertArchitecture { domain.doesNotDependOn(adapter, port) }
+            scope.assertArchitecture { domain.doesNotDependOn(adapter, common) }
         }
 
         // then
@@ -131,7 +131,7 @@ class Architecture7Test {
         val sut = {
             scope
                 .files
-                .assertArchitecture { domain.doesNotDependOn(adapter, port) }
+                .assertArchitecture { domain.doesNotDependOn(adapter, common) }
         }
 
         // then
@@ -141,7 +141,7 @@ class Architecture7Test {
     @Test
     fun `fails when bad dependency using doesNotDependsOn is set and architecture is passed as parameter (scope)`() {
         // given
-        val architecture = architecture { domain.doesNotDependOn(adapter, port) }
+        val architecture = architecture { domain.doesNotDependOn(adapter, common) }
 
         val sut = {
             scope.assertArchitecture(architecture)
@@ -154,7 +154,7 @@ class Architecture7Test {
     @Test
     fun `fails when bad dependency using doesNotDependsOn is set and architecture is passed as parameter (files)`() {
         // given
-        val architecture = architecture { domain.doesNotDependOn(adapter, port) }
+        val architecture = architecture { domain.doesNotDependOn(adapter, common) }
 
         val sut = {
             scope

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/api/architecture/DependencyRules.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/api/architecture/DependencyRules.kt
@@ -19,6 +19,18 @@ interface DependencyRules {
     ): Unit
 
     /**
+     * Specifies that the current layer does not depend on any given layer.
+     *
+     * @param layer The layer that the current layer does not depend on.
+     * @param layers The layers that the current layer does not depend on.
+     * @receiver The [Layer] that does not depend on other layers.
+     */
+    fun Layer.doesNotDependOn(
+        layer: Layer,
+        vararg layers: Layer,
+    ): Unit
+
+    /**
      * Specifies that the current layer does not depend on any other layer.
      *
      * @receiver The [Layer] that does not depend on any other layer.

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/core/architecture/DependencyRulesCore.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/core/architecture/DependencyRulesCore.kt
@@ -37,6 +37,33 @@ class DependencyRulesCore : DependencyRules {
         }
     }
 
+    override fun Layer.doesNotDependOn(
+        layer: Layer,
+        vararg layers: Layer,
+    ) {
+        checkIfLayerHasTheSameValuesAsOtherLayer(this, layer, *layers)
+        checkIfLayerIsDependentOnItself(this, layer, *layers)
+        checkStatusOfLayer(false, this, layer, *layers)
+        checkCircularDependencies(this, layer, *layers)
+
+        allLayers =
+            (allLayers + this + layer + layers)
+                .distinct()
+                .toMutableList()
+
+        dependencies[this] = (dependencies.getOrDefault(this, setOf(this))) + allLayers - layer - layers.toSet()
+        statuses[this] = Status.DEPEND_ON_LAYER
+
+        if (statuses.getOrDefault(layer, Status.NONE) == Status.NONE) {
+            statuses[layer] = Status.NONE
+        }
+        layers.onEach {
+            if (statuses.getOrDefault(it, Status.NONE) == Status.NONE) {
+                statuses[it] = Status.NONE
+            }
+        }
+    }
+
     override fun Layer.dependsOnNothing() {
         checkIfLayerHasTheSameValuesAsOtherLayer(this)
         checkStatusOfLayer(true, this)

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/core/architecture/DependencyRulesCore.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/core/architecture/DependencyRulesCore.kt
@@ -5,7 +5,8 @@ import com.lemonappdev.konsist.api.architecture.Layer
 import com.lemonappdev.konsist.core.exception.KoPreconditionFailedException
 
 class DependencyRulesCore : DependencyRules {
-    internal val dependencies = mutableMapOf<Layer, Set<Layer>>()
+    internal val positiveDependencies = mutableMapOf<Layer, Set<Layer>>()
+    internal val negativeDependencies = mutableMapOf<Layer, Set<Layer>>()
     internal val statuses = mutableMapOf<Layer, Status>()
 
     internal var allLayers = mutableListOf<Layer>()
@@ -24,7 +25,7 @@ class DependencyRulesCore : DependencyRules {
                 .distinct()
                 .toMutableList()
 
-        dependencies[this] = (dependencies.getOrDefault(this, setOf(this))) + layer + layers
+        positiveDependencies[this] = (positiveDependencies.getOrDefault(this, setOf(this))) + layer + layers
         statuses[this] = Status.DEPEND_ON_LAYER
 
         if (statuses.getOrDefault(layer, Status.NONE) == Status.NONE) {
@@ -51,8 +52,8 @@ class DependencyRulesCore : DependencyRules {
                 .distinct()
                 .toMutableList()
 
-        dependencies[this] = (dependencies.getOrDefault(this, setOf(this))) + allLayers - layer - layers.toSet()
-        statuses[this] = Status.DEPEND_ON_LAYER
+        negativeDependencies[this] = setOf(layer) + layers
+        statuses[this] = Status.NOT_DEPEND_ON_LAYER
 
         if (statuses.getOrDefault(layer, Status.NONE) == Status.NONE) {
             statuses[layer] = Status.NONE
@@ -72,7 +73,8 @@ class DependencyRulesCore : DependencyRules {
             (allLayers + this)
                 .distinct()
                 .toMutableList()
-        dependencies[this] = setOf(this)
+
+        positiveDependencies[this] = setOf(this)
         statuses[this] = Status.DEPENDENT_ON_NOTHING
     }
 
@@ -102,7 +104,7 @@ class DependencyRulesCore : DependencyRules {
                 )
             }
         } else if (statuses[layer] == Status.DEPEND_ON_LAYER) {
-            val dependency = dependencies.getOrDefault(layer, emptySet())
+            val dependency = positiveDependencies.getOrDefault(layer, emptySet())
 
             if (toBeIndependent) {
                 val alreadySetLayer = dependency.first { it != layer }
@@ -149,7 +151,7 @@ class DependencyRulesCore : DependencyRules {
         alreadyChecked: List<Layer>,
         potentialCircular: List<Layer>,
     ): List<Layer?> {
-        val layerToCheckDependencies = dependencies.getOrDefault(layerToCheck, emptySet()) - layerToCheck
+        val layerToCheckDependencies = positiveDependencies.getOrDefault(layerToCheck, emptySet()) - layerToCheck
 
         if (layerToCheckDependencies.isEmpty()) {
             return potentialCircular
@@ -203,5 +205,6 @@ class DependencyRulesCore : DependencyRules {
 internal enum class Status {
     DEPENDENT_ON_NOTHING,
     DEPEND_ON_LAYER,
+    NOT_DEPEND_ON_LAYER,
     NONE,
 }

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/core/verify/KoArchitectureAssert.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/core/verify/KoArchitectureAssert.kt
@@ -192,6 +192,7 @@ private data class FailedFiles(
     val imports: List<KoImportDeclaration>,
 )
 
+@Suppress("detekt.LongParameterList")
 private fun getCheckFailedMessages(
     failedFiles: List<FailedFiles>,
     positiveDependencies: Map<Layer, Set<Layer>>,


### PR DESCRIPTION
Added `doesNotDependOn` method to architectural checks. 

Eg. It is possible to write such tests for this architecture

![image](https://github.com/user-attachments/assets/6d0b2a38-ebb8-4d64-9144-fb443b0b3067)

```kotlin
    private val scope = Konsist.scopeFromProject()

    private val adapter = Layer("Adapter", "com.samplepackage.adapter..")
    private val common = Layer("Common", "com.samplepackage.common..")
    private val domain = Layer("Domain", "com.samplepackage.domain..")
    private val port = Layer("Port", "com.samplepackage.port..")
    
    @Test
    fun `Domain layer not depend on Adapter and Port layers and Adapter layer not depend on Domain layer`() {
       	 scope.assertArchitecture { 
       	 	domain.doesNotDependOn(adapter, port)
            adapter.doesNotDependOn(domain)
       	 }
    }
```