### PR TITLE
KON-680 Rename `isGenericType` to `isGeneric`

### DIFF
--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koclass/KoClassDeclarationForKoTypeParameterProviderTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koclass/KoClassDeclarationForKoTypeParameterProviderTest.kt
@@ -114,7 +114,7 @@ class KoClassDeclarationForKoTypeParameterProviderTest {
             hasTypeParameter { it.name == "T" } shouldBeEqualTo true
             hasTypeParameter { param -> param.isTypeParameter } shouldBeEqualTo true
             hasAllTypeParameters { it.name == "T" || it.name == "V" } shouldBeEqualTo true
-            hasAllTypeParameters { param -> param.isExternalDeclaration } shouldBeEqualTo false
+            hasAllTypeParameters { param -> param.isExternal } shouldBeEqualTo false
         }
     }
 

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/kofunction/KoFunctionDeclarationForKoTypeParameterProviderTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/kofunction/KoFunctionDeclarationForKoTypeParameterProviderTest.kt
@@ -114,7 +114,7 @@ class KoFunctionDeclarationForKoTypeParameterProviderTest {
             hasTypeParameter { it.name == "T" } shouldBeEqualTo true
             hasTypeParameter { param -> param.isTypeParameter } shouldBeEqualTo true
             hasAllTypeParameters { it.name == "T" || it.name == "V" } shouldBeEqualTo true
-            hasAllTypeParameters { param -> param.isExternalDeclaration } shouldBeEqualTo false
+            hasAllTypeParameters { param -> param.isExternal } shouldBeEqualTo false
         }
     }
 

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/kointerface/KoInterfaceDeclarationForKoTypeParameterProviderTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/kointerface/KoInterfaceDeclarationForKoTypeParameterProviderTest.kt
@@ -114,7 +114,7 @@ class KoInterfaceDeclarationForKoTypeParameterProviderTest {
             hasTypeParameter { it.name == "T" } shouldBeEqualTo true
             hasTypeParameter { param -> param.isTypeParameter } shouldBeEqualTo true
             hasAllTypeParameters { it.name == "T" || it.name == "V" } shouldBeEqualTo true
-            hasAllTypeParameters { param -> param.isExternalDeclaration } shouldBeEqualTo false
+            hasAllTypeParameters { param -> param.isExternal } shouldBeEqualTo false
         }
     }
 

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koparent/KoParentDeclarationForKoDeclarationCastProviderTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koparent/KoParentDeclarationForKoDeclarationCastProviderTest.kt
@@ -49,7 +49,7 @@ class KoParentDeclarationForKoDeclarationCastProviderTest {
             isKotlinBasicType shouldBeEqualTo false
             isKotlinCollectionType shouldBeEqualTo false
             isTypeParameter shouldBeEqualTo false
-            isExternalDeclaration shouldBeEqualTo false
+            isExternal shouldBeEqualTo false
             asClassDeclaration() shouldBeInstanceOf KoClassDeclaration::class
             hasClassDeclaration() shouldBeEqualTo true
             hasClassDeclaration { decl -> decl.name == "SampleSuperClass" } shouldBeEqualTo true
@@ -109,7 +109,7 @@ class KoParentDeclarationForKoDeclarationCastProviderTest {
             isKotlinBasicType shouldBeEqualTo false
             isKotlinCollectionType shouldBeEqualTo false
             isTypeParameter shouldBeEqualTo false
-            isExternalDeclaration shouldBeEqualTo false
+            isExternal shouldBeEqualTo false
             asClassDeclaration() shouldBeInstanceOf KoClassDeclaration::class
             hasClassDeclaration() shouldBeEqualTo true
             hasClassDeclaration { decl -> decl.name == "SampleGenericSuperClass" } shouldBeEqualTo true
@@ -169,7 +169,7 @@ class KoParentDeclarationForKoDeclarationCastProviderTest {
             isKotlinBasicType shouldBeEqualTo false
             isKotlinCollectionType shouldBeEqualTo false
             isTypeParameter shouldBeEqualTo false
-            isExternalDeclaration shouldBeEqualTo false
+            isExternal shouldBeEqualTo false
             asClassDeclaration() shouldBeInstanceOf KoClassDeclaration::class
             hasClassDeclaration() shouldBeEqualTo true
             hasClassDeclaration { decl -> decl.name == "SampleParametrizedSuperClass" } shouldBeEqualTo true
@@ -229,7 +229,7 @@ class KoParentDeclarationForKoDeclarationCastProviderTest {
             isKotlinBasicType shouldBeEqualTo false
             isKotlinCollectionType shouldBeEqualTo false
             isTypeParameter shouldBeEqualTo false
-            isExternalDeclaration shouldBeEqualTo false
+            isExternal shouldBeEqualTo false
             asClassDeclaration() shouldBeInstanceOf KoClassDeclaration::class
             hasClassDeclaration() shouldBeEqualTo true
             hasClassDeclaration { decl -> decl.name == "SampleParametrizedSuperClass" } shouldBeEqualTo true
@@ -289,7 +289,7 @@ class KoParentDeclarationForKoDeclarationCastProviderTest {
             isKotlinBasicType shouldBeEqualTo false
             isKotlinCollectionType shouldBeEqualTo false
             isTypeParameter shouldBeEqualTo false
-            isExternalDeclaration shouldBeEqualTo false
+            isExternal shouldBeEqualTo false
             asClassDeclaration() shouldBeEqualTo null
             hasClassDeclaration() shouldBeEqualTo false
             hasClassDeclaration { decl -> decl.name == "SampleSuperInterface" } shouldBeEqualTo false
@@ -349,7 +349,7 @@ class KoParentDeclarationForKoDeclarationCastProviderTest {
             isKotlinBasicType shouldBeEqualTo false
             isKotlinCollectionType shouldBeEqualTo false
             isTypeParameter shouldBeEqualTo false
-            isExternalDeclaration shouldBeEqualTo false
+            isExternal shouldBeEqualTo false
             asClassDeclaration() shouldBeEqualTo null
             hasClassDeclaration() shouldBeEqualTo false
             hasClassDeclaration { decl -> decl.name == "SampleGenericSuperInterface" } shouldBeEqualTo false
@@ -409,7 +409,7 @@ class KoParentDeclarationForKoDeclarationCastProviderTest {
             isKotlinBasicType shouldBeEqualTo false
             isKotlinCollectionType shouldBeEqualTo false
             isTypeParameter shouldBeEqualTo false
-            isExternalDeclaration shouldBeEqualTo false
+            isExternal shouldBeEqualTo false
             asClassDeclaration() shouldBeEqualTo null
             hasClassDeclaration() shouldBeEqualTo false
             hasClassDeclaration { decl -> decl.name == "SampleSuperInterface" } shouldBeEqualTo false
@@ -469,7 +469,7 @@ class KoParentDeclarationForKoDeclarationCastProviderTest {
             isKotlinBasicType shouldBeEqualTo false
             isKotlinCollectionType shouldBeEqualTo false
             isTypeParameter shouldBeEqualTo false
-            isExternalDeclaration shouldBeEqualTo false
+            isExternal shouldBeEqualTo false
             asClassDeclaration() shouldBeInstanceOf KoClassDeclaration::class
             hasClassDeclaration() shouldBeEqualTo true
             hasClassDeclaration { decl -> decl.name == "SampleParentClass" } shouldBeEqualTo true
@@ -537,7 +537,7 @@ class KoParentDeclarationForKoDeclarationCastProviderTest {
             isKotlinBasicType shouldBeEqualTo false
             isKotlinCollectionType shouldBeEqualTo false
             isTypeParameter shouldBeEqualTo false
-            isExternalDeclaration shouldBeEqualTo false
+            isExternal shouldBeEqualTo false
             asClassDeclaration() shouldBeInstanceOf KoClassDeclaration::class
             hasClassDeclaration() shouldBeEqualTo true
             hasClassDeclaration { decl -> decl.name == "SampleCollection1" } shouldBeEqualTo true
@@ -605,7 +605,7 @@ class KoParentDeclarationForKoDeclarationCastProviderTest {
             isKotlinBasicType shouldBeEqualTo false
             isKotlinCollectionType shouldBeEqualTo false
             isTypeParameter shouldBeEqualTo false
-            isExternalDeclaration shouldBeEqualTo false
+            isExternal shouldBeEqualTo false
             asClassDeclaration() shouldBeInstanceOf KoClassDeclaration::class
             hasClassDeclaration() shouldBeEqualTo true
             hasClassDeclaration { decl -> decl.name == "SampleClassWithParameter" } shouldBeEqualTo true
@@ -673,7 +673,7 @@ class KoParentDeclarationForKoDeclarationCastProviderTest {
             isKotlinBasicType shouldBeEqualTo false
             isKotlinCollectionType shouldBeEqualTo false
             isTypeParameter shouldBeEqualTo false
-            isExternalDeclaration shouldBeEqualTo false
+            isExternal shouldBeEqualTo false
             asClassDeclaration() shouldBeInstanceOf KoClassDeclaration::class
             hasClassDeclaration() shouldBeEqualTo true
             hasClassDeclaration { decl -> decl.name == "SampleGenericClassWithParameter" } shouldBeEqualTo true
@@ -741,7 +741,7 @@ class KoParentDeclarationForKoDeclarationCastProviderTest {
             isKotlinBasicType shouldBeEqualTo false
             isKotlinCollectionType shouldBeEqualTo false
             isTypeParameter shouldBeEqualTo false
-            isExternalDeclaration shouldBeEqualTo false
+            isExternal shouldBeEqualTo false
             asClassDeclaration() shouldBeEqualTo null
             hasClassDeclaration() shouldBeEqualTo false
             hasClassDeclaration { decl -> decl.name == "SampleInterface" } shouldBeEqualTo false
@@ -801,7 +801,7 @@ class KoParentDeclarationForKoDeclarationCastProviderTest {
             isKotlinBasicType shouldBeEqualTo false
             isKotlinCollectionType shouldBeEqualTo false
             isTypeParameter shouldBeEqualTo false
-            isExternalDeclaration shouldBeEqualTo false
+            isExternal shouldBeEqualTo false
             asClassDeclaration() shouldBeEqualTo null
             hasClassDeclaration() shouldBeEqualTo false
             hasClassDeclaration { decl -> decl.name == "SampleGenericSuperInterface" } shouldBeEqualTo false
@@ -861,7 +861,7 @@ class KoParentDeclarationForKoDeclarationCastProviderTest {
             isKotlinBasicType shouldBeEqualTo false
             isKotlinCollectionType shouldBeEqualTo false
             isTypeParameter shouldBeEqualTo false
-            isExternalDeclaration shouldBeEqualTo false
+            isExternal shouldBeEqualTo false
             asClassDeclaration() shouldBeEqualTo null
             hasClassDeclaration() shouldBeEqualTo false
             hasClassDeclaration { decl -> decl.name == "SampleInterface" } shouldBeEqualTo false
@@ -921,7 +921,7 @@ class KoParentDeclarationForKoDeclarationCastProviderTest {
             isKotlinBasicType shouldBeEqualTo false
             isKotlinCollectionType shouldBeEqualTo false
             isTypeParameter shouldBeEqualTo false
-            isExternalDeclaration shouldBeEqualTo true
+            isExternal shouldBeEqualTo true
             asClassDeclaration() shouldBeEqualTo null
             hasClassDeclaration() shouldBeEqualTo false
             hasClassDeclaration { decl -> decl.name == "SampleExternalClass" } shouldBeEqualTo false
@@ -982,7 +982,7 @@ class KoParentDeclarationForKoDeclarationCastProviderTest {
             isKotlinBasicType shouldBeEqualTo false
             isKotlinCollectionType shouldBeEqualTo false
             isTypeParameter shouldBeEqualTo false
-            isExternalDeclaration shouldBeEqualTo true
+            isExternal shouldBeEqualTo true
             asClassDeclaration() shouldBeEqualTo null
             hasClassDeclaration() shouldBeEqualTo false
             hasClassDeclaration { decl -> decl.name == "SampleExternalGenericClass" } shouldBeEqualTo false
@@ -1043,7 +1043,7 @@ class KoParentDeclarationForKoDeclarationCastProviderTest {
             isKotlinBasicType shouldBeEqualTo false
             isKotlinCollectionType shouldBeEqualTo false
             isTypeParameter shouldBeEqualTo false
-            isExternalDeclaration shouldBeEqualTo true
+            isExternal shouldBeEqualTo true
             asClassDeclaration() shouldBeEqualTo null
             hasClassDeclaration() shouldBeEqualTo false
             hasClassDeclaration { decl -> decl.name == "SampleExternalClassWithParameter" } shouldBeEqualTo false
@@ -1104,7 +1104,7 @@ class KoParentDeclarationForKoDeclarationCastProviderTest {
             isKotlinBasicType shouldBeEqualTo false
             isKotlinCollectionType shouldBeEqualTo false
             isTypeParameter shouldBeEqualTo false
-            isExternalDeclaration shouldBeEqualTo true
+            isExternal shouldBeEqualTo true
             asClassDeclaration() shouldBeEqualTo null
             hasClassDeclaration() shouldBeEqualTo false
             hasClassDeclaration { decl -> decl.name == "SampleExternalGenericClassWithParameter" } shouldBeEqualTo false
@@ -1165,7 +1165,7 @@ class KoParentDeclarationForKoDeclarationCastProviderTest {
             isKotlinBasicType shouldBeEqualTo false
             isKotlinCollectionType shouldBeEqualTo false
             isTypeParameter shouldBeEqualTo false
-            isExternalDeclaration shouldBeEqualTo true
+            isExternal shouldBeEqualTo true
             asClassDeclaration() shouldBeEqualTo null
             hasClassDeclaration() shouldBeEqualTo false
             hasClassDeclaration { decl -> decl.name == "SampleExternalInterface" } shouldBeEqualTo false
@@ -1226,7 +1226,7 @@ class KoParentDeclarationForKoDeclarationCastProviderTest {
             isKotlinBasicType shouldBeEqualTo false
             isKotlinCollectionType shouldBeEqualTo false
             isTypeParameter shouldBeEqualTo false
-            isExternalDeclaration shouldBeEqualTo true
+            isExternal shouldBeEqualTo true
             asClassDeclaration() shouldBeEqualTo null
             hasClassDeclaration() shouldBeEqualTo false
             hasClassDeclaration { decl -> decl.name == "SampleExternalGenericInterface" } shouldBeEqualTo false
@@ -1287,7 +1287,7 @@ class KoParentDeclarationForKoDeclarationCastProviderTest {
             isKotlinBasicType shouldBeEqualTo false
             isKotlinCollectionType shouldBeEqualTo false
             isTypeParameter shouldBeEqualTo false
-            isExternalDeclaration shouldBeEqualTo true
+            isExternal shouldBeEqualTo true
             asClassDeclaration() shouldBeEqualTo null
             hasClassDeclaration() shouldBeEqualTo false
             hasClassDeclaration { decl -> decl.name == "SampleExternalInterface" } shouldBeEqualTo false
@@ -1348,7 +1348,7 @@ class KoParentDeclarationForKoDeclarationCastProviderTest {
             isKotlinBasicType shouldBeEqualTo false
             isKotlinCollectionType shouldBeEqualTo false
             isTypeParameter shouldBeEqualTo false
-            isExternalDeclaration shouldBeEqualTo false
+            isExternal shouldBeEqualTo false
             asClassDeclaration() shouldBeEqualTo null
             hasClassDeclaration() shouldBeEqualTo false
             hasClassDeclaration { decl -> decl.name == "SampleTypeAlias" } shouldBeEqualTo false
@@ -1409,7 +1409,7 @@ class KoParentDeclarationForKoDeclarationCastProviderTest {
             isKotlinBasicType shouldBeEqualTo false
             isKotlinCollectionType shouldBeEqualTo false
             isTypeParameter shouldBeEqualTo false
-            isExternalDeclaration shouldBeEqualTo false
+            isExternal shouldBeEqualTo false
             asClassDeclaration() shouldBeEqualTo null
             hasClassDeclaration() shouldBeEqualTo false
             hasClassDeclaration { decl -> decl.name == "SampleImportAlias" } shouldBeEqualTo false
@@ -1470,7 +1470,7 @@ class KoParentDeclarationForKoDeclarationCastProviderTest {
             isKotlinBasicType shouldBeEqualTo false
             isKotlinCollectionType shouldBeEqualTo false
             isTypeParameter shouldBeEqualTo false
-            isExternalDeclaration shouldBeEqualTo false
+            isExternal shouldBeEqualTo false
             asClassDeclaration() shouldBeEqualTo null
             hasClassDeclaration() shouldBeEqualTo false
             hasClassDeclaration { decl -> decl.name == "SampleSuperInterface" } shouldBeEqualTo false
@@ -1530,7 +1530,7 @@ class KoParentDeclarationForKoDeclarationCastProviderTest {
             isKotlinBasicType shouldBeEqualTo false
             isKotlinCollectionType shouldBeEqualTo false
             isTypeParameter shouldBeEqualTo false
-            isExternalDeclaration shouldBeEqualTo false
+            isExternal shouldBeEqualTo false
             asClassDeclaration() shouldBeEqualTo null
             hasClassDeclaration() shouldBeEqualTo false
             hasClassDeclaration { decl -> decl.name == "SampleGenericSuperInterface" } shouldBeEqualTo false
@@ -1590,7 +1590,7 @@ class KoParentDeclarationForKoDeclarationCastProviderTest {
             isKotlinBasicType shouldBeEqualTo false
             isKotlinCollectionType shouldBeEqualTo false
             isTypeParameter shouldBeEqualTo false
-            isExternalDeclaration shouldBeEqualTo false
+            isExternal shouldBeEqualTo false
             asClassDeclaration() shouldBeEqualTo null
             hasClassDeclaration() shouldBeEqualTo false
             hasClassDeclaration { decl -> decl.name == "SampleParentInterface" } shouldBeEqualTo false
@@ -1650,7 +1650,7 @@ class KoParentDeclarationForKoDeclarationCastProviderTest {
             isKotlinBasicType shouldBeEqualTo false
             isKotlinCollectionType shouldBeEqualTo false
             isTypeParameter shouldBeEqualTo false
-            isExternalDeclaration shouldBeEqualTo false
+            isExternal shouldBeEqualTo false
             asClassDeclaration() shouldBeEqualTo null
             hasClassDeclaration() shouldBeEqualTo false
             hasClassDeclaration { decl -> decl.name == "SampleGenericSuperInterface" } shouldBeEqualTo false
@@ -1710,7 +1710,7 @@ class KoParentDeclarationForKoDeclarationCastProviderTest {
             isKotlinBasicType shouldBeEqualTo false
             isKotlinCollectionType shouldBeEqualTo false
             isTypeParameter shouldBeEqualTo false
-            isExternalDeclaration shouldBeEqualTo true
+            isExternal shouldBeEqualTo true
             asClassDeclaration() shouldBeEqualTo null
             hasClassDeclaration() shouldBeEqualTo false
             hasClassDeclaration { decl -> decl.name == "SampleExternalInterface" } shouldBeEqualTo false
@@ -1771,7 +1771,7 @@ class KoParentDeclarationForKoDeclarationCastProviderTest {
             isKotlinBasicType shouldBeEqualTo false
             isKotlinCollectionType shouldBeEqualTo false
             isTypeParameter shouldBeEqualTo false
-            isExternalDeclaration shouldBeEqualTo true
+            isExternal shouldBeEqualTo true
             asClassDeclaration() shouldBeEqualTo null
             hasClassDeclaration() shouldBeEqualTo false
             hasClassDeclaration { decl -> decl.name == "SampleExternalGenericInterface" } shouldBeEqualTo false
@@ -1832,7 +1832,7 @@ class KoParentDeclarationForKoDeclarationCastProviderTest {
             isKotlinBasicType shouldBeEqualTo false
             isKotlinCollectionType shouldBeEqualTo false
             isTypeParameter shouldBeEqualTo false
-            isExternalDeclaration shouldBeEqualTo false
+            isExternal shouldBeEqualTo false
             asClassDeclaration() shouldBeEqualTo null
             hasClassDeclaration() shouldBeEqualTo false
             hasClassDeclaration { decl -> decl.name == "SampleTypeAlias" } shouldBeEqualTo false
@@ -1893,7 +1893,7 @@ class KoParentDeclarationForKoDeclarationCastProviderTest {
             isKotlinBasicType shouldBeEqualTo false
             isKotlinCollectionType shouldBeEqualTo false
             isTypeParameter shouldBeEqualTo false
-            isExternalDeclaration shouldBeEqualTo false
+            isExternal shouldBeEqualTo false
             asClassDeclaration() shouldBeEqualTo null
             hasClassDeclaration() shouldBeEqualTo false
             hasClassDeclaration { decl -> decl.name == "SampleImportAlias" } shouldBeEqualTo false
@@ -1954,7 +1954,7 @@ class KoParentDeclarationForKoDeclarationCastProviderTest {
             isKotlinBasicType shouldBeEqualTo false
             isKotlinCollectionType shouldBeEqualTo false
             isTypeParameter shouldBeEqualTo false
-            isExternalDeclaration shouldBeEqualTo false
+            isExternal shouldBeEqualTo false
             asClassDeclaration() shouldBeInstanceOf KoClassDeclaration::class
             hasClassDeclaration() shouldBeEqualTo true
             hasClassDeclaration { decl -> decl.name == "SampleSuperClass" } shouldBeEqualTo true
@@ -2014,7 +2014,7 @@ class KoParentDeclarationForKoDeclarationCastProviderTest {
             isKotlinBasicType shouldBeEqualTo false
             isKotlinCollectionType shouldBeEqualTo false
             isTypeParameter shouldBeEqualTo false
-            isExternalDeclaration shouldBeEqualTo false
+            isExternal shouldBeEqualTo false
             asClassDeclaration() shouldBeInstanceOf KoClassDeclaration::class
             hasClassDeclaration() shouldBeEqualTo true
             hasClassDeclaration { decl -> decl.name == "SampleGenericSuperClass" } shouldBeEqualTo true
@@ -2074,7 +2074,7 @@ class KoParentDeclarationForKoDeclarationCastProviderTest {
             isKotlinBasicType shouldBeEqualTo false
             isKotlinCollectionType shouldBeEqualTo false
             isTypeParameter shouldBeEqualTo false
-            isExternalDeclaration shouldBeEqualTo false
+            isExternal shouldBeEqualTo false
             asClassDeclaration() shouldBeInstanceOf KoClassDeclaration::class
             hasClassDeclaration() shouldBeEqualTo true
             hasClassDeclaration { decl -> decl.name == "SampleParametrizedSuperClass" } shouldBeEqualTo true
@@ -2134,7 +2134,7 @@ class KoParentDeclarationForKoDeclarationCastProviderTest {
             isKotlinBasicType shouldBeEqualTo false
             isKotlinCollectionType shouldBeEqualTo false
             isTypeParameter shouldBeEqualTo false
-            isExternalDeclaration shouldBeEqualTo false
+            isExternal shouldBeEqualTo false
             asClassDeclaration() shouldBeInstanceOf KoClassDeclaration::class
             hasClassDeclaration() shouldBeEqualTo true
             hasClassDeclaration { decl -> decl.name == "SampleParametrizedSuperClass" } shouldBeEqualTo true
@@ -2194,7 +2194,7 @@ class KoParentDeclarationForKoDeclarationCastProviderTest {
             isKotlinBasicType shouldBeEqualTo false
             isKotlinCollectionType shouldBeEqualTo false
             isTypeParameter shouldBeEqualTo false
-            isExternalDeclaration shouldBeEqualTo false
+            isExternal shouldBeEqualTo false
             asClassDeclaration() shouldBeEqualTo null
             hasClassDeclaration() shouldBeEqualTo false
             hasClassDeclaration { decl -> decl.name == "SampleSuperInterface" } shouldBeEqualTo false
@@ -2254,7 +2254,7 @@ class KoParentDeclarationForKoDeclarationCastProviderTest {
             isKotlinBasicType shouldBeEqualTo false
             isKotlinCollectionType shouldBeEqualTo false
             isTypeParameter shouldBeEqualTo false
-            isExternalDeclaration shouldBeEqualTo false
+            isExternal shouldBeEqualTo false
             asClassDeclaration() shouldBeEqualTo null
             hasClassDeclaration() shouldBeEqualTo false
             hasClassDeclaration { decl -> decl.name == "SampleGenericSuperInterface" } shouldBeEqualTo false
@@ -2314,7 +2314,7 @@ class KoParentDeclarationForKoDeclarationCastProviderTest {
             isKotlinBasicType shouldBeEqualTo false
             isKotlinCollectionType shouldBeEqualTo false
             isTypeParameter shouldBeEqualTo false
-            isExternalDeclaration shouldBeEqualTo false
+            isExternal shouldBeEqualTo false
             asClassDeclaration() shouldBeInstanceOf KoClassDeclaration::class
             hasClassDeclaration() shouldBeEqualTo true
             hasClassDeclaration { decl -> decl.name == "SampleParentClass" } shouldBeEqualTo true
@@ -2382,7 +2382,7 @@ class KoParentDeclarationForKoDeclarationCastProviderTest {
             isKotlinBasicType shouldBeEqualTo false
             isKotlinCollectionType shouldBeEqualTo false
             isTypeParameter shouldBeEqualTo false
-            isExternalDeclaration shouldBeEqualTo false
+            isExternal shouldBeEqualTo false
             asClassDeclaration() shouldBeInstanceOf KoClassDeclaration::class
             hasClassDeclaration() shouldBeEqualTo true
             hasClassDeclaration { decl -> decl.name == "SampleCollection1" } shouldBeEqualTo true
@@ -2450,7 +2450,7 @@ class KoParentDeclarationForKoDeclarationCastProviderTest {
             isKotlinBasicType shouldBeEqualTo false
             isKotlinCollectionType shouldBeEqualTo false
             isTypeParameter shouldBeEqualTo false
-            isExternalDeclaration shouldBeEqualTo false
+            isExternal shouldBeEqualTo false
             asClassDeclaration() shouldBeInstanceOf KoClassDeclaration::class
             hasClassDeclaration() shouldBeEqualTo true
             hasClassDeclaration { decl -> decl.name == "SampleClassWithParameter" } shouldBeEqualTo true
@@ -2518,7 +2518,7 @@ class KoParentDeclarationForKoDeclarationCastProviderTest {
             isKotlinBasicType shouldBeEqualTo false
             isKotlinCollectionType shouldBeEqualTo false
             isTypeParameter shouldBeEqualTo false
-            isExternalDeclaration shouldBeEqualTo false
+            isExternal shouldBeEqualTo false
             asClassDeclaration() shouldBeInstanceOf KoClassDeclaration::class
             hasClassDeclaration() shouldBeEqualTo true
             hasClassDeclaration { decl -> decl.name == "SampleGenericClassWithParameter" } shouldBeEqualTo true
@@ -2586,7 +2586,7 @@ class KoParentDeclarationForKoDeclarationCastProviderTest {
             isKotlinBasicType shouldBeEqualTo false
             isKotlinCollectionType shouldBeEqualTo false
             isTypeParameter shouldBeEqualTo false
-            isExternalDeclaration shouldBeEqualTo false
+            isExternal shouldBeEqualTo false
             asClassDeclaration() shouldBeEqualTo null
             hasClassDeclaration() shouldBeEqualTo false
             hasClassDeclaration { decl -> decl.name == "SampleInterface" } shouldBeEqualTo false
@@ -2646,7 +2646,7 @@ class KoParentDeclarationForKoDeclarationCastProviderTest {
             isKotlinBasicType shouldBeEqualTo false
             isKotlinCollectionType shouldBeEqualTo false
             isTypeParameter shouldBeEqualTo false
-            isExternalDeclaration shouldBeEqualTo false
+            isExternal shouldBeEqualTo false
             asClassDeclaration() shouldBeEqualTo null
             hasClassDeclaration() shouldBeEqualTo false
             hasClassDeclaration { decl -> decl.name == "SampleGenericSuperInterface" } shouldBeEqualTo false
@@ -2706,7 +2706,7 @@ class KoParentDeclarationForKoDeclarationCastProviderTest {
             isKotlinBasicType shouldBeEqualTo false
             isKotlinCollectionType shouldBeEqualTo false
             isTypeParameter shouldBeEqualTo false
-            isExternalDeclaration shouldBeEqualTo true
+            isExternal shouldBeEqualTo true
             asClassDeclaration() shouldBeEqualTo null
             hasClassDeclaration() shouldBeEqualTo false
             hasClassDeclaration { decl -> decl.name == "SampleExternalClass" } shouldBeEqualTo false
@@ -2767,7 +2767,7 @@ class KoParentDeclarationForKoDeclarationCastProviderTest {
             isKotlinBasicType shouldBeEqualTo false
             isKotlinCollectionType shouldBeEqualTo false
             isTypeParameter shouldBeEqualTo false
-            isExternalDeclaration shouldBeEqualTo true
+            isExternal shouldBeEqualTo true
             asClassDeclaration() shouldBeEqualTo null
             hasClassDeclaration() shouldBeEqualTo false
             hasClassDeclaration { decl -> decl.name == "SampleExternalGenericClass" } shouldBeEqualTo false
@@ -2828,7 +2828,7 @@ class KoParentDeclarationForKoDeclarationCastProviderTest {
             isKotlinBasicType shouldBeEqualTo false
             isKotlinCollectionType shouldBeEqualTo false
             isTypeParameter shouldBeEqualTo false
-            isExternalDeclaration shouldBeEqualTo true
+            isExternal shouldBeEqualTo true
             asClassDeclaration() shouldBeEqualTo null
             hasClassDeclaration() shouldBeEqualTo false
             hasClassDeclaration { decl -> decl.name == "SampleExternalClassWithParameter" } shouldBeEqualTo false
@@ -2889,7 +2889,7 @@ class KoParentDeclarationForKoDeclarationCastProviderTest {
             isKotlinBasicType shouldBeEqualTo false
             isKotlinCollectionType shouldBeEqualTo false
             isTypeParameter shouldBeEqualTo false
-            isExternalDeclaration shouldBeEqualTo true
+            isExternal shouldBeEqualTo true
             asClassDeclaration() shouldBeEqualTo null
             hasClassDeclaration() shouldBeEqualTo false
             hasClassDeclaration { decl -> decl.name == "SampleExternalGenericClassWithParameter" } shouldBeEqualTo false
@@ -2950,7 +2950,7 @@ class KoParentDeclarationForKoDeclarationCastProviderTest {
             isKotlinBasicType shouldBeEqualTo false
             isKotlinCollectionType shouldBeEqualTo false
             isTypeParameter shouldBeEqualTo false
-            isExternalDeclaration shouldBeEqualTo true
+            isExternal shouldBeEqualTo true
             asClassDeclaration() shouldBeEqualTo null
             hasClassDeclaration() shouldBeEqualTo false
             hasClassDeclaration { decl -> decl.name == "SampleExternalInterface" } shouldBeEqualTo false
@@ -3011,7 +3011,7 @@ class KoParentDeclarationForKoDeclarationCastProviderTest {
             isKotlinBasicType shouldBeEqualTo false
             isKotlinCollectionType shouldBeEqualTo false
             isTypeParameter shouldBeEqualTo false
-            isExternalDeclaration shouldBeEqualTo true
+            isExternal shouldBeEqualTo true
             asClassDeclaration() shouldBeEqualTo null
             hasClassDeclaration() shouldBeEqualTo false
             hasClassDeclaration { decl -> decl.name == "SampleExternalGenericInterface" } shouldBeEqualTo false
@@ -3072,7 +3072,7 @@ class KoParentDeclarationForKoDeclarationCastProviderTest {
             isKotlinBasicType shouldBeEqualTo false
             isKotlinCollectionType shouldBeEqualTo false
             isTypeParameter shouldBeEqualTo false
-            isExternalDeclaration shouldBeEqualTo false
+            isExternal shouldBeEqualTo false
             asClassDeclaration() shouldBeEqualTo null
             hasClassDeclaration() shouldBeEqualTo false
             hasClassDeclaration { decl -> decl.name == "SampleTypeAlias" } shouldBeEqualTo false
@@ -3133,7 +3133,7 @@ class KoParentDeclarationForKoDeclarationCastProviderTest {
             isKotlinBasicType shouldBeEqualTo false
             isKotlinCollectionType shouldBeEqualTo false
             isTypeParameter shouldBeEqualTo false
-            isExternalDeclaration shouldBeEqualTo false
+            isExternal shouldBeEqualTo false
             asClassDeclaration() shouldBeEqualTo null
             hasClassDeclaration() shouldBeEqualTo false
             hasClassDeclaration { decl -> decl.name == "SampleImportAlias" } shouldBeEqualTo false

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koparent/KoParentDeclarationForKoTypeArgumentProviderTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koparent/KoParentDeclarationForKoTypeArgumentProviderTest.kt
@@ -37,8 +37,8 @@ class KoParentDeclarationForKoTypeArgumentProviderTest {
             hasAllTypeArgumentsOf(String::class, Int::class) shouldBeEqualTo false
             hasAllTypeArgumentsOf(listOf(String::class, Int::class)) shouldBeEqualTo false
             hasAllTypeArgumentsOf(listOf(SampleClass::class, Int::class)) shouldBeEqualTo false
-            hasTypeArgument { type -> type.sourceDeclaration?.isExternalDeclaration == true } shouldBeEqualTo false
-            hasAllTypeArguments { type -> type.sourceDeclaration?.isExternalDeclaration == true } shouldBeEqualTo false
+            hasTypeArgument { type -> type.sourceDeclaration?.isExternal == true } shouldBeEqualTo false
+            hasAllTypeArguments { type -> type.sourceDeclaration?.isExternal == true } shouldBeEqualTo false
         }
     }
 
@@ -82,9 +82,9 @@ class KoParentDeclarationForKoTypeArgumentProviderTest {
             hasAllTypeArgumentsOf(listOf(Int::class, String::class)) shouldBeEqualTo false
             hasAllTypeArgumentsOf(listOf(SampleClass::class, String::class)) shouldBeEqualTo false
             hasTypeArgument { type -> type.sourceDeclaration?.isKotlinType == true } shouldBeEqualTo true
-            hasTypeArgument { type -> type.sourceDeclaration?.isExternalDeclaration == true } shouldBeEqualTo false
+            hasTypeArgument { type -> type.sourceDeclaration?.isExternal == true } shouldBeEqualTo false
             hasAllTypeArguments { type -> type.sourceDeclaration?.isKotlinType == true } shouldBeEqualTo true
-            hasAllTypeArguments { type -> type.sourceDeclaration?.isExternalDeclaration == true } shouldBeEqualTo false
+            hasAllTypeArguments { type -> type.sourceDeclaration?.isExternal == true } shouldBeEqualTo false
         }
     }
 
@@ -112,8 +112,8 @@ class KoParentDeclarationForKoTypeArgumentProviderTest {
             hasAllTypeArgumentsOf(String::class, Int::class) shouldBeEqualTo false
             hasAllTypeArgumentsOf(listOf(String::class, Int::class)) shouldBeEqualTo false
             hasAllTypeArgumentsOf(listOf(SampleClass::class, Int::class)) shouldBeEqualTo false
-            hasTypeArgument { type -> type.sourceDeclaration?.isExternalDeclaration == true } shouldBeEqualTo false
-            hasAllTypeArguments { type -> type.sourceDeclaration?.isExternalDeclaration == true } shouldBeEqualTo false
+            hasTypeArgument { type -> type.sourceDeclaration?.isExternal == true } shouldBeEqualTo false
+            hasAllTypeArguments { type -> type.sourceDeclaration?.isExternal == true } shouldBeEqualTo false
         }
     }
 
@@ -158,9 +158,9 @@ class KoParentDeclarationForKoTypeArgumentProviderTest {
             hasAllTypeArgumentsOf(listOf(Int::class, String::class)) shouldBeEqualTo false
             hasAllTypeArgumentsOf(listOf(SampleClass::class, String::class)) shouldBeEqualTo false
             hasTypeArgument { type -> type.sourceDeclaration?.isKotlinType == true } shouldBeEqualTo true
-            hasTypeArgument { type -> type.sourceDeclaration?.isExternalDeclaration == true } shouldBeEqualTo false
+            hasTypeArgument { type -> type.sourceDeclaration?.isExternal == true } shouldBeEqualTo false
             hasAllTypeArguments { type -> type.sourceDeclaration?.isKotlinType == true } shouldBeEqualTo true
-            hasAllTypeArguments { type -> type.sourceDeclaration?.isExternalDeclaration == true } shouldBeEqualTo false
+            hasAllTypeArguments { type -> type.sourceDeclaration?.isExternal == true } shouldBeEqualTo false
         }
     }
 
@@ -188,8 +188,8 @@ class KoParentDeclarationForKoTypeArgumentProviderTest {
             hasAllTypeArgumentsOf(String::class, Int::class) shouldBeEqualTo false
             hasAllTypeArgumentsOf(listOf(String::class, Int::class)) shouldBeEqualTo false
             hasAllTypeArgumentsOf(listOf(SampleClass::class, Int::class)) shouldBeEqualTo false
-            hasTypeArgument { type -> type.sourceDeclaration?.isExternalDeclaration == true } shouldBeEqualTo false
-            hasAllTypeArguments { type -> type.sourceDeclaration?.isExternalDeclaration == true } shouldBeEqualTo false
+            hasTypeArgument { type -> type.sourceDeclaration?.isExternal == true } shouldBeEqualTo false
+            hasAllTypeArguments { type -> type.sourceDeclaration?.isExternal == true } shouldBeEqualTo false
         }
     }
 
@@ -234,9 +234,9 @@ class KoParentDeclarationForKoTypeArgumentProviderTest {
             hasAllTypeArgumentsOf(listOf(Int::class, String::class)) shouldBeEqualTo false
             hasAllTypeArgumentsOf(listOf(SampleClass::class, String::class)) shouldBeEqualTo false
             hasTypeArgument { type -> type.sourceDeclaration?.isKotlinType == true } shouldBeEqualTo true
-            hasTypeArgument { type -> type.sourceDeclaration?.isExternalDeclaration == true } shouldBeEqualTo false
+            hasTypeArgument { type -> type.sourceDeclaration?.isExternal == true } shouldBeEqualTo false
             hasAllTypeArguments { type -> type.sourceDeclaration?.isKotlinType == true } shouldBeEqualTo true
-            hasAllTypeArguments { type -> type.sourceDeclaration?.isExternalDeclaration == true } shouldBeEqualTo false
+            hasAllTypeArguments { type -> type.sourceDeclaration?.isExternal == true } shouldBeEqualTo false
         }
     }
 

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koproperty/KoPropertyDeclarationForKoTypeParameterProviderTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koproperty/KoPropertyDeclarationForKoTypeParameterProviderTest.kt
@@ -114,7 +114,7 @@ class KoPropertyDeclarationForKoTypeParameterProviderTest {
             hasTypeParameter { it.name == "T" } shouldBeEqualTo true
             hasTypeParameter { param -> param.isTypeParameter } shouldBeEqualTo true
             hasAllTypeParameters { it.name == "T" || it.name == "V" } shouldBeEqualTo true
-            hasAllTypeParameters { param -> param.isExternalDeclaration } shouldBeEqualTo false
+            hasAllTypeParameters { param -> param.isExternal } shouldBeEqualTo false
         }
     }
 

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/kotypealias/KoTypeAliasDeclarationForKoTypeParameterProviderTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/kotypealias/KoTypeAliasDeclarationForKoTypeParameterProviderTest.kt
@@ -114,7 +114,7 @@ class KoTypeAliasDeclarationForKoTypeParameterProviderTest {
             hasTypeParameter { it.name == "T" } shouldBeEqualTo true
             hasTypeParameter { param -> param.isTypeParameter } shouldBeEqualTo true
             hasAllTypeParameters { it.name == "T" || it.name == "V" } shouldBeEqualTo true
-            hasAllTypeParameters { param -> param.isExternalDeclaration } shouldBeEqualTo false
+            hasAllTypeParameters { param -> param.isExternal } shouldBeEqualTo false
         }
     }
 

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/kotypeargument/KoTypeArgumentDeclarationForKoDeclarationCastProviderTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/kotypeargument/KoTypeArgumentDeclarationForKoDeclarationCastProviderTest.kt
@@ -47,7 +47,7 @@ class KoTypeArgumentDeclarationForKoDeclarationCastProviderTest {
             it?.isKotlinBasicType shouldBeEqualTo false
             it?.isKotlinCollectionType shouldBeEqualTo false
             it?.isTypeParameter shouldBeEqualTo false
-            it?.isExternalDeclaration shouldBeEqualTo false
+            it?.isExternal shouldBeEqualTo false
             it?.asClassDeclaration() shouldBeInstanceOf KoClassDeclaration::class
             it?.asClassDeclaration()?.name shouldBeEqualTo "SampleType"
             it?.hasClassDeclaration() shouldBeEqualTo true
@@ -106,7 +106,7 @@ class KoTypeArgumentDeclarationForKoDeclarationCastProviderTest {
             it?.isKotlinBasicType shouldBeEqualTo false
             it?.isKotlinCollectionType shouldBeEqualTo false
             it?.isTypeParameter shouldBeEqualTo false
-            it?.isExternalDeclaration shouldBeEqualTo false
+            it?.isExternal shouldBeEqualTo false
             it?.asObjectDeclaration() shouldBeInstanceOf KoObjectDeclaration::class
             it?.asObjectDeclaration()?.name shouldBeEqualTo "SampleObject"
             it?.hasObjectDeclaration() shouldBeEqualTo true
@@ -165,7 +165,7 @@ class KoTypeArgumentDeclarationForKoDeclarationCastProviderTest {
             it?.isKotlinBasicType shouldBeEqualTo false
             it?.isKotlinCollectionType shouldBeEqualTo false
             it?.isTypeParameter shouldBeEqualTo false
-            it?.isExternalDeclaration shouldBeEqualTo false
+            it?.isExternal shouldBeEqualTo false
             it?.asInterfaceDeclaration() shouldBeInstanceOf KoInterfaceDeclaration::class
             it?.asInterfaceDeclaration()?.name shouldBeEqualTo "SampleInterface"
             it?.hasInterfaceDeclaration() shouldBeEqualTo true
@@ -224,7 +224,7 @@ class KoTypeArgumentDeclarationForKoDeclarationCastProviderTest {
             it?.isKotlinBasicType shouldBeEqualTo false
             it?.isKotlinCollectionType shouldBeEqualTo false
             it?.isTypeParameter shouldBeEqualTo false
-            it?.isExternalDeclaration shouldBeEqualTo false
+            it?.isExternal shouldBeEqualTo false
             it?.asImportAliasDeclaration() shouldBeInstanceOf KoImportAliasDeclaration::class
             it?.asImportAliasDeclaration()?.name shouldBeEqualTo "ImportAlias"
             it?.hasImportAliasDeclaration() shouldBeEqualTo true
@@ -278,7 +278,7 @@ class KoTypeArgumentDeclarationForKoDeclarationCastProviderTest {
             it?.isKotlinBasicType shouldBeEqualTo false
             it?.isKotlinCollectionType shouldBeEqualTo false
             it?.isTypeParameter shouldBeEqualTo true
-            it?.isExternalDeclaration shouldBeEqualTo false
+            it?.isExternal shouldBeEqualTo false
             it?.asTypeParameterDeclaration() shouldBeInstanceOf KoTypeParameterDeclaration::class
             it?.asTypeParameterDeclaration()?.name shouldBeEqualTo "TestType"
             it?.hasTypeParameterDeclaration() shouldBeEqualTo true
@@ -332,7 +332,7 @@ class KoTypeArgumentDeclarationForKoDeclarationCastProviderTest {
             it?.isKotlinBasicType shouldBeEqualTo false
             it?.isKotlinCollectionType shouldBeEqualTo false
             it?.isTypeParameter shouldBeEqualTo false
-            it?.isExternalDeclaration shouldBeEqualTo false
+            it?.isExternal shouldBeEqualTo false
             it?.asTypeAliasDeclaration() shouldBeInstanceOf KoTypeAliasDeclaration::class
             it?.asTypeAliasDeclaration()?.name shouldBeEqualTo "SampleTypeAlias"
             it?.hasTypeAliasDeclaration() shouldBeEqualTo true
@@ -386,7 +386,7 @@ class KoTypeArgumentDeclarationForKoDeclarationCastProviderTest {
             it?.isKotlinBasicType shouldBeEqualTo true
             it?.isKotlinCollectionType shouldBeEqualTo false
             it?.isTypeParameter shouldBeEqualTo false
-            it?.isExternalDeclaration shouldBeEqualTo false
+            it?.isExternal shouldBeEqualTo false
             it?.asKotlinTypeDeclaration() shouldBeInstanceOf KoKotlinTypeDeclaration::class
             it?.asKotlinTypeDeclaration()?.name shouldBeEqualTo "String"
             it?.hasKotlinTypeDeclaration() shouldBeEqualTo true
@@ -450,7 +450,7 @@ class KoTypeArgumentDeclarationForKoDeclarationCastProviderTest {
             it?.isKotlinBasicType shouldBeEqualTo false
             it?.isKotlinCollectionType shouldBeEqualTo false
             it?.isTypeParameter shouldBeEqualTo false
-            it?.isExternalDeclaration shouldBeEqualTo false
+            it?.isExternal shouldBeEqualTo false
             it?.asClassDeclaration() shouldBeEqualTo null
             it?.hasClassDeclaration() shouldBeEqualTo false
             it?.asObjectDeclaration() shouldBeEqualTo null
@@ -501,7 +501,7 @@ class KoTypeArgumentDeclarationForKoDeclarationCastProviderTest {
             it?.isKotlinBasicType shouldBeEqualTo false
             it?.isKotlinCollectionType shouldBeEqualTo false
             it?.isTypeParameter shouldBeEqualTo false
-            it?.isExternalDeclaration shouldBeEqualTo false
+            it?.isExternal shouldBeEqualTo false
             it?.asClassDeclaration() shouldBeInstanceOf KoClassDeclaration::class
             it?.asClassDeclaration()?.name shouldBeEqualTo "SampleCollection1"
             it?.hasClassDeclaration() shouldBeEqualTo true
@@ -560,7 +560,7 @@ class KoTypeArgumentDeclarationForKoDeclarationCastProviderTest {
             it?.isKotlinBasicType shouldBeEqualTo false
             it?.isKotlinCollectionType shouldBeEqualTo false
             it?.isTypeParameter shouldBeEqualTo false
-            it?.isExternalDeclaration shouldBeEqualTo true
+            it?.isExternal shouldBeEqualTo true
             it?.asExternalDeclaration() shouldBeInstanceOf KoExternalDeclaration::class
             it?.asExternalDeclaration()?.name shouldBeEqualTo "SampleExternalClass"
             it?.hasExternalDeclaration() shouldBeEqualTo true

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/kotypeargument/KoTypeArgumentDeclarationForKoFunctionTypeDeclarationProviderTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/kotypeargument/KoTypeArgumentDeclarationForKoFunctionTypeDeclarationProviderTest.kt
@@ -87,9 +87,9 @@ class KoTypeArgumentDeclarationForKoFunctionTypeDeclarationProviderTest {
             it?.countParameterTypes { parameter -> parameter.type.isKotlinBasicType } shouldBeEqualTo 1
             it?.countParameterTypes { parameter -> parameter.type.isClass } shouldBeEqualTo 0
             it?.hasParameterType { parameter -> parameter.type.isKotlinType } shouldBeEqualTo true
-            it?.hasParameterType { parameter -> parameter.type.isExternalDeclaration } shouldBeEqualTo false
+            it?.hasParameterType { parameter -> parameter.type.isExternal } shouldBeEqualTo false
             it?.hasAllParameterTypes { parameter -> parameter.type.isKotlinType } shouldBeEqualTo true
-            it?.hasAllParameterTypes { parameter -> parameter.type.isExternalDeclaration } shouldBeEqualTo false
+            it?.hasAllParameterTypes { parameter -> parameter.type.isExternal } shouldBeEqualTo false
             it?.parameters?.map { parameter -> parameter.type.name } shouldBeEqualTo listOf("String")
             it?.numParameters shouldBeEqualTo 1
             it?.countParameters { parameter -> parameter.type.isKotlinType } shouldBeEqualTo 1
@@ -97,9 +97,9 @@ class KoTypeArgumentDeclarationForKoFunctionTypeDeclarationProviderTest {
             it?.countParameters { parameter -> parameter.type.isKotlinBasicType } shouldBeEqualTo 1
             it?.countParameters { parameter -> parameter.type.isClass } shouldBeEqualTo 0
             it?.hasParameter { parameter -> parameter.type.isKotlinType } shouldBeEqualTo true
-            it?.hasParameter { parameter -> parameter.type.isExternalDeclaration } shouldBeEqualTo false
+            it?.hasParameter { parameter -> parameter.type.isExternal } shouldBeEqualTo false
             it?.hasAllParameters { parameter -> parameter.type.isKotlinType } shouldBeEqualTo true
-            it?.hasAllParameters { parameter -> parameter.type.isExternalDeclaration } shouldBeEqualTo false
+            it?.hasAllParameters { parameter -> parameter.type.isExternal } shouldBeEqualTo false
         }
     }
 
@@ -123,9 +123,9 @@ class KoTypeArgumentDeclarationForKoFunctionTypeDeclarationProviderTest {
             it?.countParameterTypes { parameter -> parameter.type.isKotlinBasicType } shouldBeEqualTo 1
             it?.countParameterTypes { parameter -> parameter.type.isClass } shouldBeEqualTo 0
             it?.hasParameterType { parameter -> parameter.type.isKotlinType } shouldBeEqualTo true
-            it?.hasParameterType { parameter -> parameter.type.isExternalDeclaration } shouldBeEqualTo false
+            it?.hasParameterType { parameter -> parameter.type.isExternal } shouldBeEqualTo false
             it?.hasAllParameterTypes { parameter -> parameter.type.isKotlinType || parameter.type.isGenericType } shouldBeEqualTo true
-            it?.hasAllParameterTypes { parameter -> parameter.type.isExternalDeclaration } shouldBeEqualTo false
+            it?.hasAllParameterTypes { parameter -> parameter.type.isExternal } shouldBeEqualTo false
             it?.parameters?.map { parameter -> parameter.type.name } shouldBeEqualTo listOf("String", "List<Int>")
             it?.numParameters shouldBeEqualTo 2
             it?.countParameters { parameter -> parameter.type.isKotlinType } shouldBeEqualTo 2
@@ -133,9 +133,9 @@ class KoTypeArgumentDeclarationForKoFunctionTypeDeclarationProviderTest {
             it?.countParameters { parameter -> parameter.type.isKotlinBasicType } shouldBeEqualTo 1
             it?.countParameters { parameter -> parameter.type.isClass } shouldBeEqualTo 0
             it?.hasParameter { parameter -> parameter.type.isKotlinType } shouldBeEqualTo true
-            it?.hasParameter { parameter -> parameter.type.isExternalDeclaration } shouldBeEqualTo false
+            it?.hasParameter { parameter -> parameter.type.isExternal } shouldBeEqualTo false
             it?.hasAllParameters { parameter -> parameter.type.isKotlinType || parameter.type.isGenericType } shouldBeEqualTo true
-            it?.hasAllParameters { parameter -> parameter.type.isExternalDeclaration } shouldBeEqualTo false
+            it?.hasAllParameters { parameter -> parameter.type.isExternal } shouldBeEqualTo false
         }
     }
 
@@ -174,7 +174,7 @@ class KoTypeArgumentDeclarationForKoFunctionTypeDeclarationProviderTest {
         assertSoftly(sut) {
             it?.returnType shouldBeEqualTo null
             it?.hasReturnType { type -> type.isKotlinType } shouldBeEqualTo false
-            it?.hasReturnType { type -> type.isExternalDeclaration } shouldBeEqualTo false
+            it?.hasReturnType { type -> type.isExternal } shouldBeEqualTo false
             it?.hasReturnTypeOf(Unit::class) shouldBeEqualTo false
             it?.hasReturnTypeOf(String::class) shouldBeEqualTo false
         }
@@ -195,7 +195,7 @@ class KoTypeArgumentDeclarationForKoFunctionTypeDeclarationProviderTest {
         assertSoftly(sut) {
             it?.returnType?.name shouldBeEqualTo "Unit"
             it?.hasReturnType { type -> type.isKotlinType } shouldBeEqualTo true
-            it?.hasReturnType { type -> type.isExternalDeclaration } shouldBeEqualTo false
+            it?.hasReturnType { type -> type.isExternal } shouldBeEqualTo false
             it?.hasReturnTypeOf(Unit::class) shouldBeEqualTo true
             it?.hasReturnTypeOf(String::class) shouldBeEqualTo false
         }
@@ -216,7 +216,7 @@ class KoTypeArgumentDeclarationForKoFunctionTypeDeclarationProviderTest {
         assertSoftly(sut) {
             it?.returnType?.name shouldBeEqualTo "List<String>"
             it?.hasReturnType { type -> type.isGenericType } shouldBeEqualTo true
-            it?.hasReturnType { type -> type.isExternalDeclaration } shouldBeEqualTo false
+            it?.hasReturnType { type -> type.isExternal } shouldBeEqualTo false
             it?.hasReturnTypeOf(String::class) shouldBeEqualTo false
         }
     }
@@ -236,7 +236,7 @@ class KoTypeArgumentDeclarationForKoFunctionTypeDeclarationProviderTest {
         assertSoftly(sut) {
             it?.returnType?.name shouldBeEqualTo "SampleClass"
             it?.hasReturnType { type -> type.isClass } shouldBeEqualTo true
-            it?.hasReturnType { type -> type.isExternalDeclaration } shouldBeEqualTo false
+            it?.hasReturnType { type -> type.isExternal } shouldBeEqualTo false
             it?.hasReturnTypeOf(SampleClass::class) shouldBeEqualTo true
             it?.hasReturnTypeOf(String::class) shouldBeEqualTo false
         }

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/kotypeargument/KoTypeArgumentDeclarationForKoIsGenericProviderTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/kotypeargument/KoTypeArgumentDeclarationForKoIsGenericProviderTest.kt
@@ -1,0 +1,75 @@
+package com.lemonappdev.konsist.core.declaration.kotypeargument
+
+import com.lemonappdev.konsist.TestSnippetProvider
+import org.amshove.kluent.shouldBeEqualTo
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.Arguments.arguments
+import org.junit.jupiter.params.provider.MethodSource
+
+class KoTypeArgumentDeclarationForKoIsGenericProviderTest {
+    @ParameterizedTest
+    @MethodSource("provideValues")
+    fun `type-argument-is-not-generic`(fileName: String) {
+        // given
+        val sut =
+            getSnippetFile(fileName)
+                .properties()
+                .first()
+                .type
+                ?.typeArguments
+                ?.firstOrNull()
+
+        // then
+        sut?.isGeneric shouldBeEqualTo false
+    }
+
+    @Test
+    fun `generic-type-argument`() {
+        // given
+        val sut =
+            getSnippetFile("generic-type-argument")
+                .properties()
+                .first()
+                .type
+                ?.typeArguments
+                ?.firstOrNull()
+
+        // then
+        sut?.isGeneric shouldBeEqualTo true
+    }
+
+    @Test
+    fun `typealias-with-generic-type-argument`() {
+        // given
+        val sut =
+            getSnippetFile("typealias-with-generic-type-argument")
+                .properties()
+                .first()
+                .type
+                ?.typeArguments
+                ?.firstOrNull()
+
+        // then
+        sut?.isGeneric shouldBeEqualTo true
+    }
+
+    private fun getSnippetFile(fileName: String) =
+        TestSnippetProvider.getSnippetKoScope("core/declaration/kotypeargument/snippet/forkoisgenericprovider/", fileName)
+
+    companion object {
+        @Suppress("unused")
+        @JvmStatic
+        fun provideValues() =
+            listOf(
+                arguments("class-type-argument"),
+                arguments("external-type-argument"),
+                arguments("function-type-argument"),
+                arguments("import-alias-type-argument"),
+                arguments("interface-type-argument"),
+                arguments("kotlin-type-argument"),
+                arguments("object-type-argument"),
+                arguments("typealias-without-generic-type-argument"),
+            )
+    }
+}

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/kotypeargument/KoTypeArgumentDeclarationForKoSourceDeclarationProviderTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/kotypeargument/KoTypeArgumentDeclarationForKoSourceDeclarationProviderTest.kt
@@ -25,7 +25,7 @@ class KoTypeArgumentDeclarationForKoSourceDeclarationProviderTest {
             it?.sourceDeclaration shouldBeInstanceOf KoKotlinTypeDeclaration::class
             it?.sourceDeclaration?.name shouldBeEqualTo "String"
             it?.hasSourceDeclaration { sourceDeclaration -> sourceDeclaration.isKotlinType } shouldBeEqualTo true
-            it?.hasSourceDeclaration { sourceDeclaration -> sourceDeclaration.isExternalDeclaration } shouldBeEqualTo false
+            it?.hasSourceDeclaration { sourceDeclaration -> sourceDeclaration.isExternal } shouldBeEqualTo false
             it?.hasSourceDeclarationOf(String::class) shouldBeEqualTo true
             it?.hasSourceDeclarationOf(Int::class) shouldBeEqualTo false
         }
@@ -47,7 +47,7 @@ class KoTypeArgumentDeclarationForKoSourceDeclarationProviderTest {
             it?.sourceDeclaration shouldBeInstanceOf KoKotlinTypeDeclaration::class
             it?.sourceDeclaration?.name shouldBeEqualTo "Set"
             it?.hasSourceDeclaration { sourceDeclaration -> sourceDeclaration.isKotlinCollectionType } shouldBeEqualTo true
-            it?.hasSourceDeclaration { sourceDeclaration -> sourceDeclaration.isExternalDeclaration } shouldBeEqualTo false
+            it?.hasSourceDeclaration { sourceDeclaration -> sourceDeclaration.isExternal } shouldBeEqualTo false
             it?.hasSourceDeclarationOf(String::class) shouldBeEqualTo false
         }
     }
@@ -68,7 +68,7 @@ class KoTypeArgumentDeclarationForKoSourceDeclarationProviderTest {
             it?.sourceDeclaration shouldBeInstanceOf KoKotlinTypeDeclaration::class
             it?.sourceDeclaration?.name shouldBeEqualTo "Map"
             it?.hasSourceDeclaration { sourceDeclaration -> sourceDeclaration.isKotlinCollectionType } shouldBeEqualTo true
-            it?.hasSourceDeclaration { sourceDeclaration -> sourceDeclaration.isExternalDeclaration } shouldBeEqualTo false
+            it?.hasSourceDeclaration { sourceDeclaration -> sourceDeclaration.isExternal } shouldBeEqualTo false
             it?.hasSourceDeclarationOf(String::class) shouldBeEqualTo false
         }
     }
@@ -89,7 +89,7 @@ class KoTypeArgumentDeclarationForKoSourceDeclarationProviderTest {
             it?.sourceDeclaration shouldBeInstanceOf KoStarProjectionDeclaration::class
             it?.sourceDeclaration?.name shouldBeEqualTo "*"
             it?.hasSourceDeclaration { sourceDeclaration -> sourceDeclaration.isStarProjection } shouldBeEqualTo true
-            it?.hasSourceDeclaration { sourceDeclaration -> sourceDeclaration.isExternalDeclaration } shouldBeEqualTo false
+            it?.hasSourceDeclaration { sourceDeclaration -> sourceDeclaration.isExternal } shouldBeEqualTo false
             it?.hasSourceDeclarationOf(String::class) shouldBeEqualTo false
         }
     }
@@ -110,7 +110,7 @@ class KoTypeArgumentDeclarationForKoSourceDeclarationProviderTest {
             it?.sourceDeclaration shouldBeInstanceOf KoKotlinTypeDeclaration::class
             it?.sourceDeclaration?.name shouldBeEqualTo "String"
             it?.hasSourceDeclaration { sourceDeclaration -> sourceDeclaration.isKotlinType } shouldBeEqualTo true
-            it?.hasSourceDeclaration { sourceDeclaration -> sourceDeclaration.isExternalDeclaration } shouldBeEqualTo false
+            it?.hasSourceDeclaration { sourceDeclaration -> sourceDeclaration.isExternal } shouldBeEqualTo false
             it?.hasSourceDeclarationOf(String::class) shouldBeEqualTo true
             it?.hasSourceDeclarationOf(Int::class) shouldBeEqualTo false
         }
@@ -132,7 +132,7 @@ class KoTypeArgumentDeclarationForKoSourceDeclarationProviderTest {
             it?.sourceDeclaration shouldBeInstanceOf KoKotlinTypeDeclaration::class
             it?.sourceDeclaration?.name shouldBeEqualTo "String"
             it?.hasSourceDeclaration { sourceDeclaration -> sourceDeclaration.isKotlinType } shouldBeEqualTo true
-            it?.hasSourceDeclaration { sourceDeclaration -> sourceDeclaration.isExternalDeclaration } shouldBeEqualTo false
+            it?.hasSourceDeclaration { sourceDeclaration -> sourceDeclaration.isExternal } shouldBeEqualTo false
             it?.hasSourceDeclarationOf(String::class) shouldBeEqualTo true
             it?.hasSourceDeclarationOf(Int::class) shouldBeEqualTo false
         }

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/kotypeargument/KoTypeArgumentDeclarationForKoTypeArgumentProviderTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/kotypeargument/KoTypeArgumentDeclarationForKoTypeArgumentProviderTest.kt
@@ -85,9 +85,9 @@ class KoTypeArgumentDeclarationForKoTypeArgumentProviderTest {
             it?.hasAllTypeArgumentsOf(listOf(String::class, Int::class)) shouldBeEqualTo false
             it?.hasAllTypeArgumentsOf(listOf(SampleClass::class, Int::class)) shouldBeEqualTo false
             it?.hasTypeArgument { type -> type.sourceDeclaration?.isKotlinType == true } shouldBeEqualTo true
-            it?.hasTypeArgument { type -> type.sourceDeclaration?.isExternalDeclaration == true } shouldBeEqualTo false
+            it?.hasTypeArgument { type -> type.sourceDeclaration?.isExternal == true } shouldBeEqualTo false
             it?.hasAllTypeArguments { type -> type.sourceDeclaration?.isKotlinType == true } shouldBeEqualTo true
-            it?.hasAllTypeArguments { type -> type.sourceDeclaration?.isExternalDeclaration == true } shouldBeEqualTo false
+            it?.hasAllTypeArguments { type -> type.sourceDeclaration?.isExternal == true } shouldBeEqualTo false
         }
     }
 
@@ -150,9 +150,9 @@ class KoTypeArgumentDeclarationForKoTypeArgumentProviderTest {
             it?.hasAllTypeArgumentsOf(listOf(Int::class, String::class)) shouldBeEqualTo false
             it?.hasAllTypeArgumentsOf(listOf(SampleClass::class, String::class)) shouldBeEqualTo false
             it?.hasTypeArgument { type -> type.sourceDeclaration?.isKotlinType == true } shouldBeEqualTo true
-            it?.hasTypeArgument { type -> type.sourceDeclaration?.isExternalDeclaration == true } shouldBeEqualTo false
+            it?.hasTypeArgument { type -> type.sourceDeclaration?.isExternal == true } shouldBeEqualTo false
             it?.hasAllTypeArguments { type -> type.sourceDeclaration?.isKotlinType == true } shouldBeEqualTo true
-            it?.hasAllTypeArguments { type -> type.sourceDeclaration?.isExternalDeclaration == true } shouldBeEqualTo false
+            it?.hasAllTypeArguments { type -> type.sourceDeclaration?.isExternal == true } shouldBeEqualTo false
         }
     }
 
@@ -181,8 +181,8 @@ class KoTypeArgumentDeclarationForKoTypeArgumentProviderTest {
             it?.hasTypeArgumentOf(listOf(SampleClass::class, Int::class)) shouldBeEqualTo false
             it?.hasAllTypeArgumentsOf(String::class) shouldBeEqualTo false
             it?.hasAllTypeArgumentsOf(listOf(String::class)) shouldBeEqualTo false
-            it?.hasTypeArgument { type -> type.sourceDeclaration?.isExternalDeclaration == true } shouldBeEqualTo false
-            it?.hasAllTypeArguments { type -> type.sourceDeclaration?.isExternalDeclaration == true } shouldBeEqualTo false
+            it?.hasTypeArgument { type -> type.sourceDeclaration?.isExternal == true } shouldBeEqualTo false
+            it?.hasAllTypeArguments { type -> type.sourceDeclaration?.isExternal == true } shouldBeEqualTo false
         }
     }
 
@@ -262,9 +262,9 @@ class KoTypeArgumentDeclarationForKoTypeArgumentProviderTest {
             it?.hasAllTypeArgumentsOf(listOf(String::class, Int::class)) shouldBeEqualTo false
             it?.hasAllTypeArgumentsOf(listOf(SampleClass::class, Int::class)) shouldBeEqualTo false
             it?.hasTypeArgument { type -> type.sourceDeclaration?.isKotlinType == true } shouldBeEqualTo true
-            it?.hasTypeArgument { type -> type.sourceDeclaration?.isExternalDeclaration == true } shouldBeEqualTo false
+            it?.hasTypeArgument { type -> type.sourceDeclaration?.isExternal == true } shouldBeEqualTo false
             it?.hasAllTypeArguments { type -> type.sourceDeclaration?.isKotlinType == true } shouldBeEqualTo true
-            it?.hasAllTypeArguments { type -> type.sourceDeclaration?.isExternalDeclaration == true } shouldBeEqualTo false
+            it?.hasAllTypeArguments { type -> type.sourceDeclaration?.isExternal == true } shouldBeEqualTo false
         }
     }
 
@@ -344,9 +344,9 @@ class KoTypeArgumentDeclarationForKoTypeArgumentProviderTest {
             it?.hasAllTypeArgumentsOf(listOf(String::class, Int::class)) shouldBeEqualTo false
             it?.hasAllTypeArgumentsOf(listOf(SampleClass::class, Int::class)) shouldBeEqualTo false
             it?.hasTypeArgument { type -> type.sourceDeclaration?.isKotlinType == true } shouldBeEqualTo true
-            it?.hasTypeArgument { type -> type.sourceDeclaration?.isExternalDeclaration == true } shouldBeEqualTo false
+            it?.hasTypeArgument { type -> type.sourceDeclaration?.isExternal == true } shouldBeEqualTo false
             it?.hasAllTypeArguments { type -> type.sourceDeclaration?.isKotlinType == true } shouldBeEqualTo true
-            it?.hasAllTypeArguments { type -> type.sourceDeclaration?.isExternalDeclaration == true } shouldBeEqualTo false
+            it?.hasAllTypeArguments { type -> type.sourceDeclaration?.isExternal == true } shouldBeEqualTo false
         }
     }
 

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/kotypeargument/snippet/forkoisgenericprovider/class-type-argument.kttest
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/kotypeargument/snippet/forkoisgenericprovider/class-type-argument.kttest
@@ -1,0 +1,3 @@
+import com.lemonappdev.konsist.testdata.SampleClass
+
+val sampleProperty1: List<SampleClass> = emptyList()

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/kotypeargument/snippet/forkoisgenericprovider/external-type-argument.kttest
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/kotypeargument/snippet/forkoisgenericprovider/external-type-argument.kttest
@@ -1,0 +1,3 @@
+import com.lemonappdev.konsist.externalsample.SampleExternalClass
+
+val sampleProperty1: List<SampleExternalClass> = emptyList()

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/kotypeargument/snippet/forkoisgenericprovider/function-type-argument.kttest
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/kotypeargument/snippet/forkoisgenericprovider/function-type-argument.kttest
@@ -1,0 +1,1 @@
+val sampleProperty1: List<(String) -> Unit> = emptyList()

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/kotypeargument/snippet/forkoisgenericprovider/generic-type-argument.kttest
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/kotypeargument/snippet/forkoisgenericprovider/generic-type-argument.kttest
@@ -1,0 +1,1 @@
+val sampleProperty1: List<Set<String>> = listOf()

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/kotypeargument/snippet/forkoisgenericprovider/import-alias-type-argument.kttest
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/kotypeargument/snippet/forkoisgenericprovider/import-alias-type-argument.kttest
@@ -1,0 +1,3 @@
+import com.lemonappdev.konsist.testdata.SampleClass as SampleAlias
+
+val sampleProperty1: List<SampleAlias> = emptyList()

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/kotypeargument/snippet/forkoisgenericprovider/interface-type-argument.kttest
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/kotypeargument/snippet/forkoisgenericprovider/interface-type-argument.kttest
@@ -1,0 +1,5 @@
+import com.lemonappdev.konsist.testdata.SampleInterface
+
+val sampleProperty1: List<SampleInterface> = emptyList()
+
+class SampleClass : SampleInterface

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/kotypeargument/snippet/forkoisgenericprovider/kotlin-type-argument.kttest
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/kotypeargument/snippet/forkoisgenericprovider/kotlin-type-argument.kttest
@@ -1,0 +1,1 @@
+val sampleProperty1: List<String> = emptyList()

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/kotypeargument/snippet/forkoisgenericprovider/object-type-argument.kttest
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/kotypeargument/snippet/forkoisgenericprovider/object-type-argument.kttest
@@ -1,0 +1,3 @@
+import com.lemonappdev.konsist.testdata.SampleObject
+
+val sampleProperty1: List<SampleObject> = emptyList()

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/kotypeargument/snippet/forkoisgenericprovider/typealias-with-generic-type-argument.kttest
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/kotypeargument/snippet/forkoisgenericprovider/typealias-with-generic-type-argument.kttest
@@ -1,0 +1,5 @@
+import com.lemonappdev.konsist.testdata.SampleClass
+
+val sampleProperty1: List<SampleTypeAlias> = emptyList()
+
+typealias SampleTypeAlias = Set<String>

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/kotypeargument/snippet/forkoisgenericprovider/typealias-without-generic-type-argument.kttest
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/kotypeargument/snippet/forkoisgenericprovider/typealias-without-generic-type-argument.kttest
@@ -1,0 +1,5 @@
+import com.lemonappdev.konsist.testdata.SampleClass
+
+val sampleProperty1: List<SampleTypeAlias> = emptyList()
+
+typealias SampleTypeAlias = (SampleClass) -> Unit

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/type/kostarprojection/KoStarProjectionDeclarationForKoDeclarationCastProviderTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/type/kostarprojection/KoStarProjectionDeclarationForKoDeclarationCastProviderTest.kt
@@ -33,7 +33,7 @@ class KoStarProjectionDeclarationForKoDeclarationCastProviderTest {
             it?.isKotlinBasicType shouldBeEqualTo false
             it?.isKotlinCollectionType shouldBeEqualTo false
             it?.isTypeParameter shouldBeEqualTo false
-            it?.isExternalDeclaration shouldBeEqualTo false
+            it?.isExternal shouldBeEqualTo false
             it?.asClassDeclaration() shouldBeEqualTo null
             it?.hasClassDeclaration() shouldBeEqualTo false
             it?.hasClassDeclaration { decl -> decl.name == "someName" } shouldBeEqualTo false

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/type/kotype/KoTypeDeclarationForKoDeclarationCastProviderTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/type/kotype/KoTypeDeclarationForKoDeclarationCastProviderTest.kt
@@ -46,7 +46,7 @@ class KoTypeDeclarationForKoDeclarationCastProviderTest {
             it?.isKotlinBasicType shouldBeEqualTo false
             it?.isKotlinCollectionType shouldBeEqualTo false
             it?.isTypeParameter shouldBeEqualTo false
-            it?.isExternalDeclaration shouldBeEqualTo false
+            it?.isExternal shouldBeEqualTo false
             it?.asClassDeclaration() shouldBeInstanceOf KoClassDeclaration::class
             it?.asClassDeclaration()?.name shouldBeEqualTo "SampleType"
             it?.hasClassDeclaration() shouldBeEqualTo true
@@ -103,7 +103,7 @@ class KoTypeDeclarationForKoDeclarationCastProviderTest {
             it?.isKotlinBasicType shouldBeEqualTo false
             it?.isKotlinCollectionType shouldBeEqualTo false
             it?.isTypeParameter shouldBeEqualTo false
-            it?.isExternalDeclaration shouldBeEqualTo false
+            it?.isExternal shouldBeEqualTo false
             it?.asClassDeclaration() shouldBeInstanceOf KoClassDeclaration::class
             it?.asClassDeclaration()?.name shouldBeEqualTo "SampleType"
             it?.hasClassDeclaration() shouldBeEqualTo true
@@ -160,7 +160,7 @@ class KoTypeDeclarationForKoDeclarationCastProviderTest {
             it?.isKotlinBasicType shouldBeEqualTo false
             it?.isKotlinCollectionType shouldBeEqualTo false
             it?.isTypeParameter shouldBeEqualTo false
-            it?.isExternalDeclaration shouldBeEqualTo false
+            it?.isExternal shouldBeEqualTo false
             it?.asObjectDeclaration() shouldBeInstanceOf KoObjectDeclaration::class
             it?.asObjectDeclaration()?.name shouldBeEqualTo "SampleObject"
             it?.hasObjectDeclaration() shouldBeEqualTo true
@@ -217,7 +217,7 @@ class KoTypeDeclarationForKoDeclarationCastProviderTest {
             it?.isKotlinBasicType shouldBeEqualTo false
             it?.isKotlinCollectionType shouldBeEqualTo false
             it?.isTypeParameter shouldBeEqualTo false
-            it?.isExternalDeclaration shouldBeEqualTo false
+            it?.isExternal shouldBeEqualTo false
             it?.asObjectDeclaration() shouldBeInstanceOf KoObjectDeclaration::class
             it?.asObjectDeclaration()?.name shouldBeEqualTo "SampleObject"
             it?.hasObjectDeclaration() shouldBeEqualTo true
@@ -274,7 +274,7 @@ class KoTypeDeclarationForKoDeclarationCastProviderTest {
             it?.isKotlinBasicType shouldBeEqualTo false
             it?.isKotlinCollectionType shouldBeEqualTo false
             it?.isTypeParameter shouldBeEqualTo false
-            it?.isExternalDeclaration shouldBeEqualTo false
+            it?.isExternal shouldBeEqualTo false
             it?.asInterfaceDeclaration() shouldBeInstanceOf KoInterfaceDeclaration::class
             it?.asInterfaceDeclaration()?.name shouldBeEqualTo "SampleInterface"
             it?.hasInterfaceDeclaration() shouldBeEqualTo true
@@ -331,7 +331,7 @@ class KoTypeDeclarationForKoDeclarationCastProviderTest {
             it?.isKotlinBasicType shouldBeEqualTo false
             it?.isKotlinCollectionType shouldBeEqualTo false
             it?.isTypeParameter shouldBeEqualTo false
-            it?.isExternalDeclaration shouldBeEqualTo false
+            it?.isExternal shouldBeEqualTo false
             it?.asInterfaceDeclaration() shouldBeInstanceOf KoInterfaceDeclaration::class
             it?.asInterfaceDeclaration()?.name shouldBeEqualTo "SampleInterface"
             it?.hasInterfaceDeclaration() shouldBeEqualTo true
@@ -388,7 +388,7 @@ class KoTypeDeclarationForKoDeclarationCastProviderTest {
             it?.isKotlinBasicType shouldBeEqualTo false
             it?.isKotlinCollectionType shouldBeEqualTo false
             it?.isTypeParameter shouldBeEqualTo false
-            it?.isExternalDeclaration shouldBeEqualTo false
+            it?.isExternal shouldBeEqualTo false
             it?.asImportAliasDeclaration() shouldBeInstanceOf KoImportAliasDeclaration::class
             it?.asImportAliasDeclaration()?.name shouldBeEqualTo "ImportAlias"
             it?.hasImportAliasDeclaration() shouldBeEqualTo true
@@ -440,7 +440,7 @@ class KoTypeDeclarationForKoDeclarationCastProviderTest {
             it?.isKotlinBasicType shouldBeEqualTo false
             it?.isKotlinCollectionType shouldBeEqualTo false
             it?.isTypeParameter shouldBeEqualTo false
-            it?.isExternalDeclaration shouldBeEqualTo false
+            it?.isExternal shouldBeEqualTo false
             it?.asTypeAliasDeclaration() shouldBeInstanceOf KoTypeAliasDeclaration::class
             it?.asTypeAliasDeclaration()?.name shouldBeEqualTo "SampleTypeAlias"
             it?.hasTypeAliasDeclaration() shouldBeEqualTo true
@@ -492,7 +492,7 @@ class KoTypeDeclarationForKoDeclarationCastProviderTest {
             it?.isKotlinBasicType shouldBeEqualTo false
             it?.isKotlinCollectionType shouldBeEqualTo false
             it?.isTypeParameter shouldBeEqualTo false
-            it?.isExternalDeclaration shouldBeEqualTo false
+            it?.isExternal shouldBeEqualTo false
             it?.asImportAliasDeclaration() shouldBeInstanceOf KoImportAliasDeclaration::class
             it?.asImportAliasDeclaration()?.name shouldBeEqualTo "ImportAlias"
             it?.hasImportAliasDeclaration() shouldBeEqualTo true
@@ -544,7 +544,7 @@ class KoTypeDeclarationForKoDeclarationCastProviderTest {
             it?.isKotlinBasicType shouldBeEqualTo false
             it?.isKotlinCollectionType shouldBeEqualTo false
             it?.isTypeParameter shouldBeEqualTo true
-            it?.isExternalDeclaration shouldBeEqualTo false
+            it?.isExternal shouldBeEqualTo false
             it?.asTypeParameterDeclaration() shouldBeInstanceOf KoTypeParameterDeclaration::class
             it?.asTypeParameterDeclaration()?.name shouldBeEqualTo "TestType"
             it?.hasTypeParameterDeclaration() shouldBeEqualTo true
@@ -596,7 +596,7 @@ class KoTypeDeclarationForKoDeclarationCastProviderTest {
             it?.isKotlinBasicType shouldBeEqualTo false
             it?.isKotlinCollectionType shouldBeEqualTo false
             it?.isTypeParameter shouldBeEqualTo true
-            it?.isExternalDeclaration shouldBeEqualTo false
+            it?.isExternal shouldBeEqualTo false
             it?.asTypeParameterDeclaration() shouldBeInstanceOf KoTypeParameterDeclaration::class
             it?.asTypeParameterDeclaration()?.name shouldBeEqualTo "TestType"
             it?.hasTypeParameterDeclaration() shouldBeEqualTo true
@@ -648,7 +648,7 @@ class KoTypeDeclarationForKoDeclarationCastProviderTest {
             it?.isKotlinBasicType shouldBeEqualTo false
             it?.isKotlinCollectionType shouldBeEqualTo false
             it?.isTypeParameter shouldBeEqualTo false
-            it?.isExternalDeclaration shouldBeEqualTo false
+            it?.isExternal shouldBeEqualTo false
             it?.asTypeAliasDeclaration() shouldBeInstanceOf KoTypeAliasDeclaration::class
             it?.asTypeAliasDeclaration()?.name shouldBeEqualTo "SampleTypeAlias"
             it?.hasTypeAliasDeclaration() shouldBeEqualTo true
@@ -700,7 +700,7 @@ class KoTypeDeclarationForKoDeclarationCastProviderTest {
             it?.isKotlinBasicType shouldBeEqualTo true
             it?.isKotlinCollectionType shouldBeEqualTo false
             it?.isTypeParameter shouldBeEqualTo false
-            it?.isExternalDeclaration shouldBeEqualTo false
+            it?.isExternal shouldBeEqualTo false
             it?.asKotlinTypeDeclaration() shouldBeInstanceOf KoKotlinTypeDeclaration::class
             it?.asKotlinTypeDeclaration()?.name shouldBeEqualTo "String"
             it?.hasKotlinTypeDeclaration() shouldBeEqualTo true
@@ -762,7 +762,7 @@ class KoTypeDeclarationForKoDeclarationCastProviderTest {
             it?.isKotlinBasicType shouldBeEqualTo true
             it?.isKotlinCollectionType shouldBeEqualTo false
             it?.isTypeParameter shouldBeEqualTo false
-            it?.isExternalDeclaration shouldBeEqualTo false
+            it?.isExternal shouldBeEqualTo false
             it?.asKotlinTypeDeclaration() shouldBeInstanceOf KoKotlinTypeDeclaration::class
             it?.asKotlinTypeDeclaration()?.name shouldBeEqualTo "String"
             it?.hasKotlinTypeDeclaration() shouldBeEqualTo true
@@ -824,7 +824,7 @@ class KoTypeDeclarationForKoDeclarationCastProviderTest {
             it?.isKotlinBasicType shouldBeEqualTo false
             it?.isKotlinCollectionType shouldBeEqualTo false
             it?.isTypeParameter shouldBeEqualTo false
-            it?.isExternalDeclaration shouldBeEqualTo false
+            it?.isExternal shouldBeEqualTo false
             it?.asClassDeclaration() shouldBeEqualTo null
             it?.hasClassDeclaration() shouldBeEqualTo false
             it?.asObjectDeclaration() shouldBeEqualTo null
@@ -873,7 +873,7 @@ class KoTypeDeclarationForKoDeclarationCastProviderTest {
             it?.isKotlinBasicType shouldBeEqualTo false
             it?.isKotlinCollectionType shouldBeEqualTo false
             it?.isTypeParameter shouldBeEqualTo false
-            it?.isExternalDeclaration shouldBeEqualTo false
+            it?.isExternal shouldBeEqualTo false
             it?.asClassDeclaration() shouldBeEqualTo null
             it?.hasClassDeclaration() shouldBeEqualTo false
             it?.asObjectDeclaration() shouldBeEqualTo null
@@ -922,7 +922,7 @@ class KoTypeDeclarationForKoDeclarationCastProviderTest {
             it?.isKotlinBasicType shouldBeEqualTo false
             it?.isKotlinCollectionType shouldBeEqualTo false
             it?.isTypeParameter shouldBeEqualTo false
-            it?.isExternalDeclaration shouldBeEqualTo false
+            it?.isExternal shouldBeEqualTo false
             it?.asClassDeclaration() shouldBeInstanceOf KoClassDeclaration::class
             it?.asClassDeclaration()?.name shouldBeEqualTo "SampleCollection1"
             it?.hasClassDeclaration() shouldBeEqualTo true
@@ -979,7 +979,7 @@ class KoTypeDeclarationForKoDeclarationCastProviderTest {
             it?.isKotlinBasicType shouldBeEqualTo false
             it?.isKotlinCollectionType shouldBeEqualTo false
             it?.isTypeParameter shouldBeEqualTo false
-            it?.isExternalDeclaration shouldBeEqualTo false
+            it?.isExternal shouldBeEqualTo false
             it?.asClassDeclaration() shouldBeInstanceOf KoClassDeclaration::class
             it?.asClassDeclaration()?.name shouldBeEqualTo "SampleCollection1"
             it?.hasClassDeclaration() shouldBeEqualTo true
@@ -1036,7 +1036,7 @@ class KoTypeDeclarationForKoDeclarationCastProviderTest {
             it?.isKotlinBasicType shouldBeEqualTo false
             it?.isKotlinCollectionType shouldBeEqualTo false
             it?.isTypeParameter shouldBeEqualTo false
-            it?.isExternalDeclaration shouldBeEqualTo true
+            it?.isExternal shouldBeEqualTo true
             it?.asExternalDeclaration() shouldBeInstanceOf KoExternalDeclaration::class
             it?.asExternalDeclaration()?.name shouldBeEqualTo "SampleExternalClass"
             it?.hasExternalDeclaration() shouldBeEqualTo true
@@ -1094,7 +1094,7 @@ class KoTypeDeclarationForKoDeclarationCastProviderTest {
             it?.isKotlinBasicType shouldBeEqualTo false
             it?.isKotlinCollectionType shouldBeEqualTo false
             it?.isTypeParameter shouldBeEqualTo false
-            it?.isExternalDeclaration shouldBeEqualTo true
+            it?.isExternal shouldBeEqualTo true
             it?.asExternalDeclaration() shouldBeInstanceOf KoExternalDeclaration::class
             it?.asExternalDeclaration()?.name shouldBeEqualTo "SampleExternalClass"
             it?.hasExternalDeclaration() shouldBeEqualTo true
@@ -1155,7 +1155,7 @@ class KoTypeDeclarationForKoDeclarationCastProviderTest {
             it?.isKotlinBasicType shouldBeEqualTo false
             it?.isKotlinCollectionType shouldBeEqualTo false
             it?.isTypeParameter shouldBeEqualTo false
-            it?.isExternalDeclaration shouldBeEqualTo false
+            it?.isExternal shouldBeEqualTo false
             it shouldBeInstanceOf KoStarProjectionDeclaration::class
             it?.asClassDeclaration() shouldBeEqualTo null
             it?.hasClassDeclaration() shouldBeEqualTo false

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/type/kotype/KoTypeDeclarationForKoFunctionTypeDeclarationProviderTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/type/kotype/KoTypeDeclarationForKoFunctionTypeDeclarationProviderTest.kt
@@ -81,9 +81,9 @@ class KoTypeDeclarationForKoFunctionTypeDeclarationProviderTest {
             it?.countParameterTypes { parameter -> parameter.type.isKotlinBasicType } shouldBeEqualTo 1
             it?.countParameterTypes { parameter -> parameter.type.isClass } shouldBeEqualTo 0
             it?.hasParameterType { parameter -> parameter.type.isKotlinType } shouldBeEqualTo true
-            it?.hasParameterType { parameter -> parameter.type.isExternalDeclaration } shouldBeEqualTo false
+            it?.hasParameterType { parameter -> parameter.type.isExternal } shouldBeEqualTo false
             it?.hasAllParameterTypes { parameter -> parameter.type.isKotlinType } shouldBeEqualTo true
-            it?.hasAllParameterTypes { parameter -> parameter.type.isExternalDeclaration } shouldBeEqualTo false
+            it?.hasAllParameterTypes { parameter -> parameter.type.isExternal } shouldBeEqualTo false
             it?.parameters?.map { parameter -> parameter.type.name } shouldBeEqualTo listOf("String")
             it?.numParameters shouldBeEqualTo 1
             it?.countParameters { parameter -> parameter.type.isKotlinType } shouldBeEqualTo 1
@@ -91,9 +91,9 @@ class KoTypeDeclarationForKoFunctionTypeDeclarationProviderTest {
             it?.countParameters { parameter -> parameter.type.isKotlinBasicType } shouldBeEqualTo 1
             it?.countParameters { parameter -> parameter.type.isClass } shouldBeEqualTo 0
             it?.hasParameter { parameter -> parameter.type.isKotlinType } shouldBeEqualTo true
-            it?.hasParameter { parameter -> parameter.type.isExternalDeclaration } shouldBeEqualTo false
+            it?.hasParameter { parameter -> parameter.type.isExternal } shouldBeEqualTo false
             it?.hasAllParameters { parameter -> parameter.type.isKotlinType } shouldBeEqualTo true
-            it?.hasAllParameters { parameter -> parameter.type.isExternalDeclaration } shouldBeEqualTo false
+            it?.hasAllParameters { parameter -> parameter.type.isExternal } shouldBeEqualTo false
         }
     }
 
@@ -115,9 +115,9 @@ class KoTypeDeclarationForKoFunctionTypeDeclarationProviderTest {
             it?.countParameterTypes { parameter -> parameter.type.isKotlinBasicType } shouldBeEqualTo 1
             it?.countParameterTypes { parameter -> parameter.type.isClass } shouldBeEqualTo 0
             it?.hasParameterType { parameter -> parameter.type.isKotlinType } shouldBeEqualTo true
-            it?.hasParameterType { parameter -> parameter.type.isExternalDeclaration } shouldBeEqualTo false
+            it?.hasParameterType { parameter -> parameter.type.isExternal } shouldBeEqualTo false
             it?.hasAllParameterTypes { parameter -> parameter.type.isKotlinType || parameter.type.isGenericType } shouldBeEqualTo true
-            it?.hasAllParameterTypes { parameter -> parameter.type.isExternalDeclaration } shouldBeEqualTo false
+            it?.hasAllParameterTypes { parameter -> parameter.type.isExternal } shouldBeEqualTo false
             it?.parameters?.map { parameter -> parameter.type.name } shouldBeEqualTo listOf("String", "List<Int>")
             it?.numParameters shouldBeEqualTo 2
             it?.countParameters { parameter -> parameter.type.isKotlinType } shouldBeEqualTo 2
@@ -125,9 +125,9 @@ class KoTypeDeclarationForKoFunctionTypeDeclarationProviderTest {
             it?.countParameters { parameter -> parameter.type.isKotlinBasicType } shouldBeEqualTo 1
             it?.countParameters { parameter -> parameter.type.isClass } shouldBeEqualTo 0
             it?.hasParameter { parameter -> parameter.type.isKotlinType } shouldBeEqualTo true
-            it?.hasParameter { parameter -> parameter.type.isExternalDeclaration } shouldBeEqualTo false
+            it?.hasParameter { parameter -> parameter.type.isExternal } shouldBeEqualTo false
             it?.hasAllParameters { parameter -> parameter.type.isKotlinType || parameter.type.isGenericType } shouldBeEqualTo true
-            it?.hasAllParameters { parameter -> parameter.type.isExternalDeclaration } shouldBeEqualTo false
+            it?.hasAllParameters { parameter -> parameter.type.isExternal } shouldBeEqualTo false
         }
     }
 
@@ -162,7 +162,7 @@ class KoTypeDeclarationForKoFunctionTypeDeclarationProviderTest {
         assertSoftly(sut) {
             it?.returnType shouldBeEqualTo null
             it?.hasReturnType { type -> type.isKotlinType } shouldBeEqualTo false
-            it?.hasReturnType { type -> type.isExternalDeclaration } shouldBeEqualTo false
+            it?.hasReturnType { type -> type.isExternal } shouldBeEqualTo false
             it?.hasReturnTypeOf(Unit::class) shouldBeEqualTo false
             it?.hasReturnTypeOf(String::class) shouldBeEqualTo false
         }
@@ -181,7 +181,7 @@ class KoTypeDeclarationForKoFunctionTypeDeclarationProviderTest {
         assertSoftly(sut) {
             it?.returnType?.name shouldBeEqualTo "Unit"
             it?.hasReturnType { type -> type.isKotlinType } shouldBeEqualTo true
-            it?.hasReturnType { type -> type.isExternalDeclaration } shouldBeEqualTo false
+            it?.hasReturnType { type -> type.isExternal } shouldBeEqualTo false
             it?.hasReturnTypeOf(Unit::class) shouldBeEqualTo true
             it?.hasReturnTypeOf(String::class) shouldBeEqualTo false
         }
@@ -200,7 +200,7 @@ class KoTypeDeclarationForKoFunctionTypeDeclarationProviderTest {
         assertSoftly(sut) {
             it?.returnType?.name shouldBeEqualTo "List<String>"
             it?.hasReturnType { type -> type.isGenericType } shouldBeEqualTo true
-            it?.hasReturnType { type -> type.isExternalDeclaration } shouldBeEqualTo false
+            it?.hasReturnType { type -> type.isExternal } shouldBeEqualTo false
             it?.hasReturnTypeOf(String::class) shouldBeEqualTo false
         }
     }
@@ -218,7 +218,7 @@ class KoTypeDeclarationForKoFunctionTypeDeclarationProviderTest {
         assertSoftly(sut) {
             it?.returnType?.name shouldBeEqualTo "SampleClass"
             it?.hasReturnType { type -> type.isClass } shouldBeEqualTo true
-            it?.hasReturnType { type -> type.isExternalDeclaration } shouldBeEqualTo false
+            it?.hasReturnType { type -> type.isExternal } shouldBeEqualTo false
             it?.hasReturnTypeOf(SampleClass::class) shouldBeEqualTo true
             it?.hasReturnTypeOf(String::class) shouldBeEqualTo false
         }

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/type/kotype/KoTypeDeclarationForKoIsGenericProviderTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/type/kotype/KoTypeDeclarationForKoIsGenericProviderTest.kt
@@ -1,0 +1,49 @@
+package com.lemonappdev.konsist.core.declaration.type.kotype
+
+import com.lemonappdev.konsist.TestSnippetProvider
+import org.amshove.kluent.shouldBeEqualTo
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.Arguments.arguments
+import org.junit.jupiter.params.provider.MethodSource
+
+class KoTypeDeclarationForKoIsGenericProviderTest {
+    @ParameterizedTest
+    @MethodSource("provideValues")
+    fun `is-generic`(
+        fileName: String,
+        value: Boolean,
+    ) {
+        // given
+        val sut =
+            getSnippetFile(fileName)
+                .properties()
+                .first()
+                .type
+
+        // then
+        sut?.isGeneric shouldBeEqualTo value
+    }
+
+    private fun getSnippetFile(fileName: String) =
+        TestSnippetProvider.getSnippetKoScope("core/declaration/type/kotype/snippet/forkoisgenericprovider/", fileName)
+
+    companion object {
+        @Suppress("unused")
+        @JvmStatic
+        fun provideValues() =
+            listOf(
+                arguments("kotlin-type", false),
+                arguments("generic-type", true),
+                arguments("generic-class-type", true),
+                arguments("not-generic-class-type", false),
+                arguments("interface-type", false),
+                arguments("object-type", false),
+                arguments("function-type", false),
+                arguments("generic-import-alias-type", true),
+                arguments("not-generic-import-alias-type", false),
+                arguments("generic-typealias-type", true),
+                arguments("not-generic-typealias-type", false),
+                arguments("external-type", false),
+            )
+    }
+}

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/type/kotype/KoTypeDeclarationForKoTypeArgumentProviderTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/type/kotype/KoTypeDeclarationForKoTypeArgumentProviderTest.kt
@@ -42,8 +42,8 @@ class KoTypeDeclarationForKoTypeArgumentProviderTest {
             it?.hasAllTypeArgumentsOf(String::class, Int::class) shouldBeEqualTo false
             it?.hasAllTypeArgumentsOf(listOf(String::class, Int::class)) shouldBeEqualTo false
             it?.hasAllTypeArgumentsOf(listOf(SampleClass::class, Int::class)) shouldBeEqualTo false
-            it?.hasTypeArgument { type -> type.sourceDeclaration?.isExternalDeclaration == true } shouldBeEqualTo false
-            it?.hasAllTypeArguments { type -> type.sourceDeclaration?.isExternalDeclaration == true } shouldBeEqualTo false
+            it?.hasTypeArgument { type -> type.sourceDeclaration?.isExternal == true } shouldBeEqualTo false
+            it?.hasAllTypeArguments { type -> type.sourceDeclaration?.isExternal == true } shouldBeEqualTo false
         }
     }
 
@@ -88,9 +88,9 @@ class KoTypeDeclarationForKoTypeArgumentProviderTest {
             it?.hasAllTypeArgumentsOf(listOf(String::class, Int::class)) shouldBeEqualTo false
             it?.hasAllTypeArgumentsOf(listOf(SampleClass::class, Int::class)) shouldBeEqualTo false
             it?.hasTypeArgument { type -> type.sourceDeclaration?.isKotlinType == true } shouldBeEqualTo true
-            it?.hasTypeArgument { type -> type.sourceDeclaration?.isExternalDeclaration == true } shouldBeEqualTo false
+            it?.hasTypeArgument { type -> type.sourceDeclaration?.isExternal == true } shouldBeEqualTo false
             it?.hasAllTypeArguments { type -> type.sourceDeclaration?.isKotlinType == true } shouldBeEqualTo true
-            it?.hasAllTypeArguments { type -> type.sourceDeclaration?.isExternalDeclaration == true } shouldBeEqualTo false
+            it?.hasAllTypeArguments { type -> type.sourceDeclaration?.isExternal == true } shouldBeEqualTo false
         }
     }
 
@@ -113,7 +113,7 @@ class KoTypeDeclarationForKoTypeArgumentProviderTest {
             it?.typeArguments?.firstOrNull()?.name shouldBeEqualTo "SampleClass"
             it?.numTypeArguments shouldBeEqualTo 1
             it?.countTypeArguments { type -> type.sourceDeclaration?.isClass == true } shouldBeEqualTo 1
-            it?.countTypeArguments { type -> type.sourceDeclaration?.isExternalDeclaration == true } shouldBeEqualTo 0
+            it?.countTypeArguments { type -> type.sourceDeclaration?.isExternal == true } shouldBeEqualTo 0
             it?.hasTypeArgumentWithName("SampleClass", "Int") shouldBeEqualTo true
             it?.hasTypeArgumentWithName("OtherClass", "Int") shouldBeEqualTo false
             it?.hasTypeArgumentWithName(listOf("SampleClass", "Int")) shouldBeEqualTo true
@@ -135,9 +135,9 @@ class KoTypeDeclarationForKoTypeArgumentProviderTest {
             it?.hasAllTypeArgumentsOf(listOf(SampleClass::class, Int::class)) shouldBeEqualTo false
             it?.hasAllTypeArgumentsOf(listOf(SampleInterface::class, Int::class)) shouldBeEqualTo false
             it?.hasTypeArgument { type -> type.sourceDeclaration?.isClass == true } shouldBeEqualTo true
-            it?.hasTypeArgument { type -> type.sourceDeclaration?.isExternalDeclaration == true } shouldBeEqualTo false
+            it?.hasTypeArgument { type -> type.sourceDeclaration?.isExternal == true } shouldBeEqualTo false
             it?.hasAllTypeArguments { type -> type.sourceDeclaration?.isClass == true } shouldBeEqualTo true
-            it?.hasAllTypeArguments { type -> type.sourceDeclaration?.isExternalDeclaration == true } shouldBeEqualTo false
+            it?.hasAllTypeArguments { type -> type.sourceDeclaration?.isExternal == true } shouldBeEqualTo false
         }
     }
 
@@ -182,9 +182,9 @@ class KoTypeDeclarationForKoTypeArgumentProviderTest {
             it?.hasAllTypeArgumentsOf(listOf(SampleInterface::class, Int::class)) shouldBeEqualTo false
             it?.hasAllTypeArgumentsOf(listOf(SampleClass::class, Int::class)) shouldBeEqualTo false
             it?.hasTypeArgument { type -> type.sourceDeclaration?.isInterface == true } shouldBeEqualTo true
-            it?.hasTypeArgument { type -> type.sourceDeclaration?.isExternalDeclaration == true } shouldBeEqualTo false
+            it?.hasTypeArgument { type -> type.sourceDeclaration?.isExternal == true } shouldBeEqualTo false
             it?.hasAllTypeArguments { type -> type.sourceDeclaration?.isInterface == true } shouldBeEqualTo true
-            it?.hasAllTypeArguments { type -> type.sourceDeclaration?.isExternalDeclaration == true } shouldBeEqualTo false
+            it?.hasAllTypeArguments { type -> type.sourceDeclaration?.isExternal == true } shouldBeEqualTo false
         }
     }
 
@@ -229,9 +229,9 @@ class KoTypeDeclarationForKoTypeArgumentProviderTest {
             it?.hasAllTypeArgumentsOf(listOf(SampleObject::class, Int::class)) shouldBeEqualTo false
             it?.hasAllTypeArgumentsOf(listOf(SampleClass::class, Int::class)) shouldBeEqualTo false
             it?.hasTypeArgument { type -> type.sourceDeclaration?.isObject == true } shouldBeEqualTo true
-            it?.hasTypeArgument { type -> type.sourceDeclaration?.isExternalDeclaration == true } shouldBeEqualTo false
+            it?.hasTypeArgument { type -> type.sourceDeclaration?.isExternal == true } shouldBeEqualTo false
             it?.hasAllTypeArguments { type -> type.sourceDeclaration?.isObject == true } shouldBeEqualTo true
-            it?.hasAllTypeArguments { type -> type.sourceDeclaration?.isExternalDeclaration == true } shouldBeEqualTo false
+            it?.hasAllTypeArguments { type -> type.sourceDeclaration?.isExternal == true } shouldBeEqualTo false
         }
     }
 
@@ -274,9 +274,9 @@ class KoTypeDeclarationForKoTypeArgumentProviderTest {
             it?.hasAllTypeArgumentsOf(listOf(Set::class)) shouldBeEqualTo true
             it?.hasAllTypeArgumentsOf(listOf(List::class)) shouldBeEqualTo false
             it?.hasTypeArgument { type -> type.sourceDeclaration?.isKotlinType == true } shouldBeEqualTo true
-            it?.hasTypeArgument { type -> type.sourceDeclaration?.isExternalDeclaration == true } shouldBeEqualTo false
+            it?.hasTypeArgument { type -> type.sourceDeclaration?.isExternal == true } shouldBeEqualTo false
             it?.hasAllTypeArguments { type -> type.sourceDeclaration?.isKotlinType == true } shouldBeEqualTo true
-            it?.hasAllTypeArguments { type -> type.sourceDeclaration?.isExternalDeclaration == true } shouldBeEqualTo false
+            it?.hasAllTypeArguments { type -> type.sourceDeclaration?.isExternal == true } shouldBeEqualTo false
         }
     }
 
@@ -335,7 +335,7 @@ class KoTypeDeclarationForKoTypeArgumentProviderTest {
 
             it?.typeArguments?.firstOrNull()?.name shouldBeEqualTo "() -> Unit"
             it?.numTypeArguments shouldBeEqualTo 1
-            it?.countTypeArguments { type -> type.sourceDeclaration?.isExternalDeclaration == true } shouldBeEqualTo 0
+            it?.countTypeArguments { type -> type.sourceDeclaration?.isExternal == true } shouldBeEqualTo 0
             it?.hasTypeArgumentWithName("() -> Unit", "Int") shouldBeEqualTo true
             it?.hasTypeArgumentWithName("OtherClass", "Int") shouldBeEqualTo false
             it?.hasTypeArgumentWithName(listOf("() -> Unit", "Int")) shouldBeEqualTo true
@@ -350,8 +350,8 @@ class KoTypeDeclarationForKoTypeArgumentProviderTest {
             it?.hasTypeArgumentOf(listOf(SampleInterface::class, Int::class)) shouldBeEqualTo false
             it?.hasAllTypeArgumentsOf(SampleInterface::class, Int::class) shouldBeEqualTo false
             it?.hasAllTypeArgumentsOf(listOf(SampleInterface::class, Int::class)) shouldBeEqualTo false
-            it?.hasTypeArgument { type -> type.sourceDeclaration?.isExternalDeclaration == true } shouldBeEqualTo false
-            it?.hasAllTypeArguments { type -> type.sourceDeclaration?.isExternalDeclaration == true } shouldBeEqualTo false
+            it?.hasTypeArgument { type -> type.sourceDeclaration?.isExternal == true } shouldBeEqualTo false
+            it?.hasAllTypeArguments { type -> type.sourceDeclaration?.isExternal == true } shouldBeEqualTo false
         }
     }
 
@@ -374,7 +374,7 @@ class KoTypeDeclarationForKoTypeArgumentProviderTest {
             it?.typeArguments?.firstOrNull()?.name shouldBeEqualTo "ImportAlias"
             it?.numTypeArguments shouldBeEqualTo 1
             it?.countTypeArguments { type -> type.sourceDeclaration?.isImportAlias == true } shouldBeEqualTo 1
-            it?.countTypeArguments { type -> type.sourceDeclaration?.isExternalDeclaration == true } shouldBeEqualTo 0
+            it?.countTypeArguments { type -> type.sourceDeclaration?.isExternal == true } shouldBeEqualTo 0
             it?.hasTypeArgumentWithName("ImportAlias", "Int") shouldBeEqualTo true
             it?.hasTypeArgumentWithName("OtherClass", "Int") shouldBeEqualTo false
             it?.hasTypeArgumentWithName(listOf("ImportAlias", "Int")) shouldBeEqualTo true
@@ -390,9 +390,9 @@ class KoTypeDeclarationForKoTypeArgumentProviderTest {
             it?.hasAllTypeArgumentsOf(SampleInterface::class, Int::class) shouldBeEqualTo false
             it?.hasAllTypeArgumentsOf(listOf(SampleInterface::class, Int::class)) shouldBeEqualTo false
             it?.hasTypeArgument { type -> type.sourceDeclaration?.isImportAlias == true } shouldBeEqualTo true
-            it?.hasTypeArgument { type -> type.sourceDeclaration?.isExternalDeclaration == true } shouldBeEqualTo false
+            it?.hasTypeArgument { type -> type.sourceDeclaration?.isExternal == true } shouldBeEqualTo false
             it?.hasAllTypeArguments { type -> type.sourceDeclaration?.isImportAlias == true } shouldBeEqualTo true
-            it?.hasAllTypeArguments { type -> type.sourceDeclaration?.isExternalDeclaration == true } shouldBeEqualTo false
+            it?.hasAllTypeArguments { type -> type.sourceDeclaration?.isExternal == true } shouldBeEqualTo false
         }
     }
 
@@ -415,7 +415,7 @@ class KoTypeDeclarationForKoTypeArgumentProviderTest {
             it?.typeArguments?.firstOrNull()?.name shouldBeEqualTo "SampleTypeAlias"
             it?.numTypeArguments shouldBeEqualTo 1
             it?.countTypeArguments { type -> type.sourceDeclaration?.isTypeAlias == true } shouldBeEqualTo 1
-            it?.countTypeArguments { type -> type.sourceDeclaration?.isExternalDeclaration == true } shouldBeEqualTo 0
+            it?.countTypeArguments { type -> type.sourceDeclaration?.isExternal == true } shouldBeEqualTo 0
             it?.hasTypeArgumentWithName("SampleTypeAlias", "Int") shouldBeEqualTo true
             it?.hasTypeArgumentWithName("OtherClass", "Int") shouldBeEqualTo false
             it?.hasTypeArgumentWithName(listOf("SampleTypeAlias", "Int")) shouldBeEqualTo true
@@ -431,9 +431,9 @@ class KoTypeDeclarationForKoTypeArgumentProviderTest {
             it?.hasAllTypeArgumentsOf(SampleInterface::class, Int::class) shouldBeEqualTo false
             it?.hasAllTypeArgumentsOf(listOf(SampleInterface::class, Int::class)) shouldBeEqualTo false
             it?.hasTypeArgument { type -> type.sourceDeclaration?.isTypeAlias == true } shouldBeEqualTo true
-            it?.hasTypeArgument { type -> type.sourceDeclaration?.isExternalDeclaration == true } shouldBeEqualTo false
+            it?.hasTypeArgument { type -> type.sourceDeclaration?.isExternal == true } shouldBeEqualTo false
             it?.hasAllTypeArguments { type -> type.sourceDeclaration?.isTypeAlias == true } shouldBeEqualTo true
-            it?.hasAllTypeArguments { type -> type.sourceDeclaration?.isExternalDeclaration == true } shouldBeEqualTo false
+            it?.hasAllTypeArguments { type -> type.sourceDeclaration?.isExternal == true } shouldBeEqualTo false
         }
     }
 
@@ -455,7 +455,7 @@ class KoTypeDeclarationForKoTypeArgumentProviderTest {
 
             it?.typeArguments?.firstOrNull()?.name shouldBeEqualTo "SampleExternalClass"
             it?.numTypeArguments shouldBeEqualTo 1
-            it?.countTypeArguments { type -> type.sourceDeclaration?.isExternalDeclaration == true } shouldBeEqualTo 1
+            it?.countTypeArguments { type -> type.sourceDeclaration?.isExternal == true } shouldBeEqualTo 1
             it?.countTypeArguments { type -> type.sourceDeclaration?.isInterface == true } shouldBeEqualTo 0
             it?.hasTypeArgumentWithName("SampleExternalClass", "Int") shouldBeEqualTo true
             it?.hasTypeArgumentWithName("OtherClass", "Int") shouldBeEqualTo false
@@ -477,9 +477,9 @@ class KoTypeDeclarationForKoTypeArgumentProviderTest {
             it?.hasAllTypeArgumentsOf(listOf(SampleExternalClass::class)) shouldBeEqualTo true
             it?.hasAllTypeArgumentsOf(listOf(SampleExternalClass::class, Int::class)) shouldBeEqualTo false
             it?.hasAllTypeArgumentsOf(listOf(SampleInterface::class, Int::class)) shouldBeEqualTo false
-            it?.hasTypeArgument { type -> type.sourceDeclaration?.isExternalDeclaration == true } shouldBeEqualTo true
+            it?.hasTypeArgument { type -> type.sourceDeclaration?.isExternal == true } shouldBeEqualTo true
             it?.hasTypeArgument { type -> type.sourceDeclaration?.isInterface == true } shouldBeEqualTo false
-            it?.hasAllTypeArguments { type -> type.sourceDeclaration?.isExternalDeclaration == true } shouldBeEqualTo true
+            it?.hasAllTypeArguments { type -> type.sourceDeclaration?.isExternal == true } shouldBeEqualTo true
             it?.hasAllTypeArguments { type -> type.sourceDeclaration?.isInterface == true } shouldBeEqualTo false
         }
     }

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/type/kotype/snippet/forkoisgenericprovider/external-type.kttest
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/type/kotype/snippet/forkoisgenericprovider/external-type.kttest
@@ -1,0 +1,3 @@
+import com.lemonappdev.konsist.externalsample.SampleExternalClass
+
+val sampleProperty1: SampleExternalClass = SampleExternalClass()

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/type/kotype/snippet/forkoisgenericprovider/function-type.kttest
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/type/kotype/snippet/forkoisgenericprovider/function-type.kttest
@@ -1,0 +1,3 @@
+import com.lemonappdev.konsist.testdata.SampleObject
+
+val sampleProperty1: (String) -> Unit = {}

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/type/kotype/snippet/forkoisgenericprovider/generic-class-type.kttest
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/type/kotype/snippet/forkoisgenericprovider/generic-class-type.kttest
@@ -1,0 +1,3 @@
+import com.lemonappdev.konsist.testdata.SampleGenericClassWithParameter
+
+val sampleProperty1: SampleGenericClassWithParameter<String> = SampleGenericClassWithParameter("")

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/type/kotype/snippet/forkoisgenericprovider/generic-import-alias-type.kttest
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/type/kotype/snippet/forkoisgenericprovider/generic-import-alias-type.kttest
@@ -1,0 +1,3 @@
+import com.lemonappdev.konsist.testdata.SampleGenericClassWithParameter as SampleAlias
+
+val sampleProperty1: SampleAlias<String> = SampleAlias("")

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/type/kotype/snippet/forkoisgenericprovider/generic-type.kttest
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/type/kotype/snippet/forkoisgenericprovider/generic-type.kttest
@@ -1,0 +1,1 @@
+val sampleProperty1: List<Set<String>> = listOf()

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/type/kotype/snippet/forkoisgenericprovider/generic-typealias-type.kttest
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/type/kotype/snippet/forkoisgenericprovider/generic-typealias-type.kttest
@@ -1,0 +1,5 @@
+import com.lemonappdev.konsist.testdata.SampleGenericClassWithParameter
+
+val sampleProperty1: SampleTypeAlias = SampleTypeAlias("")
+
+typealias SampleTypeAlias = SampleGenericClassWithParameter<String>

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/type/kotype/snippet/forkoisgenericprovider/interface-type.kttest
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/type/kotype/snippet/forkoisgenericprovider/interface-type.kttest
@@ -1,0 +1,5 @@
+import com.lemonappdev.konsist.testdata.SampleInterface
+
+val sampleProperty1: SampleInterface = SampleClass()
+
+class SampleClass : SampleInterface

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/type/kotype/snippet/forkoisgenericprovider/kotlin-type.kttest
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/type/kotype/snippet/forkoisgenericprovider/kotlin-type.kttest
@@ -1,0 +1,1 @@
+val sampleProperty1: String = ""

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/type/kotype/snippet/forkoisgenericprovider/not-generic-class-type.kttest
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/type/kotype/snippet/forkoisgenericprovider/not-generic-class-type.kttest
@@ -1,0 +1,3 @@
+import com.lemonappdev.konsist.testdata.SampleClass
+
+val sampleProperty1: SampleClass = SampleClass()

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/type/kotype/snippet/forkoisgenericprovider/not-generic-import-alias-type.kttest
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/type/kotype/snippet/forkoisgenericprovider/not-generic-import-alias-type.kttest
@@ -1,0 +1,3 @@
+import com.lemonappdev.konsist.testdata.SampleClass as SampleAlias
+
+val sampleProperty1: SampleAlias = SampleAlias()

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/type/kotype/snippet/forkoisgenericprovider/not-generic-typealias-type.kttest
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/type/kotype/snippet/forkoisgenericprovider/not-generic-typealias-type.kttest
@@ -1,0 +1,5 @@
+import com.lemonappdev.konsist.testdata.SampleClass
+
+val sampleProperty1: SampleTypeAlias = {}
+
+typealias SampleTypeAlias = (SampleClass) -> Unit

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/type/kotype/snippet/forkoisgenericprovider/object-type.kttest
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/type/kotype/snippet/forkoisgenericprovider/object-type.kttest
@@ -1,0 +1,3 @@
+import com.lemonappdev.konsist.testdata.SampleObject
+
+val sampleProperty1: SampleObject = SampleObject

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/api/declaration/KoTypeArgumentDeclaration.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/api/declaration/KoTypeArgumentDeclaration.kt
@@ -4,6 +4,7 @@ import com.lemonappdev.konsist.api.provider.KoBaseProvider
 import com.lemonappdev.konsist.api.provider.KoDeclarationCastProvider
 import com.lemonappdev.konsist.api.provider.KoFunctionTypeDeclarationProvider
 import com.lemonappdev.konsist.api.provider.KoIsFunctionTypeProvider
+import com.lemonappdev.konsist.api.provider.KoIsGenericProvider
 import com.lemonappdev.konsist.api.provider.KoIsGenericTypeProvider
 import com.lemonappdev.konsist.api.provider.KoLocationProvider
 import com.lemonappdev.konsist.api.provider.KoNameProvider
@@ -32,5 +33,6 @@ interface KoTypeArgumentDeclaration :
     KoPathProvider,
     KoDeclarationCastProvider,
     KoIsGenericTypeProvider,
+    KoIsGenericProvider,
     KoIsFunctionTypeProvider,
     KoFunctionTypeDeclarationProvider

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/api/declaration/type/KoTypeDeclaration.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/api/declaration/type/KoTypeDeclaration.kt
@@ -9,6 +9,7 @@ import com.lemonappdev.konsist.api.provider.KoDeclarationCastProvider
 import com.lemonappdev.konsist.api.provider.KoFunctionTypeDeclarationProvider
 import com.lemonappdev.konsist.api.provider.KoGenericTypeProvider
 import com.lemonappdev.konsist.api.provider.KoIsFunctionTypeProvider
+import com.lemonappdev.konsist.api.provider.KoIsGenericProvider
 import com.lemonappdev.konsist.api.provider.KoIsGenericTypeProvider
 import com.lemonappdev.konsist.api.provider.KoIsMutableTypeProvider
 import com.lemonappdev.konsist.api.provider.KoIsNullableProvider
@@ -46,6 +47,7 @@ interface KoTypeDeclaration :
     KoStarProjectionProvider,
     KoGenericTypeProvider,
     KoIsGenericTypeProvider,
+    KoIsGenericProvider,
     KoIsFunctionTypeProvider,
     KoSourceAndAliasTypeProvider,
     KoPackageProvider,

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/api/ext/list/KoDeclarationCastProviderListExt.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/api/ext/list/KoDeclarationCastProviderListExt.kt
@@ -817,13 +817,13 @@ fun <T : KoDeclarationCastProvider> List<T>.withoutTypeParameterDeclaration(
 /**
  * List containing declarations with the specified external declaration.
  *
- * @param predicate The predicate function to determine if a external declaration satisfies a condition.
+ * @param predicate The predicate function to determine if an external declaration satisfies a condition.
  * @return A list containing declarations with the specified external declaration.
  */
 fun <T : KoDeclarationCastProvider> List<T>.withExternalDeclaration(predicate: ((KoExternalDeclaration) -> Boolean)? = null): List<T> =
     filter {
         when (predicate) {
-            null -> it.isExternalDeclaration
+            null -> it.isExternal
             else ->
                 it
                     .asExternalDeclaration()
@@ -834,13 +834,13 @@ fun <T : KoDeclarationCastProvider> List<T>.withExternalDeclaration(predicate: (
 /**
  * List containing declarations without the specified external declaration.
  *
- * @param predicate The predicate function to determine if a external declaration satisfies a condition.
+ * @param predicate The predicate function to determine if an external declaration satisfies a condition.
  * @return A list containing declarations without the specified external declaration.
  */
 fun <T : KoDeclarationCastProvider> List<T>.withoutExternalDeclaration(predicate: ((KoExternalDeclaration) -> Boolean)? = null): List<T> =
     filterNot {
         when (predicate) {
-            null -> it.isExternalDeclaration
+            null -> it.isExternal
             else ->
                 it
                     .asExternalDeclaration()
@@ -903,7 +903,7 @@ fun <T : KoDeclarationCastProvider> List<T>.withoutExternalDeclarationOf(kClasse
 /**
  * List containing declarations with the specified external declaration.
  *
- * @param predicate The predicate function to determine if a external declaration satisfies a condition.
+ * @param predicate The predicate function to determine if an external declaration satisfies a condition.
  * @return A list containing declarations with the specified external declaration.
  */
 @Deprecated("Will be removed in version 0.19.0", ReplaceWith("withExternalDeclaration"))
@@ -921,7 +921,7 @@ fun <T : KoDeclarationCastProvider> List<T>.withExternalTypeDeclaration(predicat
 /**
  * List containing declarations without the specified external declaration.
  *
- * @param predicate The predicate function to determine if a external declaration satisfies a condition.
+ * @param predicate The predicate function to determine if an external declaration satisfies a condition.
  * @return A list containing declarations without the specified external declaration.
  */
 @Deprecated("Will be removed in version 0.19.0", ReplaceWith("withoutExternalDeclaration"))

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/api/ext/list/KoIsGenericProviderListExt.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/api/ext/list/KoIsGenericProviderListExt.kt
@@ -1,0 +1,17 @@
+package com.lemonappdev.konsist.api.ext.list
+
+import com.lemonappdev.konsist.api.provider.KoIsGenericProvider
+
+/**
+ * List containing declarations that are generic.
+ *
+ * @return A list containing only the elements that are generic.
+ */
+fun <T : KoIsGenericProvider> List<T>.withGeneric(): List<T> = filter { it.isGeneric }
+
+/**
+ * List containing declarations that are not generic.
+ *
+ * @return A list containing only the elements that are not generic.
+ */
+fun <T : KoIsGenericProvider> List<T>.withoutGeneric(): List<T> = filterNot { it.isGeneric }

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/api/ext/list/KoIsGenericTypeProviderListExt.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/api/ext/list/KoIsGenericTypeProviderListExt.kt
@@ -7,6 +7,7 @@ import com.lemonappdev.konsist.api.provider.KoIsGenericTypeProvider
  *
  * @return A list containing declarations with the generic types.
  */
+@Deprecated("Will be removed in version 0.19.0", ReplaceWith("withGeneric"))
 fun <T : KoIsGenericTypeProvider> List<T>.withGenericType(): List<T> = filter { it.isGenericType }
 
 /**
@@ -14,4 +15,5 @@ fun <T : KoIsGenericTypeProvider> List<T>.withGenericType(): List<T> = filter { 
  *
  * @return A list containing declarations without the generic types.
  */
+@Deprecated("Will be removed in version 0.19.0", ReplaceWith("withoutGeneric"))
 fun <T : KoIsGenericTypeProvider> List<T>.withoutGenericType(): List<T> = filterNot { it.isGenericType }

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/api/provider/KoDeclarationCastProvider.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/api/provider/KoDeclarationCastProvider.kt
@@ -65,16 +65,16 @@ interface KoDeclarationCastProvider : KoBaseProvider {
     val isTypeParameter: Boolean
 
     /**
-     * Determines whatever declaration is an external type.
-     * An external type refers to a type that is defined outside the project's codebase. for e.g. in external library.
+     * Determines whatever declaration is an external.
+     * An external declaration refers to a declaration that is defined outside the project's codebase. for e.g. in external library.
      */
-    val isExternalDeclaration: Boolean
+    val isExternal: Boolean
 
     /**
      * Determines whatever source declaration is an external type.
      * An external type refers to a type that is defined outside the project's codebase. for e.g. in external library.
      */
-    @Deprecated("Will be removed in version 0.19.0", ReplaceWith("isExternalDeclaration"))
+    @Deprecated("Will be removed in version 0.19.0", ReplaceWith("isExternal"))
     val isExternalType: Boolean
 
     /**
@@ -154,7 +154,7 @@ interface KoDeclarationCastProvider : KoBaseProvider {
      *
      * @return the external declaration associated with this declaration.
      */
-    @Deprecated("Will be removed in version 0.19.0", ReplaceWith("asExternalDeclaration"))
+    @Deprecated("Will be removed in version 0.19.0", ReplaceWith("asExternal"))
     fun asExternalTypeDeclaration(): KoExternalDeclaration?
 
     /**

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/api/provider/KoGenericTypeProvider.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/api/provider/KoGenericTypeProvider.kt
@@ -8,5 +8,6 @@ interface KoGenericTypeProvider : KoBaseProvider {
     /**
      * Determines whatever type is generic type.
      */
+    @Deprecated("Will be removed in version 0.18.0", ReplaceWith("isGeneric"))
     val isGenericType: Boolean
 }

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/api/provider/KoIsGenericProvider.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/api/provider/KoIsGenericProvider.kt
@@ -1,0 +1,11 @@
+package com.lemonappdev.konsist.api.provider
+
+/**
+ * An interface representing a Kotlin declaration that provides information about whether it is a generic.
+ */
+interface KoIsGenericProvider : KoBaseProvider {
+    /**
+     * Determines whatever declaration is generic.
+     */
+    val isGeneric: Boolean
+}

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/api/provider/KoIsGenericTypeProvider.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/api/provider/KoIsGenericTypeProvider.kt
@@ -3,9 +3,11 @@ package com.lemonappdev.konsist.api.provider
 /**
  * An interface representing a Kotlin declaration that provides information about whether it is a generic type.
  */
+@Deprecated("Will be removed in version 0.19.0", ReplaceWith("KoIsGenericProvider"))
 interface KoIsGenericTypeProvider : KoBaseProvider {
     /**
      * Determines whatever type is generic type.
      */
+    @Deprecated("Will be removed in version 0.19.0", ReplaceWith("isGeneric"))
     val isGenericType: Boolean
 }

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/core/declaration/KoTypeArgumentDeclarationCore.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/core/declaration/KoTypeArgumentDeclarationCore.kt
@@ -3,7 +3,6 @@ package com.lemonappdev.konsist.core.declaration
 import com.lemonappdev.konsist.api.KoModifier
 import com.lemonappdev.konsist.api.declaration.KoSourceDeclaration
 import com.lemonappdev.konsist.api.declaration.KoTypeArgumentDeclaration
-import com.lemonappdev.konsist.api.provider.KoIsGenericProvider
 import com.lemonappdev.konsist.core.provider.KoBaseProviderCore
 import com.lemonappdev.konsist.core.provider.KoDeclarationCastProviderCore
 import com.lemonappdev.konsist.core.provider.KoFunctionTypeDeclarationProviderCore

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/core/declaration/KoTypeArgumentDeclarationCore.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/core/declaration/KoTypeArgumentDeclarationCore.kt
@@ -3,10 +3,12 @@ package com.lemonappdev.konsist.core.declaration
 import com.lemonappdev.konsist.api.KoModifier
 import com.lemonappdev.konsist.api.declaration.KoSourceDeclaration
 import com.lemonappdev.konsist.api.declaration.KoTypeArgumentDeclaration
+import com.lemonappdev.konsist.api.provider.KoIsGenericProvider
 import com.lemonappdev.konsist.core.provider.KoBaseProviderCore
 import com.lemonappdev.konsist.core.provider.KoDeclarationCastProviderCore
 import com.lemonappdev.konsist.core.provider.KoFunctionTypeDeclarationProviderCore
 import com.lemonappdev.konsist.core.provider.KoIsFunctionTypeProviderCore
+import com.lemonappdev.konsist.core.provider.KoIsGenericProviderCore
 import com.lemonappdev.konsist.core.provider.KoIsGenericTypeProviderCore
 import com.lemonappdev.konsist.core.provider.KoLocationProviderCore
 import com.lemonappdev.konsist.core.provider.KoNameProviderCore
@@ -46,6 +48,7 @@ data class KoTypeArgumentDeclarationCore(
     KoPathProviderCore,
     KoDeclarationCastProviderCore,
     KoIsGenericTypeProviderCore,
+    KoIsGenericProviderCore,
     KoIsFunctionTypeProviderCore,
     KoFunctionTypeDeclarationProviderCore {
     override val ktElement: KtElement by lazy { ktTypeProjection }

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/core/declaration/type/KoTypeDeclarationCore.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/core/declaration/type/KoTypeDeclarationCore.kt
@@ -14,6 +14,7 @@ import com.lemonappdev.konsist.core.provider.KoDeclarationCastProviderCore
 import com.lemonappdev.konsist.core.provider.KoFunctionTypeDeclarationProviderCore
 import com.lemonappdev.konsist.core.provider.KoGenericTypeProviderCore
 import com.lemonappdev.konsist.core.provider.KoIsFunctionTypeProviderCore
+import com.lemonappdev.konsist.core.provider.KoIsGenericProviderCore
 import com.lemonappdev.konsist.core.provider.KoIsGenericTypeProviderCore
 import com.lemonappdev.konsist.core.provider.KoIsMutableTypeProviderCore
 import com.lemonappdev.konsist.core.provider.KoIsNullableProviderCore
@@ -61,6 +62,7 @@ internal class KoTypeDeclarationCore private constructor(
     KoSourceAndAliasTypeProviderCore,
     KoGenericTypeProviderCore,
     KoIsGenericTypeProviderCore,
+    KoIsGenericProviderCore,
     KoIsFunctionTypeProviderCore,
     KoPackageProviderCore,
     KoResideInPackageProviderCore,

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/KoDeclarationCastProviderCore.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/KoDeclarationCastProviderCore.kt
@@ -52,12 +52,12 @@ internal interface KoDeclarationCastProviderCore :
     override val isTypeParameter: Boolean
         get() = koDeclarationCastProviderDeclaration is KoTypeParameterDeclaration
 
-    override val isExternalDeclaration: Boolean
+    override val isExternal: Boolean
         get() = koDeclarationCastProviderDeclaration is KoExternalDeclaration
 
-    @Deprecated("Will be removed in version 0.19.0", ReplaceWith("isExternalDeclaration"))
+    @Deprecated("Will be removed in version 0.19.0", ReplaceWith("isExternal"))
     override val isExternalType: Boolean
-        get() = isExternalDeclaration
+        get() = isExternal
 
     override fun asClassDeclaration(): KoClassDeclaration? = koDeclarationCastProviderDeclaration as? KoClassDeclaration
 
@@ -157,7 +157,7 @@ internal interface KoDeclarationCastProviderCore :
 
     override fun hasExternalDeclaration(predicate: ((KoExternalDeclaration) -> Boolean)?): Boolean =
         when (predicate) {
-            null -> isExternalDeclaration
+            null -> isExternal
             else -> asExternalDeclaration()?.let { predicate(it) } ?: false
         }
 

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/KoExternalParentProviderCore.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/KoExternalParentProviderCore.kt
@@ -10,7 +10,7 @@ internal interface KoExternalParentProviderCore :
     KoBaseProviderCore,
     KoParentProviderCore {
     override fun externalParents(indirectParents: Boolean): List<KoParentDeclaration> =
-        parents(indirectParents).filter { it.sourceDeclaration?.isExternalDeclaration == true }
+        parents(indirectParents).filter { it.sourceDeclaration?.isExternal == true }
 
     override fun numExternalParents(indirectParents: Boolean): Int = externalParents(indirectParents).size
 

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/KoIsGenericProviderCore.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/KoIsGenericProviderCore.kt
@@ -1,0 +1,26 @@
+package com.lemonappdev.konsist.core.provider
+
+import com.lemonappdev.konsist.api.provider.KoDeclarationCastProvider
+import com.lemonappdev.konsist.api.provider.KoIsGenericProvider
+import com.lemonappdev.konsist.api.provider.KoNameProvider
+
+internal interface KoIsGenericProviderCore :
+    KoIsGenericProvider,
+    KoBaseProviderCore {
+    override val isGeneric: Boolean
+        get() {
+            val regex = "\\w+<[a-zA-Z*<>(), ]+>".toRegex()
+
+            val type =
+                if ((this as? KoDeclarationCastProvider)?.isTypeAlias == true) {
+                    (this as? KoDeclarationCastProvider)
+                        ?.asTypeAliasDeclaration()
+                        ?.type
+                        ?.text
+                } else {
+                    (this as? KoNameProvider)?.name
+                }
+
+            return type?.let { regex.matches(it) } ?: false
+        }
+}

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/KoIsGenericTypeProviderCore.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/KoIsGenericTypeProviderCore.kt
@@ -1,26 +1,13 @@
 package com.lemonappdev.konsist.core.provider
 
-import com.lemonappdev.konsist.api.provider.KoDeclarationCastProvider
 import com.lemonappdev.konsist.api.provider.KoIsGenericTypeProvider
-import com.lemonappdev.konsist.api.provider.KoNameProvider
 
+@Deprecated("Will be removed in version 0.19.0", ReplaceWith("KoIsGenericProviderCore"))
 internal interface KoIsGenericTypeProviderCore :
     KoIsGenericTypeProvider,
-    KoBaseProviderCore {
+    KoBaseProviderCore,
+    KoIsGenericProviderCore {
+    @Deprecated("Will be removed in version 0.19.0", replaceWith = ReplaceWith("isGeneric"))
     override val isGenericType: Boolean
-        get() {
-            val regex = "\\w+<[a-zA-Z*<>(), ]+>".toRegex()
-
-            val type =
-                if ((this as? KoDeclarationCastProvider)?.isTypeAlias == true) {
-                    (this as? KoDeclarationCastProvider)
-                        ?.asTypeAliasDeclaration()
-                        ?.type
-                        ?.text
-                } else {
-                    (this as? KoNameProvider)?.name
-                }
-
-            return type?.let { regex.matches(it) } ?: false
-        }
+        get() = isGeneric
 }

--- a/lib/src/test/kotlin/com/lemonappdev/konsist/api/ext/list/KoDeclarationCastProviderListExtTest.kt
+++ b/lib/src/test/kotlin/com/lemonappdev/konsist/api/ext/list/KoDeclarationCastProviderListExtTest.kt
@@ -3261,11 +3261,11 @@ class KoDeclarationCastProviderListExtTest {
         // given
         val declaration1: KoDeclarationCastProvider =
             mockk {
-                every { isExternalDeclaration } returns true
+                every { isExternal } returns true
             }
         val declaration2: KoDeclarationCastProvider =
             mockk {
-                every { isExternalDeclaration } returns false
+                every { isExternal } returns false
             }
         val declarations = listOf(declaration1, declaration2)
 
@@ -3355,11 +3355,11 @@ class KoDeclarationCastProviderListExtTest {
         // given
         val declaration1: KoDeclarationCastProvider =
             mockk {
-                every { isExternalDeclaration } returns true
+                every { isExternal } returns true
             }
         val declaration2: KoDeclarationCastProvider =
             mockk {
-                every { isExternalDeclaration } returns false
+                every { isExternal } returns false
             }
         val declarations = listOf(declaration1, declaration2)
 

--- a/lib/src/test/kotlin/com/lemonappdev/konsist/api/ext/list/KoIsGenericProviderListExtTest.kt
+++ b/lib/src/test/kotlin/com/lemonappdev/konsist/api/ext/list/KoIsGenericProviderListExtTest.kt
@@ -1,0 +1,49 @@
+package com.lemonappdev.konsist.api.ext.list
+
+import com.lemonappdev.konsist.api.provider.KoIsGenericProvider
+import io.mockk.every
+import io.mockk.mockk
+import org.amshove.kluent.shouldBeEqualTo
+import org.junit.jupiter.api.Test
+
+class KoIsGenericProviderListExtTest {
+    @Test
+    fun `withGeneric() returns type with generic type`() {
+        // given
+        val type1: KoIsGenericProvider =
+            mockk {
+                every { isGeneric } returns true
+            }
+        val type2: KoIsGenericProvider =
+            mockk {
+                every { isGeneric } returns false
+            }
+        val types = listOf(type1, type2)
+
+        // when
+        val sut = types.withGeneric()
+
+        // then
+        sut shouldBeEqualTo listOf(type1)
+    }
+
+    @Test
+    fun `withoutGeneric() returns type without generic type`() {
+        // given
+        val type1: KoIsGenericProvider =
+            mockk {
+                every { isGeneric } returns true
+            }
+        val type2: KoIsGenericProvider =
+            mockk {
+                every { isGeneric } returns false
+            }
+        val types = listOf(type1, type2)
+
+        // when
+        val sut = types.withoutGeneric()
+
+        // then
+        sut shouldBeEqualTo listOf(type2)
+    }
+}


### PR DESCRIPTION
1. Renames the `isGenericType` property to `isGeneric` to provide a clearer, more accurate name, particularly when used with non-type elements such as parent declarations. The original `isGenericType` property has been deprecated.

**Details:**
- **New Property**: `isGeneric` replaces `isGenericType` as the preferred name.
- **Deprecation**: `isGenericType` is marked as deprecated.

**Example Use Case:**
The old property name could lead to confusion, especially in cases where `isGenericType` is applied to non-type elements:

  **Snippet:**
  ```kotlin
  class SampleClass : SampleSuperClass<Int>
  ```

  **Test Case:**
  ```kotlin
  // Before
  scope
    .classes()
    .parents()
    .assertTrue { it.isGenericType }
    
  // After
  scope
    .classes()
    .parents()
    .assertTrue { it.isGeneric }
  ```

  Here, `SampleSuperClass<Int>` is a generic parent declaration, not a type, making `isGeneric` a more accurate and contextually appropriate term.
  
  2. Renames `isExternalDeclaration` to `isExternal` (without deprecation because it was added in this version)