### PR TITLE
KON-679 Allow To Call Layer Dependency Method On Collections

### DIFF
--- a/lib/src/konsistTest/kotlin/com/lemonappdev/konsist/core/EnumKonsistTest.kt
+++ b/lib/src/konsistTest/kotlin/com/lemonappdev/konsist/core/EnumKonsistTest.kt
@@ -9,7 +9,7 @@ import org.junit.jupiter.api.Test
 
 class EnumKonsistTest {
     @Test
-    fun `enums consts are defined interface alphabetical order `() {
+    fun `enums consts are defined interface alphabetical order`() {
         Konsist
             .scopeFromProduction()
             .classes()

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/api/architecture/LayerDependencies.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/api/architecture/LayerDependencies.kt
@@ -39,12 +39,41 @@ interface LayerDependencies {
     ): Unit
 
     /**
+     * Adds dependencies between each layer in the collection and the specified layer.
+     *
+     * Example usage:
+     * ```
+     * val layers = setOf(domainLayer, dataLayer)
+     * layers.dependsOn(presentationLayer)
+     * ```
+     *
+     * @receiver The collection of [Layer]s that depends on other layer.
+     * @param layer The layer that the collection of layers depends on.
+     */
+    fun Collection<Layer>.dependsOn(layer: Layer): Unit
+
+    /**
      * Specifies that the current layer does not depend on the given list of layers.
      *
      * @param layers The list of layers that the current layer does not depend on.
      * @receiver The [Layer] that does not depend on other layers.
      */
     fun Layer.doesNotDependOn(layers: Set<Layer>): Unit
+
+    /**
+     * Adds dependencies between each layer in the collection and the specified layers.
+     *
+     * Example usage:
+     * ```
+     * val sourceLayers = setOf(domainLayer, dataLayer)
+     * val targetLayers = setOf(presentationLayer, infrastructureLayer)
+     * sourceLayers.dependsOn(targetLayers)
+     * ```
+     *
+     * @receiver The collection of [Layer]s that depends on other layers.
+     * @param layers The set of layers that the collection of layers depends on.
+     */
+    fun Collection<Layer>.dependsOn(layers: Set<Layer>): Unit
 
     /**
      * Specifies that the current layer does not depend on any other layer.
@@ -56,6 +85,49 @@ interface LayerDependencies {
     fun Layer.dependsOnNothing(): Unit
 
     /**
+     * Specifies that none of the layers in the collection depend on any other layer.
+     *
+     * Example usage:
+     * ```
+     * val layers = setOf(domainLayer, dataLayer)
+     * layers.dependsOnNothing()
+     * ```
+     *
+     * @receiver The collection of [Layer]s that should not depend on any other layer.
+     * @see include
+     */
+    fun Collection<Layer>.dependsOnNothing(): Unit
+
+    /**
+     * Specifies that none of the layers in the collection depend on the specified layer.
+     *
+     * Example usage:
+     * ```
+     * val layers = setOf(domainLayer, dataLayer)
+     * layers.doesNotDependOn(presentationLayer)
+     * ```
+     *
+     * @receiver The collection of [Layer]s that do not depend on the specified layer.
+     * @param layer The layer that none of the collection layers should depend on.
+     */
+    fun Collection<Layer>.doesNotDependOn(layer: Layer): Unit
+
+    /**
+     * Specifies that none of the layers in the collection depend on any of the specified layers.
+     *
+     * Example usage:
+     * ```
+     * val sourceLayers = setOf(domainLayer, dataLayer)
+     * val targetLayers = setOf(presentationLayer, infrastructureLayer)
+     * sourceLayers.doesNotDependOn(targetLayers)
+     * ```
+     *
+     * @receiver The collection of [Layer]s that do not depend on the specified layers.
+     * @param layers The set of layers that none of the collection layers should depend on.
+     */
+    fun Collection<Layer>.doesNotDependOn(layers: Set<Layer>): Unit
+
+    /**
      * This function is used to include a Layer in the architecture without specifying any dependencies.
      * It can be used in combination with dependsOnNothing() to specify that a layer does not depend on any other layer.
      *
@@ -63,4 +135,18 @@ interface LayerDependencies {
      * @return The LayerDependenciesCore instance for chaining
      */
     fun Layer.include(): Unit
+
+    /**
+     * Includes all layers from the collection in the architecture without specifying any dependencies.
+     * This can be used in combination with dependsOnNothing() to specify that multiple layers do not depend on any other layer.
+     *
+     * Example usage:
+     * ```
+     * val layers = setOf(domainLayer, dataLayer)
+     * layers.include()
+     * ```
+     *
+     * @receiver The collection of [Layer]s to be included in the architecture.
+     */
+    fun Collection<Layer>.include(): Unit
 }

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/core/architecture/LayerDependenciesCore.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/core/architecture/LayerDependenciesCore.kt
@@ -17,7 +17,7 @@ internal class LayerDependenciesCore(
     internal val dependsOnDependencies: Map<Layer, Set<Layer>>
         get() =
             layerDependencies
-                .filter { it.dependencyType == LayerDependencyType.DEPEND_ON_LAYER }
+                .filter { it.dependencyType == LayerDependencyType.DEPENDS_ON_LAYER }
                 .groupBy { it.layer1 }
                 .mapValues { (_, dependencies) ->
                     dependencies.mapNotNull { it.layer2 }.toSet()
@@ -87,10 +87,18 @@ internal class LayerDependenciesCore(
         }
 
         layers.forEach {
-            addLayerDependency(this, LayerDependencyType.DEPEND_ON_LAYER, it)
+            addLayerDependency(this, LayerDependencyType.DEPENDS_ON_LAYER, it)
         }
 
         layerValidatorManager.validateLayerDependencies(layerDependencies)
+    }
+
+    override fun Collection<Layer>.dependsOn(layer: Layer) {
+        forEach { it.dependsOn(layer) }
+    }
+
+    override fun Collection<Layer>.dependsOn(layers: Set<Layer>) {
+        forEach { it.dependsOn(layers) }
     }
 
     private fun getLayersMessage(layers: Set<Layer>) =
@@ -131,6 +139,14 @@ internal class LayerDependenciesCore(
         layerValidatorManager.validateLayerDependencies(layerDependencies)
     }
 
+    override fun Collection<Layer>.doesNotDependOn(layer: Layer) {
+        forEach { it.doesNotDependOn(layer) }
+    }
+
+    override fun Collection<Layer>.doesNotDependOn(layers: Set<Layer>) {
+        forEach { it.doesNotDependOn(layers) }
+    }
+
     override fun Layer.dependsOnNothing() {
         val dependOnLayerDependencies = getLayersWithDependOnLayerDependency(this)
         val dependOnLayers =
@@ -151,9 +167,17 @@ internal class LayerDependenciesCore(
         layerValidatorManager.validateLayerDependencies(layerDependencies)
     }
 
+    override fun Collection<Layer>.dependsOnNothing() {
+        forEach { it.dependsOnNothing() }
+    }
+
     override fun Layer.include() {
         layers.add(this)
         layerDependencies.add(LayerDependency(this, LayerDependencyType.NONE, null))
+    }
+
+    override fun Collection<Layer>.include() {
+        forEach { it.include() }
     }
 
     private fun getLayerWithDependOnNothingDependency(layer: Layer): LayerDependency? {
@@ -167,7 +191,7 @@ internal class LayerDependenciesCore(
     private fun getLayersWithDependOnLayerDependency(layer: Layer): Set<LayerDependency> {
         val dependOnLayerDependency =
             layerDependencies.filter {
-                it.layer1 == layer && it.dependencyType == LayerDependencyType.DEPEND_ON_LAYER
+                it.layer1 == layer && it.dependencyType == LayerDependencyType.DEPENDS_ON_LAYER
             }
 
         return dependOnLayerDependency.toSet()

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/core/architecture/LayerDependency.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/core/architecture/LayerDependency.kt
@@ -8,7 +8,7 @@ internal data class LayerDependency(
     val layer2: Layer? = null,
 ) {
     init {
-        require(!((dependencyType == LayerDependencyType.DEPEND_ON_LAYER) && layer2 == null)) {
+        require(!((dependencyType == LayerDependencyType.DEPENDS_ON_LAYER) && layer2 == null)) {
             "layer2 cannot be null when dependency type is DEPEND_ON_LAYER"
         }
     }

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/core/architecture/LayerDependencyType.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/core/architecture/LayerDependencyType.kt
@@ -1,8 +1,9 @@
 package com.lemonappdev.konsist.core.architecture
 
 internal enum class LayerDependencyType {
-    DEPENDS_ON_LAYER,
     DEPEND_ON_NOTHING,
+    DEPENDS_ON_LAYER,
     DOES_NOT_DEPEND_ON_LAYER,
     NONE,
 }
+

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/core/architecture/LayerDependencyType.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/core/architecture/LayerDependencyType.kt
@@ -1,7 +1,7 @@
 package com.lemonappdev.konsist.core.architecture
 
 internal enum class LayerDependencyType {
-    DEPEND_ON_LAYER,
+    DEPENDS_ON_LAYER,
     DEPEND_ON_NOTHING,
     DOES_NOT_DEPEND_ON_LAYER,
     NONE,

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/core/architecture/LayerDependencyType.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/core/architecture/LayerDependencyType.kt
@@ -6,4 +6,3 @@ internal enum class LayerDependencyType {
     DOES_NOT_DEPEND_ON_LAYER,
     NONE,
 }
-

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/core/architecture/validator/rule/CircularDependencyDependenciesRule.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/core/architecture/validator/rule/CircularDependencyDependenciesRule.kt
@@ -26,7 +26,7 @@ internal class CircularDependencyDependenciesRule : LayerDependenciesRule {
 
     private fun buildDependencyGraph(dependencies: Set<LayerDependency>): Map<Layer, Set<Layer>> =
         dependencies
-            .filter { it.dependencyType == LayerDependencyType.DEPEND_ON_LAYER && it.layer2 != null }
+            .filter { it.dependencyType == LayerDependencyType.DEPENDS_ON_LAYER && it.layer2 != null }
             .groupBy { it.layer1 }
             .mapValues { (_, deps) -> deps.mapNotNull { it.layer2 }.toSet() }
 

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/core/architecture/validator/rule/DependOnLayerThenDependentOnNothingRule.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/core/architecture/validator/rule/DependOnLayerThenDependentOnNothingRule.kt
@@ -8,7 +8,7 @@ internal class DependOnLayerThenDependentOnNothingRule : LayerDependenciesRule {
     override fun validate(layerDependencies: Set<LayerDependency>) {
         val layersWithDependencies =
             layerDependencies
-                .filter { it.dependencyType == LayerDependencyType.DEPEND_ON_LAYER }
+                .filter { it.dependencyType == LayerDependencyType.DEPENDS_ON_LAYER }
                 .map { it.layer1 }
 
         val conflictingDependencies =

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/core/architecture/validator/rule/DependentOnNothingThenDependOnLayerDependenciesRule.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/core/architecture/validator/rule/DependentOnNothingThenDependOnLayerDependenciesRule.kt
@@ -13,7 +13,7 @@ internal class DependentOnNothingThenDependOnLayerDependenciesRule : LayerDepend
 
         val conflictingDependencies =
             layerDependencies
-                .filter { it.dependencyType == LayerDependencyType.DEPEND_ON_LAYER && independentLayers.contains(it.layer1) }
+                .filter { it.dependencyType == LayerDependencyType.DEPENDS_ON_LAYER && independentLayers.contains(it.layer1) }
 
         if (conflictingDependencies.isNotEmpty()) {
             val violations =

--- a/lib/src/test/kotlin/com/lemonappdev/konsist/core/architecture/LayerDependenciesCoreTest.kt
+++ b/lib/src/test/kotlin/com/lemonappdev/konsist/core/architecture/LayerDependenciesCoreTest.kt
@@ -387,8 +387,8 @@ class LayerDependenciesCoreTest {
         // then
         sut.layerDependencies shouldContainAll
             setOf(
-                LayerDependency(layer1, LayerDependencyType.DEPEND_ON_LAYER, layer2),
-                LayerDependency(layer1, LayerDependencyType.DEPEND_ON_LAYER, layer3),
+                LayerDependency(layer1, LayerDependencyType.DEPENDS_ON_LAYER, layer2),
+                LayerDependency(layer1, LayerDependencyType.DEPENDS_ON_LAYER, layer3),
             )
     }
 
@@ -816,6 +816,130 @@ class LayerDependenciesCoreTest {
         sut.layers shouldContain layer2
         sut.layerDependencies shouldContain LayerDependency(layer1, LayerDependencyType.NONE, null)
         sut.layerDependencies shouldContain LayerDependency(layer2, LayerDependencyType.NONE, null)
+    }
+    // endregion
+
+    // region Collection<Layer> dependencies
+    @Test
+    fun `collection dependsOn single layer creates dependencies for all layers in collection`() {
+        // given
+        val sut = LayerDependenciesCore()
+        val sourceLayer1 = Layer("Domain", "com.example.domain..")
+        val sourceLayer2 = Layer("Data", "com.example.data..")
+        val targetLayer = Layer("Presentation", "com.example.presentation..")
+        val sourceLayers = setOf(sourceLayer1, sourceLayer2)
+
+        // when
+        with(sut) {
+            sourceLayers.dependsOn(targetLayer)
+        }
+
+        // then
+        sut.layerDependencies shouldContain LayerDependency(sourceLayer1, LayerDependencyType.DEPENDS_ON_LAYER, targetLayer)
+        sut.layerDependencies shouldContain LayerDependency(sourceLayer2, LayerDependencyType.DEPENDS_ON_LAYER, targetLayer)
+    }
+
+    @Test
+    fun `collection dependsOn set of layers creates dependencies for all combinations`() {
+        // given
+        val sut = LayerDependenciesCore()
+        val sourceLayer1 = Layer("Domain", "com.example.domain..")
+        val sourceLayer2 = Layer("Data", "com.example.data..")
+        val targetLayer1 = Layer("Presentation", "com.example.presentation..")
+        val targetLayer2 = Layer("Infrastructure", "com.example.infrastructure..")
+        val sourceLayers = setOf(sourceLayer1, sourceLayer2)
+        val targetLayers = setOf(targetLayer1, targetLayer2)
+
+        // when
+        with(sut) {
+            sourceLayers.dependsOn(targetLayers)
+        }
+
+        // then
+        sut.layerDependencies shouldContain LayerDependency(sourceLayer1, LayerDependencyType.DEPENDS_ON_LAYER, targetLayer1)
+        sut.layerDependencies shouldContain LayerDependency(sourceLayer1, LayerDependencyType.DEPENDS_ON_LAYER, targetLayer2)
+        sut.layerDependencies shouldContain LayerDependency(sourceLayer2, LayerDependencyType.DEPENDS_ON_LAYER, targetLayer1)
+        sut.layerDependencies shouldContain LayerDependency(sourceLayer2, LayerDependencyType.DEPENDS_ON_LAYER, targetLayer2)
+    }
+
+    @Test
+    fun `collection dependsOnNothing creates dependencies for all layers in collection`() {
+        // given
+        val sut = LayerDependenciesCore()
+        val sourceLayer1 = Layer("Domain", "com.example.domain..")
+        val sourceLayer2 = Layer("Data", "com.example.data..")
+        val sourceLayers = setOf(sourceLayer1, sourceLayer2)
+
+        // when
+        with(sut) {
+            sourceLayers.dependsOnNothing()
+        }
+
+        // then
+        sut.layerDependencies shouldContain LayerDependency(sourceLayer1, LayerDependencyType.DEPEND_ON_NOTHING, null)
+        sut.layerDependencies shouldContain LayerDependency(sourceLayer2, LayerDependencyType.DEPEND_ON_NOTHING, null)
+    }
+
+    @Test
+    fun `collection include adds all layers to layers collection`() {
+        // given
+        val sut = LayerDependenciesCore()
+        val layer1 = Layer("Domain", "com.example.domain..")
+        val layer2 = Layer("Data", "com.example.data..")
+        val layers = setOf(layer1, layer2)
+
+        // when
+        with(sut) {
+            layers.include()
+        }
+
+        // then
+        sut.layers shouldContain layer1
+        sut.layers shouldContain layer2
+        sut.layerDependencies shouldContain LayerDependency(layer1, LayerDependencyType.NONE, null)
+        sut.layerDependencies shouldContain LayerDependency(layer2, LayerDependencyType.NONE, null)
+    }
+
+    @Test
+    fun `collection doesNotDependOn single layer creates dependencies for all layers in collection`() {
+        // given
+        val sut = LayerDependenciesCore()
+        val sourceLayer1 = Layer("Domain", "com.example.domain..")
+        val sourceLayer2 = Layer("Data", "com.example.data..")
+        val targetLayer = Layer("Presentation", "com.example.presentation..")
+        val sourceLayers = setOf(sourceLayer1, sourceLayer2)
+
+        // when
+        with(sut) {
+            sourceLayers.doesNotDependOn(targetLayer)
+        }
+
+        // then
+        sut.layerDependencies shouldContain LayerDependency(sourceLayer1, LayerDependencyType.DOES_NOT_DEPEND_ON_LAYER, targetLayer)
+        sut.layerDependencies shouldContain LayerDependency(sourceLayer2, LayerDependencyType.DOES_NOT_DEPEND_ON_LAYER, targetLayer)
+    }
+
+    @Test
+    fun `collection doesNotDependOn set of layers creates dependencies for all combinations`() {
+        // given
+        val sut = LayerDependenciesCore()
+        val sourceLayer1 = Layer("Domain", "com.example.domain..")
+        val sourceLayer2 = Layer("Data", "com.example.data..")
+        val targetLayer1 = Layer("Presentation", "com.example.presentation..")
+        val targetLayer2 = Layer("Infrastructure", "com.example.infrastructure..")
+        val sourceLayers = setOf(sourceLayer1, sourceLayer2)
+        val targetLayers = setOf(targetLayer1, targetLayer2)
+
+        // when
+        with(sut) {
+            sourceLayers.doesNotDependOn(targetLayers)
+        }
+
+        // then
+        sut.layerDependencies shouldContain LayerDependency(sourceLayer1, LayerDependencyType.DOES_NOT_DEPEND_ON_LAYER, targetLayer1)
+        sut.layerDependencies shouldContain LayerDependency(sourceLayer1, LayerDependencyType.DOES_NOT_DEPEND_ON_LAYER, targetLayer2)
+        sut.layerDependencies shouldContain LayerDependency(sourceLayer2, LayerDependencyType.DOES_NOT_DEPEND_ON_LAYER, targetLayer1)
+        sut.layerDependencies shouldContain LayerDependency(sourceLayer2, LayerDependencyType.DOES_NOT_DEPEND_ON_LAYER, targetLayer2)
     }
     // endregion
 }

--- a/lib/src/test/kotlin/com/lemonappdev/konsist/core/architecture/LayerDependencyTest.kt
+++ b/lib/src/test/kotlin/com/lemonappdev/konsist/core/architecture/LayerDependencyTest.kt
@@ -13,7 +13,7 @@ class LayerDependencyTest {
         val layer2 = Layer("layer2", "package2..")
 
         // when / Then
-        LayerDependency(layer1, LayerDependencyType.DEPEND_ON_LAYER, layer2) // Should not throw
+        LayerDependency(layer1, LayerDependencyType.DEPENDS_ON_LAYER, layer2) // Should not throw
     }
 
     @Test
@@ -34,7 +34,7 @@ class LayerDependencyTest {
         val layer1 = Layer("layer1", "package1..")
 
         // when
-        val func = { LayerDependency(layer1, LayerDependencyType.DEPEND_ON_LAYER, null) }
+        val func = { LayerDependency(layer1, LayerDependencyType.DEPENDS_ON_LAYER, null) }
 
         // then
         func shouldThrow IllegalArgumentException::class withMessage "layer2 cannot be null when dependency type is DEPEND_ON_LAYER"

--- a/lib/src/test/kotlin/com/lemonappdev/konsist/core/architecture/validator/rule/CircularDependencyDependenciesRuleTest.kt
+++ b/lib/src/test/kotlin/com/lemonappdev/konsist/core/architecture/validator/rule/CircularDependencyDependenciesRuleTest.kt
@@ -23,12 +23,12 @@ class CircularDependencyDependenciesRuleTest {
                 LayerDependency(
                     layer1 = layer1,
                     layer2 = layer2,
-                    dependencyType = LayerDependencyType.DEPEND_ON_LAYER,
+                    dependencyType = LayerDependencyType.DEPENDS_ON_LAYER,
                 ),
                 LayerDependency(
                     layer1 = layer2,
                     layer2 = layer3,
-                    dependencyType = LayerDependencyType.DEPEND_ON_LAYER,
+                    dependencyType = LayerDependencyType.DEPENDS_ON_LAYER,
                 ),
             )
 
@@ -50,12 +50,12 @@ class CircularDependencyDependenciesRuleTest {
                 LayerDependency(
                     layer1 = layer1,
                     layer2 = layer2,
-                    dependencyType = LayerDependencyType.DEPEND_ON_LAYER,
+                    dependencyType = LayerDependencyType.DEPENDS_ON_LAYER,
                 ),
                 LayerDependency(
                     layer1 = layer2,
                     layer2 = layer1,
-                    dependencyType = LayerDependencyType.DEPEND_ON_LAYER,
+                    dependencyType = LayerDependencyType.DEPENDS_ON_LAYER,
                 ),
             )
 
@@ -102,22 +102,22 @@ class CircularDependencyDependenciesRuleTest {
                 LayerDependency(
                     layer1 = layer1,
                     layer2 = layer2,
-                    dependencyType = LayerDependencyType.DEPEND_ON_LAYER,
+                    dependencyType = LayerDependencyType.DEPENDS_ON_LAYER,
                 ),
                 LayerDependency(
                     layer1 = layer2,
                     layer2 = layer3,
-                    dependencyType = LayerDependencyType.DEPEND_ON_LAYER,
+                    dependencyType = LayerDependencyType.DEPENDS_ON_LAYER,
                 ),
                 LayerDependency(
                     layer1 = layer3,
                     layer2 = layer4,
-                    dependencyType = LayerDependencyType.DEPEND_ON_LAYER,
+                    dependencyType = LayerDependencyType.DEPENDS_ON_LAYER,
                 ),
                 LayerDependency(
                     layer1 = layer4,
                     layer2 = layer1,
-                    dependencyType = LayerDependencyType.DEPEND_ON_LAYER,
+                    dependencyType = LayerDependencyType.DEPENDS_ON_LAYER,
                 ),
             )
 

--- a/lib/src/test/kotlin/com/lemonappdev/konsist/core/architecture/validator/rule/DependOnLayerThenDependentOnNothingRuleTest.kt
+++ b/lib/src/test/kotlin/com/lemonappdev/konsist/core/architecture/validator/rule/DependOnLayerThenDependentOnNothingRuleTest.kt
@@ -27,7 +27,7 @@ class DependOnLayerThenDependentOnNothingRuleTest {
                 LayerDependency(
                     layer1 = layer,
                     layer2 = dependentLayer,
-                    dependencyType = LayerDependencyType.DEPEND_ON_LAYER,
+                    dependencyType = LayerDependencyType.DEPENDS_ON_LAYER,
                 ),
                 LayerDependency(
                     layer1 = layer,
@@ -65,12 +65,12 @@ class DependOnLayerThenDependentOnNothingRuleTest {
                 LayerDependency(
                     layer1 = layer1,
                     layer2 = dependentLayer,
-                    dependencyType = LayerDependencyType.DEPEND_ON_LAYER,
+                    dependencyType = LayerDependencyType.DEPENDS_ON_LAYER,
                 ),
                 LayerDependency(
                     layer1 = layer2,
                     layer2 = dependentLayer,
-                    dependencyType = LayerDependencyType.DEPEND_ON_LAYER,
+                    dependencyType = LayerDependencyType.DEPENDS_ON_LAYER,
                 ),
                 LayerDependency(
                     layer1 = layer1,
@@ -109,7 +109,7 @@ class DependOnLayerThenDependentOnNothingRuleTest {
                 LayerDependency(
                     layer1 = layer,
                     layer2 = dependentLayer,
-                    dependencyType = LayerDependencyType.DEPEND_ON_LAYER,
+                    dependencyType = LayerDependencyType.DEPENDS_ON_LAYER,
                 ),
             )
 

--- a/lib/src/test/kotlin/com/lemonappdev/konsist/core/architecture/validator/rule/DependentOnNothingThenDependOnLayerDependenciesRuleTest.kt
+++ b/lib/src/test/kotlin/com/lemonappdev/konsist/core/architecture/validator/rule/DependentOnNothingThenDependOnLayerDependenciesRuleTest.kt
@@ -32,7 +32,7 @@ class DependentOnNothingThenDependOnLayerDependenciesRuleTest {
                 LayerDependency(
                     layer1 = layer,
                     layer2 = dependentLayer,
-                    dependencyType = LayerDependencyType.DEPEND_ON_LAYER,
+                    dependencyType = LayerDependencyType.DEPENDS_ON_LAYER,
                 ),
             )
 
@@ -77,12 +77,12 @@ class DependentOnNothingThenDependOnLayerDependenciesRuleTest {
                 LayerDependency(
                     layer1 = layer1,
                     layer2 = dependentLayer1,
-                    dependencyType = LayerDependencyType.DEPEND_ON_LAYER,
+                    dependencyType = LayerDependencyType.DEPENDS_ON_LAYER,
                 ),
                 LayerDependency(
                     layer1 = layer2,
                     layer2 = dependentLayer2,
-                    dependencyType = LayerDependencyType.DEPEND_ON_LAYER,
+                    dependencyType = LayerDependencyType.DEPENDS_ON_LAYER,
                 ),
             )
 
@@ -111,7 +111,7 @@ class DependentOnNothingThenDependOnLayerDependenciesRuleTest {
                 LayerDependency(
                     layer1 = layer,
                     layer2 = dependentLayer,
-                    dependencyType = LayerDependencyType.DEPEND_ON_LAYER,
+                    dependencyType = LayerDependencyType.DEPENDS_ON_LAYER,
                 ),
             )
 

--- a/lib/src/test/kotlin/com/lemonappdev/konsist/core/architecture/validator/rule/UniqueLayerRuleTest.kt
+++ b/lib/src/test/kotlin/com/lemonappdev/konsist/core/architecture/validator/rule/UniqueLayerRuleTest.kt
@@ -46,7 +46,7 @@ class UniqueLayerRuleTest {
             setOf(
                 LayerDependency(
                     layer1 = layer1,
-                    dependencyType = LayerDependencyType.DEPEND_ON_LAYER,
+                    dependencyType = LayerDependencyType.DEPENDS_ON_LAYER,
                     layer2 = layer2,
                 ),
             )
@@ -88,7 +88,7 @@ class UniqueLayerRuleTest {
             setOf(
                 LayerDependency(
                     layer1 = layer1,
-                    dependencyType = LayerDependencyType.DEPEND_ON_LAYER,
+                    dependencyType = LayerDependencyType.DEPENDS_ON_LAYER,
                     layer2 = layer2,
                 ),
             )
@@ -127,7 +127,7 @@ class UniqueLayerRuleTest {
             setOf(
                 LayerDependency(
                     layer1 = layer1,
-                    dependencyType = LayerDependencyType.DEPEND_ON_LAYER,
+                    dependencyType = LayerDependencyType.DEPENDS_ON_LAYER,
                     layer2 = layer2,
                 ),
             )
@@ -166,7 +166,7 @@ class UniqueLayerRuleTest {
             setOf(
                 LayerDependency(
                     layer1 = layer1,
-                    dependencyType = LayerDependencyType.DEPEND_ON_LAYER,
+                    dependencyType = LayerDependencyType.DEPENDS_ON_LAYER,
                     layer2 = layer2,
                 ),
             )
@@ -221,7 +221,7 @@ class UniqueLayerRuleTest {
             setOf(
                 LayerDependency(
                     layer1 = layer1,
-                    dependencyType = LayerDependencyType.DEPEND_ON_LAYER,
+                    dependencyType = LayerDependencyType.DEPENDS_ON_LAYER,
                     layer2 = layer2,
                 ),
                 LayerDependency(
@@ -250,12 +250,12 @@ class UniqueLayerRuleTest {
             setOf(
                 LayerDependency(
                     layer1 = layer1,
-                    dependencyType = LayerDependencyType.DEPEND_ON_LAYER,
+                    dependencyType = LayerDependencyType.DEPENDS_ON_LAYER,
                     layer2 = layer2,
                 ),
                 LayerDependency(
                     layer1 = layer1,
-                    dependencyType = LayerDependencyType.DEPEND_ON_LAYER,
+                    dependencyType = LayerDependencyType.DEPENDS_ON_LAYER,
                     layer2 = layer3,
                 ),
                 LayerDependency(
@@ -281,7 +281,7 @@ class UniqueLayerRuleTest {
             setOf(
                 LayerDependency(
                     layer1 = layer1,
-                    dependencyType = LayerDependencyType.DEPEND_ON_LAYER,
+                    dependencyType = LayerDependencyType.DEPENDS_ON_LAYER,
                     layer2 = layer1,
                 ),
             )
@@ -306,12 +306,12 @@ class UniqueLayerRuleTest {
             setOf(
                 LayerDependency(
                     layer1 = layer1,
-                    dependencyType = LayerDependencyType.DEPEND_ON_LAYER,
+                    dependencyType = LayerDependencyType.DEPENDS_ON_LAYER,
                     layer2 = layer2,
                 ),
                 LayerDependency(
                     layer1 = layer2,
-                    dependencyType = LayerDependencyType.DEPEND_ON_LAYER,
+                    dependencyType = LayerDependencyType.DEPENDS_ON_LAYER,
                     layer2 = layer3,
                 ),
                 LayerDependency(
@@ -321,7 +321,7 @@ class UniqueLayerRuleTest {
                 ),
                 LayerDependency(
                     layer1 = layer4,
-                    dependencyType = LayerDependencyType.DEPEND_ON_LAYER,
+                    dependencyType = LayerDependencyType.DEPENDS_ON_LAYER,
                     layer2 = layer1,
                 ),
             )
@@ -345,7 +345,7 @@ class UniqueLayerRuleTest {
             setOf(
                 LayerDependency(
                     layer1 = layer1,
-                    dependencyType = LayerDependencyType.DEPEND_ON_LAYER,
+                    dependencyType = LayerDependencyType.DEPENDS_ON_LAYER,
                     layer2 = layer2,
                 ),
                 LayerDependency(
@@ -377,12 +377,12 @@ class UniqueLayerRuleTest {
             setOf(
                 LayerDependency(
                     layer1 = layer1,
-                    dependencyType = LayerDependencyType.DEPEND_ON_LAYER,
+                    dependencyType = LayerDependencyType.DEPENDS_ON_LAYER,
                     layer2 = layer2,
                 ),
                 LayerDependency(
                     layer1 = layer2,
-                    dependencyType = LayerDependencyType.DEPEND_ON_LAYER,
+                    dependencyType = LayerDependencyType.DEPENDS_ON_LAYER,
                     layer2 = layer1,
                 ),
             )


### PR DESCRIPTION
```kotlin
val sourceLayer1 = Layer("Domain", "com.example.domain..")
val sourceLayer2 = Layer("Data", "com.example.data..")
val sourceLayers = setOf(sourceLayer1, sourceLayer2)

val targetLayer = Layer("Presentation", "com.example.presentation..")

...
assertArchitecture {
      // Call dependsOn, doesNotDependOn, dependsOnNothing, include on collections
       sourceLayers.dependsOn(targetLayer)
}
```