### PR TITLE
Revert "KON-653 Deprecate `KoModifier.FUN`"

### DIFF
--- a/lib/src/main/kotlin/com/lemonappdev/konsist/api/KoModifier.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/api/KoModifier.kt
@@ -164,6 +164,5 @@ enum class KoModifier(
     /**
      * The `fun` modifier.
      */
-    @Deprecated("Will be removed in version 0.19.0", ReplaceWith("koScope.functions()"))
     FUN("fun"),
 }

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/api/ext/list/modifierprovider/KoFunModifierProviderListExt.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/api/ext/list/modifierprovider/KoFunModifierProviderListExt.kt
@@ -7,7 +7,6 @@ import com.lemonappdev.konsist.api.provider.modifier.KoFunModifierProvider
  *
  * @return A list containing declarations with the `fun` modifier.
  */
-@Deprecated("Will be removed in version 0.19.0", ReplaceWith("koScope.functions()"))
 fun <T : KoFunModifierProvider> List<T>.withFunModifier(): List<T> = filter { it.hasFunModifier }
 
 /**
@@ -15,5 +14,4 @@ fun <T : KoFunModifierProvider> List<T>.withFunModifier(): List<T> = filter { it
  *
  * @return A list containing declarations without the `fun` modifier.
  */
-@Deprecated("Will be removed in version 0.19.0", ReplaceWith("koScope.functions()"))
 fun <T : KoFunModifierProvider> List<T>.withoutFunModifier(): List<T> = filterNot { it.hasFunModifier }

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/api/provider/modifier/KoFunModifierProvider.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/api/provider/modifier/KoFunModifierProvider.kt
@@ -5,13 +5,11 @@ import com.lemonappdev.konsist.api.provider.KoBaseProvider
 /**
  * An interface representing a Kotlin declaration that provides information about whether it has `fun` modifier.
  */
-@Deprecated("Will be removed in version 0.19.0", ReplaceWith("koScope.functions()"))
 interface KoFunModifierProvider :
     KoBaseProvider,
     KoModifierProvider {
     /**
      * Determines whatever declaration has a `fun` modifier.
      */
-    @Deprecated("Will be removed in version 0.19.0", ReplaceWith("koScope.functions()"))
     val hasFunModifier: Boolean
 }

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/modifier/KoFunModifierProviderCore.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/modifier/KoFunModifierProviderCore.kt
@@ -4,12 +4,10 @@ import com.lemonappdev.konsist.api.KoModifier
 import com.lemonappdev.konsist.api.provider.modifier.KoFunModifierProvider
 import com.lemonappdev.konsist.core.provider.KoBaseProviderCore
 
-@Deprecated("Will be removed in version 0.19.0", ReplaceWith("koScope.functions()"))
 internal interface KoFunModifierProviderCore :
     KoFunModifierProvider,
     KoBaseProviderCore,
     KoModifierProviderCore {
-    @Deprecated("Will be removed in version 0.19.0", ReplaceWith("koScope.functions()"))
     override val hasFunModifier: Boolean
         get() = hasModifier(KoModifier.FUN)
 }


### PR DESCRIPTION
Reversed because interface can have `fun` modifier

```kotlin
fun interface A {
    fun a()
}
```