### PR TITLE
Fix Jobs that are failing forked repositories external 

### DIFF
--- a/.github/workflows/check-ktdoc-snippets.yml
+++ b/.github/workflows/check-ktdoc-snippets.yml
@@ -13,6 +13,12 @@ jobs:
     name: Get Branches And Changed Files
     runs-on: ubuntu-latest
 
+    # Allow the workflow to read the contents of the repository and pull request to be
+    # able to retrieve list of changed files when PR is opened from forked repository.
+    permissions:
+      contents: read
+      pull-requests: read
+
     steps:
       - name: Get branch name
         id: branch-name

--- a/.github/workflows/check-kttest-snippets.yml
+++ b/.github/workflows/check-kttest-snippets.yml
@@ -4,6 +4,12 @@ on:
   pull_request:
     types: [ opened, synchronize ]
 
+# Allow the workflow to read the contents of the repository and pull request to be
+#  able to retrieve list of changed files.
+permissions:
+  contents: read
+  pull-requests: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
@@ -12,6 +18,12 @@ jobs:
   get-github-context:
     name: Get Branches And Changed Files
     runs-on: ubuntu-latest
+
+    # Allow the workflow to read the contents of the repository and pull request to be
+    # able to retrieve list of changed files when PR is opened from forked repository.
+    permissions:
+      contents: read
+      pull-requests: read
 
     steps:
       - name: Get branch name

--- a/.github/workflows/check-starter-projects.yml
+++ b/.github/workflows/check-starter-projects.yml
@@ -13,6 +13,12 @@ jobs:
     name: Get GitHub Context
     runs-on: ubuntu-latest
 
+    # Allow the workflow to read the contents of the repository and pull request to be
+    # able to retrieve list of changed files when PR is opened from forked repository.
+    permissions:
+      contents: read
+      pull-requests: read
+
     steps:
       - name: Get branch name
         id: branch-name


### PR DESCRIPTION
When PR is opened from forked repository it some job are failing. This PR is an attempt to fix this issue by updating jobs permissions.

Failing Jobs:

<img width="927" alt="image" src="https://github.com/user-attachments/assets/3f9c23ca-68ca-4dca-ba4e-ab6db811508a">



<img width="1008" alt="image" src="https://github.com/user-attachments/assets/a1a4b707-ed63-49c2-b58b-00c6553707fb">