### PR TITLE
KON-668 Change the version of deleting declarations annotated as deprecated in this release from 0.18.0 to 0.19.0

### DIFF
--- a/lib/src/main/kotlin/com/lemonappdev/konsist/api/ext/list/modifierprovider/KoValModifierProviderListExt.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/api/ext/list/modifierprovider/KoValModifierProviderListExt.kt
@@ -7,7 +7,7 @@ import com.lemonappdev.konsist.api.provider.modifier.KoValModifierProvider
  *
  * @return A list containing declarations with the `val` modifier.
  */
-@Deprecated("Will be removed in version 0.18.0", ReplaceWith("withVal"))
+@Deprecated("Will be removed in version 0.19.0", ReplaceWith("withVal"))
 fun <T : KoValModifierProvider> List<T>.withValModifier(): List<T> = filter { it.hasValModifier }
 
 /**
@@ -15,5 +15,5 @@ fun <T : KoValModifierProvider> List<T>.withValModifier(): List<T> = filter { it
  *
  * @return A list containing declarations without the `val` modifier.
  */
-@Deprecated("Will be removed in version 0.18.0", ReplaceWith("withoutVal"))
+@Deprecated("Will be removed in version 0.19.0", ReplaceWith("withoutVal"))
 fun <T : KoValModifierProvider> List<T>.withoutValModifier(): List<T> = filterNot { it.hasValModifier }

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/api/ext/list/modifierprovider/KoVarModifierProviderListExt.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/api/ext/list/modifierprovider/KoVarModifierProviderListExt.kt
@@ -7,7 +7,7 @@ import com.lemonappdev.konsist.api.provider.modifier.KoVarModifierProvider
  *
  * @return A list containing declarations with the `var` modifier.
  */
-@Deprecated("Will be removed in version 0.18.0", ReplaceWith("withVar"))
+@Deprecated("Will be removed in version 0.19.0", ReplaceWith("withVar"))
 fun <T : KoVarModifierProvider> List<T>.withVarModifier(): List<T> = filter { it.hasVarModifier }
 
 /**
@@ -15,5 +15,5 @@ fun <T : KoVarModifierProvider> List<T>.withVarModifier(): List<T> = filter { it
  *
  * @return A list containing declarations without the `var` modifier.
  */
-@Deprecated("Will be removed in version 0.18.0", ReplaceWith("withoutVar"))
+@Deprecated("Will be removed in version 0.19.0", ReplaceWith("withoutVar"))
 fun <T : KoVarModifierProvider> List<T>.withoutVarModifier(): List<T> = filterNot { it.hasVarModifier }

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/api/provider/modifier/KoValModifierProvider.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/api/provider/modifier/KoValModifierProvider.kt
@@ -5,11 +5,11 @@ import com.lemonappdev.konsist.api.provider.KoBaseProvider
 /**
  * An interface representing a Kotlin declaration that provides information about whether it has a `val` modifier.
  */
-@Deprecated("Will be removed in version 0.18.0", ReplaceWith(""))
+@Deprecated("Will be removed in version 0.19.0", ReplaceWith("KoIsValProvider"))
 interface KoValModifierProvider : KoBaseProvider {
     /**
      * Determines whatever the declaration has `val` modifier.
      */
-    @Deprecated("Will be removed in version 0.18.0", ReplaceWith("isVal"))
+    @Deprecated("Will be removed in version 0.19.0", ReplaceWith("isVal"))
     val hasValModifier: Boolean
 }

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/api/provider/modifier/KoVarModifierProvider.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/api/provider/modifier/KoVarModifierProvider.kt
@@ -5,11 +5,11 @@ import com.lemonappdev.konsist.api.provider.KoBaseProvider
 /**
  * An interface representing a Kotlin declaration that provides information about whether it has a `var` modifier.
  */
-@Deprecated("Will be removed in version 0.18.0", ReplaceWith(""))
+@Deprecated("Will be removed in version 0.19.0", ReplaceWith("KoIsVarProvider"))
 interface KoVarModifierProvider : KoBaseProvider {
     /**
      * Determines whatever the declaration has `var` modifier.
      */
-    @Deprecated("Will be removed in version 0.18.0", ReplaceWith("isVar"))
+    @Deprecated("Will be removed in version 0.19.0", ReplaceWith("isVar"))
     val hasVarModifier: Boolean
 }

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/core/annotation/RemoveInVersion.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/core/annotation/RemoveInVersion.kt
@@ -10,4 +10,7 @@ import kotlin.annotation.AnnotationTarget.PROPERTY_SETTER
 import kotlin.annotation.AnnotationTarget.TYPEALIAS
 
 @Target(CLASS, FUNCTION, PROPERTY, ANNOTATION_CLASS, CONSTRUCTOR, PROPERTY_SETTER, PROPERTY_GETTER, TYPEALIAS)
-internal annotation class RemoveInVersion(val version: String, val message: String = "")
+internal annotation class RemoveInVersion(
+    val version: String,
+    val message: String = "",
+)

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/core/annotation/RemoveInVersion.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/core/annotation/RemoveInVersion.kt
@@ -1,0 +1,13 @@
+package com.lemonappdev.konsist.core.annotation
+
+import kotlin.annotation.AnnotationTarget.ANNOTATION_CLASS
+import kotlin.annotation.AnnotationTarget.CLASS
+import kotlin.annotation.AnnotationTarget.CONSTRUCTOR
+import kotlin.annotation.AnnotationTarget.FUNCTION
+import kotlin.annotation.AnnotationTarget.PROPERTY
+import kotlin.annotation.AnnotationTarget.PROPERTY_GETTER
+import kotlin.annotation.AnnotationTarget.PROPERTY_SETTER
+import kotlin.annotation.AnnotationTarget.TYPEALIAS
+
+@Target(CLASS, FUNCTION, PROPERTY, ANNOTATION_CLASS, CONSTRUCTOR, PROPERTY_SETTER, PROPERTY_GETTER, TYPEALIAS)
+internal annotation class RemoveInVersion(val version: String, val message: String = "")

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/core/declaration/KoFunctionDeclarationCore.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/core/declaration/KoFunctionDeclarationCore.kt
@@ -128,10 +128,14 @@ internal class KoFunctionDeclarationCore private constructor(
         KoLocalDeclarationProviderCoreUtil.getKoLocalDeclarations(psiElements, this)
     }
 
-    @Deprecated("Will be removed in version 0.18.0", ReplaceWith(""))
+    /*
+    Remove in version 0.18.0
+     */
     override val isInitialized: Boolean by lazy { super<KoIsInitializedProviderCore>.isInitialized }
 
-    @Deprecated("Will be removed in version 0.18.0", ReplaceWith(""))
+    /*
+    Remove in version 0.18.0
+     */
     override val isTopLevel: Boolean by lazy { super<KoIsTopLevelProviderCore>.isTopLevel }
 
     override val fullyQualifiedName: String? by lazy {

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/core/declaration/KoFunctionDeclarationCore.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/core/declaration/KoFunctionDeclarationCore.kt
@@ -2,6 +2,7 @@ package com.lemonappdev.konsist.core.declaration
 
 import com.lemonappdev.konsist.api.declaration.KoBaseDeclaration
 import com.lemonappdev.konsist.api.declaration.KoFunctionDeclaration
+import com.lemonappdev.konsist.core.annotation.RemoveInVersion
 import com.lemonappdev.konsist.core.cache.KoDeclarationCache
 import com.lemonappdev.konsist.core.provider.KoAnnotationProviderCore
 import com.lemonappdev.konsist.core.provider.KoBaseProviderCore
@@ -128,14 +129,10 @@ internal class KoFunctionDeclarationCore private constructor(
         KoLocalDeclarationProviderCoreUtil.getKoLocalDeclarations(psiElements, this)
     }
 
-    /*
-    Remove in version 0.18.0
-     */
+    @RemoveInVersion("0.18.0")
     override val isInitialized: Boolean by lazy { super<KoIsInitializedProviderCore>.isInitialized }
 
-    /*
-    Remove in version 0.18.0
-     */
+    @RemoveInVersion("0.18.0")
     override val isTopLevel: Boolean by lazy { super<KoIsTopLevelProviderCore>.isTopLevel }
 
     override val fullyQualifiedName: String? by lazy {

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/core/declaration/KoImportDeclarationCore.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/core/declaration/KoImportDeclarationCore.kt
@@ -6,6 +6,7 @@ import com.lemonappdev.konsist.api.declaration.KoImportDeclaration
 import com.lemonappdev.konsist.api.declaration.KoSourceDeclaration
 import com.lemonappdev.konsist.api.declaration.type.KoKotlinTypeDeclaration
 import com.lemonappdev.konsist.api.provider.KoFullyQualifiedNameProvider
+import com.lemonappdev.konsist.core.annotation.RemoveInVersion
 import com.lemonappdev.konsist.core.cache.KoDeclarationCache
 import com.lemonappdev.konsist.core.declaration.type.KoKotlinTypeDeclarationCore
 import com.lemonappdev.konsist.core.ext.castToKoBaseDeclaration
@@ -58,9 +59,7 @@ internal class KoImportDeclarationCore private constructor(
             ?.let { KoImportAliasDeclarationCore.getInstance(it, this) }
     }
 
-    /*
-    Remove in version 0.18.0
-     */
+    @RemoveInVersion("0.18.0")
     override val isWildcard: Boolean by lazy { super<KoIsWildcardProviderCore>.isWildcard }
 
     override val sourceDeclaration: KoSourceDeclaration by lazy {
@@ -70,7 +69,7 @@ internal class KoImportDeclarationCore private constructor(
             .declarations
             .filterIsInstance<KoFullyQualifiedNameProvider>()
             .firstOrNull { it.fullyQualifiedName == name }
-            as? KoSourceDeclaration
+                as? KoSourceDeclaration
             ?: getKotlinType(shortName)
             ?: KoExternalDeclarationCore.getInstance(shortName, ktImportDirective)
     }

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/core/declaration/KoImportDeclarationCore.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/core/declaration/KoImportDeclarationCore.kt
@@ -58,7 +58,9 @@ internal class KoImportDeclarationCore private constructor(
             ?.let { KoImportAliasDeclarationCore.getInstance(it, this) }
     }
 
-    @Deprecated("Will be removed in version 0.18.0", ReplaceWith(""))
+    /*
+    Remove in version 0.18.0
+     */
     override val isWildcard: Boolean by lazy { super<KoIsWildcardProviderCore>.isWildcard }
 
     override val sourceDeclaration: KoSourceDeclaration by lazy {

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/core/declaration/KoImportDeclarationCore.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/core/declaration/KoImportDeclarationCore.kt
@@ -69,7 +69,7 @@ internal class KoImportDeclarationCore private constructor(
             .declarations
             .filterIsInstance<KoFullyQualifiedNameProvider>()
             .firstOrNull { it.fullyQualifiedName == name }
-                as? KoSourceDeclaration
+            as? KoSourceDeclaration
             ?: getKotlinType(shortName)
             ?: KoExternalDeclarationCore.getInstance(shortName, ktImportDirective)
     }

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/core/declaration/KoParameterDeclarationCore.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/core/declaration/KoParameterDeclarationCore.kt
@@ -82,10 +82,10 @@ internal class KoParameterDeclarationCore private constructor(
 
     override fun representsType(name: String?): Boolean = type.name == name
 
-    @Deprecated("Will be removed in version 0.18.0", replaceWith = ReplaceWith("isVal"))
+    @Deprecated("Will be removed in version 0.19.0", ReplaceWith("isVal"))
     override val hasValModifier: Boolean by lazy { ktParameter.valOrVarKeyword?.text == "val" }
 
-    @Deprecated("Will be removed in version 0.18.0")
+    @Deprecated("Will be removed in version 0.19.0", ReplaceWith("isVar"))
     override val hasVarModifier: Boolean by lazy { ktParameter.valOrVarKeyword?.text == "var" }
 
     override val isVal: Boolean by lazy { ktParameter.valOrVarKeyword?.text == "val" }

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/core/declaration/KoPropertyDeclarationCore.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/core/declaration/KoPropertyDeclarationCore.kt
@@ -4,6 +4,7 @@ import com.lemonappdev.konsist.api.declaration.KoBaseDeclaration
 import com.lemonappdev.konsist.api.declaration.KoKDocDeclaration
 import com.lemonappdev.konsist.api.declaration.KoPropertyDeclaration
 import com.lemonappdev.konsist.api.provider.KoKDocProvider
+import com.lemonappdev.konsist.core.annotation.RemoveInVersion
 import com.lemonappdev.konsist.core.cache.KoDeclarationCache
 import com.lemonappdev.konsist.core.provider.KoAnnotationProviderCore
 import com.lemonappdev.konsist.core.provider.KoBaseProviderCore
@@ -137,24 +138,16 @@ internal class KoPropertyDeclarationCore private constructor(
 
     override val ktProperty: KtProperty? by lazy { ktCallableDeclaration as? KtProperty }
 
-    /*
-    Remove in version 0.18.0
-     */
+    @RemoveInVersion("0.18.0")
     override val isInitialized: Boolean by lazy { super<KoIsInitializedProviderCore>.isInitialized }
 
-    /*
-    Remove in version 0.18.0
-     */
+    @RemoveInVersion("0.18.0")
     override val isConstructorDefined: Boolean by lazy { super<KoIsConstructorDefinedProviderCore>.isConstructorDefined }
 
-    /*
-    Remove in version 0.18.0
-     */
+    @RemoveInVersion("0.18.0")
     override val isReadOnly: Boolean by lazy { super<KoIsReadOnlyProviderCore>.isReadOnly }
 
-    /*
-    Remove in version 0.18.0
-     */
+    @RemoveInVersion("0.18.0")
     override val isTopLevel: Boolean by lazy { super<KoIsTopLevelProviderCore>.isTopLevel }
 
     override val ktExpression: KtExpression? by lazy {

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/core/declaration/KoPropertyDeclarationCore.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/core/declaration/KoPropertyDeclarationCore.kt
@@ -137,16 +137,24 @@ internal class KoPropertyDeclarationCore private constructor(
 
     override val ktProperty: KtProperty? by lazy { ktCallableDeclaration as? KtProperty }
 
-    @Deprecated("Will be removed in version 0.18.0", ReplaceWith(""))
+    /*
+    Remove in version 0.18.0
+    */
     override val isInitialized: Boolean by lazy { super<KoIsInitializedProviderCore>.isInitialized }
 
-    @Deprecated("Will be removed in version 0.18.0", ReplaceWith(""))
+    /*
+    Remove in version 0.18.0
+    */
     override val isConstructorDefined: Boolean by lazy { super<KoIsConstructorDefinedProviderCore>.isConstructorDefined }
 
-    @Deprecated("Will be removed in version 0.18.0", ReplaceWith(""))
+        /*
+    Remove in version 0.18.0
+     */
     override val isReadOnly: Boolean by lazy { super<KoIsReadOnlyProviderCore>.isReadOnly }
 
-    @Deprecated("Will be removed in version 0.18.0", ReplaceWith(""))
+        /*
+    Remove in version 0.18.0
+     */
     override val isTopLevel: Boolean by lazy { super<KoIsTopLevelProviderCore>.isTopLevel }
 
     override val ktExpression: KtExpression? by lazy {
@@ -156,8 +164,8 @@ internal class KoPropertyDeclarationCore private constructor(
             .filterIsInstance<KtExpression>()
             .firstOrNull()
     }
-
-    @Deprecated("Will be removed in version 0.18.0", replaceWith = ReplaceWith("isVal"))
+    
+    @Deprecated("Will be removed in version 0.19.0", ReplaceWith("isVal"))
     override val hasValModifier: Boolean by lazy {
         when (ktCallableDeclaration) {
             is KtProperty -> !ktCallableDeclaration.isVar
@@ -165,8 +173,8 @@ internal class KoPropertyDeclarationCore private constructor(
             else -> false
         }
     }
-
-    @Deprecated("Will be removed in version 0.18.0")
+    
+    @Deprecated("Will be removed in version 0.19.0", ReplaceWith("isVar"))
     override val hasVarModifier: Boolean by lazy {
         when (ktCallableDeclaration) {
             is KtProperty -> ktCallableDeclaration.isVar

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/core/declaration/KoPropertyDeclarationCore.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/core/declaration/KoPropertyDeclarationCore.kt
@@ -139,20 +139,20 @@ internal class KoPropertyDeclarationCore private constructor(
 
     /*
     Remove in version 0.18.0
-    */
+     */
     override val isInitialized: Boolean by lazy { super<KoIsInitializedProviderCore>.isInitialized }
 
     /*
     Remove in version 0.18.0
-    */
+     */
     override val isConstructorDefined: Boolean by lazy { super<KoIsConstructorDefinedProviderCore>.isConstructorDefined }
 
-        /*
+    /*
     Remove in version 0.18.0
      */
     override val isReadOnly: Boolean by lazy { super<KoIsReadOnlyProviderCore>.isReadOnly }
 
-        /*
+    /*
     Remove in version 0.18.0
      */
     override val isTopLevel: Boolean by lazy { super<KoIsTopLevelProviderCore>.isTopLevel }
@@ -164,7 +164,7 @@ internal class KoPropertyDeclarationCore private constructor(
             .filterIsInstance<KtExpression>()
             .firstOrNull()
     }
-    
+
     @Deprecated("Will be removed in version 0.19.0", ReplaceWith("isVal"))
     override val hasValModifier: Boolean by lazy {
         when (ktCallableDeclaration) {
@@ -173,7 +173,7 @@ internal class KoPropertyDeclarationCore private constructor(
             else -> false
         }
     }
-    
+
     @Deprecated("Will be removed in version 0.19.0", ReplaceWith("isVar"))
     override val hasVarModifier: Boolean by lazy {
         when (ktCallableDeclaration) {

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/core/declaration/KoVariableDeclarationCore.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/core/declaration/KoVariableDeclarationCore.kt
@@ -73,10 +73,10 @@ internal class KoVariableDeclarationCore private constructor(
             .firstOrNull()
     }
 
-    @Deprecated("Will be removed in version 0.18.0", replaceWith = ReplaceWith("isVal"))
+    @Deprecated("Will be removed in version 0.19.0", ReplaceWith("isVal"))
     override val hasValModifier: Boolean by lazy { !ktProperty.isVar }
 
-    @Deprecated("Will be removed in version 0.18.0")
+    @Deprecated("Will be removed in version 0.19.0", ReplaceWith("isVar"))
     override val hasVarModifier: Boolean by lazy { ktProperty.isVar }
 
     override val isVal: Boolean by lazy { !ktProperty.isVar }

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/core/declaration/combined/KoClassAndInterfaceAndObjectDeclarationCore.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/core/declaration/combined/KoClassAndInterfaceAndObjectDeclarationCore.kt
@@ -97,7 +97,9 @@ internal interface KoClassAndInterfaceAndObjectDeclarationCore :
     override val ktElement: KtElement
         get() = ktClassOrObject
 
-    @Deprecated("Will be removed in version 0.18.0", ReplaceWith(""))
+    /*
+    Remove in version 0.18.0
+     */
     override val isTopLevel: Boolean
         get() = super<KoIsTopLevelProviderCore>.isTopLevel
 

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/core/declaration/combined/KoClassAndInterfaceAndObjectDeclarationCore.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/core/declaration/combined/KoClassAndInterfaceAndObjectDeclarationCore.kt
@@ -2,6 +2,7 @@ package com.lemonappdev.konsist.core.declaration.combined
 
 import com.lemonappdev.konsist.api.declaration.KoBaseDeclaration
 import com.lemonappdev.konsist.api.declaration.combined.KoClassAndInterfaceAndObjectDeclaration
+import com.lemonappdev.konsist.core.annotation.RemoveInVersion
 import com.lemonappdev.konsist.core.declaration.KoChildDeclarationCore
 import com.lemonappdev.konsist.core.declaration.type.KoBaseTypeDeclarationCore
 import com.lemonappdev.konsist.core.provider.KoAnnotationProviderCore
@@ -97,14 +98,13 @@ internal interface KoClassAndInterfaceAndObjectDeclarationCore :
     override val ktElement: KtElement
         get() = ktClassOrObject
 
-    /*
-    Remove in version 0.18.0
-     */
+    @RemoveInVersion("0.18.0")
     override val isTopLevel: Boolean
         get() = super<KoIsTopLevelProviderCore>.isTopLevel
 
     override fun declarations(
         includeNested: Boolean,
         includeLocal: Boolean,
-    ): List<KoBaseDeclaration> = KoDeclarationProviderCoreUtil.getKoDeclarations(ktClassOrObject, includeNested, includeLocal, this)
+    ): List<KoBaseDeclaration> =
+        KoDeclarationProviderCoreUtil.getKoDeclarations(ktClassOrObject, includeNested, includeLocal, this)
 }

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/core/declaration/combined/KoClassAndInterfaceAndObjectDeclarationCore.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/core/declaration/combined/KoClassAndInterfaceAndObjectDeclarationCore.kt
@@ -105,6 +105,5 @@ internal interface KoClassAndInterfaceAndObjectDeclarationCore :
     override fun declarations(
         includeNested: Boolean,
         includeLocal: Boolean,
-    ): List<KoBaseDeclaration> =
-        KoDeclarationProviderCoreUtil.getKoDeclarations(ktClassOrObject, includeNested, includeLocal, this)
+    ): List<KoBaseDeclaration> = KoDeclarationProviderCoreUtil.getKoDeclarations(ktClassOrObject, includeNested, includeLocal, this)
 }

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/core/declaration/type/KoTypeDeclarationCore.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/core/declaration/type/KoTypeDeclarationCore.kt
@@ -127,10 +127,14 @@ internal class KoTypeDeclarationCore private constructor(
 
     override val packagee: KoPackageDeclaration? by lazy { containingFile.packagee }
 
-    @Deprecated("Will be removed in version 0.18.0")
+    /*
+    Remove in version 0.18.0
+     */
     override val isGenericType: Boolean by lazy { super<KoIsGenericTypeProviderCore>.isGenericType }
 
-    @Deprecated("Will be removed in version 0.18.0")
+    /*
+    Remove in version 0.18.0
+     */
     override val isNullable: Boolean by lazy { super<KoIsNullableProviderCore>.isNullable }
 
     override fun toString(): String = text

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/core/declaration/type/KoTypeDeclarationCore.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/core/declaration/type/KoTypeDeclarationCore.kt
@@ -4,6 +4,7 @@ import com.lemonappdev.konsist.api.declaration.KoBaseDeclaration
 import com.lemonappdev.konsist.api.declaration.KoPackageDeclaration
 import com.lemonappdev.konsist.api.declaration.KoSourceDeclaration
 import com.lemonappdev.konsist.api.declaration.type.KoTypeDeclaration
+import com.lemonappdev.konsist.core.annotation.RemoveInVersion
 import com.lemonappdev.konsist.core.cache.KoDeclarationCache
 import com.lemonappdev.konsist.core.provider.KoAnnotationProviderCore
 import com.lemonappdev.konsist.core.provider.KoBaseProviderCore
@@ -78,12 +79,12 @@ internal class KoTypeDeclarationCore private constructor(
 
     override val psiElement: PsiElement by lazy {
         ktTypeReference ?: ktNameReferenceExpression ?: ktTypeProjection
-            ?: error("KtTypeReference, KtNameReferenceExpression and KtTypeProjection are null")
+        ?: error("KtTypeReference, KtNameReferenceExpression and KtTypeProjection are null")
     }
 
     override val ktElement: KtElement by lazy {
         ktTypeReference ?: ktNameReferenceExpression ?: ktTypeProjection
-            ?: error("KtTypeReference, KtNameReferenceExpression and KtTypeProjection are null")
+        ?: error("KtTypeReference, KtNameReferenceExpression and KtTypeProjection are null")
     }
 
     override val ktUserType: KtUserType? by lazy {
@@ -127,14 +128,10 @@ internal class KoTypeDeclarationCore private constructor(
 
     override val packagee: KoPackageDeclaration? by lazy { containingFile.packagee }
 
-    /*
-    Remove in version 0.18.0
-     */
+    @RemoveInVersion("0.18.0")
     override val isGenericType: Boolean by lazy { super<KoIsGenericTypeProviderCore>.isGenericType }
 
-    /*
-    Remove in version 0.18.0
-     */
+    @RemoveInVersion("0.18.0")
     override val isNullable: Boolean by lazy { super<KoIsNullableProviderCore>.isNullable }
 
     override fun toString(): String = text

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/core/declaration/type/KoTypeDeclarationCore.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/core/declaration/type/KoTypeDeclarationCore.kt
@@ -79,12 +79,12 @@ internal class KoTypeDeclarationCore private constructor(
 
     override val psiElement: PsiElement by lazy {
         ktTypeReference ?: ktNameReferenceExpression ?: ktTypeProjection
-        ?: error("KtTypeReference, KtNameReferenceExpression and KtTypeProjection are null")
+            ?: error("KtTypeReference, KtNameReferenceExpression and KtTypeProjection are null")
     }
 
     override val ktElement: KtElement by lazy {
         ktTypeReference ?: ktNameReferenceExpression ?: ktTypeProjection
-        ?: error("KtTypeReference, KtNameReferenceExpression and KtTypeProjection are null")
+            ?: error("KtTypeReference, KtNameReferenceExpression and KtTypeProjection are null")
     }
 
     override val ktUserType: KtUserType? by lazy {

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/KoDeclarationCastProviderCore.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/KoDeclarationCastProviderCore.kt
@@ -55,7 +55,7 @@ internal interface KoDeclarationCastProviderCore :
     override val isExternalDeclaration: Boolean
         get() = koDeclarationCastProviderDeclaration is KoExternalDeclaration
 
-    @Deprecated("Will be removed in version 0.19.0", replaceWith = ReplaceWith("isExternalDeclaration"))
+    @Deprecated("Will be removed in version 0.19.0", ReplaceWith("isExternalDeclaration"))
     override val isExternalType: Boolean
         get() = isExternalDeclaration
 
@@ -82,7 +82,7 @@ internal interface KoDeclarationCastProviderCore :
 
     override fun asExternalDeclaration(): KoExternalDeclaration? = koDeclarationCastProviderDeclaration as? KoExternalDeclaration
 
-    @Deprecated("Will be removed in version 0.19.0", replaceWith = ReplaceWith("asExternalDeclaration"))
+    @Deprecated("Will be removed in version 0.19.0", ReplaceWith("asExternalDeclaration"))
     override fun asExternalTypeDeclaration(): KoExternalDeclaration? = asExternalDeclaration()
 
     override fun hasClassDeclaration(predicate: ((KoClassDeclaration) -> Boolean)?): Boolean =
@@ -163,9 +163,9 @@ internal interface KoDeclarationCastProviderCore :
 
     override fun hasExternalDeclarationOf(kClass: KClass<*>): Boolean = kClass.qualifiedName == asExternalDeclaration()?.fullyQualifiedName
 
-    @Deprecated("Will be removed in version 0.19.0", replaceWith = ReplaceWith("hasExternalDeclaration"))
+    @Deprecated("Will be removed in version 0.19.0", ReplaceWith("hasExternalDeclaration"))
     override fun hasExternalTypeDeclaration(predicate: ((KoExternalDeclaration) -> Boolean)?): Boolean = hasExternalDeclaration()
 
-    @Deprecated("Will be removed in version 0.19.0", replaceWith = ReplaceWith("hasExternalDeclarationOf"))
+    @Deprecated("Will be removed in version 0.19.0", ReplaceWith("hasExternalDeclarationOf"))
     override fun hasExternalTypeDeclarationOf(kClass: KClass<*>): Boolean = hasExternalDeclarationOf(kClass)
 }

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/modifier/KoValModifierProviderCore.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/modifier/KoValModifierProviderCore.kt
@@ -3,7 +3,7 @@ package com.lemonappdev.konsist.core.provider.modifier
 import com.lemonappdev.konsist.api.provider.modifier.KoValModifierProvider
 import com.lemonappdev.konsist.core.provider.KoBaseProviderCore
 
-@Deprecated("Will be removed in version 0.18.0", ReplaceWith(""))
+@Deprecated("Will be removed in version 0.19.0", ReplaceWith("KoIsValProvider"))
 internal interface KoValModifierProviderCore :
     KoValModifierProvider,
     KoBaseProviderCore

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/modifier/KoVarModifierProviderCore.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/modifier/KoVarModifierProviderCore.kt
@@ -3,7 +3,7 @@ package com.lemonappdev.konsist.core.provider.modifier
 import com.lemonappdev.konsist.api.provider.modifier.KoVarModifierProvider
 import com.lemonappdev.konsist.core.provider.KoBaseProviderCore
 
-@Deprecated("Will be removed in version 0.18.0", ReplaceWith(""))
+@Deprecated("Will be removed in version 0.19.0", ReplaceWith("KoIsVarProvider"))
 internal interface KoVarModifierProviderCore :
     KoVarModifierProvider,
     KoBaseProviderCore


### PR DESCRIPTION
1. The version in deprecated declarations in this version has been updated from `0.18.0` to `0.19.0` to correct a previous error.

2. The `@RemoveInVersion` annotations have been introduced to mark code elements that are not currently deprecated but will be unnecessary in a future version. For example:

    ```kotlin
    @RemoveInVersion("0.18.0")
    override val isInitialized: Boolean by lazy { super<KoIsInitializedProviderCore>.isInitialized }
    ```

    This addition addresses the current situation where there are two providers (one deprecated) that provide the same declaration, necessitating the specification of which implementation to consider. Once the deprecated element is removed, these declarations will no longer be required.

3. The Python code for creating releases has been updated to check for `@RemoveInVersion` annotations with the specified version.