### PR TITLE
KON-605 KoImportDeclaration add represents type

### DIFF
--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/api/ext/provider/korepresentstype/KoRepresentsTypeProviderExtTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/api/ext/provider/korepresentstype/KoRepresentsTypeProviderExtTest.kt
@@ -117,8 +117,7 @@ class KoRepresentsTypeProviderExtTest {
         }
     }
 
-    private fun getSnippetFile(fileName: String) =
-        getSnippetKoScope("api/ext/provider/korepresentstype/snippet/", fileName)
+    private fun getSnippetFile(fileName: String) = getSnippetKoScope("api/ext/provider/korepresentstype/snippet/", fileName)
 
     companion object {
         @Suppress("unused")

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/api/ext/provider/korepresentstype/KoRepresentsTypeProviderExtTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/api/ext/provider/korepresentstype/KoRepresentsTypeProviderExtTest.kt
@@ -64,6 +64,36 @@ class KoRepresentsTypeProviderExtTest {
         }
     }
 
+    @Test
+    fun `import-represents-complex-type`() {
+        // given
+        val sut =
+            getSnippetFile("import-represents-complex-type")
+                .imports
+                .first()
+
+        // then
+        assertSoftly(sut) {
+            representsTypeOf<SampleClass>() shouldBeEqualTo true
+            representsTypeOf<String>() shouldBeEqualTo false
+        }
+    }
+
+    @Test
+    fun `import-represents-kotlin-type`() {
+        // given
+        val sut =
+            getSnippetFile("import-represents-kotlin-type")
+                .imports
+                .first()
+
+        // then
+        assertSoftly(sut) {
+            representsTypeOf<String>() shouldBeEqualTo true
+            representsTypeOf<SampleType>() shouldBeEqualTo false
+        }
+    }
+
     @ParameterizedTest
     @MethodSource("provideValues")
     fun `declaration-represents-type`(
@@ -87,7 +117,8 @@ class KoRepresentsTypeProviderExtTest {
         }
     }
 
-    private fun getSnippetFile(fileName: String) = getSnippetKoScope("api/ext/provider/korepresentstype/snippet/", fileName)
+    private fun getSnippetFile(fileName: String) =
+        getSnippetKoScope("api/ext/provider/korepresentstype/snippet/", fileName)
 
     companion object {
         @Suppress("unused")

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/api/ext/provider/korepresentstype/snippet/import-represents-complex-type.kttest
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/api/ext/provider/korepresentstype/snippet/import-represents-complex-type.kttest
@@ -1,0 +1,5 @@
+package com.lemonappdev.konsist.api.ext.provider.korepresentstype.snippet
+
+import com.lemonappdev.konsist.testdata.SampleClass
+
+val sampleProperty = SampleClass()

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/api/ext/provider/korepresentstype/snippet/import-represents-kotlin-type.kttest
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/api/ext/provider/korepresentstype/snippet/import-represents-kotlin-type.kttest
@@ -1,0 +1,5 @@
+package com.lemonappdev.konsist.api.ext.provider.korepresentstype.snippet
+
+import kotlin.String
+
+val sampleProperty: String = ""

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koimport/KoImportDeclarationForKoRepresentsTypeProviderTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koimport/KoImportDeclarationForKoRepresentsTypeProviderTest.kt
@@ -1,0 +1,69 @@
+package com.lemonappdev.konsist.core.declaration.koimport
+
+import com.lemonappdev.konsist.TestSnippetProvider.getSnippetKoScope
+import org.amshove.kluent.shouldBeEqualTo
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.Arguments.arguments
+import org.junit.jupiter.params.provider.MethodSource
+
+class KoImportDeclarationForKoRepresentsTypeProviderTest {
+    @ParameterizedTest
+    @MethodSource("provideValuesForComplexType")
+    fun `import-represents-complex-type`(
+        type: String?,
+        value: Boolean,
+    ) {
+        // given
+        val sut =
+            getSnippetFile("import-represents-complex-type")
+                .imports
+                .first()
+
+        // then
+        sut.representsType(type) shouldBeEqualTo value
+    }
+
+    @ParameterizedTest
+    @MethodSource("provideValuesForKotlinBasicType")
+    fun `import-represents-kotlin-type`(
+        type: String?,
+        value: Boolean,
+    ) {
+        // given
+        val sut =
+            getSnippetFile("import-represents-kotlin-type")
+                .imports
+                .first()
+
+        // then
+        sut.representsType(type) shouldBeEqualTo value
+    }
+
+    @Suppress("SameParameterValue")
+    private fun getSnippetFile(fileName: String) =
+        getSnippetKoScope("core/declaration/koimport/snippet/forkorepresentstypeprovider/", fileName)
+
+    companion object {
+        @Suppress("unused")
+        @JvmStatic
+        fun provideValuesForComplexType() =
+            listOf(
+                arguments("SampleClass", true),
+                arguments("OtherClass", false),
+                arguments("com.lemonappdev.konsist.testdata.SampleClass", true),
+                arguments("com.lemonappdev.konsist.testdata.OtherClass", false),
+                arguments(null, false),
+            )
+
+        @Suppress("unused")
+        @JvmStatic
+        fun provideValuesForKotlinBasicType() =
+            listOf(
+                arguments("String", true),
+                arguments("List", false),
+                arguments("kotlin.String", true),
+                arguments("kotlin.collection.List", false),
+                arguments(null, false),
+            )
+    }
+}

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koimport/snippet/forkorepresentstypeprovider/import-represents-complex-type.kttest
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koimport/snippet/forkorepresentstypeprovider/import-represents-complex-type.kttest
@@ -1,0 +1,3 @@
+import com.lemonappdev.konsist.testdata.SampleClass
+
+val sampleProperty = SampleClass()

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koimport/snippet/forkorepresentstypeprovider/import-represents-kotlin-type.kttest
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koimport/snippet/forkorepresentstypeprovider/import-represents-kotlin-type.kttest
@@ -1,0 +1,3 @@
+import kotlin.String
+
+val sampleProperty: String = ""

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/api/declaration/KoImportDeclaration.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/api/declaration/KoImportDeclaration.kt
@@ -8,6 +8,7 @@ import com.lemonappdev.konsist.api.provider.KoMatchesProvider
 import com.lemonappdev.konsist.api.provider.KoModuleProvider
 import com.lemonappdev.konsist.api.provider.KoNameProvider
 import com.lemonappdev.konsist.api.provider.KoPathProvider
+import com.lemonappdev.konsist.api.provider.KoRepresentsTypeProvider
 import com.lemonappdev.konsist.api.provider.KoSourceSetProvider
 import com.lemonappdev.konsist.api.provider.KoTextProvider
 import com.lemonappdev.konsist.api.provider.KoWildcardProvider
@@ -27,4 +28,5 @@ interface KoImportDeclaration :
     KoModuleProvider,
     KoSourceSetProvider,
     KoTextProvider,
-    KoWildcardProvider
+    KoWildcardProvider,
+    KoRepresentsTypeProvider

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/core/declaration/KoImportDeclarationCore.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/core/declaration/KoImportDeclarationCore.kt
@@ -3,7 +3,6 @@ package com.lemonappdev.konsist.core.declaration
 import com.lemonappdev.konsist.api.declaration.KoBaseDeclaration
 import com.lemonappdev.konsist.api.declaration.KoImportAliasDeclaration
 import com.lemonappdev.konsist.api.declaration.KoImportDeclaration
-import com.lemonappdev.konsist.api.provider.KoRepresentsTypeProvider
 import com.lemonappdev.konsist.core.cache.KoDeclarationCache
 import com.lemonappdev.konsist.core.provider.KoAliasProviderCore
 import com.lemonappdev.konsist.core.provider.KoBaseProviderCore
@@ -35,33 +34,33 @@ internal class KoImportDeclarationCore private constructor(override val ktImport
     KoTextProviderCore,
     KoWildcardProviderCore,
     KoRepresentsTypeProviderCore {
-    override val psiElement: PsiElement by lazy { ktImportDirective }
+        override val psiElement: PsiElement by lazy { ktImportDirective }
 
-    override val ktElement: KtElement by lazy { ktImportDirective }
+        override val ktElement: KtElement by lazy { ktImportDirective }
 
-    override val name: String by lazy { ktImportDirective.importPath?.fqName.toString() }
+        override val name: String by lazy { ktImportDirective.importPath?.fqName.toString() }
 
-    override val alias: KoImportAliasDeclaration? by lazy {
-        ktImportDirective
-            .alias
-            ?.let { KoImportAliasDeclarationCore.getInstance(it, this) }
+        override val alias: KoImportAliasDeclaration? by lazy {
+            ktImportDirective
+                .alias
+                ?.let { KoImportAliasDeclarationCore.getInstance(it, this) }
+        }
+
+        override fun representsType(name: String?): Boolean = name?.let { this.name.endsWith(it) } ?: false
+
+        override fun toString(): String = name
+
+        internal companion object {
+            private val cache: KoDeclarationCache<KoImportDeclaration> = KoDeclarationCache()
+
+            internal fun getInstance(
+                ktImportDirective: KtImportDirective,
+                containingDeclaration: KoBaseDeclaration,
+            ): KoImportDeclaration =
+                cache.getOrCreateInstance(ktImportDirective, containingDeclaration) {
+                    KoImportDeclarationCore(
+                        ktImportDirective,
+                    )
+                }
+        }
     }
-
-    override fun representsType(name: String?): Boolean = name?.let { this.name.endsWith(it) } ?: false
-
-    override fun toString(): String = name
-
-    internal companion object {
-        private val cache: KoDeclarationCache<KoImportDeclaration> = KoDeclarationCache()
-
-        internal fun getInstance(
-            ktImportDirective: KtImportDirective,
-            containingDeclaration: KoBaseDeclaration,
-        ): KoImportDeclaration =
-            cache.getOrCreateInstance(ktImportDirective, containingDeclaration) {
-                KoImportDeclarationCore(
-                    ktImportDirective
-                )
-            }
-    }
-}

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/core/declaration/KoImportDeclarationCore.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/core/declaration/KoImportDeclarationCore.kt
@@ -58,9 +58,7 @@ internal class KoImportDeclarationCore private constructor(override val ktImport
                 containingDeclaration: KoBaseDeclaration,
             ): KoImportDeclaration =
                 cache.getOrCreateInstance(ktImportDirective, containingDeclaration) {
-                    KoImportDeclarationCore(
-                        ktImportDirective,
-                    )
+                    KoImportDeclarationCore(ktImportDirective,)
                 }
         }
     }

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/core/declaration/KoImportDeclarationCore.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/core/declaration/KoImportDeclarationCore.kt
@@ -12,7 +12,6 @@ import com.lemonappdev.konsist.core.provider.KoMatchesProviderCore
 import com.lemonappdev.konsist.core.provider.KoModuleProviderCore
 import com.lemonappdev.konsist.core.provider.KoNameProviderCore
 import com.lemonappdev.konsist.core.provider.KoPathProviderCore
-import com.lemonappdev.konsist.core.provider.KoRepresentsTypeProviderCore
 import com.lemonappdev.konsist.core.provider.KoSourceSetProviderCore
 import com.lemonappdev.konsist.core.provider.KoTextProviderCore
 import com.lemonappdev.konsist.core.provider.KoWildcardProviderCore
@@ -32,8 +31,7 @@ internal class KoImportDeclarationCore private constructor(override val ktImport
     KoModuleProviderCore,
     KoSourceSetProviderCore,
     KoTextProviderCore,
-    KoWildcardProviderCore,
-    KoRepresentsTypeProviderCore {
+    KoWildcardProviderCore {
         override val psiElement: PsiElement by lazy { ktImportDirective }
 
         override val ktElement: KtElement by lazy { ktImportDirective }
@@ -46,6 +44,8 @@ internal class KoImportDeclarationCore private constructor(override val ktImport
                 ?.let { KoImportAliasDeclarationCore.getInstance(it, this) }
         }
 
+        // KoImportDeclarationCore does not implement KoRepresentsTypeProviderCore because it internally implements
+        // KoFullyQualifiedNameProviderCore, which import declaration does not possess. Therefore, this function is manually overridden.
         override fun representsType(name: String?): Boolean = name?.let { this.name.endsWith(it) } ?: false
 
         override fun toString(): String = name

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/core/declaration/KoImportDeclarationCore.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/core/declaration/KoImportDeclarationCore.kt
@@ -58,7 +58,7 @@ internal class KoImportDeclarationCore private constructor(override val ktImport
                 containingDeclaration: KoBaseDeclaration,
             ): KoImportDeclaration =
                 cache.getOrCreateInstance(ktImportDirective, containingDeclaration) {
-                    KoImportDeclarationCore(ktImportDirective,)
+                    KoImportDeclarationCore(ktImportDirective)
                 }
         }
     }

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/core/declaration/KoImportDeclarationCore.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/core/declaration/KoImportDeclarationCore.kt
@@ -3,6 +3,7 @@ package com.lemonappdev.konsist.core.declaration
 import com.lemonappdev.konsist.api.declaration.KoBaseDeclaration
 import com.lemonappdev.konsist.api.declaration.KoImportAliasDeclaration
 import com.lemonappdev.konsist.api.declaration.KoImportDeclaration
+import com.lemonappdev.konsist.api.provider.KoRepresentsTypeProvider
 import com.lemonappdev.konsist.core.cache.KoDeclarationCache
 import com.lemonappdev.konsist.core.provider.KoAliasProviderCore
 import com.lemonappdev.konsist.core.provider.KoBaseProviderCore
@@ -12,6 +13,7 @@ import com.lemonappdev.konsist.core.provider.KoMatchesProviderCore
 import com.lemonappdev.konsist.core.provider.KoModuleProviderCore
 import com.lemonappdev.konsist.core.provider.KoNameProviderCore
 import com.lemonappdev.konsist.core.provider.KoPathProviderCore
+import com.lemonappdev.konsist.core.provider.KoRepresentsTypeProviderCore
 import com.lemonappdev.konsist.core.provider.KoSourceSetProviderCore
 import com.lemonappdev.konsist.core.provider.KoTextProviderCore
 import com.lemonappdev.konsist.core.provider.KoWildcardProviderCore
@@ -31,28 +33,35 @@ internal class KoImportDeclarationCore private constructor(override val ktImport
     KoModuleProviderCore,
     KoSourceSetProviderCore,
     KoTextProviderCore,
-    KoWildcardProviderCore {
-        override val psiElement: PsiElement by lazy { ktImportDirective }
+    KoWildcardProviderCore,
+    KoRepresentsTypeProviderCore {
+    override val psiElement: PsiElement by lazy { ktImportDirective }
 
-        override val ktElement: KtElement by lazy { ktImportDirective }
+    override val ktElement: KtElement by lazy { ktImportDirective }
 
-        override val name: String by lazy { ktImportDirective.importPath?.fqName.toString() }
+    override val name: String by lazy { ktImportDirective.importPath?.fqName.toString() }
 
-        override val alias: KoImportAliasDeclaration? by lazy {
-            ktImportDirective
-                .alias
-                ?.let { KoImportAliasDeclarationCore.getInstance(it, this) }
-        }
-
-        override fun toString(): String = name
-
-        internal companion object {
-            private val cache: KoDeclarationCache<KoImportDeclaration> = KoDeclarationCache()
-
-            internal fun getInstance(
-                ktImportDirective: KtImportDirective,
-                containingDeclaration: KoBaseDeclaration,
-            ): KoImportDeclaration =
-                cache.getOrCreateInstance(ktImportDirective, containingDeclaration) { KoImportDeclarationCore(ktImportDirective) }
-        }
+    override val alias: KoImportAliasDeclaration? by lazy {
+        ktImportDirective
+            .alias
+            ?.let { KoImportAliasDeclarationCore.getInstance(it, this) }
     }
+
+    override fun representsType(name: String?): Boolean = name?.let { this.name.endsWith(it) } ?: false
+
+    override fun toString(): String = name
+
+    internal companion object {
+        private val cache: KoDeclarationCache<KoImportDeclaration> = KoDeclarationCache()
+
+        internal fun getInstance(
+            ktImportDirective: KtImportDirective,
+            containingDeclaration: KoBaseDeclaration,
+        ): KoImportDeclaration =
+            cache.getOrCreateInstance(ktImportDirective, containingDeclaration) {
+                KoImportDeclarationCore(
+                    ktImportDirective
+                )
+            }
+    }
+}


### PR DESCRIPTION
Added `KoRepresentsTypeProvider` for `KoImportDeclaration`. Now, it's possible to write tests like below:

```kotlin
// 1
scope
	.files
	.withImport { it.representsType<SampleType>() }
	.assertTrue { ... }

// 2
scope
	.imports
	.withRepresentedType("SampleType")
	.assertTrue { ... }
```