### PR TITLE
Add file information to getKtFile IllegalArgumentException

### DIFF
--- a/lib/src/main/kotlin/com/lemonappdev/konsist/core/util/KotlinFileParser.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/core/util/KotlinFileParser.kt
@@ -32,7 +32,7 @@ object KotlinFileParser {
 
     @Suppress("detekt.TooGenericExceptionCaught")
     private fun getKtFile(file: File): KtFile {
-        require(file.isKotlinFile || file.isKotlinSnippetFile) { "File must be a Kotlin file" }
+        require(file.isKotlinFile || file.isKotlinSnippetFile) { "File must be a Kotlin file: ${file.path}" }
 
         try {
             val fileContent =


### PR DESCRIPTION
We've encountered issues in our CI due to some bogus file in the custom scope we were creating, in a flakey test. 

But finding the offending file is harder than it needs to be, as the exception won't say which file it is.

I'm adding the file path to the error, to know earlier which file caused the issues. It's also consistent with the exception being thrown in L49 in KotlinFileParser.kt.