### PR TITLE
KON-657 Deprecate isValModifier/isVarModifier and add isVal/isVar

### DIFF
--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koparameter/KoParameterDeclarationForKoIsValProviderTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koparameter/KoParameterDeclarationForKoIsValProviderTest.kt
@@ -1,0 +1,39 @@
+package com.lemonappdev.konsist.core.declaration.koparameter
+
+import com.lemonappdev.konsist.TestSnippetProvider.getSnippetKoScope
+import org.amshove.kluent.shouldBeEqualTo
+import org.junit.jupiter.api.Test
+
+class KoParameterDeclarationForKoIsValProviderTest {
+    @Test
+    fun `parameter-without-val-keyword`() {
+        // given
+        val sut =
+            getSnippetFile("parameter-without-val-keyword")
+                .classes()
+                .first()
+                .primaryConstructor
+                ?.parameters
+                ?.first()
+
+        // then
+        sut?.isVal shouldBeEqualTo false
+    }
+
+    @Test
+    fun `parameter-with-val-keyword`() {
+        // given
+        val sut =
+            getSnippetFile("parameter-with-val-keyword")
+                .classes()
+                .first()
+                .primaryConstructor
+                ?.parameters
+                ?.first()
+
+        // then
+        sut?.isVal shouldBeEqualTo true
+    }
+
+    private fun getSnippetFile(fileName: String) = getSnippetKoScope("core/declaration/koparameter/snippet/forkoisvalprovider/", fileName)
+}

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koparameter/KoParameterDeclarationForKoIsVarProviderTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koparameter/KoParameterDeclarationForKoIsVarProviderTest.kt
@@ -1,0 +1,39 @@
+package com.lemonappdev.konsist.core.declaration.koparameter
+
+import com.lemonappdev.konsist.TestSnippetProvider.getSnippetKoScope
+import org.amshove.kluent.shouldBeEqualTo
+import org.junit.jupiter.api.Test
+
+class KoParameterDeclarationForKoIsVarProviderTest {
+    @Test
+    fun `parameter-without-var-keyword`() {
+        // given
+        val sut =
+            getSnippetFile("parameter-without-var-keyword")
+                .classes()
+                .first()
+                .primaryConstructor
+                ?.parameters
+                ?.first()
+
+        // then
+        sut?.isVar shouldBeEqualTo false
+    }
+
+    @Test
+    fun `parameter-with-var-keyword`() {
+        // given
+        val sut =
+            getSnippetFile("parameter-with-var-keyword")
+                .classes()
+                .first()
+                .primaryConstructor
+                ?.parameters
+                ?.first()
+
+        // then
+        sut?.isVar shouldBeEqualTo true
+    }
+
+    private fun getSnippetFile(fileName: String) = getSnippetKoScope("core/declaration/koparameter/snippet/forkoisvarprovider/", fileName)
+}

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koparameter/snippet/forkoisvalprovider/parameter-with-val-keyword.kttest
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koparameter/snippet/forkoisvalprovider/parameter-with-val-keyword.kttest
@@ -1,0 +1,3 @@
+import com.lemonappdev.konsist.testdata.SampleType
+
+class SampleClass(val sampleParameter: SampleType)

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koparameter/snippet/forkoisvalprovider/parameter-without-val-keyword.kttest
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koparameter/snippet/forkoisvalprovider/parameter-without-val-keyword.kttest
@@ -1,0 +1,3 @@
+import com.lemonappdev.konsist.testdata.SampleType
+
+class SampleClass(vararg sampleParameter: SampleType)

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koparameter/snippet/forkoisvarprovider/parameter-with-var-keyword.kttest
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koparameter/snippet/forkoisvarprovider/parameter-with-var-keyword.kttest
@@ -1,0 +1,3 @@
+import com.lemonappdev.konsist.testdata.SampleType
+
+class SampleClass(var sampleParameter: SampleType)

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koparameter/snippet/forkoisvarprovider/parameter-without-var-keyword.kttest
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koparameter/snippet/forkoisvarprovider/parameter-without-var-keyword.kttest
@@ -1,0 +1,3 @@
+import com.lemonappdev.konsist.testdata.SampleType
+
+class SampleClass(val sampleParameter: SampleType)

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koproperty/KoPropertyDeclarationForKoIsValProviderTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koproperty/KoPropertyDeclarationForKoIsValProviderTest.kt
@@ -1,0 +1,64 @@
+package com.lemonappdev.konsist.core.declaration.koproperty
+
+import com.lemonappdev.konsist.TestSnippetProvider
+import com.lemonappdev.konsist.api.ext.list.properties
+import org.amshove.kluent.shouldBeEqualTo
+import org.junit.jupiter.api.Test
+
+class KoPropertyDeclarationForKoIsValProviderTest {
+    @Test
+    fun `property-has-no-val-keyword`() {
+        // given
+        val sut =
+            getSnippetFile("property-has-no-val-keyword")
+                .properties()
+                .first()
+
+        // then
+        sut.isVal shouldBeEqualTo false
+    }
+
+    @Test
+    fun `property-has-val-keyword`() {
+        // given
+        val sut =
+            getSnippetFile("property-has-val-keyword")
+                .properties()
+                .first()
+
+        // then
+        sut.isVal shouldBeEqualTo true
+    }
+
+    @Test
+    fun `property-defined-in-constructor-has-no-val-keyword`() {
+        // given
+        val sut =
+            getSnippetFile("property-defined-in-constructor-has-no-val-keyword")
+                .classes()
+                .properties()
+                .first()
+
+        // then
+        sut.isVal shouldBeEqualTo false
+    }
+
+    @Test
+    fun `property-defined-in-constructor-has-val-keyword`() {
+        // given
+        val sut =
+            getSnippetFile("property-defined-in-constructor-has-val-keyword")
+                .classes()
+                .properties()
+                .first()
+
+        // then
+        sut.isVal shouldBeEqualTo true
+    }
+
+    private fun getSnippetFile(fileName: String) =
+        TestSnippetProvider.getSnippetKoScope(
+            "core/declaration/koproperty/snippet/forkoisvalprovider/",
+            fileName,
+        )
+}

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koproperty/KoPropertyDeclarationForKoIsVarProviderTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koproperty/KoPropertyDeclarationForKoIsVarProviderTest.kt
@@ -1,0 +1,64 @@
+package com.lemonappdev.konsist.core.declaration.koproperty
+
+import com.lemonappdev.konsist.TestSnippetProvider
+import com.lemonappdev.konsist.api.ext.list.properties
+import org.amshove.kluent.shouldBeEqualTo
+import org.junit.jupiter.api.Test
+
+class KoPropertyDeclarationForKoIsVarProviderTest {
+    @Test
+    fun `property-has-no-var-keyword`() {
+        // given
+        val sut =
+            getSnippetFile("property-has-no-var-keyword")
+                .properties()
+                .first()
+
+        // then
+        sut.isVar shouldBeEqualTo false
+    }
+
+    @Test
+    fun `property-has-var-keyword`() {
+        // given
+        val sut =
+            getSnippetFile("property-has-var-keyword")
+                .properties()
+                .first()
+
+        // then
+        sut.isVar shouldBeEqualTo true
+    }
+
+    @Test
+    fun `property-defined-in-constructor-has-no-var-keyword`() {
+        // given
+        val sut =
+            getSnippetFile("property-defined-in-constructor-has-no-var-keyword")
+                .classes()
+                .properties()
+                .first()
+
+        // then
+        sut.isVar shouldBeEqualTo false
+    }
+
+    @Test
+    fun `property-defined-in-constructor-has-var-keyword`() {
+        // given
+        val sut =
+            getSnippetFile("property-defined-in-constructor-has-var-keyword")
+                .classes()
+                .properties()
+                .first()
+
+        // then
+        sut.isVar shouldBeEqualTo true
+    }
+
+    private fun getSnippetFile(fileName: String) =
+        TestSnippetProvider.getSnippetKoScope(
+            "core/declaration/koproperty/snippet/forkoisvarprovider/",
+            fileName,
+        )
+}

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koproperty/snippet/forkoisvalprovider/property-defined-in-constructor-has-no-val-keyword.kttest
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koproperty/snippet/forkoisvalprovider/property-defined-in-constructor-has-no-val-keyword.kttest
@@ -1,0 +1,1 @@
+class SampleClass(var sampleProperty: Int)

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koproperty/snippet/forkoisvalprovider/property-defined-in-constructor-has-val-keyword.kttest
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koproperty/snippet/forkoisvalprovider/property-defined-in-constructor-has-val-keyword.kttest
@@ -1,0 +1,1 @@
+class SampleClass(val sampleProperty: Int)

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koproperty/snippet/forkoisvalprovider/property-has-no-val-keyword.kttest
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koproperty/snippet/forkoisvalprovider/property-has-no-val-keyword.kttest
@@ -1,0 +1,1 @@
+var sampleProperty: Boolean = true

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koproperty/snippet/forkoisvalprovider/property-has-val-keyword.kttest
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koproperty/snippet/forkoisvalprovider/property-has-val-keyword.kttest
@@ -1,0 +1,1 @@
+val sampleProperty: Int = 6

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koproperty/snippet/forkoisvarprovider/property-defined-in-constructor-has-no-var-keyword.kttest
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koproperty/snippet/forkoisvarprovider/property-defined-in-constructor-has-no-var-keyword.kttest
@@ -1,0 +1,1 @@
+class SampleClass(val sampleProperty: Int)

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koproperty/snippet/forkoisvarprovider/property-defined-in-constructor-has-var-keyword.kttest
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koproperty/snippet/forkoisvarprovider/property-defined-in-constructor-has-var-keyword.kttest
@@ -1,0 +1,1 @@
+class SampleClass(var sampleProperty: Int)

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koproperty/snippet/forkoisvarprovider/property-has-no-var-keyword.kttest
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koproperty/snippet/forkoisvarprovider/property-has-no-var-keyword.kttest
@@ -1,0 +1,1 @@
+val sampleProperty: Int = 6

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koproperty/snippet/forkoisvarprovider/property-has-var-keyword.kttest
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koproperty/snippet/forkoisvarprovider/property-has-var-keyword.kttest
@@ -1,0 +1,1 @@
+var sampleProperty: Boolean = true

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/kovariable/KoVariableDeclarationForKoIsValProviderTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/kovariable/KoVariableDeclarationForKoIsValProviderTest.kt
@@ -1,0 +1,40 @@
+package com.lemonappdev.konsist.core.declaration.kovariable
+
+import com.lemonappdev.konsist.TestSnippetProvider
+import com.lemonappdev.konsist.api.ext.list.variables
+import org.amshove.kluent.shouldBeEqualTo
+import org.junit.jupiter.api.Test
+
+class KoVariableDeclarationForKoIsValProviderTest {
+    @Test
+    fun `variable-has-no-val-keyword`() {
+        // given
+        val sut =
+            getSnippetFile("variable-has-no-val-keyword")
+                .functions()
+                .variables
+                .first()
+
+        // then
+        sut.isVal shouldBeEqualTo false
+    }
+
+    @Test
+    fun `variable-has-val-keyword`() {
+        // given
+        val sut =
+            getSnippetFile("variable-has-val-keyword")
+                .functions()
+                .variables
+                .first()
+
+        // then
+        sut.isVal shouldBeEqualTo true
+    }
+
+    private fun getSnippetFile(fileName: String) =
+        TestSnippetProvider.getSnippetKoScope(
+            "core/declaration/kovariable/snippet/forkoisvalprovider/",
+            fileName,
+        )
+}

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/kovariable/KoVariableDeclarationForKoIsVarProviderTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/kovariable/KoVariableDeclarationForKoIsVarProviderTest.kt
@@ -1,0 +1,40 @@
+package com.lemonappdev.konsist.core.declaration.kovariable
+
+import com.lemonappdev.konsist.TestSnippetProvider
+import com.lemonappdev.konsist.api.ext.list.variables
+import org.amshove.kluent.shouldBeEqualTo
+import org.junit.jupiter.api.Test
+
+class KoVariableDeclarationForKoIsVarProviderTest {
+    @Test
+    fun `variable-has-no-var-keyword`() {
+        // given
+        val sut =
+            getSnippetFile("variable-has-no-var-keyword")
+                .functions()
+                .variables
+                .first()
+
+        // then
+        sut.isVar shouldBeEqualTo false
+    }
+
+    @Test
+    fun `variable-has-var-keyword`() {
+        // given
+        val sut =
+            getSnippetFile("variable-has-var-keyword")
+                .functions()
+                .variables
+                .first()
+
+        // then
+        sut.isVar shouldBeEqualTo true
+    }
+
+    private fun getSnippetFile(fileName: String) =
+        TestSnippetProvider.getSnippetKoScope(
+            "core/declaration/kovariable/snippet/forkoisvarprovider/",
+            fileName,
+        )
+}

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/kovariable/snippet/forkoisvalprovider/variable-has-no-val-keyword.kttest
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/kovariable/snippet/forkoisvalprovider/variable-has-no-val-keyword.kttest
@@ -1,0 +1,3 @@
+fun sampleFunction() {
+    var sampleProperty = ""
+}

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/kovariable/snippet/forkoisvalprovider/variable-has-val-keyword.kttest
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/kovariable/snippet/forkoisvalprovider/variable-has-val-keyword.kttest
@@ -1,0 +1,3 @@
+fun sampleFunction() {
+    val sampleProperty = ""
+}

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/kovariable/snippet/forkoisvarprovider/variable-has-no-var-keyword.kttest
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/kovariable/snippet/forkoisvarprovider/variable-has-no-var-keyword.kttest
@@ -1,0 +1,3 @@
+fun sampleFunction() {
+    val sampleProperty = ""
+}

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/kovariable/snippet/forkoisvarprovider/variable-has-var-keyword.kttest
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/kovariable/snippet/forkoisvarprovider/variable-has-var-keyword.kttest
@@ -1,0 +1,3 @@
+fun sampleFunction() {
+    var sampleProperty = ""
+}

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/api/declaration/KoParameterDeclaration.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/api/declaration/KoParameterDeclaration.kt
@@ -5,6 +5,8 @@ import com.lemonappdev.konsist.api.provider.KoBaseProvider
 import com.lemonappdev.konsist.api.provider.KoContainingDeclarationProvider
 import com.lemonappdev.konsist.api.provider.KoContainingFileProvider
 import com.lemonappdev.konsist.api.provider.KoDefaultValueProvider
+import com.lemonappdev.konsist.api.provider.KoIsValProvider
+import com.lemonappdev.konsist.api.provider.KoIsVarProvider
 import com.lemonappdev.konsist.api.provider.KoLocationProvider
 import com.lemonappdev.konsist.api.provider.KoModuleProvider
 import com.lemonappdev.konsist.api.provider.KoNameProvider
@@ -47,4 +49,6 @@ interface KoParameterDeclaration :
     KoValModifierProvider,
     KoVarArgModifierProvider,
     KoNoInlineModifierProvider,
-    KoCrossInlineModifierProvider
+    KoCrossInlineModifierProvider,
+    KoIsValProvider,
+    KoIsVarProvider

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/api/declaration/KoPropertyDeclaration.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/api/declaration/KoPropertyDeclaration.kt
@@ -14,6 +14,8 @@ import com.lemonappdev.konsist.api.provider.KoIsExtensionProvider
 import com.lemonappdev.konsist.api.provider.KoIsInitializedProvider
 import com.lemonappdev.konsist.api.provider.KoIsReadOnlyProvider
 import com.lemonappdev.konsist.api.provider.KoIsTopLevelProvider
+import com.lemonappdev.konsist.api.provider.KoIsValProvider
+import com.lemonappdev.konsist.api.provider.KoIsVarProvider
 import com.lemonappdev.konsist.api.provider.KoKDocProvider
 import com.lemonappdev.konsist.api.provider.KoLocationProvider
 import com.lemonappdev.konsist.api.provider.KoModuleProvider
@@ -90,4 +92,6 @@ interface KoPropertyDeclaration :
     KoReadOnlyProvider,
     KoIsReadOnlyProvider,
     KoTacitTypeProvider,
-    KoIsExtensionProvider
+    KoIsExtensionProvider,
+    KoIsValProvider,
+    KoIsVarProvider

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/api/declaration/KoVariableDeclaration.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/api/declaration/KoVariableDeclaration.kt
@@ -5,6 +5,8 @@ import com.lemonappdev.konsist.api.provider.KoBaseProvider
 import com.lemonappdev.konsist.api.provider.KoContainingDeclarationProvider
 import com.lemonappdev.konsist.api.provider.KoContainingFileProvider
 import com.lemonappdev.konsist.api.provider.KoDelegateProvider
+import com.lemonappdev.konsist.api.provider.KoIsValProvider
+import com.lemonappdev.konsist.api.provider.KoIsVarProvider
 import com.lemonappdev.konsist.api.provider.KoKDocProvider
 import com.lemonappdev.konsist.api.provider.KoLocationProvider
 import com.lemonappdev.konsist.api.provider.KoModuleProvider
@@ -43,4 +45,6 @@ interface KoVariableDeclaration :
     KoValModifierProvider,
     KoValueProvider,
     KoVarModifierProvider,
-    KoTacitTypeProvider
+    KoTacitTypeProvider,
+    KoIsValProvider,
+    KoIsVarProvider

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/api/ext/list/KoIsValProviderListExt.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/api/ext/list/KoIsValProviderListExt.kt
@@ -1,0 +1,17 @@
+package com.lemonappdev.konsist.api.ext.list
+
+import com.lemonappdev.konsist.api.provider.KoIsValProvider
+
+/**
+ * List containing declarations with `val` keyword.
+ *
+ * @return A list containing declarations with the `val` keyword.
+ */
+fun <T : KoIsValProvider> List<T>.withVal(): List<T> = filter { it.isVal }
+
+/**
+ * List containing declarations without `val` keyword.
+ *
+ * @return A list containing declarations without the `val` keyword.
+ */
+fun <T : KoIsValProvider> List<T>.withoutVal(): List<T> = filterNot { it.isVal }

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/api/ext/list/KoIsVarProviderListExt.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/api/ext/list/KoIsVarProviderListExt.kt
@@ -1,0 +1,17 @@
+package com.lemonappdev.konsist.api.ext.list
+
+import com.lemonappdev.konsist.api.provider.KoIsVarProvider
+
+/**
+ * List containing declarations with `var` keyword.
+ *
+ * @return A list containing declarations with the `var` keyword.
+ */
+fun <T : KoIsVarProvider> List<T>.withVar(): List<T> = filter { it.isVar }
+
+/**
+ * List containing declarations without `var` keyword.
+ *
+ * @return A list containing declarations without the `var` keyword.
+ */
+fun <T : KoIsVarProvider> List<T>.withoutVar(): List<T> = filterNot { it.isVar }

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/api/ext/list/modifierprovider/KoValModifierProviderListExt.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/api/ext/list/modifierprovider/KoValModifierProviderListExt.kt
@@ -7,6 +7,7 @@ import com.lemonappdev.konsist.api.provider.modifier.KoValModifierProvider
  *
  * @return A list containing declarations with the `val` modifier.
  */
+@Deprecated("Will be removed in version 0.18.0", ReplaceWith("withVal"))
 fun <T : KoValModifierProvider> List<T>.withValModifier(): List<T> = filter { it.hasValModifier }
 
 /**
@@ -14,4 +15,5 @@ fun <T : KoValModifierProvider> List<T>.withValModifier(): List<T> = filter { it
  *
  * @return A list containing declarations without the `val` modifier.
  */
+@Deprecated("Will be removed in version 0.18.0", ReplaceWith("withoutVal"))
 fun <T : KoValModifierProvider> List<T>.withoutValModifier(): List<T> = filterNot { it.hasValModifier }

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/api/ext/list/modifierprovider/KoVarModifierProviderListExt.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/api/ext/list/modifierprovider/KoVarModifierProviderListExt.kt
@@ -7,6 +7,7 @@ import com.lemonappdev.konsist.api.provider.modifier.KoVarModifierProvider
  *
  * @return A list containing declarations with the `var` modifier.
  */
+@Deprecated("Will be removed in version 0.18.0", ReplaceWith("withVar"))
 fun <T : KoVarModifierProvider> List<T>.withVarModifier(): List<T> = filter { it.hasVarModifier }
 
 /**
@@ -14,4 +15,5 @@ fun <T : KoVarModifierProvider> List<T>.withVarModifier(): List<T> = filter { it
  *
  * @return A list containing declarations without the `var` modifier.
  */
+@Deprecated("Will be removed in version 0.18.0", ReplaceWith("withoutVar"))
 fun <T : KoVarModifierProvider> List<T>.withoutVarModifier(): List<T> = filterNot { it.hasVarModifier }

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/api/provider/KoIsValProvider.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/api/provider/KoIsValProvider.kt
@@ -1,0 +1,11 @@
+package com.lemonappdev.konsist.api.provider
+
+/**
+ * An interface representing a Kotlin declaration that provides information about whether it has a `val` keyword.
+ */
+interface KoIsValProvider : KoBaseProvider {
+    /**
+     * Determines whatever the declaration has `val` keyword.
+     */
+    val isVal: Boolean
+}

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/api/provider/KoIsVarProvider.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/api/provider/KoIsVarProvider.kt
@@ -1,0 +1,11 @@
+package com.lemonappdev.konsist.api.provider
+
+/**
+ * An interface representing a Kotlin declaration that provides information about whether it has a `var` keyword.
+ */
+interface KoIsVarProvider : KoBaseProvider {
+    /**
+     * Determines whatever the declaration has `var` keyword.
+     */
+    val isVar: Boolean
+}

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/api/provider/modifier/KoValModifierProvider.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/api/provider/modifier/KoValModifierProvider.kt
@@ -5,9 +5,11 @@ import com.lemonappdev.konsist.api.provider.KoBaseProvider
 /**
  * An interface representing a Kotlin declaration that provides information about whether it has a `val` modifier.
  */
+@Deprecated("Will be removed in version 0.18.0", ReplaceWith(""))
 interface KoValModifierProvider : KoBaseProvider {
     /**
      * Determines whatever the declaration has `val` modifier.
      */
+    @Deprecated("Will be removed in version 0.18.0", ReplaceWith("isVal"))
     val hasValModifier: Boolean
 }

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/api/provider/modifier/KoVarModifierProvider.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/api/provider/modifier/KoVarModifierProvider.kt
@@ -5,9 +5,11 @@ import com.lemonappdev.konsist.api.provider.KoBaseProvider
 /**
  * An interface representing a Kotlin declaration that provides information about whether it has a `var` modifier.
  */
+@Deprecated("Will be removed in version 0.18.0", ReplaceWith(""))
 interface KoVarModifierProvider : KoBaseProvider {
     /**
      * Determines whatever the declaration has `var` modifier.
      */
+    @Deprecated("Will be removed in version 0.18.0", ReplaceWith("isVar"))
     val hasVarModifier: Boolean
 }

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/core/declaration/KoParameterDeclarationCore.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/core/declaration/KoParameterDeclarationCore.kt
@@ -78,8 +78,10 @@ internal class KoParameterDeclarationCore private constructor(
 
     override fun representsType(name: String?): Boolean = type.name == name
 
+    @Deprecated("Will be removed in version 0.18.0", replaceWith = ReplaceWith("isVal"))
     override val hasValModifier: Boolean by lazy { ktParameter.valOrVarKeyword?.text == "val" }
 
+    @Deprecated("Will be removed in version 0.18.0", replaceWith = ReplaceWith(""))
     override val hasVarModifier: Boolean by lazy { ktParameter.valOrVarKeyword?.text == "var" }
 
     override fun toString(): String = name

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/core/declaration/KoParameterDeclarationCore.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/core/declaration/KoParameterDeclarationCore.kt
@@ -85,7 +85,7 @@ internal class KoParameterDeclarationCore private constructor(
     @Deprecated("Will be removed in version 0.18.0", replaceWith = ReplaceWith("isVal"))
     override val hasValModifier: Boolean by lazy { ktParameter.valOrVarKeyword?.text == "val" }
 
-    @Deprecated("Will be removed in version 0.18.0", replaceWith = ReplaceWith(""))
+    @Deprecated("Will be removed in version 0.18.0")
     override val hasVarModifier: Boolean by lazy { ktParameter.valOrVarKeyword?.text == "var" }
 
     override val isVal: Boolean by lazy { ktParameter.valOrVarKeyword?.text == "val" }

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/core/declaration/KoParameterDeclarationCore.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/core/declaration/KoParameterDeclarationCore.kt
@@ -11,6 +11,8 @@ import com.lemonappdev.konsist.core.provider.KoBaseProviderCore
 import com.lemonappdev.konsist.core.provider.KoContainingDeclarationProviderCore
 import com.lemonappdev.konsist.core.provider.KoContainingFileProviderCore
 import com.lemonappdev.konsist.core.provider.KoDefaultValueProviderCore
+import com.lemonappdev.konsist.core.provider.KoIsValProviderCore
+import com.lemonappdev.konsist.core.provider.KoIsVarProviderCore
 import com.lemonappdev.konsist.core.provider.KoLocationProviderCore
 import com.lemonappdev.konsist.core.provider.KoModuleProviderCore
 import com.lemonappdev.konsist.core.provider.KoNameProviderCore
@@ -56,7 +58,9 @@ internal class KoParameterDeclarationCore private constructor(
     KoValModifierProviderCore,
     KoVarArgModifierProviderCore,
     KoNoInlineModifierProviderCore,
-    KoCrossInlineModifierProviderCore {
+    KoCrossInlineModifierProviderCore,
+    KoIsValProviderCore,
+    KoIsVarProviderCore {
     override val ktAnnotated: KtAnnotated = ktParameter
 
     override val ktModifierListOwner: KtModifierListOwner = ktParameter
@@ -83,6 +87,10 @@ internal class KoParameterDeclarationCore private constructor(
 
     @Deprecated("Will be removed in version 0.18.0", replaceWith = ReplaceWith(""))
     override val hasVarModifier: Boolean by lazy { ktParameter.valOrVarKeyword?.text == "var" }
+
+    override val isVal: Boolean by lazy { ktParameter.valOrVarKeyword?.text == "val" }
+
+    override val isVar: Boolean by lazy { ktParameter.valOrVarKeyword?.text == "var" }
 
     override fun toString(): String = name
 

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/core/declaration/KoPropertyDeclarationCore.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/core/declaration/KoPropertyDeclarationCore.kt
@@ -178,6 +178,7 @@ internal class KoPropertyDeclarationCore private constructor(
         }
     }
 
+    @Deprecated("Will be removed in version 0.18.0", replaceWith = ReplaceWith("isVal"))
     override val hasValModifier: Boolean by lazy {
         when (ktCallableDeclaration) {
             is KtProperty -> !ktCallableDeclaration.isVar
@@ -186,6 +187,7 @@ internal class KoPropertyDeclarationCore private constructor(
         }
     }
 
+    @Deprecated("Will be removed in version 0.18.0", replaceWith = ReplaceWith(""))
     override val hasVarModifier: Boolean by lazy {
         when (ktCallableDeclaration) {
             is KtProperty -> ktCallableDeclaration.isVar

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/core/declaration/KoPropertyDeclarationCore.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/core/declaration/KoPropertyDeclarationCore.kt
@@ -191,7 +191,7 @@ internal class KoPropertyDeclarationCore private constructor(
         }
     }
 
-    @Deprecated("Will be removed in version 0.18.0", replaceWith = ReplaceWith(""))
+    @Deprecated("Will be removed in version 0.18.0")
     override val hasVarModifier: Boolean by lazy {
         when (ktCallableDeclaration) {
             is KtProperty -> ktCallableDeclaration.isVar

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/core/declaration/KoPropertyDeclarationCore.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/core/declaration/KoPropertyDeclarationCore.kt
@@ -19,6 +19,8 @@ import com.lemonappdev.konsist.core.provider.KoIsExtensionProviderCore
 import com.lemonappdev.konsist.core.provider.KoIsInitializedProviderCore
 import com.lemonappdev.konsist.core.provider.KoIsReadOnlyProviderCore
 import com.lemonappdev.konsist.core.provider.KoIsTopLevelProviderCore
+import com.lemonappdev.konsist.core.provider.KoIsValProviderCore
+import com.lemonappdev.konsist.core.provider.KoIsVarProviderCore
 import com.lemonappdev.konsist.core.provider.KoKDocProviderCore
 import com.lemonappdev.konsist.core.provider.KoLocationProviderCore
 import com.lemonappdev.konsist.core.provider.KoModuleProviderCore
@@ -119,7 +121,9 @@ internal class KoPropertyDeclarationCore private constructor(
     KoReadOnlyProviderCore,
     KoIsReadOnlyProviderCore,
     KoTypeParameterProviderCore,
-    KoIsExtensionProviderCore {
+    KoIsExtensionProviderCore,
+    KoIsValProviderCore,
+    KoIsVarProviderCore {
     override val ktAnnotated: KtAnnotated = ktCallableDeclaration
 
     override val ktModifierListOwner: KtModifierListOwner = ktCallableDeclaration
@@ -189,6 +193,22 @@ internal class KoPropertyDeclarationCore private constructor(
 
     @Deprecated("Will be removed in version 0.18.0", replaceWith = ReplaceWith(""))
     override val hasVarModifier: Boolean by lazy {
+        when (ktCallableDeclaration) {
+            is KtProperty -> ktCallableDeclaration.isVar
+            is KtParameter -> ktCallableDeclaration.valOrVarKeyword?.text == "var"
+            else -> false
+        }
+    }
+
+    override val isVal: Boolean by lazy {
+        when (ktCallableDeclaration) {
+            is KtProperty -> !ktCallableDeclaration.isVar
+            is KtParameter -> ktCallableDeclaration.valOrVarKeyword?.text == "val"
+            else -> false
+        }
+    }
+
+    override val isVar: Boolean by lazy {
         when (ktCallableDeclaration) {
             is KtProperty -> ktCallableDeclaration.isVar
             is KtParameter -> ktCallableDeclaration.valOrVarKeyword?.text == "var"

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/core/declaration/KoVariableDeclarationCore.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/core/declaration/KoVariableDeclarationCore.kt
@@ -8,6 +8,8 @@ import com.lemonappdev.konsist.core.provider.KoBaseProviderCore
 import com.lemonappdev.konsist.core.provider.KoContainingDeclarationProviderCore
 import com.lemonappdev.konsist.core.provider.KoContainingFileProviderCore
 import com.lemonappdev.konsist.core.provider.KoDelegateProviderCore
+import com.lemonappdev.konsist.core.provider.KoIsValProviderCore
+import com.lemonappdev.konsist.core.provider.KoIsVarProviderCore
 import com.lemonappdev.konsist.core.provider.KoKDocProviderCore
 import com.lemonappdev.konsist.core.provider.KoLocationProviderCore
 import com.lemonappdev.konsist.core.provider.KoModuleProviderCore
@@ -53,7 +55,9 @@ internal class KoVariableDeclarationCore private constructor(
     KoValueProviderCore,
     KoValModifierProviderCore,
     KoVarModifierProviderCore,
-    KoTacitTypeProviderCore {
+    KoTacitTypeProviderCore,
+    KoIsValProviderCore,
+    KoIsVarProviderCore {
     override val ktAnnotated: KtAnnotated = ktProperty
 
     override val ktCallableDeclaration: KtCallableDeclaration = ktProperty
@@ -85,6 +89,10 @@ internal class KoVariableDeclarationCore private constructor(
 
     @Deprecated("Will be removed in version 0.18.0", replaceWith = ReplaceWith(""))
     override val hasVarModifier: Boolean = ktProperty.isVar
+
+    override val isVal: Boolean = !ktProperty.isVar
+
+    override val isVar: Boolean = ktProperty.isVar
 
     override fun toString(): String = name
 

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/core/declaration/KoVariableDeclarationCore.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/core/declaration/KoVariableDeclarationCore.kt
@@ -80,8 +80,10 @@ internal class KoVariableDeclarationCore private constructor(
             ?.removeSuffix(" ")
     }
 
+    @Deprecated("Will be removed in version 0.18.0", replaceWith = ReplaceWith("isVal"))
     override val hasValModifier: Boolean = !ktProperty.isVar
 
+    @Deprecated("Will be removed in version 0.18.0", replaceWith = ReplaceWith(""))
     override val hasVarModifier: Boolean = ktProperty.isVar
 
     override fun toString(): String = name

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/core/declaration/KoVariableDeclarationCore.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/core/declaration/KoVariableDeclarationCore.kt
@@ -87,7 +87,7 @@ internal class KoVariableDeclarationCore private constructor(
     @Deprecated("Will be removed in version 0.18.0", replaceWith = ReplaceWith("isVal"))
     override val hasValModifier: Boolean = !ktProperty.isVar
 
-    @Deprecated("Will be removed in version 0.18.0", replaceWith = ReplaceWith(""))
+    @Deprecated("Will be removed in version 0.18.0")
     override val hasVarModifier: Boolean = ktProperty.isVar
 
     override val isVal: Boolean = !ktProperty.isVar

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/KoIsReadOnlyProviderCore.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/KoIsReadOnlyProviderCore.kt
@@ -1,11 +1,10 @@
 package com.lemonappdev.konsist.core.provider
 
 import com.lemonappdev.konsist.api.provider.KoIsReadOnlyProvider
-import com.lemonappdev.konsist.core.provider.modifier.KoValModifierProviderCore
 
 internal interface KoIsReadOnlyProviderCore :
     KoIsReadOnlyProvider,
-    KoValModifierProviderCore {
+    KoIsValProviderCore {
     override val isReadOnly: Boolean
-        get() = hasValModifier
+        get() = isVal
 }

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/KoIsValProviderCore.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/KoIsValProviderCore.kt
@@ -1,0 +1,7 @@
+package com.lemonappdev.konsist.core.provider
+
+import com.lemonappdev.konsist.api.provider.KoIsValProvider
+
+internal interface KoIsValProviderCore :
+    KoIsValProvider,
+    KoBaseProviderCore

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/KoIsVarProviderCore.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/KoIsVarProviderCore.kt
@@ -1,0 +1,7 @@
+package com.lemonappdev.konsist.core.provider
+
+import com.lemonappdev.konsist.api.provider.KoIsVarProvider
+
+internal interface KoIsVarProviderCore :
+    KoIsVarProvider,
+    KoBaseProviderCore

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/modifier/KoValModifierProviderCore.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/modifier/KoValModifierProviderCore.kt
@@ -3,6 +3,7 @@ package com.lemonappdev.konsist.core.provider.modifier
 import com.lemonappdev.konsist.api.provider.modifier.KoValModifierProvider
 import com.lemonappdev.konsist.core.provider.KoBaseProviderCore
 
+@Deprecated("Will be removed in version 0.18.0", ReplaceWith(""))
 internal interface KoValModifierProviderCore :
     KoValModifierProvider,
     KoBaseProviderCore

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/modifier/KoVarModifierProviderCore.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/modifier/KoVarModifierProviderCore.kt
@@ -3,6 +3,7 @@ package com.lemonappdev.konsist.core.provider.modifier
 import com.lemonappdev.konsist.api.provider.modifier.KoVarModifierProvider
 import com.lemonappdev.konsist.core.provider.KoBaseProviderCore
 
+@Deprecated("Will be removed in version 0.18.0", ReplaceWith(""))
 internal interface KoVarModifierProviderCore :
     KoVarModifierProvider,
     KoBaseProviderCore

--- a/lib/src/test/kotlin/com/lemonappdev/konsist/api/ext/list/KoIsGenericTypeProviderListExtTest.kt
+++ b/lib/src/test/kotlin/com/lemonappdev/konsist/api/ext/list/KoIsGenericTypeProviderListExtTest.kt
@@ -6,7 +6,6 @@ import io.mockk.mockk
 import org.amshove.kluent.shouldBeEqualTo
 import org.junit.jupiter.api.Test
 
-@Deprecated("Will be removed in version 0.18.0")
 class KoIsGenericTypeProviderListExtTest {
     @Test
     fun `withGenericType() returns type with generic type`() {

--- a/lib/src/test/kotlin/com/lemonappdev/konsist/api/ext/list/KoIsValProviderListExtTest.kt
+++ b/lib/src/test/kotlin/com/lemonappdev/konsist/api/ext/list/KoIsValProviderListExtTest.kt
@@ -1,0 +1,49 @@
+package com.lemonappdev.konsist.api.ext.list
+
+import com.lemonappdev.konsist.api.provider.KoIsValProvider
+import io.mockk.every
+import io.mockk.mockk
+import org.amshove.kluent.shouldBeEqualTo
+import org.junit.jupiter.api.Test
+
+class KoIsValProviderListExtTest {
+    @Test
+    fun `withVal() returns declaration with val keyword`() {
+        // given
+        val declaration1: KoIsValProvider =
+            mockk {
+                every { isVal } returns true
+            }
+        val declaration2: KoIsValProvider =
+            mockk {
+                every { isVal } returns false
+            }
+        val declarations = listOf(declaration1, declaration2)
+
+        // when
+        val sut = declarations.withVal()
+
+        // then
+        sut shouldBeEqualTo listOf(declaration1)
+    }
+
+    @Test
+    fun `withoutVal() returns declaration without val keyword`() {
+        // given
+        val declaration1: KoIsValProvider =
+            mockk {
+                every { isVal } returns true
+            }
+        val declaration2: KoIsValProvider =
+            mockk {
+                every { isVal } returns false
+            }
+        val declarations = listOf(declaration1, declaration2)
+
+        // when
+        val sut = declarations.withoutVal()
+
+        // then
+        sut shouldBeEqualTo listOf(declaration2)
+    }
+}

--- a/lib/src/test/kotlin/com/lemonappdev/konsist/api/ext/list/KoIsVarProviderListExtTest.kt
+++ b/lib/src/test/kotlin/com/lemonappdev/konsist/api/ext/list/KoIsVarProviderListExtTest.kt
@@ -1,0 +1,49 @@
+package com.lemonappdev.konsist.api.ext.list
+
+import com.lemonappdev.konsist.api.provider.KoIsVarProvider
+import io.mockk.every
+import io.mockk.mockk
+import org.amshove.kluent.shouldBeEqualTo
+import org.junit.jupiter.api.Test
+
+class KoIsVarProviderListExtTest {
+    @Test
+    fun `withVar() returns declaration with var keyword`() {
+        // given
+        val declaration1: KoIsVarProvider =
+            mockk {
+                every { isVar } returns true
+            }
+        val declaration2: KoIsVarProvider =
+            mockk {
+                every { isVar } returns false
+            }
+        val declarations = listOf(declaration1, declaration2)
+
+        // when
+        val sut = declarations.withVar()
+
+        // then
+        sut shouldBeEqualTo listOf(declaration1)
+    }
+
+    @Test
+    fun `withoutVar() returns declaration without var keyword`() {
+        // given
+        val declaration1: KoIsVarProvider =
+            mockk {
+                every { isVar } returns true
+            }
+        val declaration2: KoIsVarProvider =
+            mockk {
+                every { isVar } returns false
+            }
+        val declarations = listOf(declaration1, declaration2)
+
+        // when
+        val sut = declarations.withoutVar()
+
+        // then
+        sut shouldBeEqualTo listOf(declaration2)
+    }
+}

--- a/lib/src/test/kotlin/com/lemonappdev/konsist/api/ext/list/KoNullableProviderListExtTest.kt
+++ b/lib/src/test/kotlin/com/lemonappdev/konsist/api/ext/list/KoNullableProviderListExtTest.kt
@@ -6,7 +6,6 @@ import io.mockk.mockk
 import org.amshove.kluent.shouldBeEqualTo
 import org.junit.jupiter.api.Test
 
-@Deprecated("Will be removed in version 0.18.0", ReplaceWith("KoIsNullableProviderListExtTest"))
 class KoNullableProviderListExtTest {
     @Test
     fun `withNullableType() returns type with Nullable basic type`() {

--- a/lib/src/test/kotlin/com/lemonappdev/konsist/api/ext/list/modifierprovider/KoValModifierProviderListExtTest.kt
+++ b/lib/src/test/kotlin/com/lemonappdev/konsist/api/ext/list/modifierprovider/KoValModifierProviderListExtTest.kt
@@ -6,7 +6,6 @@ import io.mockk.mockk
 import org.amshove.kluent.shouldBeEqualTo
 import org.junit.jupiter.api.Test
 
-@Deprecated("Will be removed in version 0.18.0", replaceWith = ReplaceWith(""))
 class KoValModifierProviderListExtTest {
     @Test
     fun `withValModifier() returns declaration with val modifier`() {

--- a/lib/src/test/kotlin/com/lemonappdev/konsist/api/ext/list/modifierprovider/KoValModifierProviderListExtTest.kt
+++ b/lib/src/test/kotlin/com/lemonappdev/konsist/api/ext/list/modifierprovider/KoValModifierProviderListExtTest.kt
@@ -6,6 +6,7 @@ import io.mockk.mockk
 import org.amshove.kluent.shouldBeEqualTo
 import org.junit.jupiter.api.Test
 
+@Deprecated("Will be removed in version 0.18.0", replaceWith = ReplaceWith(""))
 class KoValModifierProviderListExtTest {
     @Test
     fun `withValModifier() returns declaration with val modifier`() {

--- a/lib/src/test/kotlin/com/lemonappdev/konsist/api/ext/list/modifierprovider/KoVarModifierProviderListExtTest.kt
+++ b/lib/src/test/kotlin/com/lemonappdev/konsist/api/ext/list/modifierprovider/KoVarModifierProviderListExtTest.kt
@@ -6,7 +6,6 @@ import io.mockk.mockk
 import org.amshove.kluent.shouldBeEqualTo
 import org.junit.jupiter.api.Test
 
-@Deprecated("Will be removed in version 0.18.0", replaceWith = ReplaceWith(""))
 class KoVarModifierProviderListExtTest {
     @Test
     fun `withVarModifier() returns declaration with var modifier`() {

--- a/lib/src/test/kotlin/com/lemonappdev/konsist/api/ext/list/modifierprovider/KoVarModifierProviderListExtTest.kt
+++ b/lib/src/test/kotlin/com/lemonappdev/konsist/api/ext/list/modifierprovider/KoVarModifierProviderListExtTest.kt
@@ -6,6 +6,7 @@ import io.mockk.mockk
 import org.amshove.kluent.shouldBeEqualTo
 import org.junit.jupiter.api.Test
 
+@Deprecated("Will be removed in version 0.18.0", replaceWith = ReplaceWith(""))
 class KoVarModifierProviderListExtTest {
     @Test
     fun `withVarModifier() returns declaration with var modifier`() {


### PR DESCRIPTION
- Use `KoIsValProvider` instead of `KoValModifierProvider`
	- use `isVal` property instead of `hasValModifier`
	- use `withVal()/withoutVal` extensions instead of `withValModifier()/withoutValModifier`
- Use `KoIsVarProvider` instead of `KoVarModifierProvider`
	- use `isVar` property instead of `hasVarModifier`
	- use `withVar()/withoutVar` extensions instead of `withVarModifier()/withoutVarModifier`