### PR TITLE
KON-658 Change structure of parameter types in KoFunctionTypeDeclarationProvider

### DIFF
--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/kotypeargument/KoTypeArgumentDeclarationForKoFunctionTypeDeclarationProviderTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/kotypeargument/KoTypeArgumentDeclarationForKoFunctionTypeDeclarationProviderTest.kt
@@ -27,6 +27,13 @@ class KoTypeArgumentDeclarationForKoFunctionTypeDeclarationProviderTest {
             it?.countParameterTypes { parameter -> parameter.type.isKotlinBasicType } shouldBeEqualTo 0
             it?.hasParameterType { parameter -> parameter.type.isKotlinType } shouldBeEqualTo false
             it?.hasAllParameterTypes { parameter -> parameter.type.isKotlinType } shouldBeEqualTo false
+            it?.parameters shouldBeEqualTo null
+            it?.numParameters shouldBeEqualTo 0
+            it?.countParameters { parameter -> parameter.type.isKotlinType } shouldBeEqualTo 0
+            it?.countParameters { parameter -> parameter.type.isKotlinCollectionType } shouldBeEqualTo 0
+            it?.countParameters { parameter -> parameter.type.isKotlinBasicType } shouldBeEqualTo 0
+            it?.hasParameter { parameter -> parameter.type.isKotlinType } shouldBeEqualTo false
+            it?.hasAllParameters { parameter -> parameter.type.isKotlinType } shouldBeEqualTo false
         }
     }
 
@@ -50,6 +57,13 @@ class KoTypeArgumentDeclarationForKoFunctionTypeDeclarationProviderTest {
             it?.countParameterTypes { parameter -> parameter.type.isKotlinBasicType } shouldBeEqualTo 0
             it?.hasParameterType { parameter -> parameter.type.isKotlinType } shouldBeEqualTo false
             it?.hasAllParameterTypes { parameter -> parameter.type.isKotlinType } shouldBeEqualTo true
+            it?.parameters shouldBeEqualTo emptyList()
+            it?.numParameters shouldBeEqualTo 0
+            it?.countParameters { parameter -> parameter.type.isKotlinType } shouldBeEqualTo 0
+            it?.countParameters { parameter -> parameter.type.isKotlinCollectionType } shouldBeEqualTo 0
+            it?.countParameters { parameter -> parameter.type.isKotlinBasicType } shouldBeEqualTo 0
+            it?.hasParameter { parameter -> parameter.type.isKotlinType } shouldBeEqualTo false
+            it?.hasAllParameters { parameter -> parameter.type.isKotlinType } shouldBeEqualTo true
         }
     }
 
@@ -76,6 +90,16 @@ class KoTypeArgumentDeclarationForKoFunctionTypeDeclarationProviderTest {
             it?.hasParameterType { parameter -> parameter.type.isExternalDeclaration } shouldBeEqualTo false
             it?.hasAllParameterTypes { parameter -> parameter.type.isKotlinType } shouldBeEqualTo true
             it?.hasAllParameterTypes { parameter -> parameter.type.isExternalDeclaration } shouldBeEqualTo false
+            it?.parameters?.map { parameter -> parameter.type.name } shouldBeEqualTo listOf("String")
+            it?.numParameters shouldBeEqualTo 1
+            it?.countParameters { parameter -> parameter.type.isKotlinType } shouldBeEqualTo 1
+            it?.countParameters { parameter -> parameter.type.isKotlinCollectionType } shouldBeEqualTo 0
+            it?.countParameters { parameter -> parameter.type.isKotlinBasicType } shouldBeEqualTo 1
+            it?.countParameters { parameter -> parameter.type.isClass } shouldBeEqualTo 0
+            it?.hasParameter { parameter -> parameter.type.isKotlinType } shouldBeEqualTo true
+            it?.hasParameter { parameter -> parameter.type.isExternalDeclaration } shouldBeEqualTo false
+            it?.hasAllParameters { parameter -> parameter.type.isKotlinType } shouldBeEqualTo true
+            it?.hasAllParameters { parameter -> parameter.type.isExternalDeclaration } shouldBeEqualTo false
         }
     }
 
@@ -102,6 +126,36 @@ class KoTypeArgumentDeclarationForKoFunctionTypeDeclarationProviderTest {
             it?.hasParameterType { parameter -> parameter.type.isExternalDeclaration } shouldBeEqualTo false
             it?.hasAllParameterTypes { parameter -> parameter.type.isKotlinType || parameter.type.isGenericType } shouldBeEqualTo true
             it?.hasAllParameterTypes { parameter -> parameter.type.isExternalDeclaration } shouldBeEqualTo false
+            it?.parameters?.map { parameter -> parameter.type.name } shouldBeEqualTo listOf("String", "List<Int>")
+            it?.numParameters shouldBeEqualTo 2
+            it?.countParameters { parameter -> parameter.type.isKotlinType } shouldBeEqualTo 2
+            it?.countParameters { parameter -> parameter.type.isKotlinCollectionType } shouldBeEqualTo 1
+            it?.countParameters { parameter -> parameter.type.isKotlinBasicType } shouldBeEqualTo 1
+            it?.countParameters { parameter -> parameter.type.isClass } shouldBeEqualTo 0
+            it?.hasParameter { parameter -> parameter.type.isKotlinType } shouldBeEqualTo true
+            it?.hasParameter { parameter -> parameter.type.isExternalDeclaration } shouldBeEqualTo false
+            it?.hasAllParameters { parameter -> parameter.type.isKotlinType || parameter.type.isGenericType } shouldBeEqualTo true
+            it?.hasAllParameters { parameter -> parameter.type.isExternalDeclaration } shouldBeEqualTo false
+        }
+    }
+
+    @Test
+    fun `parameters-list-has-one-element-with-name`() {
+        // given
+        val sut =
+            getSnippetFile("parameters-list-has-one-element-with-name")
+                .properties()
+                .first()
+                .type
+                ?.typeArguments
+                ?.firstOrNull()
+
+        // then
+        assertSoftly(sut) {
+            it?.parameterTypes?.map { parameter -> parameter.name } shouldBeEqualTo listOf("sampleParameter")
+            it?.parameterTypes?.map { parameter -> parameter.type.name } shouldBeEqualTo listOf("String")
+            it?.parameters?.map { parameter -> parameter.name } shouldBeEqualTo listOf("sampleParameter")
+            it?.parameters?.map { parameter -> parameter.type.name } shouldBeEqualTo listOf("String")
         }
     }
 

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/kotypeargument/snippet/forkofunctiontypedeclarationprovider/parameters-list-has-one-element-with-name.kttest
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/kotypeargument/snippet/forkofunctiontypedeclarationprovider/parameters-list-has-one-element-with-name.kttest
@@ -1,0 +1,1 @@
+val sampleProperty: List<(sampleParameter: String) -> Unit> = emptyList()

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/type/kotype/KoTypeDeclarationForKoFunctionTypeDeclarationProviderTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/type/kotype/KoTypeDeclarationForKoFunctionTypeDeclarationProviderTest.kt
@@ -25,6 +25,13 @@ class KoTypeDeclarationForKoFunctionTypeDeclarationProviderTest {
             it?.countParameterTypes { parameter -> parameter.type.isKotlinBasicType } shouldBeEqualTo 0
             it?.hasParameterType { parameter -> parameter.type.isKotlinType } shouldBeEqualTo false
             it?.hasAllParameterTypes { parameter -> parameter.type.isKotlinType } shouldBeEqualTo false
+            it?.parameters shouldBeEqualTo null
+            it?.numParameters shouldBeEqualTo 0
+            it?.countParameters { parameter -> parameter.type.isKotlinType } shouldBeEqualTo 0
+            it?.countParameters { parameter -> parameter.type.isKotlinCollectionType } shouldBeEqualTo 0
+            it?.countParameters { parameter -> parameter.type.isKotlinBasicType } shouldBeEqualTo 0
+            it?.hasParameter { parameter -> parameter.type.isKotlinType } shouldBeEqualTo false
+            it?.hasAllParameters { parameter -> parameter.type.isKotlinType } shouldBeEqualTo false
         }
     }
 
@@ -46,6 +53,13 @@ class KoTypeDeclarationForKoFunctionTypeDeclarationProviderTest {
             it?.countParameterTypes { parameter -> parameter.type.isKotlinBasicType } shouldBeEqualTo 0
             it?.hasParameterType { parameter -> parameter.type.isKotlinType } shouldBeEqualTo false
             it?.hasAllParameterTypes { parameter -> parameter.type.isKotlinType } shouldBeEqualTo true
+            it?.parameters shouldBeEqualTo emptyList()
+            it?.numParameters shouldBeEqualTo 0
+            it?.countParameters { parameter -> parameter.type.isKotlinType } shouldBeEqualTo 0
+            it?.countParameters { parameter -> parameter.type.isKotlinCollectionType } shouldBeEqualTo 0
+            it?.countParameters { parameter -> parameter.type.isKotlinBasicType } shouldBeEqualTo 0
+            it?.hasParameter { parameter -> parameter.type.isKotlinType } shouldBeEqualTo false
+            it?.hasAllParameters { parameter -> parameter.type.isKotlinType } shouldBeEqualTo true
         }
     }
 
@@ -70,6 +84,16 @@ class KoTypeDeclarationForKoFunctionTypeDeclarationProviderTest {
             it?.hasParameterType { parameter -> parameter.type.isExternalDeclaration } shouldBeEqualTo false
             it?.hasAllParameterTypes { parameter -> parameter.type.isKotlinType } shouldBeEqualTo true
             it?.hasAllParameterTypes { parameter -> parameter.type.isExternalDeclaration } shouldBeEqualTo false
+            it?.parameters?.map { parameter -> parameter.type.name } shouldBeEqualTo listOf("String")
+            it?.numParameters shouldBeEqualTo 1
+            it?.countParameters { parameter -> parameter.type.isKotlinType } shouldBeEqualTo 1
+            it?.countParameters { parameter -> parameter.type.isKotlinCollectionType } shouldBeEqualTo 0
+            it?.countParameters { parameter -> parameter.type.isKotlinBasicType } shouldBeEqualTo 1
+            it?.countParameters { parameter -> parameter.type.isClass } shouldBeEqualTo 0
+            it?.hasParameter { parameter -> parameter.type.isKotlinType } shouldBeEqualTo true
+            it?.hasParameter { parameter -> parameter.type.isExternalDeclaration } shouldBeEqualTo false
+            it?.hasAllParameters { parameter -> parameter.type.isKotlinType } shouldBeEqualTo true
+            it?.hasAllParameters { parameter -> parameter.type.isExternalDeclaration } shouldBeEqualTo false
         }
     }
 
@@ -94,6 +118,34 @@ class KoTypeDeclarationForKoFunctionTypeDeclarationProviderTest {
             it?.hasParameterType { parameter -> parameter.type.isExternalDeclaration } shouldBeEqualTo false
             it?.hasAllParameterTypes { parameter -> parameter.type.isKotlinType || parameter.type.isGenericType } shouldBeEqualTo true
             it?.hasAllParameterTypes { parameter -> parameter.type.isExternalDeclaration } shouldBeEqualTo false
+            it?.parameters?.map { parameter -> parameter.type.name } shouldBeEqualTo listOf("String", "List<Int>")
+            it?.numParameters shouldBeEqualTo 2
+            it?.countParameters { parameter -> parameter.type.isKotlinType } shouldBeEqualTo 2
+            it?.countParameters { parameter -> parameter.type.isKotlinCollectionType } shouldBeEqualTo 1
+            it?.countParameters { parameter -> parameter.type.isKotlinBasicType } shouldBeEqualTo 1
+            it?.countParameters { parameter -> parameter.type.isClass } shouldBeEqualTo 0
+            it?.hasParameter { parameter -> parameter.type.isKotlinType } shouldBeEqualTo true
+            it?.hasParameter { parameter -> parameter.type.isExternalDeclaration } shouldBeEqualTo false
+            it?.hasAllParameters { parameter -> parameter.type.isKotlinType || parameter.type.isGenericType } shouldBeEqualTo true
+            it?.hasAllParameters { parameter -> parameter.type.isExternalDeclaration } shouldBeEqualTo false
+        }
+    }
+
+    @Test
+    fun `parameters-list-has-one-element-with-name`() {
+        // given
+        val sut =
+            getSnippetFile("parameters-list-has-one-element-with-name")
+                .properties()
+                .first()
+                .type
+
+        // then
+        assertSoftly(sut) {
+            it?.parameterTypes?.map { parameter -> parameter.name } shouldBeEqualTo listOf("sampleParameter")
+            it?.parameterTypes?.map { parameter -> parameter.type.name } shouldBeEqualTo listOf("String")
+            it?.parameters?.map { parameter -> parameter.name } shouldBeEqualTo listOf("sampleParameter")
+            it?.parameters?.map { parameter -> parameter.type.name } shouldBeEqualTo listOf("String")
         }
     }
 

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/type/kotype/snippet/forkofunctiontypedeclarationprovider/parameters-list-has-one-element-with-name.kttest
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/type/kotype/snippet/forkofunctiontypedeclarationprovider/parameters-list-has-one-element-with-name.kttest
@@ -1,0 +1,1 @@
+val sampleProperty: (sampleParameter: String) -> Unit = { }

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/api/ext/list/KoFunctionTypeDeclarationProviderListExt.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/api/ext/list/KoFunctionTypeDeclarationProviderListExt.kt
@@ -14,9 +14,16 @@ val <T : KoFunctionTypeDeclarationProvider> List<T>.returnTypes: List<KoTypeDecl
 /**
  * Gets the list of parameter types for the function declarations in the list.
  */
+@Deprecated("Will be removed in version 0.19.0", ReplaceWith("parameters"))
 val <T : KoFunctionTypeDeclarationProvider> List<T>.parameterTypes: List<KoParameterDeclaration>
+    get() = parameters
+
+/**
+ * Gets the list of parameters for the function declarations in the list.
+ */
+val <T : KoFunctionTypeDeclarationProvider> List<T>.parameters: List<KoParameterDeclaration>
     get() =
-        mapNotNull { it.parameterTypes }
+        mapNotNull { it.parameters }
             .flatten()
 
 /**
@@ -95,10 +102,9 @@ fun <T : KoFunctionTypeDeclarationProvider> List<T>.withoutReturnTypeOf(kClasses
  * @param predicate A function that defines the condition to be met by the parameter type.
  * @return A list of function declarations that match the predicate for at least one parameter type.
  */
+@Deprecated("Will be removed in version 0.19.0", ReplaceWith("withParameter(predicate)"))
 fun <T : KoFunctionTypeDeclarationProvider> List<T>.withParameterType(predicate: (KoParameterDeclaration) -> Boolean): List<T> =
-    filter {
-        it.hasParameterType(predicate)
-    }
+    withParameter(predicate)
 
 /**
  * Filters the list by excluding functions that match the parameter type predicate.
@@ -106,8 +112,9 @@ fun <T : KoFunctionTypeDeclarationProvider> List<T>.withParameterType(predicate:
  * @param predicate A function that defines the condition to be met by the parameter type.
  * @return A list of function declarations that do not match the predicate for the parameter type.
  */
+@Deprecated("Will be removed in version 0.19.0", ReplaceWith("withoutParameter(predicate)"))
 fun <T : KoFunctionTypeDeclarationProvider> List<T>.withoutParameterType(predicate: (KoParameterDeclaration) -> Boolean): List<T> =
-    filterNot { it.hasParameterType(predicate) }
+    withoutParameter(predicate)
 
 /**
  * Filters the list by requiring that all parameter types match the given predicate.
@@ -115,10 +122,9 @@ fun <T : KoFunctionTypeDeclarationProvider> List<T>.withoutParameterType(predica
  * @param predicate A function that defines the condition to be met by all parameter types.
  * @return A list of function declarations where all parameter types match the given predicate.
  */
+@Deprecated("Will be removed in version 0.19.0", ReplaceWith("withAllParameters(predicate)"))
 fun <T : KoFunctionTypeDeclarationProvider> List<T>.withAllParameterTypes(predicate: (KoParameterDeclaration) -> Boolean): List<T> =
-    filter {
-        it.hasAllParameterTypes(predicate)
-    }
+    withAllParameters(predicate)
 
 /**
  * Filters the list by excluding functions where all parameter types match the given predicate.
@@ -126,8 +132,9 @@ fun <T : KoFunctionTypeDeclarationProvider> List<T>.withAllParameterTypes(predic
  * @param predicate A function that defines the condition to be met by all parameter types.
  * @return A list of function declarations where not all parameter types match the given predicate.
  */
+@Deprecated("Will be removed in version 0.19.0", ReplaceWith("withoutAllParameters(predicate)"))
 fun <T : KoFunctionTypeDeclarationProvider> List<T>.withoutAllParameterTypes(predicate: (KoParameterDeclaration) -> Boolean): List<T> =
-    filterNot { it.hasAllParameterTypes(predicate) }
+    withoutAllParameters(predicate)
 
 /**
  * Filters the list by parameter types as a collection using the given predicate.
@@ -135,8 +142,9 @@ fun <T : KoFunctionTypeDeclarationProvider> List<T>.withoutAllParameterTypes(pre
  * @param predicate A function that defines the condition to be met by the list of parameter types.
  * @return A list of function declarations that match the predicate for the list of parameter types.
  */
+@Deprecated("Will be removed in version 0.19.0", ReplaceWith("withParameters(predicate)"))
 fun <T : KoFunctionTypeDeclarationProvider> List<T>.withParameterTypes(predicate: (List<KoParameterDeclaration>) -> Boolean): List<T> =
-    filter { it.parameterTypes?.let { parameterTypes -> predicate(parameterTypes) } == true }
+    withParameters(predicate)
 
 /**
  * Filters the list by excluding functions that match the parameter types predicate as a collection.
@@ -144,5 +152,60 @@ fun <T : KoFunctionTypeDeclarationProvider> List<T>.withParameterTypes(predicate
  * @param predicate A function that defines the condition to be met by the list of parameter types.
  * @return A list of function declarations that do not match the predicate for the list of parameter types.
  */
+@Deprecated("Will be removed in version 0.19.0", ReplaceWith("withoutParameters(predicate)"))
 fun <T : KoFunctionTypeDeclarationProvider> List<T>.withoutParameterTypes(predicate: (List<KoParameterDeclaration>) -> Boolean): List<T> =
-    filterNot { it.parameterTypes?.let { parameterTypes -> predicate(parameterTypes) } == true }
+    withoutParameters(predicate)
+
+/**
+ * Filters the list by parameter using the given predicate.
+ *
+ * @param predicate A function that defines the condition to be met by the parameter.
+ * @return A list of function declarations that match the predicate for at least one parameter.
+ */
+fun <T : KoFunctionTypeDeclarationProvider> List<T>.withParameter(predicate: (KoParameterDeclaration) -> Boolean): List<T> =
+    filter { it.hasParameter(predicate) }
+
+/**
+ * Filters the list by excluding functions that match the parameter predicate.
+ *
+ * @param predicate A function that defines the condition to be met by the parameter.
+ * @return A list of function declarations that do not match the predicate for the parameter.
+ */
+fun <T : KoFunctionTypeDeclarationProvider> List<T>.withoutParameter(predicate: (KoParameterDeclaration) -> Boolean): List<T> =
+    filterNot { it.hasParameter(predicate) }
+
+/**
+ * Filters the list by requiring that all parameters match the given predicate.
+ *
+ * @param predicate A function that defines the condition to be met by all parameters.
+ * @return A list of function declarations where all parameters match the given predicate.
+ */
+fun <T : KoFunctionTypeDeclarationProvider> List<T>.withAllParameters(predicate: (KoParameterDeclaration) -> Boolean): List<T> =
+    filter { it.hasAllParameters(predicate) }
+
+/**
+ * Filters the list by excluding functions where all parameters match the given predicate.
+ *
+ * @param predicate A function that defines the condition to be met by all parameters.
+ * @return A list of function declarations where not all parameters match the given predicate.
+ */
+fun <T : KoFunctionTypeDeclarationProvider> List<T>.withoutAllParameters(predicate: (KoParameterDeclaration) -> Boolean): List<T> =
+    filterNot { it.hasAllParameters(predicate) }
+
+/**
+ * Filters the list by parameters as a collection using the given predicate.
+ *
+ * @param predicate A function that defines the condition to be met by the list of parameters.
+ * @return A list of function declarations that match the predicate for the list of parameters.
+ */
+fun <T : KoFunctionTypeDeclarationProvider> List<T>.withParameters(predicate: (List<KoParameterDeclaration>) -> Boolean): List<T> =
+    filter { it.parameters?.let { parameters -> predicate(parameters) } == true }
+
+/**
+ * Filters the list by excluding functions that match the parameters predicate as a collection.
+ *
+ * @param predicate A function that defines the condition to be met by the list of parameters.
+ * @return A list of function declarations that do not match the predicate for the list of parameters.
+ */
+fun <T : KoFunctionTypeDeclarationProvider> List<T>.withoutParameters(predicate: (List<KoParameterDeclaration>) -> Boolean): List<T> =
+    filterNot { it.parameters?.let { parameters -> predicate(parameters) } == true }

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/api/provider/KoFunctionTypeDeclarationProvider.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/api/provider/KoFunctionTypeDeclarationProvider.kt
@@ -11,12 +11,24 @@ interface KoFunctionTypeDeclarationProvider : KoBaseProvider {
     /**
      * Represents the parameters of the function type.
      */
+    @Deprecated("Will be removed in version 0.19.0", ReplaceWith("parameters"))
     val parameterTypes: List<KoParameterDeclaration>?
 
     /**
      * The number of parameters for the function type.
      */
+    @Deprecated("Will be removed in version 0.19.0", ReplaceWith("numParameters"))
     val numParameterTypes: Int
+
+    /**
+     * Represents the parameters of the function type.
+     */
+    val parameters: List<KoParameterDeclaration>?
+
+    /**
+     * The number of parameters for the function type.
+     */
+    val numParameters: Int
 
     /**
      * Represents the return type of the function type.
@@ -29,6 +41,7 @@ interface KoFunctionTypeDeclarationProvider : KoBaseProvider {
      * @param predicate A function that evaluates each parameter declaration.
      * @return The number of parameters that match the predicate.
      */
+    @Deprecated("Will be removed in version 0.19.0", ReplaceWith("countParameters"))
     fun countParameterTypes(predicate: (KoParameterDeclaration) -> Boolean): Int
 
     /**
@@ -37,6 +50,7 @@ interface KoFunctionTypeDeclarationProvider : KoBaseProvider {
      * @param predicate A function that evaluates each parameter declaration.
      * @return `true` if any parameter type matches the predicate, otherwise `false`.
      */
+    @Deprecated("Will be removed in version 0.19.0", ReplaceWith("hasParameter"))
     fun hasParameterType(predicate: (KoParameterDeclaration) -> Boolean): Boolean
 
     /**
@@ -45,7 +59,32 @@ interface KoFunctionTypeDeclarationProvider : KoBaseProvider {
      * @param predicate A function that evaluates each parameter declaration.
      * @return `true` if all parameter types match the predicate, otherwise `false`.
      */
+    @Deprecated("Will be removed in version 0.19.0", ReplaceWith("hasAllParameters"))
     fun hasAllParameterTypes(predicate: (KoParameterDeclaration) -> Boolean): Boolean
+
+    /**
+     * Counts the number of parameters that match the given predicate.
+     *
+     * @param predicate A function that evaluates each parameter declaration.
+     * @return The number of parameters that match the predicate.
+     */
+    fun countParameters(predicate: (KoParameterDeclaration) -> Boolean): Int
+
+    /**
+     * Checks if any parameter matches the given predicate.
+     *
+     * @param predicate A function that evaluates each parameter declaration.
+     * @return `true` if any parameter matches the predicate, otherwise `false`.
+     */
+    fun hasParameter(predicate: (KoParameterDeclaration) -> Boolean): Boolean
+
+    /**
+     * Checks if all parameters match the given predicate.
+     *
+     * @param predicate A function that evaluates each parameter declaration.
+     * @return `true` if all parameters match the predicate, otherwise `false`.
+     */
+    fun hasAllParameters(predicate: (KoParameterDeclaration) -> Boolean): Boolean
 
     /**
      * Checks if the return type matches the given predicate.

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/KoFunctionTypeDeclarationProviderCore.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/KoFunctionTypeDeclarationProviderCore.kt
@@ -17,7 +17,15 @@ internal interface KoFunctionTypeDeclarationProviderCore :
     KoBaseProviderCore {
     val ktFunctionType: KtFunctionType?
 
+    @Deprecated("Will be removed in version 0.19.0", replaceWith = ReplaceWith("parameters"))
     override val parameterTypes: List<KoParameterDeclaration>?
+        get() = parameters
+
+    @Deprecated("Will be removed in version 0.19.0", replaceWith = ReplaceWith("numParameters"))
+    override val numParameterTypes: Int
+        get() = numParameters
+
+    override val parameters: List<KoParameterDeclaration>?
         get() =
             ktFunctionType
                 ?.children
@@ -26,8 +34,8 @@ internal interface KoFunctionTypeDeclarationProviderCore :
                 ?.filterIsInstance<KtParameter>()
                 ?.map { KoParameterDeclarationCore.getInstance(it, this.castToKoBaseDeclaration()) }
 
-    override val numParameterTypes: Int
-        get() = parameterTypes?.size ?: 0
+    override val numParameters: Int
+        get() = parameters?.size ?: 0
 
     override val returnType: KoTypeDeclaration?
         get() {
@@ -40,9 +48,18 @@ internal interface KoFunctionTypeDeclarationProviderCore :
 
     override fun hasReturnTypeOf(kClass: KClass<*>): Boolean = hasTypeOf(returnType, kClass)
 
-    override fun countParameterTypes(predicate: (KoParameterDeclaration) -> Boolean): Int = parameterTypes?.count { predicate(it) } ?: 0
+    @Deprecated("Will be removed in version 0.19.0", replaceWith = ReplaceWith("countParameters"))
+    override fun countParameterTypes(predicate: (KoParameterDeclaration) -> Boolean): Int = countParameters(predicate)
 
-    override fun hasParameterType(predicate: (KoParameterDeclaration) -> Boolean): Boolean = parameterTypes?.any(predicate) ?: false
+    @Deprecated("Will be removed in version 0.19.0", replaceWith = ReplaceWith("hasParameter"))
+    override fun hasParameterType(predicate: (KoParameterDeclaration) -> Boolean): Boolean = hasParameter(predicate)
 
-    override fun hasAllParameterTypes(predicate: (KoParameterDeclaration) -> Boolean): Boolean = parameterTypes?.all(predicate) ?: false
+    @Deprecated("Will be removed in version 0.19.0", replaceWith = ReplaceWith("hasAllParameters"))
+    override fun hasAllParameterTypes(predicate: (KoParameterDeclaration) -> Boolean): Boolean = hasAllParameters(predicate)
+
+    override fun countParameters(predicate: (KoParameterDeclaration) -> Boolean): Int = parameters?.count { predicate(it) } ?: 0
+
+    override fun hasParameter(predicate: (KoParameterDeclaration) -> Boolean): Boolean = parameters?.any(predicate) ?: false
+
+    override fun hasAllParameters(predicate: (KoParameterDeclaration) -> Boolean): Boolean = parameters?.all(predicate) ?: false
 }

--- a/lib/src/test/kotlin/com/lemonappdev/konsist/api/ext/list/KoFunctionTypeDeclarationProviderListExtTest.kt
+++ b/lib/src/test/kotlin/com/lemonappdev/konsist/api/ext/list/KoFunctionTypeDeclarationProviderListExtTest.kt
@@ -356,6 +356,191 @@ class KoFunctionTypeDeclarationProviderListExtTest {
     }
 
     @Test
+    fun `parameters returns parameters from all declarations`() {
+        // given
+        val parameter1: KoParameterDeclaration = mockk()
+        val parameter2: KoParameterDeclaration = mockk()
+        val parameter3: KoParameterDeclaration = mockk()
+        val declaration1: KoFunctionTypeDeclarationProvider =
+            mockk {
+                every { parameters } returns listOf(parameter1, parameter2)
+            }
+        val declaration2: KoFunctionTypeDeclarationProvider =
+            mockk {
+                every { parameters } returns listOf(parameter3)
+            }
+        val declaration3: KoFunctionTypeDeclarationProvider =
+            mockk {
+                every { parameters } returns emptyList()
+            }
+        val declarations = listOf(declaration1, declaration2, declaration3)
+
+        // when
+        val sut = declarations.parameters
+
+        // then
+        sut shouldBeEqualTo listOf(parameter1, parameter2, parameter3)
+    }
+
+    @Test
+    fun `withParameter{} returns declaration with parameter which satisfy predicate`() {
+        // given
+        val suffix = "Name"
+        val predicate: (KoParameterDeclaration) -> Boolean = { it.hasNameEndingWith(suffix) }
+        val declaration1: KoFunctionTypeDeclarationProvider =
+            mockk {
+                every { hasParameter(predicate) } returns true
+            }
+        val declaration2: KoFunctionTypeDeclarationProvider =
+            mockk {
+                every { hasParameter(predicate) } returns false
+            }
+        val declarations = listOf(declaration1, declaration2)
+
+        // when
+        val sut = declarations.withParameter(predicate)
+
+        // then
+        sut shouldBeEqualTo listOf(declaration1)
+    }
+
+    @Test
+    fun `withoutParameter{} returns declaration without parameter which satisfy predicate`() {
+        // given
+        val suffix = "Name"
+        val predicate: (KoParameterDeclaration) -> Boolean = { it.hasNameEndingWith(suffix) }
+        val declaration1: KoFunctionTypeDeclarationProvider =
+            mockk {
+                every { hasParameter(predicate) } returns true
+            }
+        val declaration2: KoFunctionTypeDeclarationProvider =
+            mockk {
+                every { hasParameter(predicate) } returns false
+            }
+        val declarations = listOf(declaration1, declaration2)
+
+        // when
+        val sut = declarations.withoutParameter(predicate)
+
+        // then
+        sut shouldBeEqualTo listOf(declaration2)
+    }
+
+    @Test
+    fun `withAllParameters{} returns declaration with all parameters satisfy predicate`() {
+        // given
+        val suffix = "Name"
+        val predicate: (KoParameterDeclaration) -> Boolean = { it.hasNameEndingWith(suffix) }
+        val declaration1: KoFunctionTypeDeclarationProvider =
+            mockk {
+                every { hasAllParameters(predicate) } returns true
+            }
+        val declaration2: KoFunctionTypeDeclarationProvider =
+            mockk {
+                every { hasAllParameters(predicate) } returns false
+            }
+        val declarations = listOf(declaration1, declaration2)
+
+        // when
+        val sut = declarations.withAllParameters(predicate)
+
+        // then
+        sut shouldBeEqualTo listOf(declaration1)
+    }
+
+    @Test
+    fun `withoutAllParameters{} returns declaration with all parameters which not satisfy predicate`() {
+        // given
+        val suffix = "Name"
+        val predicate: (KoParameterDeclaration) -> Boolean = { it.hasNameEndingWith(suffix) }
+        val declaration1: KoFunctionTypeDeclarationProvider =
+            mockk {
+                every { hasAllParameters(predicate) } returns true
+            }
+        val declaration2: KoFunctionTypeDeclarationProvider =
+            mockk {
+                every { hasAllParameters(predicate) } returns false
+            }
+        val declarations = listOf(declaration1, declaration2)
+
+        // when
+        val sut = declarations.withoutAllParameters(predicate)
+
+        // then
+        sut shouldBeEqualTo listOf(declaration2)
+    }
+
+    @Test
+    fun `withParameter{} returns declaration with parameters which satisfy predicate`() {
+        // given
+        val suffix = "Name"
+        val predicate: (List<KoParameterDeclaration>) -> Boolean =
+            { it.all { argument -> argument.hasNameEndingWith(suffix) } }
+        val parameter1: KoParameterDeclaration =
+            mockk {
+                every { hasNameEndingWith(suffix) } returns true
+            }
+        val parameter2: KoParameterDeclaration =
+            mockk {
+                every { hasNameEndingWith(suffix) } returns false
+            }
+        val declaration1: KoFunctionTypeDeclarationProvider =
+            mockk {
+                every { parameters } returns listOf(parameter1)
+            }
+        val declaration2: KoFunctionTypeDeclarationProvider =
+            mockk {
+                every { parameters } returns listOf(parameter2)
+            }
+        val declaration3: KoFunctionTypeDeclarationProvider =
+            mockk {
+                every { parameters } returns emptyList()
+            }
+        val declarations = listOf(declaration1, declaration2, declaration3)
+
+        // when
+        val sut = declarations.withParameters(predicate)
+
+        // then
+        sut shouldBeEqualTo listOf(declaration1, declaration3)
+    }
+
+    @Test
+    fun `withoutParameter{} returns declaration without parameters which satisfy predicate`() {
+        // given
+        val suffix = "Name"
+        val predicate: (List<KoParameterDeclaration>) -> Boolean =
+            { it.all { argument -> argument.hasNameEndingWith(suffix) } }
+        val parameter1: KoParameterDeclaration =
+            mockk {
+                every { hasNameEndingWith(suffix) } returns true
+            }
+        val parameter2: KoParameterDeclaration =
+            mockk {
+                every { hasNameEndingWith(suffix) } returns false
+            }
+        val declaration1: KoFunctionTypeDeclarationProvider =
+            mockk {
+                every { parameters } returns listOf(parameter1)
+            }
+        val declaration2: KoFunctionTypeDeclarationProvider =
+            mockk {
+                every { parameters } returns listOf(parameter2)
+            }
+        val declaration3: KoFunctionTypeDeclarationProvider =
+            mockk {
+                every { parameters } returns emptyList()
+            }
+        val declarations = listOf(declaration1, declaration2, declaration3)
+
+        // when
+        val sut = declarations.withoutParameters(predicate)
+
+        // then
+        sut shouldBeEqualTo listOf(declaration2)
+    }
+
+    @Test
     fun `parameterTypes returns parameter types from all declarations`() {
         // given
         val parameterType1: KoParameterDeclaration = mockk()
@@ -363,15 +548,15 @@ class KoFunctionTypeDeclarationProviderListExtTest {
         val parameterType3: KoParameterDeclaration = mockk()
         val declaration1: KoFunctionTypeDeclarationProvider =
             mockk {
-                every { parameterTypes } returns listOf(parameterType1, parameterType2)
+                every { parameters } returns listOf(parameterType1, parameterType2)
             }
         val declaration2: KoFunctionTypeDeclarationProvider =
             mockk {
-                every { parameterTypes } returns listOf(parameterType3)
+                every { parameters } returns listOf(parameterType3)
             }
         val declaration3: KoFunctionTypeDeclarationProvider =
             mockk {
-                every { parameterTypes } returns emptyList()
+                every { parameters } returns emptyList()
             }
         val declarations = listOf(declaration1, declaration2, declaration3)
 
@@ -389,11 +574,11 @@ class KoFunctionTypeDeclarationProviderListExtTest {
         val predicate: (KoParameterDeclaration) -> Boolean = { it.hasNameEndingWith(suffix) }
         val declaration1: KoFunctionTypeDeclarationProvider =
             mockk {
-                every { hasParameterType(predicate) } returns true
+                every { hasParameter(predicate) } returns true
             }
         val declaration2: KoFunctionTypeDeclarationProvider =
             mockk {
-                every { hasParameterType(predicate) } returns false
+                every { hasParameter(predicate) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
 
@@ -411,11 +596,11 @@ class KoFunctionTypeDeclarationProviderListExtTest {
         val predicate: (KoParameterDeclaration) -> Boolean = { it.hasNameEndingWith(suffix) }
         val declaration1: KoFunctionTypeDeclarationProvider =
             mockk {
-                every { hasParameterType(predicate) } returns true
+                every { hasParameter(predicate) } returns true
             }
         val declaration2: KoFunctionTypeDeclarationProvider =
             mockk {
-                every { hasParameterType(predicate) } returns false
+                every { hasParameter(predicate) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
 
@@ -433,11 +618,11 @@ class KoFunctionTypeDeclarationProviderListExtTest {
         val predicate: (KoParameterDeclaration) -> Boolean = { it.hasNameEndingWith(suffix) }
         val declaration1: KoFunctionTypeDeclarationProvider =
             mockk {
-                every { hasAllParameterTypes(predicate) } returns true
+                every { hasAllParameters(predicate) } returns true
             }
         val declaration2: KoFunctionTypeDeclarationProvider =
             mockk {
-                every { hasAllParameterTypes(predicate) } returns false
+                every { hasAllParameters(predicate) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
 
@@ -455,11 +640,11 @@ class KoFunctionTypeDeclarationProviderListExtTest {
         val predicate: (KoParameterDeclaration) -> Boolean = { it.hasNameEndingWith(suffix) }
         val declaration1: KoFunctionTypeDeclarationProvider =
             mockk {
-                every { hasAllParameterTypes(predicate) } returns true
+                every { hasAllParameters(predicate) } returns true
             }
         val declaration2: KoFunctionTypeDeclarationProvider =
             mockk {
-                every { hasAllParameterTypes(predicate) } returns false
+                every { hasAllParameters(predicate) } returns false
             }
         val declarations = listOf(declaration1, declaration2)
 
@@ -486,15 +671,15 @@ class KoFunctionTypeDeclarationProviderListExtTest {
             }
         val declaration1: KoFunctionTypeDeclarationProvider =
             mockk {
-                every { parameterTypes } returns listOf(parameterType1)
+                every { parameters } returns listOf(parameterType1)
             }
         val declaration2: KoFunctionTypeDeclarationProvider =
             mockk {
-                every { parameterTypes } returns listOf(parameterType2)
+                every { parameters } returns listOf(parameterType2)
             }
         val declaration3: KoFunctionTypeDeclarationProvider =
             mockk {
-                every { parameterTypes } returns emptyList()
+                every { parameters } returns emptyList()
             }
         val declarations = listOf(declaration1, declaration2, declaration3)
 
@@ -521,15 +706,15 @@ class KoFunctionTypeDeclarationProviderListExtTest {
             }
         val declaration1: KoFunctionTypeDeclarationProvider =
             mockk {
-                every { parameterTypes } returns listOf(parameterType1)
+                every { parameters } returns listOf(parameterType1)
             }
         val declaration2: KoFunctionTypeDeclarationProvider =
             mockk {
-                every { parameterTypes } returns listOf(parameterType2)
+                every { parameters } returns listOf(parameterType2)
             }
         val declaration3: KoFunctionTypeDeclarationProvider =
             mockk {
-                every { parameterTypes } returns emptyList()
+                every { parameters } returns emptyList()
             }
         val declarations = listOf(declaration1, declaration2, declaration3)
 


### PR DESCRIPTION
In this PR, all methods related to `parameterTypes` in `KoFunctionTypeDeclarationProvider` have been deprecated. Instead, equivalent methods with the name `parameters` have been added to the provider. Similar changes have been applied to the extensions for this provider.

// Example 1 
```kotlin
// Before
scope
	.functions()
	.returnTypes
	.assertTrue { it.parameterTypes?.isEmpty() }
	
// After
scope
	.functions()
	.returnTypes
	.assertTrue { it.parameters?.isEmpty() }
```

// Example 2 
```kotlin
// Before
scope
	.functions()
	.returnTypes
	.assertTrue { it.countParameterTypes { param -> param.name == "sampleParameter" } == 1 } 
	
// After
scope
	.functions()
	.returnTypes
	.assertTrue { it.countParameters { param -> param.name == "sampleParameter" } == 1 } 
```

// Example 3 
```kotlin
// Before
scope
	.functions()
	.returnTypes
	.withParameterType { it.name == "sampleParameter" } 
	.assertTrue { ... } 
	
// After
scope
	.functions()
	.returnTypes
	.withParameter { it.name == "sampleParameter" } 
	.assertTrue { ... } 
```


