### PR TITLE
KON-683  KoSourceAndAliasTypeProvider deprecate `isAlias`

### DIFF
--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/type/kotype/KoTypeDeclarationForKoSourceTypeProviderTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/type/kotype/KoTypeDeclarationForKoSourceTypeProviderTest.kt
@@ -1,12 +1,11 @@
 package com.lemonappdev.konsist.core.declaration.type.kotype
 
 import com.lemonappdev.konsist.TestSnippetProvider
-import com.lemonappdev.konsist.api.provider.KoSourceAndAliasTypeProvider
 import org.amshove.kluent.assertSoftly
 import org.amshove.kluent.shouldBeEqualTo
 import org.junit.jupiter.api.Test
 
-class KoTypeDeclarationForKoSourceAndAliasTypeProviderTest {
+class KoTypeDeclarationForKoSourceTypeProviderTest {
     @Test
     fun `nullable-class-type`() {
         // given
@@ -14,13 +13,12 @@ class KoTypeDeclarationForKoSourceAndAliasTypeProviderTest {
             getSnippetFile("nullable-class-type")
                 .properties()
                 .first()
-                .type as? KoSourceAndAliasTypeProvider
+                .type
 
         // then
         assertSoftly(sut) {
             it?.sourceType shouldBeEqualTo "SampleType?"
             it?.bareSourceType shouldBeEqualTo "SampleType"
-            it?.isAlias shouldBeEqualTo false
         }
     }
 
@@ -31,13 +29,12 @@ class KoTypeDeclarationForKoSourceAndAliasTypeProviderTest {
             getSnippetFile("not-nullable-class-type")
                 .properties()
                 .first()
-                .type as? KoSourceAndAliasTypeProvider
+                .type
 
         // then
         assertSoftly(sut) {
             it?.sourceType shouldBeEqualTo "SampleType"
             it?.bareSourceType shouldBeEqualTo "SampleType"
-            it?.isAlias shouldBeEqualTo false
         }
     }
 
@@ -48,13 +45,12 @@ class KoTypeDeclarationForKoSourceAndAliasTypeProviderTest {
             getSnippetFile("nullable-interface-type")
                 .properties()
                 .first()
-                .type as? KoSourceAndAliasTypeProvider
+                .type
 
         // then
         assertSoftly(sut) {
             it?.sourceType shouldBeEqualTo "SampleInterface?"
             it?.bareSourceType shouldBeEqualTo "SampleInterface"
-            it?.isAlias shouldBeEqualTo false
         }
     }
 
@@ -65,13 +61,12 @@ class KoTypeDeclarationForKoSourceAndAliasTypeProviderTest {
             getSnippetFile("not-nullable-interface-type")
                 .properties()
                 .first()
-                .type as? KoSourceAndAliasTypeProvider
+                .type
 
         // then
         assertSoftly(sut) {
             it?.sourceType shouldBeEqualTo "SampleInterface"
             it?.bareSourceType shouldBeEqualTo "SampleInterface"
-            it?.isAlias shouldBeEqualTo false
         }
     }
 
@@ -82,13 +77,12 @@ class KoTypeDeclarationForKoSourceAndAliasTypeProviderTest {
             getSnippetFile("nullable-object-type")
                 .properties()
                 .first()
-                .type as? KoSourceAndAliasTypeProvider
+                .type
 
         // then
         assertSoftly(sut) {
             it?.sourceType shouldBeEqualTo "SampleObject?"
             it?.bareSourceType shouldBeEqualTo "SampleObject"
-            it?.isAlias shouldBeEqualTo false
         }
     }
 
@@ -99,13 +93,12 @@ class KoTypeDeclarationForKoSourceAndAliasTypeProviderTest {
             getSnippetFile("not-nullable-object-type")
                 .properties()
                 .first()
-                .type as? KoSourceAndAliasTypeProvider
+                .type
 
         // then
         assertSoftly(sut) {
             it?.sourceType shouldBeEqualTo "SampleObject"
             it?.bareSourceType shouldBeEqualTo "SampleObject"
-            it?.isAlias shouldBeEqualTo false
         }
     }
 
@@ -116,13 +109,12 @@ class KoTypeDeclarationForKoSourceAndAliasTypeProviderTest {
             getSnippetFile("nullable-typealias-type")
                 .properties()
                 .first()
-                .type as? KoSourceAndAliasTypeProvider
+                .type
 
         // then
         assertSoftly(sut) {
             it?.sourceType shouldBeEqualTo "SampleTypeAlias?"
             it?.bareSourceType shouldBeEqualTo "() -> Unit"
-            it?.isAlias shouldBeEqualTo false
         }
     }
 
@@ -133,13 +125,12 @@ class KoTypeDeclarationForKoSourceAndAliasTypeProviderTest {
             getSnippetFile("not-nullable-typealias-type")
                 .properties()
                 .first()
-                .type as? KoSourceAndAliasTypeProvider
+                .type
 
         // then
         assertSoftly(sut) {
             it?.sourceType shouldBeEqualTo "SampleTypeAlias"
             it?.bareSourceType shouldBeEqualTo "() -> Unit"
-            it?.isAlias shouldBeEqualTo false
         }
     }
 
@@ -153,13 +144,12 @@ class KoTypeDeclarationForKoSourceAndAliasTypeProviderTest {
                 .primaryConstructor
                 ?.parameters
                 ?.first()
-                ?.type as? KoSourceAndAliasTypeProvider
+                ?.type
 
         // then
         assertSoftly(sut) {
             it?.sourceType shouldBeEqualTo "TestType?"
             it?.bareSourceType shouldBeEqualTo "TestType"
-            it?.isAlias shouldBeEqualTo false
         }
     }
 
@@ -173,13 +163,12 @@ class KoTypeDeclarationForKoSourceAndAliasTypeProviderTest {
                 .primaryConstructor
                 ?.parameters
                 ?.first()
-                ?.type as? KoSourceAndAliasTypeProvider
+                ?.type
 
         // then
         assertSoftly(sut) {
             it?.sourceType shouldBeEqualTo "TestType"
             it?.bareSourceType shouldBeEqualTo "TestType"
-            it?.isAlias shouldBeEqualTo false
         }
     }
 
@@ -190,13 +179,12 @@ class KoTypeDeclarationForKoSourceAndAliasTypeProviderTest {
             getSnippetFile("not-nullable-kotlin-type")
                 .properties()
                 .first()
-                .type as? KoSourceAndAliasTypeProvider
+                .type
 
         // then
         assertSoftly(sut) {
             it?.sourceType shouldBeEqualTo "String"
             it?.bareSourceType shouldBeEqualTo "String"
-            it?.isAlias shouldBeEqualTo false
         }
     }
 
@@ -207,13 +195,12 @@ class KoTypeDeclarationForKoSourceAndAliasTypeProviderTest {
             getSnippetFile("nullable-kotlin-type")
                 .properties()
                 .first()
-                .type as? KoSourceAndAliasTypeProvider
+                .type
 
         // then
         assertSoftly(sut) {
             it?.sourceType shouldBeEqualTo "String?"
             it?.bareSourceType shouldBeEqualTo "String"
-            it?.isAlias shouldBeEqualTo false
         }
     }
 
@@ -224,13 +211,12 @@ class KoTypeDeclarationForKoSourceAndAliasTypeProviderTest {
             getSnippetFile("not-nullable-generic-type")
                 .properties()
                 .first()
-                .type as? KoSourceAndAliasTypeProvider
+                .type
 
         // then
         assertSoftly(sut) {
             it?.sourceType shouldBeEqualTo "List<SampleType>"
             it?.bareSourceType shouldBeEqualTo "List"
-            it?.isAlias shouldBeEqualTo false
         }
     }
 
@@ -241,13 +227,12 @@ class KoTypeDeclarationForKoSourceAndAliasTypeProviderTest {
             getSnippetFile("not-nullable-generic-type-with-nullable-type-argument")
                 .properties()
                 .first()
-                .type as? KoSourceAndAliasTypeProvider
+                .type
 
         // then
         assertSoftly(sut) {
             it?.sourceType shouldBeEqualTo "List<SampleType?>"
             it?.bareSourceType shouldBeEqualTo "List"
-            it?.isAlias shouldBeEqualTo false
         }
     }
 
@@ -258,13 +243,12 @@ class KoTypeDeclarationForKoSourceAndAliasTypeProviderTest {
             getSnippetFile("nullable-generic-type")
                 .properties()
                 .first()
-                .type as? KoSourceAndAliasTypeProvider
+                .type
 
         // then
         assertSoftly(sut) {
             it?.sourceType shouldBeEqualTo "List<SampleType>?"
             it?.bareSourceType shouldBeEqualTo "List"
-            it?.isAlias shouldBeEqualTo false
         }
     }
 
@@ -275,13 +259,12 @@ class KoTypeDeclarationForKoSourceAndAliasTypeProviderTest {
             getSnippetFile("nullable-generic-type-with-nullable-type-argument")
                 .properties()
                 .first()
-                .type as? KoSourceAndAliasTypeProvider
+                .type
 
         // then
         assertSoftly(sut) {
             it?.sourceType shouldBeEqualTo "List<SampleType?>?"
             it?.bareSourceType shouldBeEqualTo "List"
-            it?.isAlias shouldBeEqualTo false
         }
     }
 
@@ -292,13 +275,12 @@ class KoTypeDeclarationForKoSourceAndAliasTypeProviderTest {
             getSnippetFile("not-nullable-import-alias-type")
                 .properties()
                 .first()
-                .type as? KoSourceAndAliasTypeProvider
+                .type
 
         // then
         assertSoftly(sut) {
             it?.sourceType shouldBeEqualTo "SampleType"
             it?.bareSourceType shouldBeEqualTo "SampleType"
-            it?.isAlias shouldBeEqualTo true
         }
     }
 
@@ -309,13 +291,12 @@ class KoTypeDeclarationForKoSourceAndAliasTypeProviderTest {
             getSnippetFile("nullable-import-alias-type")
                 .properties()
                 .first()
-                .type as? KoSourceAndAliasTypeProvider
+                .type
 
         // then
         assertSoftly(sut) {
             it?.sourceType shouldBeEqualTo "SampleType"
             it?.bareSourceType shouldBeEqualTo "SampleType"
-            it?.isAlias shouldBeEqualTo true
         }
     }
 
@@ -326,13 +307,12 @@ class KoTypeDeclarationForKoSourceAndAliasTypeProviderTest {
             getSnippetFile("not-nullable-function-type")
                 .properties()
                 .first()
-                .type as? KoSourceAndAliasTypeProvider
+                .type
 
         // then
         assertSoftly(sut) {
             it?.sourceType shouldBeEqualTo "() -> Unit"
             it?.bareSourceType shouldBeEqualTo "() -> Unit"
-            it?.isAlias shouldBeEqualTo false
         }
     }
 
@@ -343,13 +323,12 @@ class KoTypeDeclarationForKoSourceAndAliasTypeProviderTest {
             getSnippetFile("nullable-function-type")
                 .properties()
                 .first()
-                .type as? KoSourceAndAliasTypeProvider
+                .type
 
         // then
         assertSoftly(sut) {
             it?.sourceType shouldBeEqualTo "(() -> Unit)?"
             it?.bareSourceType shouldBeEqualTo "() -> Unit"
-            it?.isAlias shouldBeEqualTo false
         }
     }
 
@@ -360,13 +339,12 @@ class KoTypeDeclarationForKoSourceAndAliasTypeProviderTest {
             getSnippetFile("not-nullable-external-type")
                 .properties()
                 .first()
-                .type as? KoSourceAndAliasTypeProvider
+                .type
 
         // then
         assertSoftly(sut) {
             it?.sourceType shouldBeEqualTo "SampleExternalClass"
             it?.bareSourceType shouldBeEqualTo "SampleExternalClass"
-            it?.isAlias shouldBeEqualTo false
         }
     }
 
@@ -377,19 +355,18 @@ class KoTypeDeclarationForKoSourceAndAliasTypeProviderTest {
             getSnippetFile("nullable-external-type")
                 .properties()
                 .first()
-                .type as? KoSourceAndAliasTypeProvider
+                .type
 
         // then
         assertSoftly(sut) {
             it?.sourceType shouldBeEqualTo "SampleExternalClass?"
             it?.bareSourceType shouldBeEqualTo "SampleExternalClass"
-            it?.isAlias shouldBeEqualTo false
         }
     }
 
     private fun getSnippetFile(fileName: String) =
         TestSnippetProvider.getSnippetKoScope(
-            "core/declaration/type/kotype/snippet/forkosourceandaliastypeprovider/",
+            "core/declaration/type/kotype/snippet/forkosourcetypeprovider/",
             fileName,
         )
 }

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/type/kotype/snippet/forkosourceandaliastypeprovider/SampleProperty.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/type/kotype/snippet/forkosourceandaliastypeprovider/SampleProperty.kt
@@ -1,1 +1,0 @@
-val sampleProperty: com.lemonappdev.konsist.testdata.SampleType? = null

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/type/kotype/snippet/forkosourceandaliastypeprovider/SamplePropertyDeprecated.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/type/kotype/snippet/forkosourceandaliastypeprovider/SamplePropertyDeprecated.kt
@@ -1,3 +1,3 @@
 import com.lemonappdev.konsist.testdata.SampleType
 
-val sampleProperty: SampleType? = null
+val samplePropertyDeprecated: SampleType? = null

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/type/kotype/snippet/forkosourcetypeprovider/SampleProperty.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/type/kotype/snippet/forkosourcetypeprovider/SampleProperty.kt
@@ -1,0 +1,1 @@
+val sampleProperty: com.lemonappdev.konsist.testdata.SampleType? = null

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/type/kotype/snippet/forkosourcetypeprovider/not-nullable-class-type.kttest
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/type/kotype/snippet/forkosourcetypeprovider/not-nullable-class-type.kttest
@@ -1,0 +1,3 @@
+import com.lemonappdev.konsist.testdata.SampleType
+
+val sampleProperty1: SampleType = SampleType()

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/type/kotype/snippet/forkosourcetypeprovider/not-nullable-external-type.kttest
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/type/kotype/snippet/forkosourcetypeprovider/not-nullable-external-type.kttest
@@ -1,0 +1,3 @@
+import com.lemonappdev.konsist.externalsample.SampleExternalClass
+
+val sampleProperty1: SampleExternalClass = SampleExternalClass()

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/type/kotype/snippet/forkosourcetypeprovider/not-nullable-function-type.kttest
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/type/kotype/snippet/forkosourcetypeprovider/not-nullable-function-type.kttest
@@ -1,0 +1,1 @@
+val sampleProperty1: () -> Unit = {}

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/type/kotype/snippet/forkosourcetypeprovider/not-nullable-generic-type-with-nullable-type-argument.kttest
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/type/kotype/snippet/forkosourcetypeprovider/not-nullable-generic-type-with-nullable-type-argument.kttest
@@ -1,0 +1,3 @@
+import com.lemonappdev.konsist.testdata.SampleType
+
+val sampleProperty1: List<SampleType?> = listOf()

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/type/kotype/snippet/forkosourcetypeprovider/not-nullable-generic-type.kttest
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/type/kotype/snippet/forkosourcetypeprovider/not-nullable-generic-type.kttest
@@ -1,0 +1,3 @@
+import com.lemonappdev.konsist.testdata.SampleType
+
+val sampleProperty1: List<SampleType> = listOf()

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/type/kotype/snippet/forkosourcetypeprovider/not-nullable-import-alias-type.kttest
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/type/kotype/snippet/forkosourcetypeprovider/not-nullable-import-alias-type.kttest
@@ -1,0 +1,3 @@
+import com.lemonappdev.konsist.testdata.SampleType as ImportAlias
+
+val sampleProperty1: ImportAlias = ImportAlias()

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/type/kotype/snippet/forkosourcetypeprovider/not-nullable-interface-type.kttest
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/type/kotype/snippet/forkosourcetypeprovider/not-nullable-interface-type.kttest
@@ -1,0 +1,5 @@
+import com.lemonappdev.konsist.testdata.SampleInterface
+
+val sampleProperty1: SampleInterface = SampleClass()
+
+class SampleClass: SampleInterface

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/type/kotype/snippet/forkosourcetypeprovider/not-nullable-kotlin-type.kttest
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/type/kotype/snippet/forkosourcetypeprovider/not-nullable-kotlin-type.kttest
@@ -1,0 +1,1 @@
+val sampleProperty1: String = ""

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/type/kotype/snippet/forkosourcetypeprovider/not-nullable-object-type.kttest
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/type/kotype/snippet/forkosourcetypeprovider/not-nullable-object-type.kttest
@@ -1,0 +1,3 @@
+import com.lemonappdev.konsist.testdata.SampleObject
+
+val sampleProperty1: SampleObject = SampleObject

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/type/kotype/snippet/forkosourcetypeprovider/not-nullable-type-parameter.kttest
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/type/kotype/snippet/forkosourcetypeprovider/not-nullable-type-parameter.kttest
@@ -1,0 +1,1 @@
+class SampleClass <TestType>(sampleProperty: TestType) {}

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/type/kotype/snippet/forkosourcetypeprovider/not-nullable-typealias-type.kttest
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/type/kotype/snippet/forkosourcetypeprovider/not-nullable-typealias-type.kttest
@@ -1,0 +1,3 @@
+val sampleProperty1: SampleTypeAlias = {}
+
+typealias SampleTypeAlias = () -> Unit

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/type/kotype/snippet/forkosourcetypeprovider/nullable-class-type.kttest
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/type/kotype/snippet/forkosourcetypeprovider/nullable-class-type.kttest
@@ -1,0 +1,3 @@
+import com.lemonappdev.konsist.testdata.SampleType
+
+val sampleProperty1: SampleType? = null

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/type/kotype/snippet/forkosourcetypeprovider/nullable-external-type.kttest
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/type/kotype/snippet/forkosourcetypeprovider/nullable-external-type.kttest
@@ -1,0 +1,3 @@
+import com.lemonappdev.konsist.externalsample.SampleExternalClass
+
+val sampleProperty1: SampleExternalClass? = null

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/type/kotype/snippet/forkosourcetypeprovider/nullable-function-type.kttest
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/type/kotype/snippet/forkosourcetypeprovider/nullable-function-type.kttest
@@ -1,0 +1,1 @@
+val sampleProperty1: (() -> Unit)? = null

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/type/kotype/snippet/forkosourcetypeprovider/nullable-generic-type-with-nullable-type-argument.kttest
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/type/kotype/snippet/forkosourcetypeprovider/nullable-generic-type-with-nullable-type-argument.kttest
@@ -1,0 +1,3 @@
+import com.lemonappdev.konsist.testdata.SampleType
+
+val sampleProperty1: List<SampleType?>? = null

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/type/kotype/snippet/forkosourcetypeprovider/nullable-generic-type.kttest
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/type/kotype/snippet/forkosourcetypeprovider/nullable-generic-type.kttest
@@ -1,0 +1,3 @@
+import com.lemonappdev.konsist.testdata.SampleType
+
+val sampleProperty1: List<SampleType>? = null

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/type/kotype/snippet/forkosourcetypeprovider/nullable-import-alias-type.kttest
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/type/kotype/snippet/forkosourcetypeprovider/nullable-import-alias-type.kttest
@@ -1,0 +1,3 @@
+import com.lemonappdev.konsist.testdata.SampleType as ImportAlias
+
+val sampleProperty1: ImportAlias? = null

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/type/kotype/snippet/forkosourcetypeprovider/nullable-interface-type.kttest
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/type/kotype/snippet/forkosourcetypeprovider/nullable-interface-type.kttest
@@ -1,0 +1,3 @@
+import com.lemonappdev.konsist.testdata.SampleInterface
+
+val sampleProperty1: SampleInterface? = null

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/type/kotype/snippet/forkosourcetypeprovider/nullable-kotlin-type.kttest
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/type/kotype/snippet/forkosourcetypeprovider/nullable-kotlin-type.kttest
@@ -1,0 +1,1 @@
+val sampleProperty1: String? = null

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/type/kotype/snippet/forkosourcetypeprovider/nullable-object-type.kttest
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/type/kotype/snippet/forkosourcetypeprovider/nullable-object-type.kttest
@@ -1,0 +1,3 @@
+import com.lemonappdev.konsist.testdata.SampleObject
+
+val sampleProperty1: SampleObject? = null

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/type/kotype/snippet/forkosourcetypeprovider/nullable-type-parameter.kttest
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/type/kotype/snippet/forkosourcetypeprovider/nullable-type-parameter.kttest
@@ -1,0 +1,1 @@
+class SampleClass <TestType>(sampleProperty: TestType?) {}

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/type/kotype/snippet/forkosourcetypeprovider/nullable-typealias-type.kttest
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/type/kotype/snippet/forkosourcetypeprovider/nullable-typealias-type.kttest
@@ -1,0 +1,3 @@
+val sampleProperty1: SampleTypeAlias? = null
+
+typealias SampleTypeAlias = () -> Unit

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/api/declaration/type/KoTypeDeclaration.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/api/declaration/type/KoTypeDeclaration.kt
@@ -23,6 +23,7 @@ import com.lemonappdev.konsist.api.provider.KoResideInPackageProvider
 import com.lemonappdev.konsist.api.provider.KoSourceAndAliasTypeProvider
 import com.lemonappdev.konsist.api.provider.KoSourceDeclarationProvider
 import com.lemonappdev.konsist.api.provider.KoSourceSetProvider
+import com.lemonappdev.konsist.api.provider.KoSourceTypeProvider
 import com.lemonappdev.konsist.api.provider.KoStarProjectionProvider
 import com.lemonappdev.konsist.api.provider.KoTextProvider
 import com.lemonappdev.konsist.api.provider.KoTypeArgumentProvider
@@ -50,6 +51,7 @@ interface KoTypeDeclaration :
     KoIsGenericProvider,
     KoIsFunctionTypeProvider,
     KoSourceAndAliasTypeProvider,
+    KoSourceTypeProvider,
     KoPackageProvider,
     KoResideInPackageProvider,
     KoAnnotationProvider,

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/api/ext/list/KoSourceTypeProviderListExt.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/api/ext/list/KoSourceTypeProviderListExt.kt
@@ -1,6 +1,6 @@
 package com.lemonappdev.konsist.api.ext.list
 
-import com.lemonappdev.konsist.api.provider.KoSourceAndAliasTypeProvider
+import com.lemonappdev.konsist.api.provider.KoSourceTypeProvider
 import kotlin.reflect.KClass
 
 /**
@@ -10,7 +10,7 @@ import kotlin.reflect.KClass
  * @param kClasses The Kotlin classes representing the source types to include.
  * @return A list containing declarations with the source type matching any of the specified types.
  */
-fun <T : KoSourceAndAliasTypeProvider> List<T>.withSourceTypeOf(
+fun <T : KoSourceTypeProvider> List<T>.withSourceTypeOf(
     kClass: KClass<*>,
     vararg kClasses: KClass<*>,
 ): List<T> = withSourceTypeOf(listOf(kClass, *kClasses))
@@ -21,7 +21,7 @@ fun <T : KoSourceAndAliasTypeProvider> List<T>.withSourceTypeOf(
  * @param kClasses The Kotlin classes representing the source types to include.
  * @return A list containing declarations with the source type matching any of the specified types.
  */
-fun <T : KoSourceAndAliasTypeProvider> List<T>.withSourceTypeOf(kClasses: Collection<KClass<*>>): List<T> =
+fun <T : KoSourceTypeProvider> List<T>.withSourceTypeOf(kClasses: Collection<KClass<*>>): List<T> =
     filter {
         when {
             kClasses.isEmpty() -> true
@@ -36,7 +36,7 @@ fun <T : KoSourceAndAliasTypeProvider> List<T>.withSourceTypeOf(kClasses: Collec
  * @param kClasses The Kotlin classes representing the source types to exclude.
  * @return A list containing declarations without source type matching any of the specified types.
  */
-fun <T : KoSourceAndAliasTypeProvider> List<T>.withoutSourceTypeOf(
+fun <T : KoSourceTypeProvider> List<T>.withoutSourceTypeOf(
     kClass: KClass<*>,
     vararg kClasses: KClass<*>,
 ): List<T> = withoutSourceTypeOf(listOf(kClass, *kClasses))
@@ -47,7 +47,7 @@ fun <T : KoSourceAndAliasTypeProvider> List<T>.withoutSourceTypeOf(
  * @param kClasses The Kotlin classes representing the source types to exclude.
  * @return A list containing declarations without source type matching any of the specified types.
  */
-fun <T : KoSourceAndAliasTypeProvider> List<T>.withoutSourceTypeOf(kClasses: Collection<KClass<*>>): List<T> =
+fun <T : KoSourceTypeProvider> List<T>.withoutSourceTypeOf(kClasses: Collection<KClass<*>>): List<T> =
     filterNot {
         when {
             kClasses.isEmpty() -> true
@@ -62,7 +62,7 @@ fun <T : KoSourceAndAliasTypeProvider> List<T>.withoutSourceTypeOf(kClasses: Col
  * @param names The source type name(s) to include.
  * @return A list containing declarations with the specified source types.
  */
-fun <T : KoSourceAndAliasTypeProvider> List<T>.withSourceType(
+fun <T : KoSourceTypeProvider> List<T>.withSourceType(
     name: String,
     vararg names: String,
 ): List<T> = withSourceType(listOf(name, *names))
@@ -73,7 +73,7 @@ fun <T : KoSourceAndAliasTypeProvider> List<T>.withSourceType(
  * @param names The source type name(s) to include.
  * @return A list containing declarations with the specified source types.
  */
-fun <T : KoSourceAndAliasTypeProvider> List<T>.withSourceType(names: Collection<String>): List<T> =
+fun <T : KoSourceTypeProvider> List<T>.withSourceType(names: Collection<String>): List<T> =
     filter {
         when {
             names.isEmpty() -> true
@@ -88,7 +88,7 @@ fun <T : KoSourceAndAliasTypeProvider> List<T>.withSourceType(names: Collection<
  * @param names The source type name(s) to exclude.
  * @return A list containing declarations without specified source types.
  */
-fun <T : KoSourceAndAliasTypeProvider> List<T>.withoutSourceType(
+fun <T : KoSourceTypeProvider> List<T>.withoutSourceType(
     name: String,
     vararg names: String,
 ): List<T> = withoutSourceType(listOf(name, *names))
@@ -99,7 +99,7 @@ fun <T : KoSourceAndAliasTypeProvider> List<T>.withoutSourceType(
  * @param names The source type name(s) to exclude.
  * @return A list containing declarations without specified source types.
  */
-fun <T : KoSourceAndAliasTypeProvider> List<T>.withoutSourceType(names: Collection<String>): List<T> =
+fun <T : KoSourceTypeProvider> List<T>.withoutSourceType(names: Collection<String>): List<T> =
     filterNot {
         when {
             names.isEmpty() -> true
@@ -114,7 +114,7 @@ fun <T : KoSourceAndAliasTypeProvider> List<T>.withoutSourceType(names: Collecti
  * @param kClasses The Kotlin classes representing the bare source types to include.
  * @return A list containing declarations with the bare source type matching any of the specified types.
  */
-fun <T : KoSourceAndAliasTypeProvider> List<T>.withBareSourceTypeOf(
+fun <T : KoSourceTypeProvider> List<T>.withBareSourceTypeOf(
     kClass: KClass<*>,
     vararg kClasses: KClass<*>,
 ): List<T> = withBareSourceTypeOf(listOf(kClass, *kClasses))
@@ -125,7 +125,7 @@ fun <T : KoSourceAndAliasTypeProvider> List<T>.withBareSourceTypeOf(
  * @param kClasses The Kotlin classes representing the bare source types to include.
  * @return A list containing declarations with the bare source type matching any of the specified types.
  */
-fun <T : KoSourceAndAliasTypeProvider> List<T>.withBareSourceTypeOf(kClasses: Collection<KClass<*>>): List<T> =
+fun <T : KoSourceTypeProvider> List<T>.withBareSourceTypeOf(kClasses: Collection<KClass<*>>): List<T> =
     filter {
         when {
             kClasses.isEmpty() -> true
@@ -140,7 +140,7 @@ fun <T : KoSourceAndAliasTypeProvider> List<T>.withBareSourceTypeOf(kClasses: Co
  * @param kClasses The Kotlin classes representing the bare source types to exclude.
  * @return A list containing declarations without bare source type matching any of the specified types.
  */
-fun <T : KoSourceAndAliasTypeProvider> List<T>.withoutBareSourceTypeOf(
+fun <T : KoSourceTypeProvider> List<T>.withoutBareSourceTypeOf(
     kClass: KClass<*>,
     vararg kClasses: KClass<*>,
 ): List<T> = withoutBareSourceTypeOf(listOf(kClass, *kClasses))
@@ -151,7 +151,7 @@ fun <T : KoSourceAndAliasTypeProvider> List<T>.withoutBareSourceTypeOf(
  * @param kClasses The Kotlin classes representing the bare source types to exclude.
  * @return A list containing declarations without bare source type matching any of the specified types.
  */
-fun <T : KoSourceAndAliasTypeProvider> List<T>.withoutBareSourceTypeOf(kClasses: Collection<KClass<*>>): List<T> =
+fun <T : KoSourceTypeProvider> List<T>.withoutBareSourceTypeOf(kClasses: Collection<KClass<*>>): List<T> =
     filterNot {
         when {
             kClasses.isEmpty() -> true
@@ -166,7 +166,7 @@ fun <T : KoSourceAndAliasTypeProvider> List<T>.withoutBareSourceTypeOf(kClasses:
  * @param names The bare source type name(s) to include.
  * @return A list containing declarations with the specified bare source types.
  */
-fun <T : KoSourceAndAliasTypeProvider> List<T>.withBareSourceType(
+fun <T : KoSourceTypeProvider> List<T>.withBareSourceType(
     name: String,
     vararg names: String,
 ): List<T> = withBareSourceType(listOf(name, *names))
@@ -177,7 +177,7 @@ fun <T : KoSourceAndAliasTypeProvider> List<T>.withBareSourceType(
  * @param names The bare source type name(s) to include.
  * @return A list containing declarations with the specified bare source types.
  */
-fun <T : KoSourceAndAliasTypeProvider> List<T>.withBareSourceType(names: Collection<String>): List<T> =
+fun <T : KoSourceTypeProvider> List<T>.withBareSourceType(names: Collection<String>): List<T> =
     filter {
         when {
             names.isEmpty() -> true
@@ -192,7 +192,7 @@ fun <T : KoSourceAndAliasTypeProvider> List<T>.withBareSourceType(names: Collect
  * @param names The bare source type name(s) to exclude.
  * @return A list containing declarations without specified base source types.
  */
-fun <T : KoSourceAndAliasTypeProvider> List<T>.withoutBareSourceType(
+fun <T : KoSourceTypeProvider> List<T>.withoutBareSourceType(
     name: String,
     vararg names: String,
 ): List<T> = withoutBareSourceType(listOf(name, *names))
@@ -203,7 +203,7 @@ fun <T : KoSourceAndAliasTypeProvider> List<T>.withoutBareSourceType(
  * @param names The bare source type name(s) to exclude.
  * @return A list containing declarations without specified base source types.
  */
-fun <T : KoSourceAndAliasTypeProvider> List<T>.withoutBareSourceType(names: Collection<String>): List<T> =
+fun <T : KoSourceTypeProvider> List<T>.withoutBareSourceType(names: Collection<String>): List<T> =
     filterNot {
         when {
             names.isEmpty() -> true

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/api/provider/KoSourceTypeProvider.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/api/provider/KoSourceTypeProvider.kt
@@ -1,19 +1,9 @@
 package com.lemonappdev.konsist.api.provider
 
 /**
- * An interface representing a Kotlin declaration that provides access to its source type and import alias name.
+ * An interface representing a Kotlin declaration that provides access to its source type.
  */
-@Deprecated("Will be removed in version 0.19.0", ReplaceWith("KoSourceTypeProvider"))
-interface KoSourceAndAliasTypeProvider : KoBaseProvider {
-    /**
-     * Returns `true` if this type is defined by the import alias.
-     *
-     * For the type import `import com.app.MyClass as MyAlias` the `isAlias` will be `true`.
-     * For the type import `import com.app.MyClass` the `isAlias` will be `false`.
-     */
-    @Deprecated("Will be removed in version 0.19.0", ReplaceWith("isImportAlias"))
-    val isAlias: Boolean
-
+interface KoSourceTypeProvider : KoBaseProvider {
     /**
      * The source type.
      * For `val car:MyClass` it will be "MyClass".

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/core/declaration/type/KoKotlinTypeDeclarationCore.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/core/declaration/type/KoKotlinTypeDeclarationCore.kt
@@ -7,7 +7,6 @@ import com.lemonappdev.konsist.core.cache.KoDeclarationCache
 import com.lemonappdev.konsist.core.declaration.KoPackageDeclarationCore
 import com.lemonappdev.konsist.core.provider.KoBaseProviderCore
 import com.lemonappdev.konsist.core.provider.KoFullyQualifiedNameProviderCore
-import com.lemonappdev.konsist.core.provider.KoSourceAndAliasTypeProviderCore
 import com.lemonappdev.konsist.core.provider.KoSourceTypeProviderCore
 import com.lemonappdev.konsist.core.util.TypeUtil
 import org.jetbrains.kotlin.com.intellij.psi.PsiElement

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/core/declaration/type/KoKotlinTypeDeclarationCore.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/core/declaration/type/KoKotlinTypeDeclarationCore.kt
@@ -8,6 +8,7 @@ import com.lemonappdev.konsist.core.declaration.KoPackageDeclarationCore
 import com.lemonappdev.konsist.core.provider.KoBaseProviderCore
 import com.lemonappdev.konsist.core.provider.KoFullyQualifiedNameProviderCore
 import com.lemonappdev.konsist.core.provider.KoSourceAndAliasTypeProviderCore
+import com.lemonappdev.konsist.core.provider.KoSourceTypeProviderCore
 import com.lemonappdev.konsist.core.util.TypeUtil
 import org.jetbrains.kotlin.com.intellij.psi.PsiElement
 import org.jetbrains.kotlin.psi.KtElement
@@ -18,7 +19,7 @@ internal class KoKotlinTypeDeclarationCore private constructor(
     KoBaseTypeDeclarationCore,
     KoBaseProviderCore,
     KoFullyQualifiedNameProviderCore,
-    KoSourceAndAliasTypeProviderCore {
+    KoSourceTypeProviderCore {
     override val psiElement: PsiElement by lazy { ktElement }
 
     override val packagee: KoPackageDeclaration? by lazy {

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/core/declaration/type/KoTypeDeclarationCore.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/core/declaration/type/KoTypeDeclarationCore.kt
@@ -27,6 +27,7 @@ import com.lemonappdev.konsist.core.provider.KoResideInPackageProviderCore
 import com.lemonappdev.konsist.core.provider.KoSourceAndAliasTypeProviderCore
 import com.lemonappdev.konsist.core.provider.KoSourceDeclarationProviderCore
 import com.lemonappdev.konsist.core.provider.KoSourceSetProviderCore
+import com.lemonappdev.konsist.core.provider.KoSourceTypeProviderCore
 import com.lemonappdev.konsist.core.provider.KoStarProjectionProviderCore
 import com.lemonappdev.konsist.core.provider.KoTextProviderCore
 import com.lemonappdev.konsist.core.provider.KoTypeArgumentProviderCore
@@ -60,6 +61,7 @@ internal class KoTypeDeclarationCore private constructor(
     KoSourceSetProviderCore,
     KoStarProjectionProviderCore,
     KoSourceAndAliasTypeProviderCore,
+    KoSourceTypeProviderCore,
     KoGenericTypeProviderCore,
     KoIsGenericTypeProviderCore,
     KoIsGenericProviderCore,
@@ -135,6 +137,12 @@ internal class KoTypeDeclarationCore private constructor(
 
     @RemoveInVersion("0.18.0")
     override val isNullable: Boolean by lazy { super<KoIsNullableProviderCore>.isNullable }
+
+    @RemoveInVersion("0.19.0")
+    override val sourceType: String by lazy { super<KoSourceTypeProviderCore>.sourceType }
+
+    @RemoveInVersion("0.19.0")
+    override val bareSourceType: String by lazy { super<KoSourceTypeProviderCore>.bareSourceType }
 
     override fun toString(): String = text
 

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/KoSourceTypeProviderCore.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/KoSourceTypeProviderCore.kt
@@ -3,7 +3,6 @@ package com.lemonappdev.konsist.core.provider
 import com.lemonappdev.konsist.api.declaration.KoFileDeclaration
 import com.lemonappdev.konsist.api.declaration.type.KoTypeDeclaration
 import com.lemonappdev.konsist.api.provider.KoDeclarationCastProvider
-import com.lemonappdev.konsist.api.provider.KoSourceAndAliasTypeProvider
 import com.lemonappdev.konsist.api.provider.KoSourceTypeProvider
 import com.lemonappdev.konsist.core.declaration.KoFileDeclarationCore
 import com.lemonappdev.konsist.core.util.TypeUtil

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/KoSourceTypeProviderCore.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/KoSourceTypeProviderCore.kt
@@ -2,14 +2,15 @@ package com.lemonappdev.konsist.core.provider
 
 import com.lemonappdev.konsist.api.declaration.KoFileDeclaration
 import com.lemonappdev.konsist.api.declaration.type.KoTypeDeclaration
+import com.lemonappdev.konsist.api.provider.KoDeclarationCastProvider
 import com.lemonappdev.konsist.api.provider.KoSourceAndAliasTypeProvider
+import com.lemonappdev.konsist.api.provider.KoSourceTypeProvider
 import com.lemonappdev.konsist.core.declaration.KoFileDeclarationCore
 import com.lemonappdev.konsist.core.util.TypeUtil
 import org.jetbrains.kotlin.psi.KtElement
 
-@Deprecated("Will be removed in version 0.19.0", ReplaceWith("KoSourceTypeProvider"))
-internal interface KoSourceAndAliasTypeProviderCore :
-    KoSourceAndAliasTypeProvider,
+internal interface KoSourceTypeProviderCore :
+    KoSourceTypeProvider,
     KoTextProviderCore,
     KoBaseProviderCore {
     val ktElement: KtElement
@@ -17,13 +18,9 @@ internal interface KoSourceAndAliasTypeProviderCore :
     private val file: KoFileDeclaration
         get() = KoFileDeclarationCore(ktElement.containingKtFile)
 
-    @Deprecated("Will be removed in version 0.19.0", replaceWith = ReplaceWith("isImportAlias"))
-    override val isAlias: Boolean
-        get() = (this as? KoTypeDeclaration)?.isImportAlias == true
-
     override val sourceType: String
         get() =
-            if (isAlias) {
+            if ((this as? KoDeclarationCastProvider)?.isImportAlias == true) {
                 file
                     .imports
                     .firstOrNull { it.alias?.name == ktElement.text.removeSuffix("?") }

--- a/lib/src/test/kotlin/com/lemonappdev/konsist/api/ext/list/KoSourceTypeProviderListExtTest.kt
+++ b/lib/src/test/kotlin/com/lemonappdev/konsist/api/ext/list/KoSourceTypeProviderListExtTest.kt
@@ -1,6 +1,6 @@
 package com.lemonappdev.konsist.api.ext.list
 
-import com.lemonappdev.konsist.api.provider.KoSourceAndAliasTypeProvider
+import com.lemonappdev.konsist.api.provider.KoSourceTypeProvider
 import com.lemonappdev.konsist.testdata.SampleClass1
 import com.lemonappdev.konsist.testdata.SampleClass2
 import io.mockk.every
@@ -8,12 +8,12 @@ import io.mockk.mockk
 import org.amshove.kluent.shouldBeEqualTo
 import org.junit.jupiter.api.Test
 
-class KoSourceAndAliasTypeProviderListExtTest {
+class KoSourceTypeProviderListExtTest {
     @Test
     fun `withSourceTypeOf(empty list) returns all declarations`() {
         // given
-        val declaration1: KoSourceAndAliasTypeProvider = mockk()
-        val declaration2: KoSourceAndAliasTypeProvider = mockk()
+        val declaration1: KoSourceTypeProvider = mockk()
+        val declaration2: KoSourceTypeProvider = mockk()
         val declarations = listOf(declaration1, declaration2)
 
         // when
@@ -26,8 +26,8 @@ class KoSourceAndAliasTypeProviderListExtTest {
     @Test
     fun `withSourceTypeOf(empty set) returns all declarations`() {
         // given
-        val declaration1: KoSourceAndAliasTypeProvider = mockk()
-        val declaration2: KoSourceAndAliasTypeProvider = mockk()
+        val declaration1: KoSourceTypeProvider = mockk()
+        val declaration2: KoSourceTypeProvider = mockk()
         val declarations = listOf(declaration1, declaration2)
 
         // when
@@ -42,11 +42,11 @@ class KoSourceAndAliasTypeProviderListExtTest {
         // given
         val sourceType1 = "SampleClass1"
         val sourceType2 = "SampleClass2"
-        val declaration1: KoSourceAndAliasTypeProvider =
+        val declaration1: KoSourceTypeProvider =
             mockk {
                 every { sourceType } returns sourceType1
             }
-        val declaration2: KoSourceAndAliasTypeProvider =
+        val declaration2: KoSourceTypeProvider =
             mockk {
                 every { sourceType } returns sourceType2
             }
@@ -65,15 +65,15 @@ class KoSourceAndAliasTypeProviderListExtTest {
         val sourceType1 = "SampleClass1"
         val sourceType2 = "SampleClass2"
         val sourceType3 = "SampleClass3"
-        val declaration1: KoSourceAndAliasTypeProvider =
+        val declaration1: KoSourceTypeProvider =
             mockk {
                 every { sourceType } returns sourceType1
             }
-        val declaration2: KoSourceAndAliasTypeProvider =
+        val declaration2: KoSourceTypeProvider =
             mockk {
                 every { sourceType } returns sourceType2
             }
-        val declaration3: KoSourceAndAliasTypeProvider =
+        val declaration3: KoSourceTypeProvider =
             mockk {
                 every { sourceType } returns sourceType3
             }
@@ -92,15 +92,15 @@ class KoSourceAndAliasTypeProviderListExtTest {
         val sourceType1 = "SampleClass1"
         val sourceType2 = "SampleClass2"
         val sourceType3 = "SampleClass3"
-        val declaration1: KoSourceAndAliasTypeProvider =
+        val declaration1: KoSourceTypeProvider =
             mockk {
                 every { sourceType } returns sourceType1
             }
-        val declaration2: KoSourceAndAliasTypeProvider =
+        val declaration2: KoSourceTypeProvider =
             mockk {
                 every { sourceType } returns sourceType2
             }
-        val declaration3: KoSourceAndAliasTypeProvider =
+        val declaration3: KoSourceTypeProvider =
             mockk {
                 every { sourceType } returns sourceType3
             }
@@ -120,15 +120,15 @@ class KoSourceAndAliasTypeProviderListExtTest {
         val sourceType1 = "SampleClass1"
         val sourceType2 = "SampleClass2"
         val sourceType3 = "SampleClass3"
-        val declaration1: KoSourceAndAliasTypeProvider =
+        val declaration1: KoSourceTypeProvider =
             mockk {
                 every { sourceType } returns sourceType1
             }
-        val declaration2: KoSourceAndAliasTypeProvider =
+        val declaration2: KoSourceTypeProvider =
             mockk {
                 every { sourceType } returns sourceType2
             }
-        val declaration3: KoSourceAndAliasTypeProvider =
+        val declaration3: KoSourceTypeProvider =
             mockk {
                 every { sourceType } returns sourceType3
             }
@@ -145,8 +145,8 @@ class KoSourceAndAliasTypeProviderListExtTest {
     @Test
     fun `withoutSourceTypeOf(empty list) returns none declaration`() {
         // given
-        val declaration1: KoSourceAndAliasTypeProvider = mockk()
-        val declaration2: KoSourceAndAliasTypeProvider = mockk()
+        val declaration1: KoSourceTypeProvider = mockk()
+        val declaration2: KoSourceTypeProvider = mockk()
         val declarations = listOf(declaration1, declaration2)
 
         // when
@@ -159,8 +159,8 @@ class KoSourceAndAliasTypeProviderListExtTest {
     @Test
     fun `withoutSourceTypeOf(empty set) returns none declaration`() {
         // given
-        val declaration1: KoSourceAndAliasTypeProvider = mockk()
-        val declaration2: KoSourceAndAliasTypeProvider = mockk()
+        val declaration1: KoSourceTypeProvider = mockk()
+        val declaration2: KoSourceTypeProvider = mockk()
         val declarations = listOf(declaration1, declaration2)
 
         // when
@@ -175,11 +175,11 @@ class KoSourceAndAliasTypeProviderListExtTest {
         // given
         val sourceType1 = "SampleClass1"
         val sourceType2 = "SampleClass2"
-        val declaration1: KoSourceAndAliasTypeProvider =
+        val declaration1: KoSourceTypeProvider =
             mockk {
                 every { sourceType } returns sourceType1
             }
-        val declaration2: KoSourceAndAliasTypeProvider =
+        val declaration2: KoSourceTypeProvider =
             mockk {
                 every { sourceType } returns sourceType2
             }
@@ -198,15 +198,15 @@ class KoSourceAndAliasTypeProviderListExtTest {
         val sourceType1 = "SampleClass1"
         val sourceType2 = "SampleClass2"
         val sourceType3 = "SampleClass3"
-        val declaration1: KoSourceAndAliasTypeProvider =
+        val declaration1: KoSourceTypeProvider =
             mockk {
                 every { sourceType } returns sourceType1
             }
-        val declaration2: KoSourceAndAliasTypeProvider =
+        val declaration2: KoSourceTypeProvider =
             mockk {
                 every { sourceType } returns sourceType2
             }
-        val declaration3: KoSourceAndAliasTypeProvider =
+        val declaration3: KoSourceTypeProvider =
             mockk {
                 every { sourceType } returns sourceType3
             }
@@ -225,15 +225,15 @@ class KoSourceAndAliasTypeProviderListExtTest {
         val sourceType1 = "SampleClass1"
         val sourceType2 = "SampleClass2"
         val sourceType3 = "SampleClass3"
-        val declaration1: KoSourceAndAliasTypeProvider =
+        val declaration1: KoSourceTypeProvider =
             mockk {
                 every { sourceType } returns sourceType1
             }
-        val declaration2: KoSourceAndAliasTypeProvider =
+        val declaration2: KoSourceTypeProvider =
             mockk {
                 every { sourceType } returns sourceType2
             }
-        val declaration3: KoSourceAndAliasTypeProvider =
+        val declaration3: KoSourceTypeProvider =
             mockk {
                 every { sourceType } returns sourceType3
             }
@@ -253,15 +253,15 @@ class KoSourceAndAliasTypeProviderListExtTest {
         val sourceType1 = "SampleClass1"
         val sourceType2 = "SampleClass2"
         val sourceType3 = "SampleClass3"
-        val declaration1: KoSourceAndAliasTypeProvider =
+        val declaration1: KoSourceTypeProvider =
             mockk {
                 every { sourceType } returns sourceType1
             }
-        val declaration2: KoSourceAndAliasTypeProvider =
+        val declaration2: KoSourceTypeProvider =
             mockk {
                 every { sourceType } returns sourceType2
             }
-        val declaration3: KoSourceAndAliasTypeProvider =
+        val declaration3: KoSourceTypeProvider =
             mockk {
                 every { sourceType } returns sourceType3
             }
@@ -278,8 +278,8 @@ class KoSourceAndAliasTypeProviderListExtTest {
     @Test
     fun `withSourceType(empty list) returns all declarations`() {
         // given
-        val declaration1: KoSourceAndAliasTypeProvider = mockk()
-        val declaration2: KoSourceAndAliasTypeProvider = mockk()
+        val declaration1: KoSourceTypeProvider = mockk()
+        val declaration2: KoSourceTypeProvider = mockk()
         val declarations = listOf(declaration1, declaration2)
 
         // when
@@ -292,8 +292,8 @@ class KoSourceAndAliasTypeProviderListExtTest {
     @Test
     fun `withSourceType(empty set) returns all declarations`() {
         // given
-        val declaration1: KoSourceAndAliasTypeProvider = mockk()
-        val declaration2: KoSourceAndAliasTypeProvider = mockk()
+        val declaration1: KoSourceTypeProvider = mockk()
+        val declaration2: KoSourceTypeProvider = mockk()
         val declarations = listOf(declaration1, declaration2)
 
         // when
@@ -308,11 +308,11 @@ class KoSourceAndAliasTypeProviderListExtTest {
         // given
         val sourceType1 = "SampleClass1"
         val sourceType2 = "SampleClass2"
-        val declaration1: KoSourceAndAliasTypeProvider =
+        val declaration1: KoSourceTypeProvider =
             mockk {
                 every { sourceType } returns sourceType1
             }
-        val declaration2: KoSourceAndAliasTypeProvider =
+        val declaration2: KoSourceTypeProvider =
             mockk {
                 every { sourceType } returns sourceType2
             }
@@ -331,15 +331,15 @@ class KoSourceAndAliasTypeProviderListExtTest {
         val sourceType1 = "SampleClass1"
         val sourceType2 = "SampleClass2"
         val sourceType3 = "SampleClass3"
-        val declaration1: KoSourceAndAliasTypeProvider =
+        val declaration1: KoSourceTypeProvider =
             mockk {
                 every { sourceType } returns sourceType1
             }
-        val declaration2: KoSourceAndAliasTypeProvider =
+        val declaration2: KoSourceTypeProvider =
             mockk {
                 every { sourceType } returns sourceType2
             }
-        val declaration3: KoSourceAndAliasTypeProvider =
+        val declaration3: KoSourceTypeProvider =
             mockk {
                 every { sourceType } returns sourceType3
             }
@@ -358,15 +358,15 @@ class KoSourceAndAliasTypeProviderListExtTest {
         val sourceType1 = "SampleClass1"
         val sourceType2 = "SampleClass2"
         val sourceType3 = "SampleClass3"
-        val declaration1: KoSourceAndAliasTypeProvider =
+        val declaration1: KoSourceTypeProvider =
             mockk {
                 every { sourceType } returns sourceType1
             }
-        val declaration2: KoSourceAndAliasTypeProvider =
+        val declaration2: KoSourceTypeProvider =
             mockk {
                 every { sourceType } returns sourceType2
             }
-        val declaration3: KoSourceAndAliasTypeProvider =
+        val declaration3: KoSourceTypeProvider =
             mockk {
                 every { sourceType } returns sourceType3
             }
@@ -386,15 +386,15 @@ class KoSourceAndAliasTypeProviderListExtTest {
         val sourceType1 = "SampleClass1"
         val sourceType2 = "SampleClass2"
         val sourceType3 = "SampleClass3"
-        val declaration1: KoSourceAndAliasTypeProvider =
+        val declaration1: KoSourceTypeProvider =
             mockk {
                 every { sourceType } returns sourceType1
             }
-        val declaration2: KoSourceAndAliasTypeProvider =
+        val declaration2: KoSourceTypeProvider =
             mockk {
                 every { sourceType } returns sourceType2
             }
-        val declaration3: KoSourceAndAliasTypeProvider =
+        val declaration3: KoSourceTypeProvider =
             mockk {
                 every { sourceType } returns sourceType3
             }
@@ -411,8 +411,8 @@ class KoSourceAndAliasTypeProviderListExtTest {
     @Test
     fun `withoutSourceType(empty list) returns none declaration`() {
         // given
-        val declaration1: KoSourceAndAliasTypeProvider = mockk()
-        val declaration2: KoSourceAndAliasTypeProvider = mockk()
+        val declaration1: KoSourceTypeProvider = mockk()
+        val declaration2: KoSourceTypeProvider = mockk()
         val declarations = listOf(declaration1, declaration2)
 
         // when
@@ -425,8 +425,8 @@ class KoSourceAndAliasTypeProviderListExtTest {
     @Test
     fun `withoutSourceType(empty set) returns none declaration`() {
         // given
-        val declaration1: KoSourceAndAliasTypeProvider = mockk()
-        val declaration2: KoSourceAndAliasTypeProvider = mockk()
+        val declaration1: KoSourceTypeProvider = mockk()
+        val declaration2: KoSourceTypeProvider = mockk()
         val declarations = listOf(declaration1, declaration2)
 
         // when
@@ -441,11 +441,11 @@ class KoSourceAndAliasTypeProviderListExtTest {
         // given
         val sourceType1 = "SampleClass1"
         val sourceType2 = "SampleClass2"
-        val declaration1: KoSourceAndAliasTypeProvider =
+        val declaration1: KoSourceTypeProvider =
             mockk {
                 every { sourceType } returns sourceType1
             }
-        val declaration2: KoSourceAndAliasTypeProvider =
+        val declaration2: KoSourceTypeProvider =
             mockk {
                 every { sourceType } returns sourceType2
             }
@@ -464,15 +464,15 @@ class KoSourceAndAliasTypeProviderListExtTest {
         val sourceType1 = "SampleClass1"
         val sourceType2 = "SampleClass2"
         val sourceType3 = "SampleClass3"
-        val declaration1: KoSourceAndAliasTypeProvider =
+        val declaration1: KoSourceTypeProvider =
             mockk {
                 every { sourceType } returns sourceType1
             }
-        val declaration2: KoSourceAndAliasTypeProvider =
+        val declaration2: KoSourceTypeProvider =
             mockk {
                 every { sourceType } returns sourceType2
             }
-        val declaration3: KoSourceAndAliasTypeProvider =
+        val declaration3: KoSourceTypeProvider =
             mockk {
                 every { sourceType } returns sourceType3
             }
@@ -491,15 +491,15 @@ class KoSourceAndAliasTypeProviderListExtTest {
         val sourceType1 = "SampleClass1"
         val sourceType2 = "SampleClass2"
         val sourceType3 = "SampleClass3"
-        val declaration1: KoSourceAndAliasTypeProvider =
+        val declaration1: KoSourceTypeProvider =
             mockk {
                 every { sourceType } returns sourceType1
             }
-        val declaration2: KoSourceAndAliasTypeProvider =
+        val declaration2: KoSourceTypeProvider =
             mockk {
                 every { sourceType } returns sourceType2
             }
-        val declaration3: KoSourceAndAliasTypeProvider =
+        val declaration3: KoSourceTypeProvider =
             mockk {
                 every { sourceType } returns sourceType3
             }
@@ -519,15 +519,15 @@ class KoSourceAndAliasTypeProviderListExtTest {
         val sourceType1 = "SampleClass1"
         val sourceType2 = "SampleClass2"
         val sourceType3 = "SampleClass3"
-        val declaration1: KoSourceAndAliasTypeProvider =
+        val declaration1: KoSourceTypeProvider =
             mockk {
                 every { sourceType } returns sourceType1
             }
-        val declaration2: KoSourceAndAliasTypeProvider =
+        val declaration2: KoSourceTypeProvider =
             mockk {
                 every { sourceType } returns sourceType2
             }
-        val declaration3: KoSourceAndAliasTypeProvider =
+        val declaration3: KoSourceTypeProvider =
             mockk {
                 every { sourceType } returns sourceType3
             }
@@ -544,8 +544,8 @@ class KoSourceAndAliasTypeProviderListExtTest {
     @Test
     fun `withBareSourceTypeOf(empty list) returns all declaration`() {
         // given
-        val declaration1: KoSourceAndAliasTypeProvider = mockk()
-        val declaration2: KoSourceAndAliasTypeProvider = mockk()
+        val declaration1: KoSourceTypeProvider = mockk()
+        val declaration2: KoSourceTypeProvider = mockk()
         val declarations = listOf(declaration1, declaration2)
 
         // when
@@ -558,8 +558,8 @@ class KoSourceAndAliasTypeProviderListExtTest {
     @Test
     fun `withBareSourceTypeOf(empty set) returns all declaration`() {
         // given
-        val declaration1: KoSourceAndAliasTypeProvider = mockk()
-        val declaration2: KoSourceAndAliasTypeProvider = mockk()
+        val declaration1: KoSourceTypeProvider = mockk()
+        val declaration2: KoSourceTypeProvider = mockk()
         val declarations = listOf(declaration1, declaration2)
 
         // when
@@ -574,11 +574,11 @@ class KoSourceAndAliasTypeProviderListExtTest {
         // given
         val bareSourceType1 = "SampleClass1"
         val bareSourceType2 = "SampleClass2"
-        val declaration1: KoSourceAndAliasTypeProvider =
+        val declaration1: KoSourceTypeProvider =
             mockk {
                 every { bareSourceType } returns bareSourceType1
             }
-        val declaration2: KoSourceAndAliasTypeProvider =
+        val declaration2: KoSourceTypeProvider =
             mockk {
                 every { bareSourceType } returns bareSourceType2
             }
@@ -597,15 +597,15 @@ class KoSourceAndAliasTypeProviderListExtTest {
         val bareSourceType1 = "SampleClass1"
         val bareSourceType2 = "SampleClass2"
         val bareSourceType3 = "SampleClass3"
-        val declaration1: KoSourceAndAliasTypeProvider =
+        val declaration1: KoSourceTypeProvider =
             mockk {
                 every { bareSourceType } returns bareSourceType1
             }
-        val declaration2: KoSourceAndAliasTypeProvider =
+        val declaration2: KoSourceTypeProvider =
             mockk {
                 every { bareSourceType } returns bareSourceType2
             }
-        val declaration3: KoSourceAndAliasTypeProvider =
+        val declaration3: KoSourceTypeProvider =
             mockk {
                 every { bareSourceType } returns bareSourceType3
             }
@@ -624,15 +624,15 @@ class KoSourceAndAliasTypeProviderListExtTest {
         val bareSourceType1 = "SampleClass1"
         val bareSourceType2 = "SampleClass2"
         val bareSourceType3 = "SampleClass3"
-        val declaration1: KoSourceAndAliasTypeProvider =
+        val declaration1: KoSourceTypeProvider =
             mockk {
                 every { bareSourceType } returns bareSourceType1
             }
-        val declaration2: KoSourceAndAliasTypeProvider =
+        val declaration2: KoSourceTypeProvider =
             mockk {
                 every { bareSourceType } returns bareSourceType2
             }
-        val declaration3: KoSourceAndAliasTypeProvider =
+        val declaration3: KoSourceTypeProvider =
             mockk {
                 every { bareSourceType } returns bareSourceType3
             }
@@ -652,15 +652,15 @@ class KoSourceAndAliasTypeProviderListExtTest {
         val bareSourceType1 = "SampleClass1"
         val bareSourceType2 = "SampleClass2"
         val bareSourceType3 = "SampleClass3"
-        val declaration1: KoSourceAndAliasTypeProvider =
+        val declaration1: KoSourceTypeProvider =
             mockk {
                 every { bareSourceType } returns bareSourceType1
             }
-        val declaration2: KoSourceAndAliasTypeProvider =
+        val declaration2: KoSourceTypeProvider =
             mockk {
                 every { bareSourceType } returns bareSourceType2
             }
-        val declaration3: KoSourceAndAliasTypeProvider =
+        val declaration3: KoSourceTypeProvider =
             mockk {
                 every { bareSourceType } returns bareSourceType3
             }
@@ -677,8 +677,8 @@ class KoSourceAndAliasTypeProviderListExtTest {
     @Test
     fun `withoutBareSourceTypeOf(empty list) returns none declaration`() {
         // given
-        val declaration1: KoSourceAndAliasTypeProvider = mockk()
-        val declaration2: KoSourceAndAliasTypeProvider = mockk()
+        val declaration1: KoSourceTypeProvider = mockk()
+        val declaration2: KoSourceTypeProvider = mockk()
         val declarations = listOf(declaration1, declaration2)
 
         // when
@@ -691,8 +691,8 @@ class KoSourceAndAliasTypeProviderListExtTest {
     @Test
     fun `withoutBareSourceTypeOf(empty set) returns none declaration`() {
         // given
-        val declaration1: KoSourceAndAliasTypeProvider = mockk()
-        val declaration2: KoSourceAndAliasTypeProvider = mockk()
+        val declaration1: KoSourceTypeProvider = mockk()
+        val declaration2: KoSourceTypeProvider = mockk()
         val declarations = listOf(declaration1, declaration2)
 
         // when
@@ -707,11 +707,11 @@ class KoSourceAndAliasTypeProviderListExtTest {
         // given
         val bareSourceType1 = "SampleClass1"
         val bareSourceType2 = "SampleClass2"
-        val declaration1: KoSourceAndAliasTypeProvider =
+        val declaration1: KoSourceTypeProvider =
             mockk {
                 every { bareSourceType } returns bareSourceType1
             }
-        val declaration2: KoSourceAndAliasTypeProvider =
+        val declaration2: KoSourceTypeProvider =
             mockk {
                 every { bareSourceType } returns bareSourceType2
             }
@@ -730,15 +730,15 @@ class KoSourceAndAliasTypeProviderListExtTest {
         val bareSourceType1 = "SampleClass1"
         val bareSourceType2 = "SampleClass2"
         val bareSourceType3 = "SampleClass3"
-        val declaration1: KoSourceAndAliasTypeProvider =
+        val declaration1: KoSourceTypeProvider =
             mockk {
                 every { bareSourceType } returns bareSourceType1
             }
-        val declaration2: KoSourceAndAliasTypeProvider =
+        val declaration2: KoSourceTypeProvider =
             mockk {
                 every { bareSourceType } returns bareSourceType2
             }
-        val declaration3: KoSourceAndAliasTypeProvider =
+        val declaration3: KoSourceTypeProvider =
             mockk {
                 every { bareSourceType } returns bareSourceType3
             }
@@ -757,15 +757,15 @@ class KoSourceAndAliasTypeProviderListExtTest {
         val bareSourceType1 = "SampleClass1"
         val bareSourceType2 = "SampleClass2"
         val bareSourceType3 = "SampleClass3"
-        val declaration1: KoSourceAndAliasTypeProvider =
+        val declaration1: KoSourceTypeProvider =
             mockk {
                 every { bareSourceType } returns bareSourceType1
             }
-        val declaration2: KoSourceAndAliasTypeProvider =
+        val declaration2: KoSourceTypeProvider =
             mockk {
                 every { bareSourceType } returns bareSourceType2
             }
-        val declaration3: KoSourceAndAliasTypeProvider =
+        val declaration3: KoSourceTypeProvider =
             mockk {
                 every { bareSourceType } returns bareSourceType3
             }
@@ -785,15 +785,15 @@ class KoSourceAndAliasTypeProviderListExtTest {
         val bareSourceType1 = "SampleClass1"
         val bareSourceType2 = "SampleClass2"
         val bareSourceType3 = "SampleClass3"
-        val declaration1: KoSourceAndAliasTypeProvider =
+        val declaration1: KoSourceTypeProvider =
             mockk {
                 every { bareSourceType } returns bareSourceType1
             }
-        val declaration2: KoSourceAndAliasTypeProvider =
+        val declaration2: KoSourceTypeProvider =
             mockk {
                 every { bareSourceType } returns bareSourceType2
             }
-        val declaration3: KoSourceAndAliasTypeProvider =
+        val declaration3: KoSourceTypeProvider =
             mockk {
                 every { bareSourceType } returns bareSourceType3
             }
@@ -810,8 +810,8 @@ class KoSourceAndAliasTypeProviderListExtTest {
     @Test
     fun `withBareSourceType(empty list) returns all declarations`() {
         // given
-        val declaration1: KoSourceAndAliasTypeProvider = mockk()
-        val declaration2: KoSourceAndAliasTypeProvider = mockk()
+        val declaration1: KoSourceTypeProvider = mockk()
+        val declaration2: KoSourceTypeProvider = mockk()
         val declarations = listOf(declaration1, declaration2)
 
         // when
@@ -824,8 +824,8 @@ class KoSourceAndAliasTypeProviderListExtTest {
     @Test
     fun `withBareSourceType(empty set) returns all declarations`() {
         // given
-        val declaration1: KoSourceAndAliasTypeProvider = mockk()
-        val declaration2: KoSourceAndAliasTypeProvider = mockk()
+        val declaration1: KoSourceTypeProvider = mockk()
+        val declaration2: KoSourceTypeProvider = mockk()
         val declarations = listOf(declaration1, declaration2)
 
         // when
@@ -840,11 +840,11 @@ class KoSourceAndAliasTypeProviderListExtTest {
         // given
         val bareSourceType1 = "SampleClass1"
         val bareSourceType2 = "SampleClass2"
-        val declaration1: KoSourceAndAliasTypeProvider =
+        val declaration1: KoSourceTypeProvider =
             mockk {
                 every { bareSourceType } returns bareSourceType1
             }
-        val declaration2: KoSourceAndAliasTypeProvider =
+        val declaration2: KoSourceTypeProvider =
             mockk {
                 every { bareSourceType } returns bareSourceType2
             }
@@ -863,15 +863,15 @@ class KoSourceAndAliasTypeProviderListExtTest {
         val bareSourceType1 = "SampleClass1"
         val bareSourceType2 = "SampleClass2"
         val bareSourceType3 = "SampleClass3"
-        val declaration1: KoSourceAndAliasTypeProvider =
+        val declaration1: KoSourceTypeProvider =
             mockk {
                 every { bareSourceType } returns bareSourceType1
             }
-        val declaration2: KoSourceAndAliasTypeProvider =
+        val declaration2: KoSourceTypeProvider =
             mockk {
                 every { bareSourceType } returns bareSourceType2
             }
-        val declaration3: KoSourceAndAliasTypeProvider =
+        val declaration3: KoSourceTypeProvider =
             mockk {
                 every { bareSourceType } returns bareSourceType3
             }
@@ -890,15 +890,15 @@ class KoSourceAndAliasTypeProviderListExtTest {
         val bareSourceType1 = "SampleClass1"
         val bareSourceType2 = "SampleClass2"
         val bareSourceType3 = "SampleClass3"
-        val declaration1: KoSourceAndAliasTypeProvider =
+        val declaration1: KoSourceTypeProvider =
             mockk {
                 every { bareSourceType } returns bareSourceType1
             }
-        val declaration2: KoSourceAndAliasTypeProvider =
+        val declaration2: KoSourceTypeProvider =
             mockk {
                 every { bareSourceType } returns bareSourceType2
             }
-        val declaration3: KoSourceAndAliasTypeProvider =
+        val declaration3: KoSourceTypeProvider =
             mockk {
                 every { bareSourceType } returns bareSourceType3
             }
@@ -918,15 +918,15 @@ class KoSourceAndAliasTypeProviderListExtTest {
         val bareSourceType1 = "SampleClass1"
         val bareSourceType2 = "SampleClass2"
         val bareSourceType3 = "SampleClass3"
-        val declaration1: KoSourceAndAliasTypeProvider =
+        val declaration1: KoSourceTypeProvider =
             mockk {
                 every { bareSourceType } returns bareSourceType1
             }
-        val declaration2: KoSourceAndAliasTypeProvider =
+        val declaration2: KoSourceTypeProvider =
             mockk {
                 every { bareSourceType } returns bareSourceType2
             }
-        val declaration3: KoSourceAndAliasTypeProvider =
+        val declaration3: KoSourceTypeProvider =
             mockk {
                 every { bareSourceType } returns bareSourceType3
             }
@@ -943,8 +943,8 @@ class KoSourceAndAliasTypeProviderListExtTest {
     @Test
     fun `withoutBareSourceType(empty list) returns none declaration`() {
         // given
-        val declaration1: KoSourceAndAliasTypeProvider = mockk()
-        val declaration2: KoSourceAndAliasTypeProvider = mockk()
+        val declaration1: KoSourceTypeProvider = mockk()
+        val declaration2: KoSourceTypeProvider = mockk()
         val declarations = listOf(declaration1, declaration2)
 
         // when
@@ -957,8 +957,8 @@ class KoSourceAndAliasTypeProviderListExtTest {
     @Test
     fun `withoutBareSourceType(empty set) returns none declaration`() {
         // given
-        val declaration1: KoSourceAndAliasTypeProvider = mockk()
-        val declaration2: KoSourceAndAliasTypeProvider = mockk()
+        val declaration1: KoSourceTypeProvider = mockk()
+        val declaration2: KoSourceTypeProvider = mockk()
         val declarations = listOf(declaration1, declaration2)
 
         // when
@@ -973,11 +973,11 @@ class KoSourceAndAliasTypeProviderListExtTest {
         // given
         val bareSourceType1 = "SampleClass1"
         val bareSourceType2 = "SampleClass2"
-        val declaration1: KoSourceAndAliasTypeProvider =
+        val declaration1: KoSourceTypeProvider =
             mockk {
                 every { bareSourceType } returns bareSourceType1
             }
-        val declaration2: KoSourceAndAliasTypeProvider =
+        val declaration2: KoSourceTypeProvider =
             mockk {
                 every { bareSourceType } returns bareSourceType2
             }
@@ -996,15 +996,15 @@ class KoSourceAndAliasTypeProviderListExtTest {
         val bareSourceType1 = "SampleClass1"
         val bareSourceType2 = "SampleClass2"
         val bareSourceType3 = "SampleClass3"
-        val declaration1: KoSourceAndAliasTypeProvider =
+        val declaration1: KoSourceTypeProvider =
             mockk {
                 every { bareSourceType } returns bareSourceType1
             }
-        val declaration2: KoSourceAndAliasTypeProvider =
+        val declaration2: KoSourceTypeProvider =
             mockk {
                 every { bareSourceType } returns bareSourceType2
             }
-        val declaration3: KoSourceAndAliasTypeProvider =
+        val declaration3: KoSourceTypeProvider =
             mockk {
                 every { bareSourceType } returns bareSourceType3
             }
@@ -1023,15 +1023,15 @@ class KoSourceAndAliasTypeProviderListExtTest {
         val bareSourceType1 = "SampleClass1"
         val bareSourceType2 = "SampleClass2"
         val bareSourceType3 = "SampleClass3"
-        val declaration1: KoSourceAndAliasTypeProvider =
+        val declaration1: KoSourceTypeProvider =
             mockk {
                 every { bareSourceType } returns bareSourceType1
             }
-        val declaration2: KoSourceAndAliasTypeProvider =
+        val declaration2: KoSourceTypeProvider =
             mockk {
                 every { bareSourceType } returns bareSourceType2
             }
-        val declaration3: KoSourceAndAliasTypeProvider =
+        val declaration3: KoSourceTypeProvider =
             mockk {
                 every { bareSourceType } returns bareSourceType3
             }
@@ -1051,15 +1051,15 @@ class KoSourceAndAliasTypeProviderListExtTest {
         val bareSourceType1 = "SampleClass1"
         val bareSourceType2 = "SampleClass2"
         val bareSourceType3 = "SampleClass3"
-        val declaration1: KoSourceAndAliasTypeProvider =
+        val declaration1: KoSourceTypeProvider =
             mockk {
                 every { bareSourceType } returns bareSourceType1
             }
-        val declaration2: KoSourceAndAliasTypeProvider =
+        val declaration2: KoSourceTypeProvider =
             mockk {
                 every { bareSourceType } returns bareSourceType2
             }
-        val declaration3: KoSourceAndAliasTypeProvider =
+        val declaration3: KoSourceTypeProvider =
             mockk {
                 every { bareSourceType } returns bareSourceType3
             }


### PR DESCRIPTION
- **Deprecation of `isAlias` property**: The `isAlias` property in `KoSourceAndAliasTypeProvider` has been deprecated as part of this update.
- **Renaming of `KoSourceAndAliasTypeProvider` to `KoSourceTypeProvider`**: The entire `KoSourceAndAliasTypeProvider` interface has been deprecated and replaced with a new interface, `KoSourceTypeProvider`, which provides the same functionality (despite deprecated `isAlias` property) under a more concise name.

### Breaking API Change:
- **Extension Changes**: All extensions previously available for `KoSourceAndAliasTypeProvider` have been removed. Equivalent extensions have been added to `KoSourceTypeProvider`