### PR TITLE
Refactor Architecture Assertions

### DIFF
--- a/lib/src/apiTest/kotlin/com/lemonappdev/konsist/architecture/dependencyrules/DependencyRulesTest.kt
+++ b/lib/src/apiTest/kotlin/com/lemonappdev/konsist/architecture/dependencyrules/DependencyRulesTest.kt
@@ -22,9 +22,7 @@ class DependencyRulesTest {
 
         // then
         sut shouldThrow KoPreconditionFailedException::class withMessage
-            """
-            Layers have the same name name: Name.
-            """.trimIndent()
+            """Layer name must be unique. Duplicated name: "Name""""
     }
 
     @Test
@@ -41,9 +39,7 @@ class DependencyRulesTest {
 
         // then
         sut shouldThrow KoPreconditionFailedException::class withMessage
-            """
-            Layers have the same name definedBy: package.. .
-            """.trimIndent()
+            """Layer definedBy must be unique. Duplicated definedBy: "package..""""
     }
 
     @Test

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/core/architecture/DependencyRulesCore.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/core/architecture/DependencyRulesCore.kt
@@ -38,7 +38,7 @@ class DependencyRulesCore : DependencyRules {
 
     private fun Layer.requireValidLayers(
         layer: Layer,
-        layers: Array<out Layer>
+        layers: Array<out Layer>,
     ) {
         requireLayerNotBeingDependentOnItself(this, layer, *layers)
         requireUniqueLayers(this, layer, *layers)

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/core/architecture/DependencyRulesCore.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/core/architecture/DependencyRulesCore.kt
@@ -7,7 +7,7 @@ import com.lemonappdev.konsist.core.exception.KoPreconditionFailedException
 class DependencyRulesCore : DependencyRules {
     internal val positiveDependencies = mutableMapOf<Layer, Set<Layer>>()
     internal val negativeDependencies = mutableMapOf<Layer, Set<Layer>>()
-    internal val statuses = mutableMapOf<Layer, Status>()
+    internal val statuses = mutableMapOf<Layer, LayerDependencyType>()
 
     internal var allLayers = mutableSetOf<Layer>()
 
@@ -24,14 +24,14 @@ class DependencyRulesCore : DependencyRules {
         }
 
         positiveDependencies[this] = (positiveDependencies.getOrDefault(this, setOf(this))) + layer + layers
-        statuses[this] = Status.DEPEND_ON_LAYER
+        statuses[this] = LayerDependencyType.DEPEND_ON_LAYER
 
-        if (statuses.getOrDefault(layer, Status.NONE) == Status.NONE) {
-            statuses[layer] = Status.NONE
+        if (statuses.getOrDefault(layer, LayerDependencyType.NONE) == LayerDependencyType.NONE) {
+            statuses[layer] = LayerDependencyType.NONE
         }
         layers.onEach {
-            if (statuses.getOrDefault(it, Status.NONE) == Status.NONE) {
-                statuses[it] = Status.NONE
+            if (statuses.getOrDefault(it, LayerDependencyType.NONE) == LayerDependencyType.NONE) {
+                statuses[it] = LayerDependencyType.NONE
             }
         }
     }
@@ -59,14 +59,14 @@ class DependencyRulesCore : DependencyRules {
         }
 
         negativeDependencies[this] = setOf(layer) + layers
-        statuses[this] = Status.NOT_DEPEND_ON_LAYER
+        statuses[this] = LayerDependencyType.NOT_DEPEND_ON_LAYER
 
-        if (statuses.getOrDefault(layer, Status.NONE) == Status.NONE) {
-            statuses[layer] = Status.NONE
+        if (statuses.getOrDefault(layer, LayerDependencyType.NONE) == LayerDependencyType.NONE) {
+            statuses[layer] = LayerDependencyType.NONE
         }
         layers.onEach {
-            if (statuses.getOrDefault(it, Status.NONE) == Status.NONE) {
-                statuses[it] = Status.NONE
+            if (statuses.getOrDefault(it, LayerDependencyType.NONE) == LayerDependencyType.NONE) {
+                statuses[it] = LayerDependencyType.NONE
             }
         }
     }
@@ -78,7 +78,7 @@ class DependencyRulesCore : DependencyRules {
         allLayers.add(this)
 
         positiveDependencies[this] = setOf(this)
-        statuses[this] = Status.DEPENDENT_ON_NOTHING
+        statuses[this] = LayerDependencyType.DEPENDENT_ON_NOTHING
     }
 
     private fun checkIfLayerIsDependentOnItself(
@@ -97,7 +97,7 @@ class DependencyRulesCore : DependencyRules {
         vararg layers: Layer,
     ) {
         val layerName = layer.name
-        if (statuses[layer] == Status.DEPENDENT_ON_NOTHING) {
+        if (statuses[layer] == LayerDependencyType.DEPENDENT_ON_NOTHING) {
             if (toBeIndependent) {
                 throw KoPreconditionFailedException("Duplicated the dependency that $layerName layer should be depend on nothing.")
             } else {
@@ -106,7 +106,7 @@ class DependencyRulesCore : DependencyRules {
                         "so it cannot depend on ${layers.first().name} layer.",
                 )
             }
-        } else if (statuses[layer] == Status.DEPEND_ON_LAYER) {
+        } else if (statuses[layer] == LayerDependencyType.DEPEND_ON_LAYER) {
             val dependency = positiveDependencies.getOrDefault(layer, emptySet())
 
             if (toBeIndependent) {
@@ -206,7 +206,7 @@ class DependencyRulesCore : DependencyRules {
     }
 }
 
-internal enum class Status {
+internal enum class LayerDependencyType {
     DEPEND_ON_LAYER,
     DEPENDENT_ON_NOTHING,
     NONE,

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/core/verify/KoArchitectureAssert.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/core/verify/KoArchitectureAssert.kt
@@ -7,7 +7,7 @@ import com.lemonappdev.konsist.api.ext.list.withPackage
 import com.lemonappdev.konsist.core.architecture.DependencyRulesCore
 import com.lemonappdev.konsist.core.architecture.KoArchitectureFiles
 import com.lemonappdev.konsist.core.architecture.KoArchitectureScope
-import com.lemonappdev.konsist.core.architecture.Status
+import com.lemonappdev.konsist.core.architecture.LayerDependencyType
 import com.lemonappdev.konsist.core.exception.KoAssertionFailedException
 import com.lemonappdev.konsist.core.exception.KoException
 import com.lemonappdev.konsist.core.exception.KoInternalException
@@ -197,7 +197,7 @@ private fun getCheckFailedMessages(
     failedFiles: List<FailedFiles>,
     positiveDependencies: Map<Layer, Set<Layer>>,
     negativeDependencies: Map<Layer, Set<Layer>>,
-    statuses: Map<Layer, Status>,
+    statuses: Map<Layer, LayerDependencyType>,
     additionalMessage: String?,
     testName: String?,
 ): String {
@@ -221,16 +221,16 @@ private fun getCheckFailedMessages(
                 val negativeLayerDependencies = (negativeDependencies.getOrDefault(layer, emptySet()) - layer).map { it.name }
 
                 val message =
-                    when (statuses.getOrDefault(layer, Status.NONE)) {
-                        Status.DEPEND_ON_LAYER -> {
+                    when (statuses.getOrDefault(layer, LayerDependencyType.NONE)) {
+                        LayerDependencyType.DEPEND_ON_LAYER -> {
                             "depends on ${positiveLayerDependencies.joinToString(", ")} assertion failure:"
                         }
 
-                        Status.NOT_DEPEND_ON_LAYER -> {
+                        LayerDependencyType.NOT_DEPEND_ON_LAYER -> {
                             "does not depend on ${negativeLayerDependencies.joinToString(", ")} assertion failure:"
                         }
 
-                        Status.DEPENDENT_ON_NOTHING -> {
+                        LayerDependencyType.DEPENDENT_ON_NOTHING -> {
                             "depends on nothing assertion failure:"
                         }
 


### PR DESCRIPTION
- store layers in `Set`
- rename `checkX` methods to `requireX`
- rename `Status` to `LayerDependencyType`
- simplify `requireNoCircularDependencies` method (previously `checkIfLayerHasTheSameValuesAsOtherLayer`)