### PR TITLE
KON-685  Add missing declaration in KoDeclarationCastProvider for combined types

### DIFF
--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koparent/KoParentDeclarationForKoDeclarationCastProviderTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koparent/KoParentDeclarationForKoDeclarationCastProviderTest.kt
@@ -1952,7 +1952,7 @@ class KoParentDeclarationForKoDeclarationCastProviderTest {
             hasClassOrInterfaceOrObjectDeclaration() shouldBeEqualTo true
             hasClassOrInterfaceOrObjectDeclaration { decl -> decl.name == "SampleGenericSuperInterface" } shouldBeEqualTo true
             hasClassOrInterfaceOrObjectDeclaration { decl -> decl.name == "SampleClass" } shouldBeEqualTo false
-            hasClassOrInterfaceOrObjectDeclarationOf(SampleGenericSuperInterface::class) shouldBeEqualTo true
+            hasClassOrInterfaceOrObjectDeclarationOf(SampleGenericSuperInterface::class) shouldBeEqualTo false
             hasClassOrInterfaceOrObjectDeclarationOf(SampleClass::class) shouldBeEqualTo false
             asClassDeclaration() shouldBeEqualTo null
             hasClassDeclaration() shouldBeEqualTo false
@@ -3992,6 +3992,6 @@ class KoParentDeclarationForKoDeclarationCastProviderTest {
     private fun getSnippetFile(fileName: String) =
         TestSnippetProvider.getSnippetKoScope(
             "core/declaration/koparent/snippet/forkodeclarationcastprovider/",
-            fileName
+            fileName,
         )
 }

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koparent/KoParentDeclarationForKoDeclarationCastProviderTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koparent/KoParentDeclarationForKoDeclarationCastProviderTest.kt
@@ -19,6 +19,7 @@ import com.lemonappdev.konsist.testdata.SampleCollection1
 import com.lemonappdev.konsist.testdata.SampleGenericClassWithParameter
 import com.lemonappdev.konsist.testdata.SampleGenericSuperInterface
 import com.lemonappdev.konsist.testdata.SampleInterface
+import com.lemonappdev.konsist.testdata.SampleObject
 import com.lemonappdev.konsist.testdata.SampleParentClass
 import com.lemonappdev.konsist.testdata.SampleParentInterface
 import com.lemonappdev.konsist.testdata.SampleType
@@ -43,6 +44,10 @@ class KoParentDeclarationForKoDeclarationCastProviderTest {
             isClass shouldBeEqualTo true
             isObject shouldBeEqualTo false
             isInterface shouldBeEqualTo false
+            isClassOrObject shouldBeEqualTo true
+            isClassOrInterface shouldBeEqualTo true
+            isInterfaceOrObject shouldBeEqualTo false
+            isClassOrInterfaceOrObject shouldBeEqualTo true
             isTypeAlias shouldBeEqualTo false
             isImportAlias shouldBeEqualTo false
             isKotlinType shouldBeEqualTo false
@@ -50,6 +55,25 @@ class KoParentDeclarationForKoDeclarationCastProviderTest {
             isKotlinCollectionType shouldBeEqualTo false
             isTypeParameter shouldBeEqualTo false
             isExternal shouldBeEqualTo false
+            asClassOrObjectDeclaration() shouldBeInstanceOf KoClassDeclaration::class
+            hasClassOrObjectDeclaration() shouldBeEqualTo true
+            hasClassOrObjectDeclaration { decl -> decl.name == "SampleSuperClass" } shouldBeEqualTo true
+            hasClassOrObjectDeclaration { decl -> decl.name == "SampleObject" } shouldBeEqualTo false
+            hasClassOrObjectDeclarationOf(SampleClass::class) shouldBeEqualTo false
+            asClassOrInterfaceDeclaration() shouldBeInstanceOf KoClassDeclaration::class
+            hasClassOrInterfaceDeclaration() shouldBeEqualTo true
+            hasClassOrInterfaceDeclaration { decl -> decl.name == "SampleSuperClass" } shouldBeEqualTo true
+            hasClassOrInterfaceDeclaration { decl -> decl.name == "SampleInterface" } shouldBeEqualTo false
+            hasClassOrInterfaceDeclarationOf(SampleClass::class) shouldBeEqualTo false
+            asInterfaceOrObjectDeclaration() shouldBeEqualTo null
+            hasInterfaceOrObjectDeclaration() shouldBeEqualTo false
+            hasInterfaceOrObjectDeclaration { decl -> decl.name == "someName" } shouldBeEqualTo false
+            hasInterfaceOrObjectDeclarationOf(SampleClass::class) shouldBeEqualTo false
+            asClassOrInterfaceOrObjectDeclaration() shouldBeInstanceOf KoClassDeclaration::class
+            hasClassOrInterfaceOrObjectDeclaration() shouldBeEqualTo true
+            hasClassOrInterfaceOrObjectDeclaration { decl -> decl.name == "SampleSuperClass" } shouldBeEqualTo true
+            hasClassOrInterfaceOrObjectDeclaration { decl -> decl.name == "SampleInterface" } shouldBeEqualTo false
+            hasClassOrInterfaceOrObjectDeclarationOf(SampleClass::class) shouldBeEqualTo false
             asClassDeclaration() shouldBeInstanceOf KoClassDeclaration::class
             hasClassDeclaration() shouldBeEqualTo true
             hasClassDeclaration { decl -> decl.name == "SampleSuperClass" } shouldBeEqualTo true
@@ -103,6 +127,10 @@ class KoParentDeclarationForKoDeclarationCastProviderTest {
             isClass shouldBeEqualTo true
             isObject shouldBeEqualTo false
             isInterface shouldBeEqualTo false
+            isClassOrObject shouldBeEqualTo true
+            isClassOrInterface shouldBeEqualTo true
+            isInterfaceOrObject shouldBeEqualTo false
+            isClassOrInterfaceOrObject shouldBeEqualTo true
             isTypeAlias shouldBeEqualTo false
             isImportAlias shouldBeEqualTo false
             isKotlinType shouldBeEqualTo false
@@ -110,6 +138,25 @@ class KoParentDeclarationForKoDeclarationCastProviderTest {
             isKotlinCollectionType shouldBeEqualTo false
             isTypeParameter shouldBeEqualTo false
             isExternal shouldBeEqualTo false
+            asClassOrObjectDeclaration() shouldBeInstanceOf KoClassDeclaration::class
+            hasClassOrObjectDeclaration() shouldBeEqualTo true
+            hasClassOrObjectDeclaration { decl -> decl.name == "SampleGenericSuperClass" } shouldBeEqualTo true
+            hasClassOrObjectDeclaration { decl -> decl.name == "SampleObject" } shouldBeEqualTo false
+            hasClassOrObjectDeclarationOf(SampleClass::class) shouldBeEqualTo false
+            asClassOrInterfaceDeclaration() shouldBeInstanceOf KoClassDeclaration::class
+            hasClassOrInterfaceDeclaration() shouldBeEqualTo true
+            hasClassOrInterfaceDeclaration { decl -> decl.name == "SampleGenericSuperClass" } shouldBeEqualTo true
+            hasClassOrInterfaceDeclaration { decl -> decl.name == "SampleInterface" } shouldBeEqualTo false
+            hasClassOrInterfaceDeclarationOf(SampleClass::class) shouldBeEqualTo false
+            asInterfaceOrObjectDeclaration() shouldBeEqualTo null
+            hasInterfaceOrObjectDeclaration() shouldBeEqualTo false
+            hasInterfaceOrObjectDeclaration { decl -> decl.name == "someName" } shouldBeEqualTo false
+            hasInterfaceOrObjectDeclarationOf(SampleClass::class) shouldBeEqualTo false
+            asClassOrInterfaceOrObjectDeclaration() shouldBeInstanceOf KoClassDeclaration::class
+            hasClassOrInterfaceOrObjectDeclaration() shouldBeEqualTo true
+            hasClassOrInterfaceOrObjectDeclaration { decl -> decl.name == "SampleGenericSuperClass" } shouldBeEqualTo true
+            hasClassOrInterfaceOrObjectDeclaration { decl -> decl.name == "SampleInterface" } shouldBeEqualTo false
+            hasClassOrInterfaceOrObjectDeclarationOf(SampleClass::class) shouldBeEqualTo false
             asClassDeclaration() shouldBeInstanceOf KoClassDeclaration::class
             hasClassDeclaration() shouldBeEqualTo true
             hasClassDeclaration { decl -> decl.name == "SampleGenericSuperClass" } shouldBeEqualTo true
@@ -163,6 +210,10 @@ class KoParentDeclarationForKoDeclarationCastProviderTest {
             isClass shouldBeEqualTo true
             isObject shouldBeEqualTo false
             isInterface shouldBeEqualTo false
+            isClassOrObject shouldBeEqualTo true
+            isClassOrInterface shouldBeEqualTo true
+            isInterfaceOrObject shouldBeEqualTo false
+            isClassOrInterfaceOrObject shouldBeEqualTo true
             isTypeAlias shouldBeEqualTo false
             isImportAlias shouldBeEqualTo false
             isKotlinType shouldBeEqualTo false
@@ -170,6 +221,25 @@ class KoParentDeclarationForKoDeclarationCastProviderTest {
             isKotlinCollectionType shouldBeEqualTo false
             isTypeParameter shouldBeEqualTo false
             isExternal shouldBeEqualTo false
+            asClassOrObjectDeclaration() shouldBeInstanceOf KoClassDeclaration::class
+            hasClassOrObjectDeclaration() shouldBeEqualTo true
+            hasClassOrObjectDeclaration { decl -> decl.name == "SampleParametrizedSuperClass" } shouldBeEqualTo true
+            hasClassOrObjectDeclaration { decl -> decl.name == "SampleObject" } shouldBeEqualTo false
+            hasClassOrObjectDeclarationOf(SampleClass::class) shouldBeEqualTo false
+            asClassOrInterfaceDeclaration() shouldBeInstanceOf KoClassDeclaration::class
+            hasClassOrInterfaceDeclaration() shouldBeEqualTo true
+            hasClassOrInterfaceDeclaration { decl -> decl.name == "SampleParametrizedSuperClass" } shouldBeEqualTo true
+            hasClassOrInterfaceDeclaration { decl -> decl.name == "SampleInterface" } shouldBeEqualTo false
+            hasClassOrInterfaceDeclarationOf(SampleClass::class) shouldBeEqualTo false
+            asInterfaceOrObjectDeclaration() shouldBeEqualTo null
+            hasInterfaceOrObjectDeclaration() shouldBeEqualTo false
+            hasInterfaceOrObjectDeclaration { decl -> decl.name == "someName" } shouldBeEqualTo false
+            hasInterfaceOrObjectDeclarationOf(SampleClass::class) shouldBeEqualTo false
+            asClassOrInterfaceOrObjectDeclaration() shouldBeInstanceOf KoClassDeclaration::class
+            hasClassOrInterfaceOrObjectDeclaration() shouldBeEqualTo true
+            hasClassOrInterfaceOrObjectDeclaration { decl -> decl.name == "SampleParametrizedSuperClass" } shouldBeEqualTo true
+            hasClassOrInterfaceOrObjectDeclaration { decl -> decl.name == "SampleInterface" } shouldBeEqualTo false
+            hasClassOrInterfaceOrObjectDeclarationOf(SampleClass::class) shouldBeEqualTo false
             asClassDeclaration() shouldBeInstanceOf KoClassDeclaration::class
             hasClassDeclaration() shouldBeEqualTo true
             hasClassDeclaration { decl -> decl.name == "SampleParametrizedSuperClass" } shouldBeEqualTo true
@@ -223,6 +293,10 @@ class KoParentDeclarationForKoDeclarationCastProviderTest {
             isClass shouldBeEqualTo true
             isObject shouldBeEqualTo false
             isInterface shouldBeEqualTo false
+            isClassOrObject shouldBeEqualTo true
+            isClassOrInterface shouldBeEqualTo true
+            isInterfaceOrObject shouldBeEqualTo false
+            isClassOrInterfaceOrObject shouldBeEqualTo true
             isTypeAlias shouldBeEqualTo false
             isImportAlias shouldBeEqualTo false
             isKotlinType shouldBeEqualTo false
@@ -230,6 +304,25 @@ class KoParentDeclarationForKoDeclarationCastProviderTest {
             isKotlinCollectionType shouldBeEqualTo false
             isTypeParameter shouldBeEqualTo false
             isExternal shouldBeEqualTo false
+            asClassOrObjectDeclaration() shouldBeInstanceOf KoClassDeclaration::class
+            hasClassOrObjectDeclaration() shouldBeEqualTo true
+            hasClassOrObjectDeclaration { decl -> decl.name == "SampleParametrizedSuperClass" } shouldBeEqualTo true
+            hasClassOrObjectDeclaration { decl -> decl.name == "SampleObject" } shouldBeEqualTo false
+            hasClassOrObjectDeclarationOf(SampleClass::class) shouldBeEqualTo false
+            asClassOrInterfaceDeclaration() shouldBeInstanceOf KoClassDeclaration::class
+            hasClassOrInterfaceDeclaration() shouldBeEqualTo true
+            hasClassOrInterfaceDeclaration { decl -> decl.name == "SampleParametrizedSuperClass" } shouldBeEqualTo true
+            hasClassOrInterfaceDeclaration { decl -> decl.name == "SampleInterface" } shouldBeEqualTo false
+            hasClassOrInterfaceDeclarationOf(SampleClass::class) shouldBeEqualTo false
+            asInterfaceOrObjectDeclaration() shouldBeEqualTo null
+            hasInterfaceOrObjectDeclaration() shouldBeEqualTo false
+            hasInterfaceOrObjectDeclaration { decl -> decl.name == "someName" } shouldBeEqualTo false
+            hasInterfaceOrObjectDeclarationOf(SampleClass::class) shouldBeEqualTo false
+            asClassOrInterfaceOrObjectDeclaration() shouldBeInstanceOf KoClassDeclaration::class
+            hasClassOrInterfaceOrObjectDeclaration() shouldBeEqualTo true
+            hasClassOrInterfaceOrObjectDeclaration { decl -> decl.name == "SampleParametrizedSuperClass" } shouldBeEqualTo true
+            hasClassOrInterfaceOrObjectDeclaration { decl -> decl.name == "SampleInterface" } shouldBeEqualTo false
+            hasClassOrInterfaceOrObjectDeclarationOf(SampleClass::class) shouldBeEqualTo false
             asClassDeclaration() shouldBeInstanceOf KoClassDeclaration::class
             hasClassDeclaration() shouldBeEqualTo true
             hasClassDeclaration { decl -> decl.name == "SampleParametrizedSuperClass" } shouldBeEqualTo true
@@ -283,6 +376,10 @@ class KoParentDeclarationForKoDeclarationCastProviderTest {
             isClass shouldBeEqualTo false
             isObject shouldBeEqualTo false
             isInterface shouldBeEqualTo true
+            isClassOrObject shouldBeEqualTo false
+            isClassOrInterface shouldBeEqualTo true
+            isInterfaceOrObject shouldBeEqualTo true
+            isClassOrInterfaceOrObject shouldBeEqualTo true
             isTypeAlias shouldBeEqualTo false
             isImportAlias shouldBeEqualTo false
             isKotlinType shouldBeEqualTo false
@@ -290,6 +387,24 @@ class KoParentDeclarationForKoDeclarationCastProviderTest {
             isKotlinCollectionType shouldBeEqualTo false
             isTypeParameter shouldBeEqualTo false
             isExternal shouldBeEqualTo false
+            asClassOrObjectDeclaration() shouldBeEqualTo null
+            hasClassOrObjectDeclaration() shouldBeEqualTo false
+            hasClassOrObjectDeclaration { decl -> decl.name == "SampleSuperInterface" } shouldBeEqualTo false
+            hasClassOrObjectDeclarationOf(SampleInterface::class) shouldBeEqualTo false
+            hasClassOrInterfaceDeclaration() shouldBeEqualTo true
+            hasClassOrInterfaceDeclaration { decl -> decl.name == "SampleSuperInterface" } shouldBeEqualTo true
+            hasClassOrInterfaceDeclaration { decl -> decl.name == "SampleClass" } shouldBeEqualTo false
+            hasClassOrInterfaceDeclarationOf(SampleInterface::class) shouldBeEqualTo false
+            asInterfaceOrObjectDeclaration() shouldBeInstanceOf KoInterfaceDeclaration::class
+            hasInterfaceOrObjectDeclaration() shouldBeEqualTo true
+            hasInterfaceOrObjectDeclaration { decl -> decl.name == "SampleSuperInterface" } shouldBeEqualTo true
+            hasInterfaceOrObjectDeclaration { decl -> decl.name == "SampleObject" } shouldBeEqualTo false
+            hasInterfaceOrObjectDeclarationOf(SampleInterface::class) shouldBeEqualTo false
+            asClassOrInterfaceOrObjectDeclaration() shouldBeInstanceOf KoInterfaceDeclaration::class
+            hasClassOrInterfaceOrObjectDeclaration() shouldBeEqualTo true
+            hasClassOrInterfaceOrObjectDeclaration { decl -> decl.name == "SampleSuperInterface" } shouldBeEqualTo true
+            hasClassOrInterfaceOrObjectDeclaration { decl -> decl.name == "SampleClass" } shouldBeEqualTo false
+            hasClassOrInterfaceOrObjectDeclarationOf(SampleInterface::class) shouldBeEqualTo false
             asClassDeclaration() shouldBeEqualTo null
             hasClassDeclaration() shouldBeEqualTo false
             hasClassDeclaration { decl -> decl.name == "SampleSuperInterface" } shouldBeEqualTo false
@@ -343,6 +458,10 @@ class KoParentDeclarationForKoDeclarationCastProviderTest {
             isClass shouldBeEqualTo false
             isObject shouldBeEqualTo false
             isInterface shouldBeEqualTo true
+            isClassOrObject shouldBeEqualTo false
+            isClassOrInterface shouldBeEqualTo true
+            isInterfaceOrObject shouldBeEqualTo true
+            isClassOrInterfaceOrObject shouldBeEqualTo true
             isTypeAlias shouldBeEqualTo false
             isImportAlias shouldBeEqualTo false
             isKotlinType shouldBeEqualTo false
@@ -350,6 +469,24 @@ class KoParentDeclarationForKoDeclarationCastProviderTest {
             isKotlinCollectionType shouldBeEqualTo false
             isTypeParameter shouldBeEqualTo false
             isExternal shouldBeEqualTo false
+            asClassOrObjectDeclaration() shouldBeEqualTo null
+            hasClassOrObjectDeclaration() shouldBeEqualTo false
+            hasClassOrObjectDeclaration { decl -> decl.name == "SampleGenericSuperInterface" } shouldBeEqualTo false
+            asClassOrInterfaceDeclaration() shouldBeInstanceOf KoInterfaceDeclaration::class
+            hasClassOrInterfaceDeclaration() shouldBeEqualTo true
+            hasClassOrInterfaceDeclaration { decl -> decl.name == "SampleGenericSuperInterface" } shouldBeEqualTo true
+            hasClassOrInterfaceDeclaration { decl -> decl.name == "SampleClass" } shouldBeEqualTo false
+            hasClassOrInterfaceDeclarationOf(SampleClass::class) shouldBeEqualTo false
+            asInterfaceOrObjectDeclaration() shouldBeInstanceOf KoInterfaceDeclaration::class
+            hasInterfaceOrObjectDeclaration() shouldBeEqualTo true
+            hasInterfaceOrObjectDeclaration { decl -> decl.name == "SampleGenericSuperInterface" } shouldBeEqualTo true
+            hasInterfaceOrObjectDeclaration { decl -> decl.name == "SampleObject" } shouldBeEqualTo false
+            hasInterfaceOrObjectDeclarationOf(SampleObject::class) shouldBeEqualTo false
+            asClassOrInterfaceOrObjectDeclaration() shouldBeInstanceOf KoInterfaceDeclaration::class
+            hasClassOrInterfaceOrObjectDeclaration() shouldBeEqualTo true
+            hasClassOrInterfaceOrObjectDeclaration { decl -> decl.name == "SampleGenericSuperInterface" } shouldBeEqualTo true
+            hasClassOrInterfaceOrObjectDeclaration { decl -> decl.name == "SampleClass" } shouldBeEqualTo false
+            hasClassOrInterfaceOrObjectDeclarationOf(SampleClass::class) shouldBeEqualTo false
             asClassDeclaration() shouldBeEqualTo null
             hasClassDeclaration() shouldBeEqualTo false
             hasClassDeclaration { decl -> decl.name == "SampleGenericSuperInterface" } shouldBeEqualTo false
@@ -403,6 +540,10 @@ class KoParentDeclarationForKoDeclarationCastProviderTest {
             isClass shouldBeEqualTo false
             isObject shouldBeEqualTo false
             isInterface shouldBeEqualTo true
+            isClassOrObject shouldBeEqualTo false
+            isClassOrInterface shouldBeEqualTo true
+            isInterfaceOrObject shouldBeEqualTo true
+            isClassOrInterfaceOrObject shouldBeEqualTo true
             isTypeAlias shouldBeEqualTo false
             isImportAlias shouldBeEqualTo false
             isKotlinType shouldBeEqualTo false
@@ -410,6 +551,24 @@ class KoParentDeclarationForKoDeclarationCastProviderTest {
             isKotlinCollectionType shouldBeEqualTo false
             isTypeParameter shouldBeEqualTo false
             isExternal shouldBeEqualTo false
+            asClassOrObjectDeclaration() shouldBeEqualTo null
+            hasClassOrObjectDeclaration() shouldBeEqualTo false
+            hasClassOrObjectDeclaration { decl -> decl.name == "SampleSuperInterface" } shouldBeEqualTo false
+            hasClassOrObjectDeclarationOf(SampleInterface::class) shouldBeEqualTo false
+            hasClassOrInterfaceDeclaration() shouldBeEqualTo true
+            hasClassOrInterfaceDeclaration { decl -> decl.name == "SampleSuperInterface" } shouldBeEqualTo true
+            hasClassOrInterfaceDeclaration { decl -> decl.name == "SampleClass" } shouldBeEqualTo false
+            hasClassOrInterfaceDeclarationOf(SampleInterface::class) shouldBeEqualTo false
+            asInterfaceOrObjectDeclaration() shouldBeInstanceOf KoInterfaceDeclaration::class
+            hasInterfaceOrObjectDeclaration() shouldBeEqualTo true
+            hasInterfaceOrObjectDeclaration { decl -> decl.name == "SampleSuperInterface" } shouldBeEqualTo true
+            hasInterfaceOrObjectDeclaration { decl -> decl.name == "SampleObject" } shouldBeEqualTo false
+            hasInterfaceOrObjectDeclarationOf(SampleInterface::class) shouldBeEqualTo false
+            asClassOrInterfaceOrObjectDeclaration() shouldBeInstanceOf KoInterfaceDeclaration::class
+            hasClassOrInterfaceOrObjectDeclaration() shouldBeEqualTo true
+            hasClassOrInterfaceOrObjectDeclaration { decl -> decl.name == "SampleSuperInterface" } shouldBeEqualTo true
+            hasClassOrInterfaceOrObjectDeclaration { decl -> decl.name == "SampleClass" } shouldBeEqualTo false
+            hasClassOrInterfaceOrObjectDeclarationOf(SampleInterface::class) shouldBeEqualTo false
             asClassDeclaration() shouldBeEqualTo null
             hasClassDeclaration() shouldBeEqualTo false
             hasClassDeclaration { decl -> decl.name == "SampleSuperInterface" } shouldBeEqualTo false
@@ -463,6 +622,10 @@ class KoParentDeclarationForKoDeclarationCastProviderTest {
             isClass shouldBeEqualTo true
             isObject shouldBeEqualTo false
             isInterface shouldBeEqualTo false
+            isClassOrObject shouldBeEqualTo true
+            isClassOrInterface shouldBeEqualTo true
+            isInterfaceOrObject shouldBeEqualTo false
+            isClassOrInterfaceOrObject shouldBeEqualTo true
             isTypeAlias shouldBeEqualTo false
             isImportAlias shouldBeEqualTo false
             isKotlinType shouldBeEqualTo false
@@ -470,6 +633,28 @@ class KoParentDeclarationForKoDeclarationCastProviderTest {
             isKotlinCollectionType shouldBeEqualTo false
             isTypeParameter shouldBeEqualTo false
             isExternal shouldBeEqualTo false
+            asClassOrObjectDeclaration() shouldBeInstanceOf KoClassDeclaration::class
+            hasClassOrObjectDeclaration() shouldBeEqualTo true
+            hasClassOrObjectDeclaration { decl -> decl.name == "SampleParentClass" } shouldBeEqualTo true
+            hasClassOrObjectDeclaration { decl -> decl.name == "SampleObject" } shouldBeEqualTo false
+            hasClassOrObjectDeclarationOf(SampleParentClass::class) shouldBeEqualTo true
+            hasClassOrObjectDeclarationOf(SampleClass::class) shouldBeEqualTo false
+            asClassOrInterfaceDeclaration() shouldBeInstanceOf KoClassDeclaration::class
+            hasClassOrInterfaceDeclaration() shouldBeEqualTo true
+            hasClassOrInterfaceDeclaration { decl -> decl.name == "SampleParentClass" } shouldBeEqualTo true
+            hasClassOrInterfaceDeclaration { decl -> decl.name == "SampleInterface" } shouldBeEqualTo false
+            hasClassOrInterfaceDeclarationOf(SampleParentClass::class) shouldBeEqualTo true
+            hasClassOrInterfaceDeclarationOf(SampleClass::class) shouldBeEqualTo false
+            asInterfaceOrObjectDeclaration() shouldBeEqualTo null
+            hasInterfaceOrObjectDeclaration() shouldBeEqualTo false
+            hasInterfaceOrObjectDeclaration { decl -> decl.name == "someName" } shouldBeEqualTo false
+            hasInterfaceOrObjectDeclarationOf(SampleClass::class) shouldBeEqualTo false
+            asClassOrInterfaceOrObjectDeclaration() shouldBeInstanceOf KoClassDeclaration::class
+            hasClassOrInterfaceOrObjectDeclaration() shouldBeEqualTo true
+            hasClassOrInterfaceOrObjectDeclaration { decl -> decl.name == "SampleParentClass" } shouldBeEqualTo true
+            hasClassOrInterfaceOrObjectDeclaration { decl -> decl.name == "SampleInterface" } shouldBeEqualTo false
+            hasClassOrInterfaceOrObjectDeclarationOf(SampleParentClass::class) shouldBeEqualTo true
+            hasClassOrInterfaceOrObjectDeclarationOf(SampleClass::class) shouldBeEqualTo false
             asClassDeclaration() shouldBeInstanceOf KoClassDeclaration::class
             hasClassDeclaration() shouldBeEqualTo true
             hasClassDeclaration { decl -> decl.name == "SampleParentClass" } shouldBeEqualTo true
@@ -531,6 +716,10 @@ class KoParentDeclarationForKoDeclarationCastProviderTest {
             isClass shouldBeEqualTo true
             isObject shouldBeEqualTo false
             isInterface shouldBeEqualTo false
+            isClassOrObject shouldBeEqualTo true
+            isClassOrInterface shouldBeEqualTo true
+            isInterfaceOrObject shouldBeEqualTo false
+            isClassOrInterfaceOrObject shouldBeEqualTo true
             isTypeAlias shouldBeEqualTo false
             isImportAlias shouldBeEqualTo false
             isKotlinType shouldBeEqualTo false
@@ -538,6 +727,28 @@ class KoParentDeclarationForKoDeclarationCastProviderTest {
             isKotlinCollectionType shouldBeEqualTo false
             isTypeParameter shouldBeEqualTo false
             isExternal shouldBeEqualTo false
+            asClassOrObjectDeclaration() shouldBeInstanceOf KoClassDeclaration::class
+            hasClassOrObjectDeclaration() shouldBeEqualTo true
+            hasClassOrObjectDeclaration { decl -> decl.name == "SampleCollection1" } shouldBeEqualTo true
+            hasClassOrObjectDeclaration { decl -> decl.name == "SampleObject" } shouldBeEqualTo false
+            hasClassOrObjectDeclarationOf(SampleCollection1::class) shouldBeEqualTo true
+            hasClassOrObjectDeclarationOf(SampleClass::class) shouldBeEqualTo false
+            asClassOrInterfaceDeclaration() shouldBeInstanceOf KoClassDeclaration::class
+            hasClassOrInterfaceDeclaration() shouldBeEqualTo true
+            hasClassOrInterfaceDeclaration { decl -> decl.name == "SampleCollection1" } shouldBeEqualTo true
+            hasClassOrInterfaceDeclaration { decl -> decl.name == "SampleInterface" } shouldBeEqualTo false
+            hasClassOrInterfaceDeclarationOf(SampleCollection1::class) shouldBeEqualTo true
+            hasClassOrInterfaceDeclarationOf(SampleClass::class) shouldBeEqualTo false
+            asInterfaceOrObjectDeclaration() shouldBeEqualTo null
+            hasInterfaceOrObjectDeclaration() shouldBeEqualTo false
+            hasInterfaceOrObjectDeclaration { decl -> decl.name == "someName" } shouldBeEqualTo false
+            hasInterfaceOrObjectDeclarationOf(SampleClass::class) shouldBeEqualTo false
+            asClassOrInterfaceOrObjectDeclaration() shouldBeInstanceOf KoClassDeclaration::class
+            hasClassOrInterfaceOrObjectDeclaration() shouldBeEqualTo true
+            hasClassOrInterfaceOrObjectDeclaration { decl -> decl.name == "SampleCollection1" } shouldBeEqualTo true
+            hasClassOrInterfaceOrObjectDeclaration { decl -> decl.name == "SampleInterface" } shouldBeEqualTo false
+            hasClassOrInterfaceOrObjectDeclarationOf(SampleCollection1::class) shouldBeEqualTo true
+            hasClassOrInterfaceOrObjectDeclarationOf(SampleClass::class) shouldBeEqualTo false
             asClassDeclaration() shouldBeInstanceOf KoClassDeclaration::class
             hasClassDeclaration() shouldBeEqualTo true
             hasClassDeclaration { decl -> decl.name == "SampleCollection1" } shouldBeEqualTo true
@@ -599,6 +810,10 @@ class KoParentDeclarationForKoDeclarationCastProviderTest {
             isClass shouldBeEqualTo true
             isObject shouldBeEqualTo false
             isInterface shouldBeEqualTo false
+            isClassOrObject shouldBeEqualTo true
+            isClassOrInterface shouldBeEqualTo true
+            isInterfaceOrObject shouldBeEqualTo false
+            isClassOrInterfaceOrObject shouldBeEqualTo true
             isTypeAlias shouldBeEqualTo false
             isImportAlias shouldBeEqualTo false
             isKotlinType shouldBeEqualTo false
@@ -606,6 +821,28 @@ class KoParentDeclarationForKoDeclarationCastProviderTest {
             isKotlinCollectionType shouldBeEqualTo false
             isTypeParameter shouldBeEqualTo false
             isExternal shouldBeEqualTo false
+            asClassOrObjectDeclaration() shouldBeInstanceOf KoClassDeclaration::class
+            hasClassOrObjectDeclaration() shouldBeEqualTo true
+            hasClassOrObjectDeclaration { decl -> decl.name == "SampleClassWithParameter" } shouldBeEqualTo true
+            hasClassOrObjectDeclaration { decl -> decl.name == "SampleObject" } shouldBeEqualTo false
+            hasClassOrObjectDeclarationOf(SampleClassWithParameter::class) shouldBeEqualTo true
+            hasClassOrObjectDeclarationOf(SampleClass::class) shouldBeEqualTo false
+            asClassOrInterfaceDeclaration() shouldBeInstanceOf KoClassDeclaration::class
+            hasClassOrInterfaceDeclaration() shouldBeEqualTo true
+            hasClassOrInterfaceDeclaration { decl -> decl.name == "SampleClassWithParameter" } shouldBeEqualTo true
+            hasClassOrInterfaceDeclaration { decl -> decl.name == "SampleInterface" } shouldBeEqualTo false
+            hasClassOrInterfaceDeclarationOf(SampleClassWithParameter::class) shouldBeEqualTo true
+            hasClassOrInterfaceDeclarationOf(SampleClass::class) shouldBeEqualTo false
+            asInterfaceOrObjectDeclaration() shouldBeEqualTo null
+            hasInterfaceOrObjectDeclaration() shouldBeEqualTo false
+            hasInterfaceOrObjectDeclaration { decl -> decl.name == "someName" } shouldBeEqualTo false
+            hasInterfaceOrObjectDeclarationOf(SampleClass::class) shouldBeEqualTo false
+            asClassOrInterfaceOrObjectDeclaration() shouldBeInstanceOf KoClassDeclaration::class
+            hasClassOrInterfaceOrObjectDeclaration() shouldBeEqualTo true
+            hasClassOrInterfaceOrObjectDeclaration { decl -> decl.name == "SampleClassWithParameter" } shouldBeEqualTo true
+            hasClassOrInterfaceOrObjectDeclaration { decl -> decl.name == "SampleInterface" } shouldBeEqualTo false
+            hasClassOrInterfaceOrObjectDeclarationOf(SampleClassWithParameter::class) shouldBeEqualTo true
+            hasClassOrInterfaceOrObjectDeclarationOf(SampleClass::class) shouldBeEqualTo false
             asClassDeclaration() shouldBeInstanceOf KoClassDeclaration::class
             hasClassDeclaration() shouldBeEqualTo true
             hasClassDeclaration { decl -> decl.name == "SampleClassWithParameter" } shouldBeEqualTo true
@@ -667,6 +904,10 @@ class KoParentDeclarationForKoDeclarationCastProviderTest {
             isClass shouldBeEqualTo true
             isObject shouldBeEqualTo false
             isInterface shouldBeEqualTo false
+            isClassOrObject shouldBeEqualTo true
+            isClassOrInterface shouldBeEqualTo true
+            isInterfaceOrObject shouldBeEqualTo false
+            isClassOrInterfaceOrObject shouldBeEqualTo true
             isTypeAlias shouldBeEqualTo false
             isImportAlias shouldBeEqualTo false
             isKotlinType shouldBeEqualTo false
@@ -674,6 +915,28 @@ class KoParentDeclarationForKoDeclarationCastProviderTest {
             isKotlinCollectionType shouldBeEqualTo false
             isTypeParameter shouldBeEqualTo false
             isExternal shouldBeEqualTo false
+            asClassOrObjectDeclaration() shouldBeInstanceOf KoClassDeclaration::class
+            hasClassOrObjectDeclaration() shouldBeEqualTo true
+            hasClassOrObjectDeclaration { decl -> decl.name == "SampleGenericClassWithParameter" } shouldBeEqualTo true
+            hasClassOrObjectDeclaration { decl -> decl.name == "SampleObject" } shouldBeEqualTo false
+            hasClassOrObjectDeclarationOf(SampleGenericClassWithParameter::class) shouldBeEqualTo true
+            hasClassOrObjectDeclarationOf(SampleClass::class) shouldBeEqualTo false
+            asClassOrInterfaceDeclaration() shouldBeInstanceOf KoClassDeclaration::class
+            hasClassOrInterfaceDeclaration() shouldBeEqualTo true
+            hasClassOrInterfaceDeclaration { decl -> decl.name == "SampleGenericClassWithParameter" } shouldBeEqualTo true
+            hasClassOrInterfaceDeclaration { decl -> decl.name == "SampleInterface" } shouldBeEqualTo false
+            hasClassOrInterfaceDeclarationOf(SampleGenericClassWithParameter::class) shouldBeEqualTo true
+            hasClassOrInterfaceDeclarationOf(SampleClass::class) shouldBeEqualTo false
+            asInterfaceOrObjectDeclaration() shouldBeEqualTo null
+            hasInterfaceOrObjectDeclaration() shouldBeEqualTo false
+            hasInterfaceOrObjectDeclaration { decl -> decl.name == "someName" } shouldBeEqualTo false
+            hasInterfaceOrObjectDeclarationOf(SampleClass::class) shouldBeEqualTo false
+            asClassOrInterfaceOrObjectDeclaration() shouldBeInstanceOf KoClassDeclaration::class
+            hasClassOrInterfaceOrObjectDeclaration() shouldBeEqualTo true
+            hasClassOrInterfaceOrObjectDeclaration { decl -> decl.name == "SampleGenericClassWithParameter" } shouldBeEqualTo true
+            hasClassOrInterfaceOrObjectDeclaration { decl -> decl.name == "SampleInterface" } shouldBeEqualTo false
+            hasClassOrInterfaceOrObjectDeclarationOf(SampleGenericClassWithParameter::class) shouldBeEqualTo true
+            hasClassOrInterfaceOrObjectDeclarationOf(SampleClass::class) shouldBeEqualTo false
             asClassDeclaration() shouldBeInstanceOf KoClassDeclaration::class
             hasClassDeclaration() shouldBeEqualTo true
             hasClassDeclaration { decl -> decl.name == "SampleGenericClassWithParameter" } shouldBeEqualTo true
@@ -735,6 +998,10 @@ class KoParentDeclarationForKoDeclarationCastProviderTest {
             isClass shouldBeEqualTo false
             isObject shouldBeEqualTo false
             isInterface shouldBeEqualTo true
+            isClassOrObject shouldBeEqualTo false
+            isClassOrInterface shouldBeEqualTo true
+            isInterfaceOrObject shouldBeEqualTo true
+            isClassOrInterfaceOrObject shouldBeEqualTo true
             isTypeAlias shouldBeEqualTo false
             isImportAlias shouldBeEqualTo false
             isKotlinType shouldBeEqualTo false
@@ -742,6 +1009,28 @@ class KoParentDeclarationForKoDeclarationCastProviderTest {
             isKotlinCollectionType shouldBeEqualTo false
             isTypeParameter shouldBeEqualTo false
             isExternal shouldBeEqualTo false
+            asClassOrObjectDeclaration() shouldBeEqualTo null
+            hasClassOrObjectDeclaration() shouldBeEqualTo false
+            hasClassOrObjectDeclaration { decl -> decl.name == "SampleInterface" } shouldBeEqualTo false
+            hasClassOrObjectDeclarationOf(SampleInterface::class) shouldBeEqualTo false
+            asClassOrInterfaceDeclaration() shouldBeInstanceOf KoInterfaceDeclaration::class
+            hasClassOrInterfaceDeclaration() shouldBeEqualTo true
+            hasClassOrInterfaceDeclaration { decl -> decl.name == "SampleInterface" } shouldBeEqualTo true
+            hasClassOrInterfaceDeclaration { decl -> decl.name == "SampleClass" } shouldBeEqualTo false
+            hasClassOrInterfaceDeclarationOf(SampleInterface::class) shouldBeEqualTo true
+            hasClassOrInterfaceDeclarationOf(SampleClass::class) shouldBeEqualTo false
+            asInterfaceOrObjectDeclaration() shouldBeInstanceOf KoInterfaceDeclaration::class
+            hasInterfaceOrObjectDeclaration() shouldBeEqualTo true
+            hasInterfaceOrObjectDeclaration { decl -> decl.name == "SampleInterface" } shouldBeEqualTo true
+            hasInterfaceOrObjectDeclaration { decl -> decl.name == "SampleObject" } shouldBeEqualTo false
+            hasInterfaceOrObjectDeclarationOf(SampleInterface::class) shouldBeEqualTo true
+            hasInterfaceOrObjectDeclarationOf(SampleObject::class) shouldBeEqualTo false
+            asClassOrInterfaceOrObjectDeclaration() shouldBeInstanceOf KoInterfaceDeclaration::class
+            hasClassOrInterfaceOrObjectDeclaration() shouldBeEqualTo true
+            hasClassOrInterfaceOrObjectDeclaration { decl -> decl.name == "SampleInterface" } shouldBeEqualTo true
+            hasClassOrInterfaceOrObjectDeclaration { decl -> decl.name == "SampleClass" } shouldBeEqualTo false
+            hasClassOrInterfaceOrObjectDeclarationOf(SampleInterface::class) shouldBeEqualTo true
+            hasClassOrInterfaceOrObjectDeclarationOf(SampleClass::class) shouldBeEqualTo false
             asClassDeclaration() shouldBeEqualTo null
             hasClassDeclaration() shouldBeEqualTo false
             hasClassDeclaration { decl -> decl.name == "SampleInterface" } shouldBeEqualTo false
@@ -795,6 +1084,10 @@ class KoParentDeclarationForKoDeclarationCastProviderTest {
             isClass shouldBeEqualTo false
             isObject shouldBeEqualTo false
             isInterface shouldBeEqualTo true
+            isClassOrObject shouldBeEqualTo false
+            isClassOrInterface shouldBeEqualTo true
+            isInterfaceOrObject shouldBeEqualTo true
+            isClassOrInterfaceOrObject shouldBeEqualTo true
             isTypeAlias shouldBeEqualTo false
             isImportAlias shouldBeEqualTo false
             isKotlinType shouldBeEqualTo false
@@ -802,6 +1095,28 @@ class KoParentDeclarationForKoDeclarationCastProviderTest {
             isKotlinCollectionType shouldBeEqualTo false
             isTypeParameter shouldBeEqualTo false
             isExternal shouldBeEqualTo false
+            asClassOrObjectDeclaration() shouldBeEqualTo null
+            hasClassOrObjectDeclaration() shouldBeEqualTo false
+            hasClassOrObjectDeclaration { decl -> decl.name == "SampleGenericSuperInterface" } shouldBeEqualTo false
+            hasClassOrObjectDeclarationOf(SampleGenericSuperInterface::class) shouldBeEqualTo false
+            asClassOrInterfaceDeclaration() shouldBeInstanceOf KoInterfaceDeclaration::class
+            hasClassOrInterfaceDeclaration() shouldBeEqualTo true
+            hasClassOrInterfaceDeclaration { decl -> decl.name == "SampleGenericSuperInterface" } shouldBeEqualTo true
+            hasClassOrInterfaceDeclaration { decl -> decl.name == "SampleClass" } shouldBeEqualTo false
+            hasClassOrInterfaceDeclarationOf(SampleGenericSuperInterface::class) shouldBeEqualTo true
+            hasClassOrInterfaceDeclarationOf(SampleClass::class) shouldBeEqualTo false
+            asInterfaceOrObjectDeclaration() shouldBeInstanceOf KoInterfaceDeclaration::class
+            hasInterfaceOrObjectDeclaration() shouldBeEqualTo true
+            hasInterfaceOrObjectDeclaration { decl -> decl.name == "SampleGenericSuperInterface" } shouldBeEqualTo true
+            hasInterfaceOrObjectDeclaration { decl -> decl.name == "SampleObject" } shouldBeEqualTo false
+            hasInterfaceOrObjectDeclarationOf(SampleGenericSuperInterface::class) shouldBeEqualTo true
+            hasInterfaceOrObjectDeclarationOf(SampleObject::class) shouldBeEqualTo false
+            asClassOrInterfaceOrObjectDeclaration() shouldBeInstanceOf KoInterfaceDeclaration::class
+            hasClassOrInterfaceOrObjectDeclaration() shouldBeEqualTo true
+            hasClassOrInterfaceOrObjectDeclaration { decl -> decl.name == "SampleGenericSuperInterface" } shouldBeEqualTo true
+            hasClassOrInterfaceOrObjectDeclaration { decl -> decl.name == "SampleClass" } shouldBeEqualTo false
+            hasClassOrInterfaceOrObjectDeclarationOf(SampleGenericSuperInterface::class) shouldBeEqualTo true
+            hasClassOrInterfaceOrObjectDeclarationOf(SampleClass::class) shouldBeEqualTo false
             asClassDeclaration() shouldBeEqualTo null
             hasClassDeclaration() shouldBeEqualTo false
             hasClassDeclaration { decl -> decl.name == "SampleGenericSuperInterface" } shouldBeEqualTo false
@@ -855,6 +1170,10 @@ class KoParentDeclarationForKoDeclarationCastProviderTest {
             isClass shouldBeEqualTo false
             isObject shouldBeEqualTo false
             isInterface shouldBeEqualTo true
+            isClassOrObject shouldBeEqualTo false
+            isClassOrInterface shouldBeEqualTo true
+            isInterfaceOrObject shouldBeEqualTo true
+            isClassOrInterfaceOrObject shouldBeEqualTo true
             isTypeAlias shouldBeEqualTo false
             isImportAlias shouldBeEqualTo false
             isKotlinType shouldBeEqualTo false
@@ -862,6 +1181,28 @@ class KoParentDeclarationForKoDeclarationCastProviderTest {
             isKotlinCollectionType shouldBeEqualTo false
             isTypeParameter shouldBeEqualTo false
             isExternal shouldBeEqualTo false
+            asClassOrObjectDeclaration() shouldBeEqualTo null
+            hasClassOrObjectDeclaration() shouldBeEqualTo false
+            hasClassOrObjectDeclaration { decl -> decl.name == "SampleInterface" } shouldBeEqualTo false
+            hasClassOrObjectDeclarationOf(SampleInterface::class) shouldBeEqualTo false
+            asClassOrInterfaceDeclaration() shouldBeInstanceOf KoInterfaceDeclaration::class
+            hasClassOrInterfaceDeclaration() shouldBeEqualTo true
+            hasClassOrInterfaceDeclaration { decl -> decl.name == "SampleInterface" } shouldBeEqualTo true
+            hasClassOrInterfaceDeclaration { decl -> decl.name == "SampleClass" } shouldBeEqualTo false
+            hasClassOrInterfaceDeclarationOf(SampleInterface::class) shouldBeEqualTo true
+            hasClassOrInterfaceDeclarationOf(SampleClass::class) shouldBeEqualTo false
+            asInterfaceOrObjectDeclaration() shouldBeInstanceOf KoInterfaceDeclaration::class
+            hasInterfaceOrObjectDeclaration() shouldBeEqualTo true
+            hasInterfaceOrObjectDeclaration { decl -> decl.name == "SampleInterface" } shouldBeEqualTo true
+            hasInterfaceOrObjectDeclaration { decl -> decl.name == "SampleObject" } shouldBeEqualTo false
+            hasInterfaceOrObjectDeclarationOf(SampleInterface::class) shouldBeEqualTo true
+            hasInterfaceOrObjectDeclarationOf(SampleObject::class) shouldBeEqualTo false
+            asClassOrInterfaceOrObjectDeclaration() shouldBeInstanceOf KoInterfaceDeclaration::class
+            hasClassOrInterfaceOrObjectDeclaration() shouldBeEqualTo true
+            hasClassOrInterfaceOrObjectDeclaration { decl -> decl.name == "SampleInterface" } shouldBeEqualTo true
+            hasClassOrInterfaceOrObjectDeclaration { decl -> decl.name == "SampleClass" } shouldBeEqualTo false
+            hasClassOrInterfaceOrObjectDeclarationOf(SampleInterface::class) shouldBeEqualTo true
+            hasClassOrInterfaceOrObjectDeclarationOf(SampleClass::class) shouldBeEqualTo false
             asClassDeclaration() shouldBeEqualTo null
             hasClassDeclaration() shouldBeEqualTo false
             hasClassDeclaration { decl -> decl.name == "SampleInterface" } shouldBeEqualTo false
@@ -915,6 +1256,10 @@ class KoParentDeclarationForKoDeclarationCastProviderTest {
             isClass shouldBeEqualTo false
             isObject shouldBeEqualTo false
             isInterface shouldBeEqualTo false
+            isClassOrObject shouldBeEqualTo false
+            isClassOrInterface shouldBeEqualTo false
+            isInterfaceOrObject shouldBeEqualTo false
+            isClassOrInterfaceOrObject shouldBeEqualTo false
             isTypeAlias shouldBeEqualTo false
             isImportAlias shouldBeEqualTo false
             isKotlinType shouldBeEqualTo false
@@ -976,6 +1321,10 @@ class KoParentDeclarationForKoDeclarationCastProviderTest {
             isClass shouldBeEqualTo false
             isObject shouldBeEqualTo false
             isInterface shouldBeEqualTo false
+            isClassOrObject shouldBeEqualTo false
+            isClassOrInterface shouldBeEqualTo false
+            isInterfaceOrObject shouldBeEqualTo false
+            isClassOrInterfaceOrObject shouldBeEqualTo false
             isTypeAlias shouldBeEqualTo false
             isImportAlias shouldBeEqualTo false
             isKotlinType shouldBeEqualTo false
@@ -1037,6 +1386,10 @@ class KoParentDeclarationForKoDeclarationCastProviderTest {
             isClass shouldBeEqualTo false
             isObject shouldBeEqualTo false
             isInterface shouldBeEqualTo false
+            isClassOrObject shouldBeEqualTo false
+            isClassOrInterface shouldBeEqualTo false
+            isInterfaceOrObject shouldBeEqualTo false
+            isClassOrInterfaceOrObject shouldBeEqualTo false
             isTypeAlias shouldBeEqualTo false
             isImportAlias shouldBeEqualTo false
             isKotlinType shouldBeEqualTo false
@@ -1098,6 +1451,10 @@ class KoParentDeclarationForKoDeclarationCastProviderTest {
             isClass shouldBeEqualTo false
             isObject shouldBeEqualTo false
             isInterface shouldBeEqualTo false
+            isClassOrObject shouldBeEqualTo false
+            isClassOrInterface shouldBeEqualTo false
+            isInterfaceOrObject shouldBeEqualTo false
+            isClassOrInterfaceOrObject shouldBeEqualTo false
             isTypeAlias shouldBeEqualTo false
             isImportAlias shouldBeEqualTo false
             isKotlinType shouldBeEqualTo false
@@ -1159,6 +1516,10 @@ class KoParentDeclarationForKoDeclarationCastProviderTest {
             isClass shouldBeEqualTo false
             isObject shouldBeEqualTo false
             isInterface shouldBeEqualTo false
+            isClassOrObject shouldBeEqualTo false
+            isClassOrInterface shouldBeEqualTo false
+            isInterfaceOrObject shouldBeEqualTo false
+            isClassOrInterfaceOrObject shouldBeEqualTo false
             isTypeAlias shouldBeEqualTo false
             isImportAlias shouldBeEqualTo false
             isKotlinType shouldBeEqualTo false
@@ -1220,6 +1581,10 @@ class KoParentDeclarationForKoDeclarationCastProviderTest {
             isClass shouldBeEqualTo false
             isObject shouldBeEqualTo false
             isInterface shouldBeEqualTo false
+            isClassOrObject shouldBeEqualTo false
+            isClassOrInterface shouldBeEqualTo false
+            isInterfaceOrObject shouldBeEqualTo false
+            isClassOrInterfaceOrObject shouldBeEqualTo false
             isTypeAlias shouldBeEqualTo false
             isImportAlias shouldBeEqualTo false
             isKotlinType shouldBeEqualTo false
@@ -1281,6 +1646,10 @@ class KoParentDeclarationForKoDeclarationCastProviderTest {
             isClass shouldBeEqualTo false
             isObject shouldBeEqualTo false
             isInterface shouldBeEqualTo false
+            isClassOrObject shouldBeEqualTo false
+            isClassOrInterface shouldBeEqualTo false
+            isInterfaceOrObject shouldBeEqualTo false
+            isClassOrInterfaceOrObject shouldBeEqualTo false
             isTypeAlias shouldBeEqualTo false
             isImportAlias shouldBeEqualTo false
             isKotlinType shouldBeEqualTo false
@@ -1342,6 +1711,10 @@ class KoParentDeclarationForKoDeclarationCastProviderTest {
             isClass shouldBeEqualTo false
             isObject shouldBeEqualTo false
             isInterface shouldBeEqualTo false
+            isClassOrObject shouldBeEqualTo false
+            isClassOrInterface shouldBeEqualTo false
+            isInterfaceOrObject shouldBeEqualTo false
+            isClassOrInterfaceOrObject shouldBeEqualTo false
             isTypeAlias shouldBeEqualTo true
             isImportAlias shouldBeEqualTo false
             isKotlinType shouldBeEqualTo false
@@ -1403,6 +1776,10 @@ class KoParentDeclarationForKoDeclarationCastProviderTest {
             isClass shouldBeEqualTo false
             isObject shouldBeEqualTo false
             isInterface shouldBeEqualTo false
+            isClassOrObject shouldBeEqualTo false
+            isClassOrInterface shouldBeEqualTo false
+            isInterfaceOrObject shouldBeEqualTo false
+            isClassOrInterfaceOrObject shouldBeEqualTo false
             isTypeAlias shouldBeEqualTo false
             isImportAlias shouldBeEqualTo true
             isKotlinType shouldBeEqualTo false
@@ -1464,6 +1841,10 @@ class KoParentDeclarationForKoDeclarationCastProviderTest {
             isClass shouldBeEqualTo false
             isObject shouldBeEqualTo false
             isInterface shouldBeEqualTo true
+            isClassOrObject shouldBeEqualTo false
+            isClassOrInterface shouldBeEqualTo true
+            isInterfaceOrObject shouldBeEqualTo true
+            isClassOrInterfaceOrObject shouldBeEqualTo true
             isTypeAlias shouldBeEqualTo false
             isImportAlias shouldBeEqualTo false
             isKotlinType shouldBeEqualTo false
@@ -1471,6 +1852,24 @@ class KoParentDeclarationForKoDeclarationCastProviderTest {
             isKotlinCollectionType shouldBeEqualTo false
             isTypeParameter shouldBeEqualTo false
             isExternal shouldBeEqualTo false
+            asClassOrObjectDeclaration() shouldBeEqualTo null
+            hasClassOrObjectDeclaration() shouldBeEqualTo false
+            hasClassOrObjectDeclaration { decl -> decl.name == "SampleSuperInterface" } shouldBeEqualTo false
+            hasClassOrObjectDeclarationOf(SampleInterface::class) shouldBeEqualTo false
+            hasClassOrInterfaceDeclaration() shouldBeEqualTo true
+            hasClassOrInterfaceDeclaration { decl -> decl.name == "SampleSuperInterface" } shouldBeEqualTo true
+            hasClassOrInterfaceDeclaration { decl -> decl.name == "SampleClass" } shouldBeEqualTo false
+            hasClassOrInterfaceDeclarationOf(SampleInterface::class) shouldBeEqualTo false
+            asInterfaceOrObjectDeclaration() shouldBeInstanceOf KoInterfaceDeclaration::class
+            hasInterfaceOrObjectDeclaration() shouldBeEqualTo true
+            hasInterfaceOrObjectDeclaration { decl -> decl.name == "SampleSuperInterface" } shouldBeEqualTo true
+            hasInterfaceOrObjectDeclaration { decl -> decl.name == "SampleObject" } shouldBeEqualTo false
+            hasInterfaceOrObjectDeclarationOf(SampleInterface::class) shouldBeEqualTo false
+            asClassOrInterfaceOrObjectDeclaration() shouldBeInstanceOf KoInterfaceDeclaration::class
+            hasClassOrInterfaceOrObjectDeclaration() shouldBeEqualTo true
+            hasClassOrInterfaceOrObjectDeclaration { decl -> decl.name == "SampleSuperInterface" } shouldBeEqualTo true
+            hasClassOrInterfaceOrObjectDeclaration { decl -> decl.name == "SampleClass" } shouldBeEqualTo false
+            hasClassOrInterfaceOrObjectDeclarationOf(SampleInterface::class) shouldBeEqualTo false
             asClassDeclaration() shouldBeEqualTo null
             hasClassDeclaration() shouldBeEqualTo false
             hasClassDeclaration { decl -> decl.name == "SampleSuperInterface" } shouldBeEqualTo false
@@ -1524,6 +1923,10 @@ class KoParentDeclarationForKoDeclarationCastProviderTest {
             isClass shouldBeEqualTo false
             isObject shouldBeEqualTo false
             isInterface shouldBeEqualTo true
+            isClassOrObject shouldBeEqualTo false
+            isClassOrInterface shouldBeEqualTo true
+            isInterfaceOrObject shouldBeEqualTo true
+            isClassOrInterfaceOrObject shouldBeEqualTo true
             isTypeAlias shouldBeEqualTo false
             isImportAlias shouldBeEqualTo false
             isKotlinType shouldBeEqualTo false
@@ -1531,6 +1934,26 @@ class KoParentDeclarationForKoDeclarationCastProviderTest {
             isKotlinCollectionType shouldBeEqualTo false
             isTypeParameter shouldBeEqualTo false
             isExternal shouldBeEqualTo false
+            asClassOrObjectDeclaration() shouldBeEqualTo null
+            hasClassOrObjectDeclaration() shouldBeEqualTo false
+            hasClassOrObjectDeclaration { decl -> decl.name == "SampleGenericSuperInterface" } shouldBeEqualTo false
+            hasClassOrObjectDeclarationOf(SampleGenericSuperInterface::class) shouldBeEqualTo false
+            asClassOrInterfaceDeclaration() shouldBeInstanceOf KoInterfaceDeclaration::class
+            hasClassOrInterfaceDeclaration() shouldBeEqualTo true
+            hasClassOrInterfaceDeclaration { decl -> decl.name == "SampleGenericSuperInterface" } shouldBeEqualTo true
+            hasClassOrInterfaceDeclaration { decl -> decl.name == "SampleClass" } shouldBeEqualTo false
+            hasClassOrInterfaceDeclarationOf(SampleGenericSuperInterface::class) shouldBeEqualTo false
+            asInterfaceOrObjectDeclaration() shouldBeInstanceOf KoInterfaceDeclaration::class
+            hasInterfaceOrObjectDeclaration() shouldBeEqualTo true
+            hasInterfaceOrObjectDeclaration { decl -> decl.name == "SampleGenericSuperInterface" } shouldBeEqualTo true
+            hasInterfaceOrObjectDeclaration { decl -> decl.name == "SampleObject" } shouldBeEqualTo false
+            hasInterfaceOrObjectDeclarationOf(SampleGenericSuperInterface::class) shouldBeEqualTo false
+            asClassOrInterfaceOrObjectDeclaration() shouldBeInstanceOf KoInterfaceDeclaration::class
+            hasClassOrInterfaceOrObjectDeclaration() shouldBeEqualTo true
+            hasClassOrInterfaceOrObjectDeclaration { decl -> decl.name == "SampleGenericSuperInterface" } shouldBeEqualTo true
+            hasClassOrInterfaceOrObjectDeclaration { decl -> decl.name == "SampleClass" } shouldBeEqualTo false
+            hasClassOrInterfaceOrObjectDeclarationOf(SampleGenericSuperInterface::class) shouldBeEqualTo true
+            hasClassOrInterfaceOrObjectDeclarationOf(SampleClass::class) shouldBeEqualTo false
             asClassDeclaration() shouldBeEqualTo null
             hasClassDeclaration() shouldBeEqualTo false
             hasClassDeclaration { decl -> decl.name == "SampleGenericSuperInterface" } shouldBeEqualTo false
@@ -1584,6 +2007,10 @@ class KoParentDeclarationForKoDeclarationCastProviderTest {
             isClass shouldBeEqualTo false
             isObject shouldBeEqualTo false
             isInterface shouldBeEqualTo true
+            isClassOrObject shouldBeEqualTo false
+            isClassOrInterface shouldBeEqualTo true
+            isInterfaceOrObject shouldBeEqualTo true
+            isClassOrInterfaceOrObject shouldBeEqualTo true
             isTypeAlias shouldBeEqualTo false
             isImportAlias shouldBeEqualTo false
             isKotlinType shouldBeEqualTo false
@@ -1591,6 +2018,28 @@ class KoParentDeclarationForKoDeclarationCastProviderTest {
             isKotlinCollectionType shouldBeEqualTo false
             isTypeParameter shouldBeEqualTo false
             isExternal shouldBeEqualTo false
+            asClassOrObjectDeclaration() shouldBeEqualTo null
+            hasClassOrObjectDeclaration() shouldBeEqualTo false
+            hasClassOrObjectDeclaration { decl -> decl.name == "SampleParentInterface" } shouldBeEqualTo false
+            hasClassOrObjectDeclarationOf(SampleParentInterface::class) shouldBeEqualTo false
+            asClassOrInterfaceDeclaration() shouldBeInstanceOf KoInterfaceDeclaration::class
+            hasClassOrInterfaceDeclaration() shouldBeEqualTo true
+            hasClassOrInterfaceDeclaration { decl -> decl.name == "SampleParentInterface" } shouldBeEqualTo true
+            hasClassOrInterfaceDeclaration { decl -> decl.name == "SampleClass" } shouldBeEqualTo false
+            hasClassOrInterfaceDeclarationOf(SampleParentInterface::class) shouldBeEqualTo true
+            hasClassOrInterfaceDeclarationOf(SampleClass::class) shouldBeEqualTo false
+            asInterfaceOrObjectDeclaration() shouldBeInstanceOf KoInterfaceDeclaration::class
+            hasInterfaceOrObjectDeclaration() shouldBeEqualTo true
+            hasInterfaceOrObjectDeclaration { decl -> decl.name == "SampleParentInterface" } shouldBeEqualTo true
+            hasInterfaceOrObjectDeclaration { decl -> decl.name == "SampleObject" } shouldBeEqualTo false
+            hasInterfaceOrObjectDeclarationOf(SampleParentInterface::class) shouldBeEqualTo true
+            hasInterfaceOrObjectDeclarationOf(SampleObject::class) shouldBeEqualTo false
+            asClassOrInterfaceOrObjectDeclaration() shouldBeInstanceOf KoInterfaceDeclaration::class
+            hasClassOrInterfaceOrObjectDeclaration() shouldBeEqualTo true
+            hasClassOrInterfaceOrObjectDeclaration { decl -> decl.name == "SampleParentInterface" } shouldBeEqualTo true
+            hasClassOrInterfaceOrObjectDeclaration { decl -> decl.name == "SampleClass" } shouldBeEqualTo false
+            hasClassOrInterfaceOrObjectDeclarationOf(SampleParentInterface::class) shouldBeEqualTo true
+            hasClassOrInterfaceOrObjectDeclarationOf(SampleClass::class) shouldBeEqualTo false
             asClassDeclaration() shouldBeEqualTo null
             hasClassDeclaration() shouldBeEqualTo false
             hasClassDeclaration { decl -> decl.name == "SampleParentInterface" } shouldBeEqualTo false
@@ -1644,6 +2093,10 @@ class KoParentDeclarationForKoDeclarationCastProviderTest {
             isClass shouldBeEqualTo false
             isObject shouldBeEqualTo false
             isInterface shouldBeEqualTo true
+            isClassOrObject shouldBeEqualTo false
+            isClassOrInterface shouldBeEqualTo true
+            isInterfaceOrObject shouldBeEqualTo true
+            isClassOrInterfaceOrObject shouldBeEqualTo true
             isTypeAlias shouldBeEqualTo false
             isImportAlias shouldBeEqualTo false
             isKotlinType shouldBeEqualTo false
@@ -1651,6 +2104,28 @@ class KoParentDeclarationForKoDeclarationCastProviderTest {
             isKotlinCollectionType shouldBeEqualTo false
             isTypeParameter shouldBeEqualTo false
             isExternal shouldBeEqualTo false
+            asClassOrObjectDeclaration() shouldBeEqualTo null
+            hasClassOrObjectDeclaration() shouldBeEqualTo false
+            hasClassOrObjectDeclaration { decl -> decl.name == "SampleGenericSuperInterface" } shouldBeEqualTo false
+            hasClassOrObjectDeclarationOf(SampleGenericSuperInterface::class) shouldBeEqualTo false
+            asClassOrInterfaceDeclaration() shouldBeInstanceOf KoInterfaceDeclaration::class
+            hasClassOrInterfaceDeclaration() shouldBeEqualTo true
+            hasClassOrInterfaceDeclaration { decl -> decl.name == "SampleGenericSuperInterface" } shouldBeEqualTo true
+            hasClassOrInterfaceDeclaration { decl -> decl.name == "SampleClass" } shouldBeEqualTo false
+            hasClassOrInterfaceDeclarationOf(SampleGenericSuperInterface::class) shouldBeEqualTo true
+            hasClassOrInterfaceDeclarationOf(SampleClass::class) shouldBeEqualTo false
+            asInterfaceOrObjectDeclaration() shouldBeInstanceOf KoInterfaceDeclaration::class
+            hasInterfaceOrObjectDeclaration() shouldBeEqualTo true
+            hasInterfaceOrObjectDeclaration { decl -> decl.name == "SampleGenericSuperInterface" } shouldBeEqualTo true
+            hasInterfaceOrObjectDeclaration { decl -> decl.name == "SampleObject" } shouldBeEqualTo false
+            hasInterfaceOrObjectDeclarationOf(SampleGenericSuperInterface::class) shouldBeEqualTo true
+            hasInterfaceOrObjectDeclarationOf(SampleObject::class) shouldBeEqualTo false
+            asClassOrInterfaceOrObjectDeclaration() shouldBeInstanceOf KoInterfaceDeclaration::class
+            hasClassOrInterfaceOrObjectDeclaration() shouldBeEqualTo true
+            hasClassOrInterfaceOrObjectDeclaration { decl -> decl.name == "SampleGenericSuperInterface" } shouldBeEqualTo true
+            hasClassOrInterfaceOrObjectDeclaration { decl -> decl.name == "SampleClass" } shouldBeEqualTo false
+            hasClassOrInterfaceOrObjectDeclarationOf(SampleGenericSuperInterface::class) shouldBeEqualTo true
+            hasClassOrInterfaceOrObjectDeclarationOf(SampleClass::class) shouldBeEqualTo false
             asClassDeclaration() shouldBeEqualTo null
             hasClassDeclaration() shouldBeEqualTo false
             hasClassDeclaration { decl -> decl.name == "SampleGenericSuperInterface" } shouldBeEqualTo false
@@ -1704,6 +2179,10 @@ class KoParentDeclarationForKoDeclarationCastProviderTest {
             isClass shouldBeEqualTo false
             isObject shouldBeEqualTo false
             isInterface shouldBeEqualTo false
+            isClassOrObject shouldBeEqualTo false
+            isClassOrInterface shouldBeEqualTo false
+            isInterfaceOrObject shouldBeEqualTo false
+            isClassOrInterfaceOrObject shouldBeEqualTo false
             isTypeAlias shouldBeEqualTo false
             isImportAlias shouldBeEqualTo false
             isKotlinType shouldBeEqualTo false
@@ -1765,6 +2244,10 @@ class KoParentDeclarationForKoDeclarationCastProviderTest {
             isClass shouldBeEqualTo false
             isObject shouldBeEqualTo false
             isInterface shouldBeEqualTo false
+            isClassOrObject shouldBeEqualTo false
+            isClassOrInterface shouldBeEqualTo false
+            isInterfaceOrObject shouldBeEqualTo false
+            isClassOrInterfaceOrObject shouldBeEqualTo false
             isTypeAlias shouldBeEqualTo false
             isImportAlias shouldBeEqualTo false
             isKotlinType shouldBeEqualTo false
@@ -1826,6 +2309,10 @@ class KoParentDeclarationForKoDeclarationCastProviderTest {
             isClass shouldBeEqualTo false
             isObject shouldBeEqualTo false
             isInterface shouldBeEqualTo false
+            isClassOrObject shouldBeEqualTo false
+            isClassOrInterface shouldBeEqualTo false
+            isInterfaceOrObject shouldBeEqualTo false
+            isClassOrInterfaceOrObject shouldBeEqualTo false
             isTypeAlias shouldBeEqualTo true
             isImportAlias shouldBeEqualTo false
             isKotlinType shouldBeEqualTo false
@@ -1887,6 +2374,10 @@ class KoParentDeclarationForKoDeclarationCastProviderTest {
             isClass shouldBeEqualTo false
             isObject shouldBeEqualTo false
             isInterface shouldBeEqualTo false
+            isClassOrObject shouldBeEqualTo false
+            isClassOrInterface shouldBeEqualTo false
+            isInterfaceOrObject shouldBeEqualTo false
+            isClassOrInterfaceOrObject shouldBeEqualTo false
             isTypeAlias shouldBeEqualTo false
             isImportAlias shouldBeEqualTo true
             isKotlinType shouldBeEqualTo false
@@ -1948,6 +2439,10 @@ class KoParentDeclarationForKoDeclarationCastProviderTest {
             isClass shouldBeEqualTo true
             isObject shouldBeEqualTo false
             isInterface shouldBeEqualTo false
+            isClassOrObject shouldBeEqualTo true
+            isClassOrInterface shouldBeEqualTo true
+            isInterfaceOrObject shouldBeEqualTo false
+            isClassOrInterfaceOrObject shouldBeEqualTo true
             isTypeAlias shouldBeEqualTo false
             isImportAlias shouldBeEqualTo false
             isKotlinType shouldBeEqualTo false
@@ -1955,6 +2450,25 @@ class KoParentDeclarationForKoDeclarationCastProviderTest {
             isKotlinCollectionType shouldBeEqualTo false
             isTypeParameter shouldBeEqualTo false
             isExternal shouldBeEqualTo false
+            asClassOrObjectDeclaration() shouldBeInstanceOf KoClassDeclaration::class
+            hasClassOrObjectDeclaration() shouldBeEqualTo true
+            hasClassOrObjectDeclaration { decl -> decl.name == "SampleSuperClass" } shouldBeEqualTo true
+            hasClassOrObjectDeclaration { decl -> decl.name == "SampleObject" } shouldBeEqualTo false
+            hasClassOrObjectDeclarationOf(SampleClass::class) shouldBeEqualTo false
+            asClassOrInterfaceDeclaration() shouldBeInstanceOf KoClassDeclaration::class
+            hasClassOrInterfaceDeclaration() shouldBeEqualTo true
+            hasClassOrInterfaceDeclaration { decl -> decl.name == "SampleSuperClass" } shouldBeEqualTo true
+            hasClassOrInterfaceDeclaration { decl -> decl.name == "SampleInterface" } shouldBeEqualTo false
+            hasClassOrInterfaceDeclarationOf(SampleClass::class) shouldBeEqualTo false
+            asInterfaceOrObjectDeclaration() shouldBeEqualTo null
+            hasInterfaceOrObjectDeclaration() shouldBeEqualTo false
+            hasInterfaceOrObjectDeclaration { decl -> decl.name == "someName" } shouldBeEqualTo false
+            hasInterfaceOrObjectDeclarationOf(SampleClass::class) shouldBeEqualTo false
+            asClassOrInterfaceOrObjectDeclaration() shouldBeInstanceOf KoClassDeclaration::class
+            hasClassOrInterfaceOrObjectDeclaration() shouldBeEqualTo true
+            hasClassOrInterfaceOrObjectDeclaration { decl -> decl.name == "SampleSuperClass" } shouldBeEqualTo true
+            hasClassOrInterfaceOrObjectDeclaration { decl -> decl.name == "SampleInterface" } shouldBeEqualTo false
+            hasClassOrInterfaceOrObjectDeclarationOf(SampleClass::class) shouldBeEqualTo false
             asClassDeclaration() shouldBeInstanceOf KoClassDeclaration::class
             hasClassDeclaration() shouldBeEqualTo true
             hasClassDeclaration { decl -> decl.name == "SampleSuperClass" } shouldBeEqualTo true
@@ -2008,6 +2522,10 @@ class KoParentDeclarationForKoDeclarationCastProviderTest {
             isClass shouldBeEqualTo true
             isObject shouldBeEqualTo false
             isInterface shouldBeEqualTo false
+            isClassOrObject shouldBeEqualTo true
+            isClassOrInterface shouldBeEqualTo true
+            isInterfaceOrObject shouldBeEqualTo false
+            isClassOrInterfaceOrObject shouldBeEqualTo true
             isTypeAlias shouldBeEqualTo false
             isImportAlias shouldBeEqualTo false
             isKotlinType shouldBeEqualTo false
@@ -2015,6 +2533,25 @@ class KoParentDeclarationForKoDeclarationCastProviderTest {
             isKotlinCollectionType shouldBeEqualTo false
             isTypeParameter shouldBeEqualTo false
             isExternal shouldBeEqualTo false
+            asClassOrObjectDeclaration() shouldBeInstanceOf KoClassDeclaration::class
+            hasClassOrObjectDeclaration() shouldBeEqualTo true
+            hasClassOrObjectDeclaration { decl -> decl.name == "SampleGenericSuperClass" } shouldBeEqualTo true
+            hasClassOrObjectDeclaration { decl -> decl.name == "SampleObject" } shouldBeEqualTo false
+            hasClassOrObjectDeclarationOf(SampleClass::class) shouldBeEqualTo false
+            asClassOrInterfaceDeclaration() shouldBeInstanceOf KoClassDeclaration::class
+            hasClassOrInterfaceDeclaration() shouldBeEqualTo true
+            hasClassOrInterfaceDeclaration { decl -> decl.name == "SampleGenericSuperClass" } shouldBeEqualTo true
+            hasClassOrInterfaceDeclaration { decl -> decl.name == "SampleInterface" } shouldBeEqualTo false
+            hasClassOrInterfaceDeclarationOf(SampleClass::class) shouldBeEqualTo false
+            asInterfaceOrObjectDeclaration() shouldBeEqualTo null
+            hasInterfaceOrObjectDeclaration() shouldBeEqualTo false
+            hasInterfaceOrObjectDeclaration { decl -> decl.name == "someName" } shouldBeEqualTo false
+            hasInterfaceOrObjectDeclarationOf(SampleClass::class) shouldBeEqualTo false
+            asClassOrInterfaceOrObjectDeclaration() shouldBeInstanceOf KoClassDeclaration::class
+            hasClassOrInterfaceOrObjectDeclaration() shouldBeEqualTo true
+            hasClassOrInterfaceOrObjectDeclaration { decl -> decl.name == "SampleGenericSuperClass" } shouldBeEqualTo true
+            hasClassOrInterfaceOrObjectDeclaration { decl -> decl.name == "SampleInterface" } shouldBeEqualTo false
+            hasClassOrInterfaceOrObjectDeclarationOf(SampleClass::class) shouldBeEqualTo false
             asClassDeclaration() shouldBeInstanceOf KoClassDeclaration::class
             hasClassDeclaration() shouldBeEqualTo true
             hasClassDeclaration { decl -> decl.name == "SampleGenericSuperClass" } shouldBeEqualTo true
@@ -2068,6 +2605,10 @@ class KoParentDeclarationForKoDeclarationCastProviderTest {
             isClass shouldBeEqualTo true
             isObject shouldBeEqualTo false
             isInterface shouldBeEqualTo false
+            isClassOrObject shouldBeEqualTo true
+            isClassOrInterface shouldBeEqualTo true
+            isInterfaceOrObject shouldBeEqualTo false
+            isClassOrInterfaceOrObject shouldBeEqualTo true
             isTypeAlias shouldBeEqualTo false
             isImportAlias shouldBeEqualTo false
             isKotlinType shouldBeEqualTo false
@@ -2075,6 +2616,25 @@ class KoParentDeclarationForKoDeclarationCastProviderTest {
             isKotlinCollectionType shouldBeEqualTo false
             isTypeParameter shouldBeEqualTo false
             isExternal shouldBeEqualTo false
+            asClassOrObjectDeclaration() shouldBeInstanceOf KoClassDeclaration::class
+            hasClassOrObjectDeclaration() shouldBeEqualTo true
+            hasClassOrObjectDeclaration { decl -> decl.name == "SampleParametrizedSuperClass" } shouldBeEqualTo true
+            hasClassOrObjectDeclaration { decl -> decl.name == "SampleObject" } shouldBeEqualTo false
+            hasClassOrObjectDeclarationOf(SampleClass::class) shouldBeEqualTo false
+            asClassOrInterfaceDeclaration() shouldBeInstanceOf KoClassDeclaration::class
+            hasClassOrInterfaceDeclaration() shouldBeEqualTo true
+            hasClassOrInterfaceDeclaration { decl -> decl.name == "SampleParametrizedSuperClass" } shouldBeEqualTo true
+            hasClassOrInterfaceDeclaration { decl -> decl.name == "SampleInterface" } shouldBeEqualTo false
+            hasClassOrInterfaceDeclarationOf(SampleClass::class) shouldBeEqualTo false
+            asInterfaceOrObjectDeclaration() shouldBeEqualTo null
+            hasInterfaceOrObjectDeclaration() shouldBeEqualTo false
+            hasInterfaceOrObjectDeclaration { decl -> decl.name == "someName" } shouldBeEqualTo false
+            hasInterfaceOrObjectDeclarationOf(SampleClass::class) shouldBeEqualTo false
+            asClassOrInterfaceOrObjectDeclaration() shouldBeInstanceOf KoClassDeclaration::class
+            hasClassOrInterfaceOrObjectDeclaration() shouldBeEqualTo true
+            hasClassOrInterfaceOrObjectDeclaration { decl -> decl.name == "SampleParametrizedSuperClass" } shouldBeEqualTo true
+            hasClassOrInterfaceOrObjectDeclaration { decl -> decl.name == "SampleInterface" } shouldBeEqualTo false
+            hasClassOrInterfaceOrObjectDeclarationOf(SampleClass::class) shouldBeEqualTo false
             asClassDeclaration() shouldBeInstanceOf KoClassDeclaration::class
             hasClassDeclaration() shouldBeEqualTo true
             hasClassDeclaration { decl -> decl.name == "SampleParametrizedSuperClass" } shouldBeEqualTo true
@@ -2128,6 +2688,10 @@ class KoParentDeclarationForKoDeclarationCastProviderTest {
             isClass shouldBeEqualTo true
             isObject shouldBeEqualTo false
             isInterface shouldBeEqualTo false
+            isClassOrObject shouldBeEqualTo true
+            isClassOrInterface shouldBeEqualTo true
+            isInterfaceOrObject shouldBeEqualTo false
+            isClassOrInterfaceOrObject shouldBeEqualTo true
             isTypeAlias shouldBeEqualTo false
             isImportAlias shouldBeEqualTo false
             isKotlinType shouldBeEqualTo false
@@ -2135,6 +2699,25 @@ class KoParentDeclarationForKoDeclarationCastProviderTest {
             isKotlinCollectionType shouldBeEqualTo false
             isTypeParameter shouldBeEqualTo false
             isExternal shouldBeEqualTo false
+            asClassOrObjectDeclaration() shouldBeInstanceOf KoClassDeclaration::class
+            hasClassOrObjectDeclaration() shouldBeEqualTo true
+            hasClassOrObjectDeclaration { decl -> decl.name == "SampleParametrizedSuperClass" } shouldBeEqualTo true
+            hasClassOrObjectDeclaration { decl -> decl.name == "SampleObject" } shouldBeEqualTo false
+            hasClassOrObjectDeclarationOf(SampleClass::class) shouldBeEqualTo false
+            asClassOrInterfaceDeclaration() shouldBeInstanceOf KoClassDeclaration::class
+            hasClassOrInterfaceDeclaration() shouldBeEqualTo true
+            hasClassOrInterfaceDeclaration { decl -> decl.name == "SampleParametrizedSuperClass" } shouldBeEqualTo true
+            hasClassOrInterfaceDeclaration { decl -> decl.name == "SampleInterface" } shouldBeEqualTo false
+            hasClassOrInterfaceDeclarationOf(SampleClass::class) shouldBeEqualTo false
+            asInterfaceOrObjectDeclaration() shouldBeEqualTo null
+            hasInterfaceOrObjectDeclaration() shouldBeEqualTo false
+            hasInterfaceOrObjectDeclaration { decl -> decl.name == "someName" } shouldBeEqualTo false
+            hasInterfaceOrObjectDeclarationOf(SampleClass::class) shouldBeEqualTo false
+            asClassOrInterfaceOrObjectDeclaration() shouldBeInstanceOf KoClassDeclaration::class
+            hasClassOrInterfaceOrObjectDeclaration() shouldBeEqualTo true
+            hasClassOrInterfaceOrObjectDeclaration { decl -> decl.name == "SampleParametrizedSuperClass" } shouldBeEqualTo true
+            hasClassOrInterfaceOrObjectDeclaration { decl -> decl.name == "SampleInterface" } shouldBeEqualTo false
+            hasClassOrInterfaceOrObjectDeclarationOf(SampleClass::class) shouldBeEqualTo false
             asClassDeclaration() shouldBeInstanceOf KoClassDeclaration::class
             hasClassDeclaration() shouldBeEqualTo true
             hasClassDeclaration { decl -> decl.name == "SampleParametrizedSuperClass" } shouldBeEqualTo true
@@ -2188,6 +2771,10 @@ class KoParentDeclarationForKoDeclarationCastProviderTest {
             isClass shouldBeEqualTo false
             isObject shouldBeEqualTo false
             isInterface shouldBeEqualTo true
+            isClassOrObject shouldBeEqualTo false
+            isClassOrInterface shouldBeEqualTo true
+            isInterfaceOrObject shouldBeEqualTo true
+            isClassOrInterfaceOrObject shouldBeEqualTo true
             isTypeAlias shouldBeEqualTo false
             isImportAlias shouldBeEqualTo false
             isKotlinType shouldBeEqualTo false
@@ -2195,6 +2782,24 @@ class KoParentDeclarationForKoDeclarationCastProviderTest {
             isKotlinCollectionType shouldBeEqualTo false
             isTypeParameter shouldBeEqualTo false
             isExternal shouldBeEqualTo false
+            asClassOrObjectDeclaration() shouldBeEqualTo null
+            hasClassOrObjectDeclaration() shouldBeEqualTo false
+            hasClassOrObjectDeclaration { decl -> decl.name == "SampleSuperInterface" } shouldBeEqualTo false
+            asClassOrInterfaceDeclaration() shouldBeInstanceOf KoInterfaceDeclaration::class
+            hasClassOrInterfaceDeclaration() shouldBeEqualTo true
+            hasClassOrInterfaceDeclaration { decl -> decl.name == "SampleSuperInterface" } shouldBeEqualTo true
+            hasClassOrInterfaceDeclaration { decl -> decl.name == "SampleClass" } shouldBeEqualTo false
+            hasClassOrInterfaceDeclarationOf(SampleClass::class) shouldBeEqualTo false
+            asInterfaceOrObjectDeclaration() shouldBeInstanceOf KoInterfaceDeclaration::class
+            hasInterfaceOrObjectDeclaration() shouldBeEqualTo true
+            hasInterfaceOrObjectDeclaration { decl -> decl.name == "SampleSuperInterface" } shouldBeEqualTo true
+            hasInterfaceOrObjectDeclaration { decl -> decl.name == "SampleObject" } shouldBeEqualTo false
+            hasInterfaceOrObjectDeclarationOf(SampleObject::class) shouldBeEqualTo false
+            asClassOrInterfaceOrObjectDeclaration() shouldBeInstanceOf KoInterfaceDeclaration::class
+            hasClassOrInterfaceOrObjectDeclaration() shouldBeEqualTo true
+            hasClassOrInterfaceOrObjectDeclaration { decl -> decl.name == "SampleSuperInterface" } shouldBeEqualTo true
+            hasClassOrInterfaceOrObjectDeclaration { decl -> decl.name == "SampleClass" } shouldBeEqualTo false
+            hasClassOrInterfaceOrObjectDeclarationOf(SampleClass::class) shouldBeEqualTo false
             asClassDeclaration() shouldBeEqualTo null
             hasClassDeclaration() shouldBeEqualTo false
             hasClassDeclaration { decl -> decl.name == "SampleSuperInterface" } shouldBeEqualTo false
@@ -2248,6 +2853,10 @@ class KoParentDeclarationForKoDeclarationCastProviderTest {
             isClass shouldBeEqualTo false
             isObject shouldBeEqualTo false
             isInterface shouldBeEqualTo true
+            isClassOrObject shouldBeEqualTo false
+            isClassOrInterface shouldBeEqualTo true
+            isInterfaceOrObject shouldBeEqualTo true
+            isClassOrInterfaceOrObject shouldBeEqualTo true
             isTypeAlias shouldBeEqualTo false
             isImportAlias shouldBeEqualTo false
             isKotlinType shouldBeEqualTo false
@@ -2255,6 +2864,24 @@ class KoParentDeclarationForKoDeclarationCastProviderTest {
             isKotlinCollectionType shouldBeEqualTo false
             isTypeParameter shouldBeEqualTo false
             isExternal shouldBeEqualTo false
+            asClassOrObjectDeclaration() shouldBeEqualTo null
+            hasClassOrObjectDeclaration() shouldBeEqualTo false
+            hasClassOrObjectDeclaration { decl -> decl.name == "SampleGenericSuperInterface" } shouldBeEqualTo false
+            asClassOrInterfaceDeclaration() shouldBeInstanceOf KoInterfaceDeclaration::class
+            hasClassOrInterfaceDeclaration() shouldBeEqualTo true
+            hasClassOrInterfaceDeclaration { decl -> decl.name == "SampleGenericSuperInterface" } shouldBeEqualTo true
+            hasClassOrInterfaceDeclaration { decl -> decl.name == "SampleClass" } shouldBeEqualTo false
+            hasClassOrInterfaceDeclarationOf(SampleClass::class) shouldBeEqualTo false
+            asInterfaceOrObjectDeclaration() shouldBeInstanceOf KoInterfaceDeclaration::class
+            hasInterfaceOrObjectDeclaration() shouldBeEqualTo true
+            hasInterfaceOrObjectDeclaration { decl -> decl.name == "SampleGenericSuperInterface" } shouldBeEqualTo true
+            hasInterfaceOrObjectDeclaration { decl -> decl.name == "SampleObject" } shouldBeEqualTo false
+            hasInterfaceOrObjectDeclarationOf(SampleObject::class) shouldBeEqualTo false
+            asClassOrInterfaceOrObjectDeclaration() shouldBeInstanceOf KoInterfaceDeclaration::class
+            hasClassOrInterfaceOrObjectDeclaration() shouldBeEqualTo true
+            hasClassOrInterfaceOrObjectDeclaration { decl -> decl.name == "SampleGenericSuperInterface" } shouldBeEqualTo true
+            hasClassOrInterfaceOrObjectDeclaration { decl -> decl.name == "SampleClass" } shouldBeEqualTo false
+            hasClassOrInterfaceOrObjectDeclarationOf(SampleClass::class) shouldBeEqualTo false
             asClassDeclaration() shouldBeEqualTo null
             hasClassDeclaration() shouldBeEqualTo false
             hasClassDeclaration { decl -> decl.name == "SampleGenericSuperInterface" } shouldBeEqualTo false
@@ -2308,6 +2935,10 @@ class KoParentDeclarationForKoDeclarationCastProviderTest {
             isClass shouldBeEqualTo true
             isObject shouldBeEqualTo false
             isInterface shouldBeEqualTo false
+            isClassOrObject shouldBeEqualTo true
+            isClassOrInterface shouldBeEqualTo true
+            isInterfaceOrObject shouldBeEqualTo false
+            isClassOrInterfaceOrObject shouldBeEqualTo true
             isTypeAlias shouldBeEqualTo false
             isImportAlias shouldBeEqualTo false
             isKotlinType shouldBeEqualTo false
@@ -2315,6 +2946,28 @@ class KoParentDeclarationForKoDeclarationCastProviderTest {
             isKotlinCollectionType shouldBeEqualTo false
             isTypeParameter shouldBeEqualTo false
             isExternal shouldBeEqualTo false
+            asClassOrObjectDeclaration() shouldBeInstanceOf KoClassDeclaration::class
+            hasClassOrObjectDeclaration() shouldBeEqualTo true
+            hasClassOrObjectDeclaration { decl -> decl.name == "SampleParentClass" } shouldBeEqualTo true
+            hasClassOrObjectDeclaration { decl -> decl.name == "SampleObject" } shouldBeEqualTo false
+            hasClassOrObjectDeclarationOf(SampleParentClass::class) shouldBeEqualTo true
+            hasClassOrObjectDeclarationOf(SampleClass::class) shouldBeEqualTo false
+            asClassOrInterfaceDeclaration() shouldBeInstanceOf KoClassDeclaration::class
+            hasClassOrInterfaceDeclaration() shouldBeEqualTo true
+            hasClassOrInterfaceDeclaration { decl -> decl.name == "SampleParentClass" } shouldBeEqualTo true
+            hasClassOrInterfaceDeclaration { decl -> decl.name == "SampleInterface" } shouldBeEqualTo false
+            hasClassOrInterfaceDeclarationOf(SampleParentClass::class) shouldBeEqualTo true
+            hasClassOrInterfaceDeclarationOf(SampleClass::class) shouldBeEqualTo false
+            asInterfaceOrObjectDeclaration() shouldBeEqualTo null
+            hasInterfaceOrObjectDeclaration() shouldBeEqualTo false
+            hasInterfaceOrObjectDeclaration { decl -> decl.name == "someName" } shouldBeEqualTo false
+            hasInterfaceOrObjectDeclarationOf(SampleClass::class) shouldBeEqualTo false
+            asClassOrInterfaceOrObjectDeclaration() shouldBeInstanceOf KoClassDeclaration::class
+            hasClassOrInterfaceOrObjectDeclaration() shouldBeEqualTo true
+            hasClassOrInterfaceOrObjectDeclaration { decl -> decl.name == "SampleParentClass" } shouldBeEqualTo true
+            hasClassOrInterfaceOrObjectDeclaration { decl -> decl.name == "SampleInterface" } shouldBeEqualTo false
+            hasClassOrInterfaceOrObjectDeclarationOf(SampleParentClass::class) shouldBeEqualTo true
+            hasClassOrInterfaceOrObjectDeclarationOf(SampleClass::class) shouldBeEqualTo false
             asClassDeclaration() shouldBeInstanceOf KoClassDeclaration::class
             hasClassDeclaration() shouldBeEqualTo true
             hasClassDeclaration { decl -> decl.name == "SampleParentClass" } shouldBeEqualTo true
@@ -2376,6 +3029,10 @@ class KoParentDeclarationForKoDeclarationCastProviderTest {
             isClass shouldBeEqualTo true
             isObject shouldBeEqualTo false
             isInterface shouldBeEqualTo false
+            isClassOrObject shouldBeEqualTo true
+            isClassOrInterface shouldBeEqualTo true
+            isInterfaceOrObject shouldBeEqualTo false
+            isClassOrInterfaceOrObject shouldBeEqualTo true
             isTypeAlias shouldBeEqualTo false
             isImportAlias shouldBeEqualTo false
             isKotlinType shouldBeEqualTo false
@@ -2383,6 +3040,28 @@ class KoParentDeclarationForKoDeclarationCastProviderTest {
             isKotlinCollectionType shouldBeEqualTo false
             isTypeParameter shouldBeEqualTo false
             isExternal shouldBeEqualTo false
+            asClassOrObjectDeclaration() shouldBeInstanceOf KoClassDeclaration::class
+            hasClassOrObjectDeclaration() shouldBeEqualTo true
+            hasClassOrObjectDeclaration { decl -> decl.name == "SampleCollection1" } shouldBeEqualTo true
+            hasClassOrObjectDeclaration { decl -> decl.name == "SampleObject" } shouldBeEqualTo false
+            hasClassOrObjectDeclarationOf(SampleCollection1::class) shouldBeEqualTo true
+            hasClassOrObjectDeclarationOf(SampleClass::class) shouldBeEqualTo false
+            asClassOrInterfaceDeclaration() shouldBeInstanceOf KoClassDeclaration::class
+            hasClassOrInterfaceDeclaration() shouldBeEqualTo true
+            hasClassOrInterfaceDeclaration { decl -> decl.name == "SampleCollection1" } shouldBeEqualTo true
+            hasClassOrInterfaceDeclaration { decl -> decl.name == "SampleInterface" } shouldBeEqualTo false
+            hasClassOrInterfaceDeclarationOf(SampleCollection1::class) shouldBeEqualTo true
+            hasClassOrInterfaceDeclarationOf(SampleClass::class) shouldBeEqualTo false
+            asInterfaceOrObjectDeclaration() shouldBeEqualTo null
+            hasInterfaceOrObjectDeclaration() shouldBeEqualTo false
+            hasInterfaceOrObjectDeclaration { decl -> decl.name == "someName" } shouldBeEqualTo false
+            hasInterfaceOrObjectDeclarationOf(SampleClass::class) shouldBeEqualTo false
+            asClassOrInterfaceOrObjectDeclaration() shouldBeInstanceOf KoClassDeclaration::class
+            hasClassOrInterfaceOrObjectDeclaration() shouldBeEqualTo true
+            hasClassOrInterfaceOrObjectDeclaration { decl -> decl.name == "SampleCollection1" } shouldBeEqualTo true
+            hasClassOrInterfaceOrObjectDeclaration { decl -> decl.name == "SampleInterface" } shouldBeEqualTo false
+            hasClassOrInterfaceOrObjectDeclarationOf(SampleCollection1::class) shouldBeEqualTo true
+            hasClassOrInterfaceOrObjectDeclarationOf(SampleClass::class) shouldBeEqualTo false
             asClassDeclaration() shouldBeInstanceOf KoClassDeclaration::class
             hasClassDeclaration() shouldBeEqualTo true
             hasClassDeclaration { decl -> decl.name == "SampleCollection1" } shouldBeEqualTo true
@@ -2444,6 +3123,10 @@ class KoParentDeclarationForKoDeclarationCastProviderTest {
             isClass shouldBeEqualTo true
             isObject shouldBeEqualTo false
             isInterface shouldBeEqualTo false
+            isClassOrObject shouldBeEqualTo true
+            isClassOrInterface shouldBeEqualTo true
+            isInterfaceOrObject shouldBeEqualTo false
+            isClassOrInterfaceOrObject shouldBeEqualTo true
             isTypeAlias shouldBeEqualTo false
             isImportAlias shouldBeEqualTo false
             isKotlinType shouldBeEqualTo false
@@ -2451,6 +3134,28 @@ class KoParentDeclarationForKoDeclarationCastProviderTest {
             isKotlinCollectionType shouldBeEqualTo false
             isTypeParameter shouldBeEqualTo false
             isExternal shouldBeEqualTo false
+            asClassOrObjectDeclaration() shouldBeInstanceOf KoClassDeclaration::class
+            hasClassOrObjectDeclaration() shouldBeEqualTo true
+            hasClassOrObjectDeclaration { decl -> decl.name == "SampleClassWithParameter" } shouldBeEqualTo true
+            hasClassOrObjectDeclaration { decl -> decl.name == "SampleObject" } shouldBeEqualTo false
+            hasClassOrObjectDeclarationOf(SampleClassWithParameter::class) shouldBeEqualTo true
+            hasClassOrObjectDeclarationOf(SampleClass::class) shouldBeEqualTo false
+            asClassOrInterfaceDeclaration() shouldBeInstanceOf KoClassDeclaration::class
+            hasClassOrInterfaceDeclaration() shouldBeEqualTo true
+            hasClassOrInterfaceDeclaration { decl -> decl.name == "SampleClassWithParameter" } shouldBeEqualTo true
+            hasClassOrInterfaceDeclaration { decl -> decl.name == "SampleInterface" } shouldBeEqualTo false
+            hasClassOrInterfaceDeclarationOf(SampleClassWithParameter::class) shouldBeEqualTo true
+            hasClassOrInterfaceDeclarationOf(SampleClass::class) shouldBeEqualTo false
+            asInterfaceOrObjectDeclaration() shouldBeEqualTo null
+            hasInterfaceOrObjectDeclaration() shouldBeEqualTo false
+            hasInterfaceOrObjectDeclaration { decl -> decl.name == "someName" } shouldBeEqualTo false
+            hasInterfaceOrObjectDeclarationOf(SampleClass::class) shouldBeEqualTo false
+            asClassOrInterfaceOrObjectDeclaration() shouldBeInstanceOf KoClassDeclaration::class
+            hasClassOrInterfaceOrObjectDeclaration() shouldBeEqualTo true
+            hasClassOrInterfaceOrObjectDeclaration { decl -> decl.name == "SampleClassWithParameter" } shouldBeEqualTo true
+            hasClassOrInterfaceOrObjectDeclaration { decl -> decl.name == "SampleInterface" } shouldBeEqualTo false
+            hasClassOrInterfaceOrObjectDeclarationOf(SampleClassWithParameter::class) shouldBeEqualTo true
+            hasClassOrInterfaceOrObjectDeclarationOf(SampleClass::class) shouldBeEqualTo false
             asClassDeclaration() shouldBeInstanceOf KoClassDeclaration::class
             hasClassDeclaration() shouldBeEqualTo true
             hasClassDeclaration { decl -> decl.name == "SampleClassWithParameter" } shouldBeEqualTo true
@@ -2512,6 +3217,10 @@ class KoParentDeclarationForKoDeclarationCastProviderTest {
             isClass shouldBeEqualTo true
             isObject shouldBeEqualTo false
             isInterface shouldBeEqualTo false
+            isClassOrObject shouldBeEqualTo true
+            isClassOrInterface shouldBeEqualTo true
+            isInterfaceOrObject shouldBeEqualTo false
+            isClassOrInterfaceOrObject shouldBeEqualTo true
             isTypeAlias shouldBeEqualTo false
             isImportAlias shouldBeEqualTo false
             isKotlinType shouldBeEqualTo false
@@ -2519,6 +3228,28 @@ class KoParentDeclarationForKoDeclarationCastProviderTest {
             isKotlinCollectionType shouldBeEqualTo false
             isTypeParameter shouldBeEqualTo false
             isExternal shouldBeEqualTo false
+            asClassOrObjectDeclaration() shouldBeInstanceOf KoClassDeclaration::class
+            hasClassOrObjectDeclaration() shouldBeEqualTo true
+            hasClassOrObjectDeclaration { decl -> decl.name == "SampleGenericClassWithParameter" } shouldBeEqualTo true
+            hasClassOrObjectDeclaration { decl -> decl.name == "SampleObject" } shouldBeEqualTo false
+            hasClassOrObjectDeclarationOf(SampleGenericClassWithParameter::class) shouldBeEqualTo true
+            hasClassOrObjectDeclarationOf(SampleClass::class) shouldBeEqualTo false
+            asClassOrInterfaceDeclaration() shouldBeInstanceOf KoClassDeclaration::class
+            hasClassOrInterfaceDeclaration() shouldBeEqualTo true
+            hasClassOrInterfaceDeclaration { decl -> decl.name == "SampleGenericClassWithParameter" } shouldBeEqualTo true
+            hasClassOrInterfaceDeclaration { decl -> decl.name == "SampleInterface" } shouldBeEqualTo false
+            hasClassOrInterfaceDeclarationOf(SampleGenericClassWithParameter::class) shouldBeEqualTo true
+            hasClassOrInterfaceDeclarationOf(SampleClass::class) shouldBeEqualTo false
+            asInterfaceOrObjectDeclaration() shouldBeEqualTo null
+            hasInterfaceOrObjectDeclaration() shouldBeEqualTo false
+            hasInterfaceOrObjectDeclaration { decl -> decl.name == "someName" } shouldBeEqualTo false
+            hasInterfaceOrObjectDeclarationOf(SampleClass::class) shouldBeEqualTo false
+            asClassOrInterfaceOrObjectDeclaration() shouldBeInstanceOf KoClassDeclaration::class
+            hasClassOrInterfaceOrObjectDeclaration() shouldBeEqualTo true
+            hasClassOrInterfaceOrObjectDeclaration { decl -> decl.name == "SampleGenericClassWithParameter" } shouldBeEqualTo true
+            hasClassOrInterfaceOrObjectDeclaration { decl -> decl.name == "SampleInterface" } shouldBeEqualTo false
+            hasClassOrInterfaceOrObjectDeclarationOf(SampleGenericClassWithParameter::class) shouldBeEqualTo true
+            hasClassOrInterfaceOrObjectDeclarationOf(SampleClass::class) shouldBeEqualTo false
             asClassDeclaration() shouldBeInstanceOf KoClassDeclaration::class
             hasClassDeclaration() shouldBeEqualTo true
             hasClassDeclaration { decl -> decl.name == "SampleGenericClassWithParameter" } shouldBeEqualTo true
@@ -2580,6 +3311,10 @@ class KoParentDeclarationForKoDeclarationCastProviderTest {
             isClass shouldBeEqualTo false
             isObject shouldBeEqualTo false
             isInterface shouldBeEqualTo true
+            isClassOrObject shouldBeEqualTo false
+            isClassOrInterface shouldBeEqualTo true
+            isInterfaceOrObject shouldBeEqualTo true
+            isClassOrInterfaceOrObject shouldBeEqualTo true
             isTypeAlias shouldBeEqualTo false
             isImportAlias shouldBeEqualTo false
             isKotlinType shouldBeEqualTo false
@@ -2587,6 +3322,28 @@ class KoParentDeclarationForKoDeclarationCastProviderTest {
             isKotlinCollectionType shouldBeEqualTo false
             isTypeParameter shouldBeEqualTo false
             isExternal shouldBeEqualTo false
+            asClassOrObjectDeclaration() shouldBeEqualTo null
+            hasClassOrObjectDeclaration() shouldBeEqualTo false
+            hasClassOrObjectDeclaration { decl -> decl.name == "SampleInterface" } shouldBeEqualTo false
+            hasClassOrObjectDeclarationOf(SampleInterface::class) shouldBeEqualTo false
+            asClassOrInterfaceDeclaration() shouldBeInstanceOf KoInterfaceDeclaration::class
+            hasClassOrInterfaceDeclaration() shouldBeEqualTo true
+            hasClassOrInterfaceDeclaration { decl -> decl.name == "SampleInterface" } shouldBeEqualTo true
+            hasClassOrInterfaceDeclaration { decl -> decl.name == "SampleClass" } shouldBeEqualTo false
+            hasClassOrInterfaceDeclarationOf(SampleInterface::class) shouldBeEqualTo true
+            hasClassOrInterfaceDeclarationOf(SampleClass::class) shouldBeEqualTo false
+            asInterfaceOrObjectDeclaration() shouldBeInstanceOf KoInterfaceDeclaration::class
+            hasInterfaceOrObjectDeclaration() shouldBeEqualTo true
+            hasInterfaceOrObjectDeclaration { decl -> decl.name == "SampleInterface" } shouldBeEqualTo true
+            hasInterfaceOrObjectDeclaration { decl -> decl.name == "SampleObject" } shouldBeEqualTo false
+            hasInterfaceOrObjectDeclarationOf(SampleInterface::class) shouldBeEqualTo true
+            hasInterfaceOrObjectDeclarationOf(SampleObject::class) shouldBeEqualTo false
+            asClassOrInterfaceOrObjectDeclaration() shouldBeInstanceOf KoInterfaceDeclaration::class
+            hasClassOrInterfaceOrObjectDeclaration() shouldBeEqualTo true
+            hasClassOrInterfaceOrObjectDeclaration { decl -> decl.name == "SampleInterface" } shouldBeEqualTo true
+            hasClassOrInterfaceOrObjectDeclaration { decl -> decl.name == "SampleClass" } shouldBeEqualTo false
+            hasClassOrInterfaceOrObjectDeclarationOf(SampleInterface::class) shouldBeEqualTo true
+            hasClassOrInterfaceOrObjectDeclarationOf(SampleClass::class) shouldBeEqualTo false
             asClassDeclaration() shouldBeEqualTo null
             hasClassDeclaration() shouldBeEqualTo false
             hasClassDeclaration { decl -> decl.name == "SampleInterface" } shouldBeEqualTo false
@@ -2640,6 +3397,10 @@ class KoParentDeclarationForKoDeclarationCastProviderTest {
             isClass shouldBeEqualTo false
             isObject shouldBeEqualTo false
             isInterface shouldBeEqualTo true
+            isClassOrObject shouldBeEqualTo false
+            isClassOrInterface shouldBeEqualTo true
+            isInterfaceOrObject shouldBeEqualTo true
+            isClassOrInterfaceOrObject shouldBeEqualTo true
             isTypeAlias shouldBeEqualTo false
             isImportAlias shouldBeEqualTo false
             isKotlinType shouldBeEqualTo false
@@ -2647,6 +3408,28 @@ class KoParentDeclarationForKoDeclarationCastProviderTest {
             isKotlinCollectionType shouldBeEqualTo false
             isTypeParameter shouldBeEqualTo false
             isExternal shouldBeEqualTo false
+            asClassOrObjectDeclaration() shouldBeEqualTo null
+            hasClassOrObjectDeclaration() shouldBeEqualTo false
+            hasClassOrObjectDeclaration { decl -> decl.name == "SampleGenericSuperInterface" } shouldBeEqualTo false
+            hasClassOrObjectDeclarationOf(SampleGenericSuperInterface::class) shouldBeEqualTo false
+            asClassOrInterfaceDeclaration() shouldBeInstanceOf KoInterfaceDeclaration::class
+            hasClassOrInterfaceDeclaration() shouldBeEqualTo true
+            hasClassOrInterfaceDeclaration { decl -> decl.name == "SampleGenericSuperInterface" } shouldBeEqualTo true
+            hasClassOrInterfaceDeclaration { decl -> decl.name == "SampleClass" } shouldBeEqualTo false
+            hasClassOrInterfaceDeclarationOf(SampleGenericSuperInterface::class) shouldBeEqualTo true
+            hasClassOrInterfaceDeclarationOf(SampleClass::class) shouldBeEqualTo false
+            asInterfaceOrObjectDeclaration() shouldBeInstanceOf KoInterfaceDeclaration::class
+            hasInterfaceOrObjectDeclaration() shouldBeEqualTo true
+            hasInterfaceOrObjectDeclaration { decl -> decl.name == "SampleGenericSuperInterface" } shouldBeEqualTo true
+            hasInterfaceOrObjectDeclaration { decl -> decl.name == "SampleObject" } shouldBeEqualTo false
+            hasInterfaceOrObjectDeclarationOf(SampleGenericSuperInterface::class) shouldBeEqualTo true
+            hasInterfaceOrObjectDeclarationOf(SampleObject::class) shouldBeEqualTo false
+            asClassOrInterfaceOrObjectDeclaration() shouldBeInstanceOf KoInterfaceDeclaration::class
+            hasClassOrInterfaceOrObjectDeclaration() shouldBeEqualTo true
+            hasClassOrInterfaceOrObjectDeclaration { decl -> decl.name == "SampleGenericSuperInterface" } shouldBeEqualTo true
+            hasClassOrInterfaceOrObjectDeclaration { decl -> decl.name == "SampleClass" } shouldBeEqualTo false
+            hasClassOrInterfaceOrObjectDeclarationOf(SampleGenericSuperInterface::class) shouldBeEqualTo true
+            hasClassOrInterfaceOrObjectDeclarationOf(SampleClass::class) shouldBeEqualTo false
             asClassDeclaration() shouldBeEqualTo null
             hasClassDeclaration() shouldBeEqualTo false
             hasClassDeclaration { decl -> decl.name == "SampleGenericSuperInterface" } shouldBeEqualTo false
@@ -2700,6 +3483,10 @@ class KoParentDeclarationForKoDeclarationCastProviderTest {
             isClass shouldBeEqualTo false
             isObject shouldBeEqualTo false
             isInterface shouldBeEqualTo false
+            isClassOrObject shouldBeEqualTo false
+            isClassOrInterface shouldBeEqualTo false
+            isInterfaceOrObject shouldBeEqualTo false
+            isClassOrInterfaceOrObject shouldBeEqualTo false
             isTypeAlias shouldBeEqualTo false
             isImportAlias shouldBeEqualTo false
             isKotlinType shouldBeEqualTo false
@@ -2761,6 +3548,10 @@ class KoParentDeclarationForKoDeclarationCastProviderTest {
             isClass shouldBeEqualTo false
             isObject shouldBeEqualTo false
             isInterface shouldBeEqualTo false
+            isClassOrObject shouldBeEqualTo false
+            isClassOrInterface shouldBeEqualTo false
+            isInterfaceOrObject shouldBeEqualTo false
+            isClassOrInterfaceOrObject shouldBeEqualTo false
             isTypeAlias shouldBeEqualTo false
             isImportAlias shouldBeEqualTo false
             isKotlinType shouldBeEqualTo false
@@ -2822,6 +3613,10 @@ class KoParentDeclarationForKoDeclarationCastProviderTest {
             isClass shouldBeEqualTo false
             isObject shouldBeEqualTo false
             isInterface shouldBeEqualTo false
+            isClassOrObject shouldBeEqualTo false
+            isClassOrInterface shouldBeEqualTo false
+            isInterfaceOrObject shouldBeEqualTo false
+            isClassOrInterfaceOrObject shouldBeEqualTo false
             isTypeAlias shouldBeEqualTo false
             isImportAlias shouldBeEqualTo false
             isKotlinType shouldBeEqualTo false
@@ -2883,6 +3678,10 @@ class KoParentDeclarationForKoDeclarationCastProviderTest {
             isClass shouldBeEqualTo false
             isObject shouldBeEqualTo false
             isInterface shouldBeEqualTo false
+            isClassOrObject shouldBeEqualTo false
+            isClassOrInterface shouldBeEqualTo false
+            isInterfaceOrObject shouldBeEqualTo false
+            isClassOrInterfaceOrObject shouldBeEqualTo false
             isTypeAlias shouldBeEqualTo false
             isImportAlias shouldBeEqualTo false
             isKotlinType shouldBeEqualTo false
@@ -2944,6 +3743,10 @@ class KoParentDeclarationForKoDeclarationCastProviderTest {
             isClass shouldBeEqualTo false
             isObject shouldBeEqualTo false
             isInterface shouldBeEqualTo false
+            isClassOrObject shouldBeEqualTo false
+            isClassOrInterface shouldBeEqualTo false
+            isInterfaceOrObject shouldBeEqualTo false
+            isClassOrInterfaceOrObject shouldBeEqualTo false
             isTypeAlias shouldBeEqualTo false
             isImportAlias shouldBeEqualTo false
             isKotlinType shouldBeEqualTo false
@@ -3005,6 +3808,10 @@ class KoParentDeclarationForKoDeclarationCastProviderTest {
             isClass shouldBeEqualTo false
             isObject shouldBeEqualTo false
             isInterface shouldBeEqualTo false
+            isClassOrObject shouldBeEqualTo false
+            isClassOrInterface shouldBeEqualTo false
+            isInterfaceOrObject shouldBeEqualTo false
+            isClassOrInterfaceOrObject shouldBeEqualTo false
             isTypeAlias shouldBeEqualTo false
             isImportAlias shouldBeEqualTo false
             isKotlinType shouldBeEqualTo false
@@ -3066,6 +3873,10 @@ class KoParentDeclarationForKoDeclarationCastProviderTest {
             isClass shouldBeEqualTo false
             isObject shouldBeEqualTo false
             isInterface shouldBeEqualTo false
+            isClassOrObject shouldBeEqualTo false
+            isClassOrInterface shouldBeEqualTo false
+            isInterfaceOrObject shouldBeEqualTo false
+            isClassOrInterfaceOrObject shouldBeEqualTo false
             isTypeAlias shouldBeEqualTo true
             isImportAlias shouldBeEqualTo false
             isKotlinType shouldBeEqualTo false
@@ -3127,6 +3938,10 @@ class KoParentDeclarationForKoDeclarationCastProviderTest {
             isClass shouldBeEqualTo false
             isObject shouldBeEqualTo false
             isInterface shouldBeEqualTo false
+            isClassOrObject shouldBeEqualTo false
+            isClassOrInterface shouldBeEqualTo false
+            isInterfaceOrObject shouldBeEqualTo false
+            isClassOrInterfaceOrObject shouldBeEqualTo false
             isTypeAlias shouldBeEqualTo false
             isImportAlias shouldBeEqualTo true
             isKotlinType shouldBeEqualTo false
@@ -3175,5 +3990,8 @@ class KoParentDeclarationForKoDeclarationCastProviderTest {
     }
 
     private fun getSnippetFile(fileName: String) =
-        TestSnippetProvider.getSnippetKoScope("core/declaration/koparent/snippet/forkodeclarationcastprovider/", fileName)
+        TestSnippetProvider.getSnippetKoScope(
+            "core/declaration/koparent/snippet/forkodeclarationcastprovider/",
+            fileName
+        )
 }

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/kotypeargument/KoTypeArgumentDeclarationForKoDeclarationCastProviderTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/kotypeargument/KoTypeArgumentDeclarationForKoDeclarationCastProviderTest.kt
@@ -20,7 +20,7 @@ import org.amshove.kluent.shouldBeEqualTo
 import org.amshove.kluent.shouldBeInstanceOf
 import org.junit.jupiter.api.Test
 
-@Suppress("detekt.LargeClass")
+@Suppress("detekt.LargeClass", "detekt.LongMethod")
 class KoTypeArgumentDeclarationForKoDeclarationCastProviderTest {
     @Test
     fun `class-type-argument`() {

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/kotypeargument/KoTypeArgumentDeclarationForKoDeclarationCastProviderTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/kotypeargument/KoTypeArgumentDeclarationForKoDeclarationCastProviderTest.kt
@@ -41,6 +41,10 @@ class KoTypeArgumentDeclarationForKoDeclarationCastProviderTest {
             it?.isClass shouldBeEqualTo true
             it?.isObject shouldBeEqualTo false
             it?.isInterface shouldBeEqualTo false
+            it?.isClassOrObject shouldBeEqualTo true
+            it?.isClassOrInterface shouldBeEqualTo true
+            it?.isInterfaceOrObject shouldBeEqualTo false
+            it?.isClassOrInterfaceOrObject shouldBeEqualTo true
             it?.isTypeAlias shouldBeEqualTo false
             it?.isImportAlias shouldBeEqualTo false
             it?.isKotlinType shouldBeEqualTo false
@@ -61,6 +65,28 @@ class KoTypeArgumentDeclarationForKoDeclarationCastProviderTest {
             it?.asInterfaceDeclaration() shouldBeEqualTo null
             it?.hasInterfaceDeclaration() shouldBeEqualTo false
             it?.hasInterfaceDeclarationOf(SampleType::class) shouldBeEqualTo false
+            it?.asClassOrObjectDeclaration() shouldBeInstanceOf KoClassDeclaration::class
+            it?.hasClassOrObjectDeclaration() shouldBeEqualTo true
+            it?.hasClassOrObjectDeclaration { decl -> decl.name == "SampleType" } shouldBeEqualTo true
+            it?.hasClassOrObjectDeclaration { decl -> decl.name == "SampleObject" } shouldBeEqualTo false
+            it?.hasClassOrObjectDeclarationOf(SampleType::class) shouldBeEqualTo true
+            it?.hasClassOrObjectDeclarationOf(SampleClass::class) shouldBeEqualTo false
+            it?.asClassOrInterfaceDeclaration() shouldBeInstanceOf KoClassDeclaration::class
+            it?.hasClassOrInterfaceDeclaration() shouldBeEqualTo true
+            it?.hasClassOrInterfaceDeclaration { decl -> decl.name == "SampleType" } shouldBeEqualTo true
+            it?.hasClassOrInterfaceDeclaration { decl -> decl.name == "SampleInterface" } shouldBeEqualTo false
+            it?.hasClassOrInterfaceDeclarationOf(SampleType::class) shouldBeEqualTo true
+            it?.hasClassOrInterfaceDeclarationOf(SampleClass::class) shouldBeEqualTo false
+            it?.asInterfaceOrObjectDeclaration() shouldBeEqualTo null
+            it?.hasInterfaceOrObjectDeclaration() shouldBeEqualTo false
+            it?.hasInterfaceOrObjectDeclaration { decl -> decl.name == "someName" } shouldBeEqualTo false
+            it?.hasInterfaceOrObjectDeclarationOf(SampleClass::class) shouldBeEqualTo false
+            it?.asClassOrInterfaceOrObjectDeclaration() shouldBeInstanceOf KoClassDeclaration::class
+            it?.hasClassOrInterfaceOrObjectDeclaration() shouldBeEqualTo true
+            it?.hasClassOrInterfaceOrObjectDeclaration { decl -> decl.name == "SampleType" } shouldBeEqualTo true
+            it?.hasClassOrInterfaceOrObjectDeclaration { decl -> decl.name == "SampleInterface" } shouldBeEqualTo false
+            it?.hasClassOrInterfaceOrObjectDeclarationOf(SampleType::class) shouldBeEqualTo true
+            it?.hasClassOrInterfaceOrObjectDeclarationOf(SampleClass::class) shouldBeEqualTo false
             it?.asTypeAliasDeclaration() shouldBeEqualTo null
             it?.hasTypeAliasDeclaration() shouldBeEqualTo false
             it?.asImportAliasDeclaration() shouldBeEqualTo null
@@ -100,6 +126,10 @@ class KoTypeArgumentDeclarationForKoDeclarationCastProviderTest {
             it?.isClass shouldBeEqualTo false
             it?.isObject shouldBeEqualTo true
             it?.isInterface shouldBeEqualTo false
+            it?.isClassOrObject shouldBeEqualTo true
+            it?.isClassOrInterface shouldBeEqualTo false
+            it?.isInterfaceOrObject shouldBeEqualTo true
+            it?.isClassOrInterfaceOrObject shouldBeEqualTo true
             it?.isTypeAlias shouldBeEqualTo false
             it?.isImportAlias shouldBeEqualTo false
             it?.isKotlinType shouldBeEqualTo false
@@ -120,6 +150,28 @@ class KoTypeArgumentDeclarationForKoDeclarationCastProviderTest {
             it?.asInterfaceDeclaration() shouldBeEqualTo null
             it?.hasInterfaceDeclaration() shouldBeEqualTo false
             it?.hasInterfaceDeclarationOf(SampleObject::class) shouldBeEqualTo false
+            it?.asClassOrObjectDeclaration() shouldBeInstanceOf KoObjectDeclaration::class
+            it?.hasClassOrObjectDeclaration() shouldBeEqualTo true
+            it?.hasClassOrObjectDeclaration { decl -> decl.name == "SampleObject" } shouldBeEqualTo true
+            it?.hasClassOrObjectDeclaration { decl -> decl.name == "SampleClass" } shouldBeEqualTo false
+            it?.hasClassOrObjectDeclarationOf(SampleObject::class) shouldBeEqualTo true
+            it?.hasClassOrObjectDeclarationOf(SampleClass::class) shouldBeEqualTo false
+            it?.asClassOrInterfaceDeclaration() shouldBeEqualTo null
+            it?.hasClassOrInterfaceDeclaration() shouldBeEqualTo false
+            it?.hasClassOrInterfaceDeclaration { decl -> decl.name == "SampleObject" } shouldBeEqualTo false
+            it?.hasClassOrInterfaceDeclarationOf(SampleObject::class) shouldBeEqualTo false
+            it?.asInterfaceOrObjectDeclaration() shouldBeInstanceOf KoObjectDeclaration::class
+            it?.hasInterfaceOrObjectDeclaration() shouldBeEqualTo true
+            it?.hasInterfaceOrObjectDeclaration { decl -> decl.name == "SampleObject" } shouldBeEqualTo true
+            it?.hasInterfaceOrObjectDeclaration { decl -> decl.name == "SampleInterface" } shouldBeEqualTo false
+            it?.hasInterfaceOrObjectDeclarationOf(SampleObject::class) shouldBeEqualTo true
+            it?.hasInterfaceOrObjectDeclarationOf(SampleInterface::class) shouldBeEqualTo false
+            it?.asClassOrInterfaceOrObjectDeclaration() shouldBeInstanceOf KoObjectDeclaration::class
+            it?.hasClassOrInterfaceOrObjectDeclaration() shouldBeEqualTo true
+            it?.hasClassOrInterfaceOrObjectDeclaration { decl -> decl.name == "SampleObject" } shouldBeEqualTo true
+            it?.hasClassOrInterfaceOrObjectDeclaration { decl -> decl.name == "SampleClass" } shouldBeEqualTo false
+            it?.hasClassOrInterfaceOrObjectDeclarationOf(SampleObject::class) shouldBeEqualTo true
+            it?.hasClassOrInterfaceOrObjectDeclarationOf(SampleClass::class) shouldBeEqualTo false
             it?.asTypeAliasDeclaration() shouldBeEqualTo null
             it?.hasTypeAliasDeclaration() shouldBeEqualTo false
             it?.asImportAliasDeclaration() shouldBeEqualTo null
@@ -159,6 +211,10 @@ class KoTypeArgumentDeclarationForKoDeclarationCastProviderTest {
             it?.isClass shouldBeEqualTo false
             it?.isObject shouldBeEqualTo false
             it?.isInterface shouldBeEqualTo true
+            it?.isClassOrObject shouldBeEqualTo false
+            it?.isClassOrInterface shouldBeEqualTo true
+            it?.isInterfaceOrObject shouldBeEqualTo true
+            it?.isClassOrInterfaceOrObject shouldBeEqualTo true
             it?.isTypeAlias shouldBeEqualTo false
             it?.isImportAlias shouldBeEqualTo false
             it?.isKotlinType shouldBeEqualTo false
@@ -179,6 +235,28 @@ class KoTypeArgumentDeclarationForKoDeclarationCastProviderTest {
             it?.asObjectDeclaration() shouldBeEqualTo null
             it?.hasObjectDeclaration() shouldBeEqualTo false
             it?.hasObjectDeclarationOf(SampleInterface::class) shouldBeEqualTo false
+            it?.asClassOrObjectDeclaration() shouldBeEqualTo null
+            it?.hasClassOrObjectDeclaration() shouldBeEqualTo false
+            it?.hasClassOrObjectDeclaration { decl -> decl.name == "SampleInterface" } shouldBeEqualTo false
+            it?.hasClassOrObjectDeclarationOf(SampleInterface::class) shouldBeEqualTo false
+            it?.asClassOrInterfaceDeclaration() shouldBeInstanceOf KoInterfaceDeclaration::class
+            it?.hasClassOrInterfaceDeclaration() shouldBeEqualTo true
+            it?.hasClassOrInterfaceDeclaration { decl -> decl.name == "SampleInterface" } shouldBeEqualTo true
+            it?.hasClassOrInterfaceDeclaration { decl -> decl.name == "SampleClass" } shouldBeEqualTo false
+            it?.hasClassOrInterfaceDeclarationOf(SampleInterface::class) shouldBeEqualTo true
+            it?.hasClassOrInterfaceDeclarationOf(SampleClass::class) shouldBeEqualTo false
+            it?.asInterfaceOrObjectDeclaration() shouldBeInstanceOf KoInterfaceDeclaration::class
+            it?.hasInterfaceOrObjectDeclaration() shouldBeEqualTo true
+            it?.hasInterfaceOrObjectDeclaration { decl -> decl.name == "SampleInterface" } shouldBeEqualTo true
+            it?.hasInterfaceOrObjectDeclaration { decl -> decl.name == "SampleObject" } shouldBeEqualTo false
+            it?.hasInterfaceOrObjectDeclarationOf(SampleInterface::class) shouldBeEqualTo true
+            it?.hasInterfaceOrObjectDeclarationOf(SampleObject::class) shouldBeEqualTo false
+            it?.asClassOrInterfaceOrObjectDeclaration() shouldBeInstanceOf KoInterfaceDeclaration::class
+            it?.hasClassOrInterfaceOrObjectDeclaration() shouldBeEqualTo true
+            it?.hasClassOrInterfaceOrObjectDeclaration { decl -> decl.name == "SampleInterface" } shouldBeEqualTo true
+            it?.hasClassOrInterfaceOrObjectDeclaration { decl -> decl.name == "SampleClass" } shouldBeEqualTo false
+            it?.hasClassOrInterfaceOrObjectDeclarationOf(SampleInterface::class) shouldBeEqualTo true
+            it?.hasClassOrInterfaceOrObjectDeclarationOf(SampleClass::class) shouldBeEqualTo false
             it?.asTypeAliasDeclaration() shouldBeEqualTo null
             it?.hasTypeAliasDeclaration() shouldBeEqualTo false
             it?.asImportAliasDeclaration() shouldBeEqualTo null
@@ -218,6 +296,10 @@ class KoTypeArgumentDeclarationForKoDeclarationCastProviderTest {
             it?.isClass shouldBeEqualTo false
             it?.isObject shouldBeEqualTo false
             it?.isInterface shouldBeEqualTo false
+            it?.isClassOrObject shouldBeEqualTo false
+            it?.isClassOrInterface shouldBeEqualTo false
+            it?.isInterfaceOrObject shouldBeEqualTo false
+            it?.isClassOrInterfaceOrObject shouldBeEqualTo false
             it?.isTypeAlias shouldBeEqualTo false
             it?.isImportAlias shouldBeEqualTo true
             it?.isKotlinType shouldBeEqualTo false
@@ -241,6 +323,22 @@ class KoTypeArgumentDeclarationForKoDeclarationCastProviderTest {
             it?.asKotlinTypeDeclaration() shouldBeEqualTo null
             it?.hasKotlinTypeDeclaration() shouldBeEqualTo false
             it?.asKotlinBasicTypeDeclaration() shouldBeEqualTo null
+            it?.asClassOrObjectDeclaration() shouldBeEqualTo null
+            it?.hasClassOrObjectDeclaration() shouldBeEqualTo false
+            it?.hasClassOrObjectDeclaration { decl -> decl.name == "someName" } shouldBeEqualTo false
+            it?.hasClassOrObjectDeclarationOf(SampleClass::class) shouldBeEqualTo false
+            it?.asClassOrInterfaceDeclaration() shouldBeEqualTo null
+            it?.hasClassOrInterfaceDeclaration() shouldBeEqualTo false
+            it?.hasClassOrInterfaceDeclaration { decl -> decl.name == "someName" } shouldBeEqualTo false
+            it?.hasClassOrInterfaceDeclarationOf(SampleClass::class) shouldBeEqualTo false
+            it?.asInterfaceOrObjectDeclaration() shouldBeEqualTo null
+            it?.hasInterfaceOrObjectDeclaration() shouldBeEqualTo false
+            it?.hasInterfaceOrObjectDeclaration { decl -> decl.name == "someName" } shouldBeEqualTo false
+            it?.hasInterfaceOrObjectDeclarationOf(SampleClass::class) shouldBeEqualTo false
+            it?.asClassOrInterfaceOrObjectDeclaration() shouldBeEqualTo null
+            it?.hasClassOrInterfaceOrObjectDeclaration() shouldBeEqualTo false
+            it?.hasClassOrInterfaceOrObjectDeclaration { decl -> decl.name == "someName" } shouldBeEqualTo false
+            it?.hasClassOrInterfaceOrObjectDeclarationOf(SampleClass::class) shouldBeEqualTo false
             it?.hasKotlinBasicTypeDeclaration() shouldBeEqualTo false
             it?.hasKotlinBasicTypeDeclarationOf(SampleType::class) shouldBeEqualTo false
             it?.asKotlinCollectionTypeDeclaration() shouldBeEqualTo null
@@ -272,6 +370,10 @@ class KoTypeArgumentDeclarationForKoDeclarationCastProviderTest {
             it?.isClass shouldBeEqualTo false
             it?.isObject shouldBeEqualTo false
             it?.isInterface shouldBeEqualTo false
+            it?.isClassOrObject shouldBeEqualTo false
+            it?.isClassOrInterface shouldBeEqualTo false
+            it?.isInterfaceOrObject shouldBeEqualTo false
+            it?.isClassOrInterfaceOrObject shouldBeEqualTo false
             it?.isTypeAlias shouldBeEqualTo false
             it?.isImportAlias shouldBeEqualTo false
             it?.isKotlinType shouldBeEqualTo false
@@ -295,6 +397,22 @@ class KoTypeArgumentDeclarationForKoDeclarationCastProviderTest {
             it?.asKotlinTypeDeclaration() shouldBeEqualTo null
             it?.hasKotlinTypeDeclaration() shouldBeEqualTo false
             it?.asKotlinBasicTypeDeclaration() shouldBeEqualTo null
+            it?.asClassOrObjectDeclaration() shouldBeEqualTo null
+            it?.hasClassOrObjectDeclaration() shouldBeEqualTo false
+            it?.hasClassOrObjectDeclaration { decl -> decl.name == "someName" } shouldBeEqualTo false
+            it?.hasClassOrObjectDeclarationOf(SampleClass::class) shouldBeEqualTo false
+            it?.asClassOrInterfaceDeclaration() shouldBeEqualTo null
+            it?.hasClassOrInterfaceDeclaration() shouldBeEqualTo false
+            it?.hasClassOrInterfaceDeclaration { decl -> decl.name == "someName" } shouldBeEqualTo false
+            it?.hasClassOrInterfaceDeclarationOf(SampleClass::class) shouldBeEqualTo false
+            it?.asInterfaceOrObjectDeclaration() shouldBeEqualTo null
+            it?.hasInterfaceOrObjectDeclaration() shouldBeEqualTo false
+            it?.hasInterfaceOrObjectDeclaration { decl -> decl.name == "someName" } shouldBeEqualTo false
+            it?.hasInterfaceOrObjectDeclarationOf(SampleClass::class) shouldBeEqualTo false
+            it?.asClassOrInterfaceOrObjectDeclaration() shouldBeEqualTo null
+            it?.hasClassOrInterfaceOrObjectDeclaration() shouldBeEqualTo false
+            it?.hasClassOrInterfaceOrObjectDeclaration { decl -> decl.name == "someName" } shouldBeEqualTo false
+            it?.hasClassOrInterfaceOrObjectDeclarationOf(SampleClass::class) shouldBeEqualTo false
             it?.hasKotlinBasicTypeDeclaration() shouldBeEqualTo false
             it?.hasKotlinBasicTypeDeclarationOf(SampleType::class) shouldBeEqualTo false
             it?.asKotlinCollectionTypeDeclaration() shouldBeEqualTo null
@@ -326,6 +444,10 @@ class KoTypeArgumentDeclarationForKoDeclarationCastProviderTest {
             it?.isClass shouldBeEqualTo false
             it?.isObject shouldBeEqualTo false
             it?.isInterface shouldBeEqualTo false
+            it?.isClassOrObject shouldBeEqualTo false
+            it?.isClassOrInterface shouldBeEqualTo false
+            it?.isInterfaceOrObject shouldBeEqualTo false
+            it?.isClassOrInterfaceOrObject shouldBeEqualTo false
             it?.isTypeAlias shouldBeEqualTo true
             it?.isImportAlias shouldBeEqualTo false
             it?.isKotlinType shouldBeEqualTo false
@@ -349,6 +471,22 @@ class KoTypeArgumentDeclarationForKoDeclarationCastProviderTest {
             it?.asKotlinTypeDeclaration() shouldBeEqualTo null
             it?.hasKotlinTypeDeclaration() shouldBeEqualTo false
             it?.asKotlinBasicTypeDeclaration() shouldBeEqualTo null
+            it?.asClassOrObjectDeclaration() shouldBeEqualTo null
+            it?.hasClassOrObjectDeclaration() shouldBeEqualTo false
+            it?.hasClassOrObjectDeclaration { decl -> decl.name == "someName" } shouldBeEqualTo false
+            it?.hasClassOrObjectDeclarationOf(SampleClass::class) shouldBeEqualTo false
+            it?.asClassOrInterfaceDeclaration() shouldBeEqualTo null
+            it?.hasClassOrInterfaceDeclaration() shouldBeEqualTo false
+            it?.hasClassOrInterfaceDeclaration { decl -> decl.name == "someName" } shouldBeEqualTo false
+            it?.hasClassOrInterfaceDeclarationOf(SampleClass::class) shouldBeEqualTo false
+            it?.asInterfaceOrObjectDeclaration() shouldBeEqualTo null
+            it?.hasInterfaceOrObjectDeclaration() shouldBeEqualTo false
+            it?.hasInterfaceOrObjectDeclaration { decl -> decl.name == "someName" } shouldBeEqualTo false
+            it?.hasInterfaceOrObjectDeclarationOf(SampleClass::class) shouldBeEqualTo false
+            it?.asClassOrInterfaceOrObjectDeclaration() shouldBeEqualTo null
+            it?.hasClassOrInterfaceOrObjectDeclaration() shouldBeEqualTo false
+            it?.hasClassOrInterfaceOrObjectDeclaration { decl -> decl.name == "someName" } shouldBeEqualTo false
+            it?.hasClassOrInterfaceOrObjectDeclarationOf(SampleClass::class) shouldBeEqualTo false
             it?.hasKotlinBasicTypeDeclaration() shouldBeEqualTo false
             it?.hasKotlinBasicTypeDeclarationOf(SampleType::class) shouldBeEqualTo false
             it?.asKotlinCollectionTypeDeclaration() shouldBeEqualTo null
@@ -380,6 +518,10 @@ class KoTypeArgumentDeclarationForKoDeclarationCastProviderTest {
             it?.isClass shouldBeEqualTo false
             it?.isObject shouldBeEqualTo false
             it?.isInterface shouldBeEqualTo false
+            it?.isClassOrObject shouldBeEqualTo false
+            it?.isClassOrInterface shouldBeEqualTo false
+            it?.isInterfaceOrObject shouldBeEqualTo false
+            it?.isClassOrInterfaceOrObject shouldBeEqualTo false
             it?.isTypeAlias shouldBeEqualTo false
             it?.isImportAlias shouldBeEqualTo false
             it?.isKotlinType shouldBeEqualTo true
@@ -403,6 +545,22 @@ class KoTypeArgumentDeclarationForKoDeclarationCastProviderTest {
             it?.hasKotlinBasicTypeDeclarationOf(Int::class) shouldBeEqualTo false
             it?.asKotlinCollectionTypeDeclaration() shouldBeEqualTo null
             it?.hasKotlinCollectionTypeDeclaration() shouldBeEqualTo false
+            it?.asClassOrObjectDeclaration() shouldBeEqualTo null
+            it?.hasClassOrObjectDeclaration() shouldBeEqualTo false
+            it?.hasClassOrObjectDeclaration { decl -> decl.name == "someName" } shouldBeEqualTo false
+            it?.hasClassOrObjectDeclarationOf(SampleClass::class) shouldBeEqualTo false
+            it?.asClassOrInterfaceDeclaration() shouldBeEqualTo null
+            it?.hasClassOrInterfaceDeclaration() shouldBeEqualTo false
+            it?.hasClassOrInterfaceDeclaration { decl -> decl.name == "someName" } shouldBeEqualTo false
+            it?.hasClassOrInterfaceDeclarationOf(SampleClass::class) shouldBeEqualTo false
+            it?.asInterfaceOrObjectDeclaration() shouldBeEqualTo null
+            it?.hasInterfaceOrObjectDeclaration() shouldBeEqualTo false
+            it?.hasInterfaceOrObjectDeclaration { decl -> decl.name == "someName" } shouldBeEqualTo false
+            it?.hasInterfaceOrObjectDeclarationOf(SampleClass::class) shouldBeEqualTo false
+            it?.asClassOrInterfaceOrObjectDeclaration() shouldBeEqualTo null
+            it?.hasClassOrInterfaceOrObjectDeclaration() shouldBeEqualTo false
+            it?.hasClassOrInterfaceOrObjectDeclaration { decl -> decl.name == "someName" } shouldBeEqualTo false
+            it?.hasClassOrInterfaceOrObjectDeclarationOf(SampleClass::class) shouldBeEqualTo false
             it?.hasKotlinCollectionTypeDeclarationOf(SampleType::class) shouldBeEqualTo false
             it?.asClassDeclaration() shouldBeEqualTo null
             it?.hasClassDeclaration() shouldBeEqualTo false
@@ -444,6 +602,10 @@ class KoTypeArgumentDeclarationForKoDeclarationCastProviderTest {
             it?.isClass shouldBeEqualTo false
             it?.isObject shouldBeEqualTo false
             it?.isInterface shouldBeEqualTo false
+            it?.isClassOrObject shouldBeEqualTo false
+            it?.isClassOrInterface shouldBeEqualTo false
+            it?.isInterfaceOrObject shouldBeEqualTo false
+            it?.isClassOrInterfaceOrObject shouldBeEqualTo false
             it?.isTypeAlias shouldBeEqualTo false
             it?.isImportAlias shouldBeEqualTo false
             it?.isKotlinType shouldBeEqualTo false
@@ -467,6 +629,22 @@ class KoTypeArgumentDeclarationForKoDeclarationCastProviderTest {
             it?.hasKotlinBasicTypeDeclaration() shouldBeEqualTo false
             it?.hasKotlinBasicTypeDeclarationOf(SampleType::class) shouldBeEqualTo false
             it?.asKotlinCollectionTypeDeclaration() shouldBeEqualTo null
+            it?.asClassOrObjectDeclaration() shouldBeEqualTo null
+            it?.hasClassOrObjectDeclaration() shouldBeEqualTo false
+            it?.hasClassOrObjectDeclaration { decl -> decl.name == "someName" } shouldBeEqualTo false
+            it?.hasClassOrObjectDeclarationOf(SampleClass::class) shouldBeEqualTo false
+            it?.asClassOrInterfaceDeclaration() shouldBeEqualTo null
+            it?.hasClassOrInterfaceDeclaration() shouldBeEqualTo false
+            it?.hasClassOrInterfaceDeclaration { decl -> decl.name == "someName" } shouldBeEqualTo false
+            it?.hasClassOrInterfaceDeclarationOf(SampleClass::class) shouldBeEqualTo false
+            it?.asInterfaceOrObjectDeclaration() shouldBeEqualTo null
+            it?.hasInterfaceOrObjectDeclaration() shouldBeEqualTo false
+            it?.hasInterfaceOrObjectDeclaration { decl -> decl.name == "someName" } shouldBeEqualTo false
+            it?.hasInterfaceOrObjectDeclarationOf(SampleClass::class) shouldBeEqualTo false
+            it?.asClassOrInterfaceOrObjectDeclaration() shouldBeEqualTo null
+            it?.hasClassOrInterfaceOrObjectDeclaration() shouldBeEqualTo false
+            it?.hasClassOrInterfaceOrObjectDeclaration { decl -> decl.name == "someName" } shouldBeEqualTo false
+            it?.hasClassOrInterfaceOrObjectDeclarationOf(SampleClass::class) shouldBeEqualTo false
             it?.hasKotlinCollectionTypeDeclaration() shouldBeEqualTo false
             it?.hasKotlinCollectionTypeDeclarationOf(SampleType::class) shouldBeEqualTo false
             it?.asExternalDeclaration() shouldBeEqualTo null
@@ -495,6 +673,10 @@ class KoTypeArgumentDeclarationForKoDeclarationCastProviderTest {
             it?.isClass shouldBeEqualTo true
             it?.isObject shouldBeEqualTo false
             it?.isInterface shouldBeEqualTo false
+            it?.isClassOrObject shouldBeEqualTo true
+            it?.isClassOrInterface shouldBeEqualTo true
+            it?.isInterfaceOrObject shouldBeEqualTo false
+            it?.isClassOrInterfaceOrObject shouldBeEqualTo true
             it?.isTypeAlias shouldBeEqualTo false
             it?.isImportAlias shouldBeEqualTo false
             it?.isKotlinType shouldBeEqualTo false
@@ -515,6 +697,28 @@ class KoTypeArgumentDeclarationForKoDeclarationCastProviderTest {
             it?.asInterfaceDeclaration() shouldBeEqualTo null
             it?.hasInterfaceDeclaration() shouldBeEqualTo false
             it?.hasInterfaceDeclarationOf(SampleCollection1::class) shouldBeEqualTo false
+            it?.asClassOrObjectDeclaration() shouldBeInstanceOf KoClassDeclaration::class
+            it?.hasClassOrObjectDeclaration() shouldBeEqualTo true
+            it?.hasClassOrObjectDeclaration { decl -> decl.name == "SampleCollection1" } shouldBeEqualTo true
+            it?.hasClassOrObjectDeclaration { decl -> decl.name == "SampleObject" } shouldBeEqualTo false
+            it?.hasClassOrObjectDeclarationOf(SampleCollection1::class) shouldBeEqualTo true
+            it?.hasClassOrObjectDeclarationOf(SampleClass::class) shouldBeEqualTo false
+            it?.asClassOrInterfaceDeclaration() shouldBeInstanceOf KoClassDeclaration::class
+            it?.hasClassOrInterfaceDeclaration() shouldBeEqualTo true
+            it?.hasClassOrInterfaceDeclaration { decl -> decl.name == "SampleCollection1" } shouldBeEqualTo true
+            it?.hasClassOrInterfaceDeclaration { decl -> decl.name == "SampleInterface" } shouldBeEqualTo false
+            it?.hasClassOrInterfaceDeclarationOf(SampleCollection1::class) shouldBeEqualTo true
+            it?.hasClassOrInterfaceDeclarationOf(SampleClass::class) shouldBeEqualTo false
+            it?.asInterfaceOrObjectDeclaration() shouldBeEqualTo null
+            it?.hasInterfaceOrObjectDeclaration() shouldBeEqualTo false
+            it?.hasInterfaceOrObjectDeclaration { decl -> decl.name == "someName" } shouldBeEqualTo false
+            it?.hasInterfaceOrObjectDeclarationOf(SampleClass::class) shouldBeEqualTo false
+            it?.asClassOrInterfaceOrObjectDeclaration() shouldBeInstanceOf KoClassDeclaration::class
+            it?.hasClassOrInterfaceOrObjectDeclaration() shouldBeEqualTo true
+            it?.hasClassOrInterfaceOrObjectDeclaration { decl -> decl.name == "SampleCollection1" } shouldBeEqualTo true
+            it?.hasClassOrInterfaceOrObjectDeclaration { decl -> decl.name == "SampleInterface" } shouldBeEqualTo false
+            it?.hasClassOrInterfaceOrObjectDeclarationOf(SampleCollection1::class) shouldBeEqualTo true
+            it?.hasClassOrInterfaceOrObjectDeclarationOf(SampleClass::class) shouldBeEqualTo false
             it?.asTypeAliasDeclaration() shouldBeEqualTo null
             it?.hasTypeAliasDeclaration() shouldBeEqualTo false
             it?.asImportAliasDeclaration() shouldBeEqualTo null
@@ -554,6 +758,10 @@ class KoTypeArgumentDeclarationForKoDeclarationCastProviderTest {
             it?.isClass shouldBeEqualTo false
             it?.isObject shouldBeEqualTo false
             it?.isInterface shouldBeEqualTo false
+            it?.isClassOrObject shouldBeEqualTo false
+            it?.isClassOrInterface shouldBeEqualTo false
+            it?.isInterfaceOrObject shouldBeEqualTo false
+            it?.isClassOrInterfaceOrObject shouldBeEqualTo false
             it?.isTypeAlias shouldBeEqualTo false
             it?.isImportAlias shouldBeEqualTo false
             it?.isKotlinType shouldBeEqualTo false
@@ -577,6 +785,22 @@ class KoTypeArgumentDeclarationForKoDeclarationCastProviderTest {
             it?.asInterfaceDeclaration() shouldBeEqualTo null
             it?.hasInterfaceDeclaration() shouldBeEqualTo false
             it?.hasInterfaceDeclarationOf(SampleExternalClass::class) shouldBeEqualTo false
+            it?.asClassOrObjectDeclaration() shouldBeEqualTo null
+            it?.hasClassOrObjectDeclaration() shouldBeEqualTo false
+            it?.hasClassOrObjectDeclaration { decl -> decl.name == "someName" } shouldBeEqualTo false
+            it?.hasClassOrObjectDeclarationOf(SampleClass::class) shouldBeEqualTo false
+            it?.asClassOrInterfaceDeclaration() shouldBeEqualTo null
+            it?.hasClassOrInterfaceDeclaration() shouldBeEqualTo false
+            it?.hasClassOrInterfaceDeclaration { decl -> decl.name == "someName" } shouldBeEqualTo false
+            it?.hasClassOrInterfaceDeclarationOf(SampleClass::class) shouldBeEqualTo false
+            it?.asInterfaceOrObjectDeclaration() shouldBeEqualTo null
+            it?.hasInterfaceOrObjectDeclaration() shouldBeEqualTo false
+            it?.hasInterfaceOrObjectDeclaration { decl -> decl.name == "someName" } shouldBeEqualTo false
+            it?.hasInterfaceOrObjectDeclarationOf(SampleClass::class) shouldBeEqualTo false
+            it?.asClassOrInterfaceOrObjectDeclaration() shouldBeEqualTo null
+            it?.hasClassOrInterfaceOrObjectDeclaration() shouldBeEqualTo false
+            it?.hasClassOrInterfaceOrObjectDeclaration { decl -> decl.name == "someName" } shouldBeEqualTo false
+            it?.hasClassOrInterfaceOrObjectDeclarationOf(SampleClass::class) shouldBeEqualTo false
             it?.asTypeAliasDeclaration() shouldBeEqualTo null
             it?.hasTypeAliasDeclaration() shouldBeEqualTo false
             it?.asImportAliasDeclaration() shouldBeEqualTo null

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/type/kostarprojection/KoStarProjectionDeclarationForKoDeclarationCastProviderTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/type/kostarprojection/KoStarProjectionDeclarationForKoDeclarationCastProviderTest.kt
@@ -10,6 +10,7 @@ import org.amshove.kluent.shouldBeEqualTo
 import org.junit.jupiter.api.Test
 
 class KoStarProjectionDeclarationForKoDeclarationCastProviderTest {
+    @Suppress("detekt.LongMethod")
     @Test
     fun `star-projection-type`() {
         // given

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/type/kostarprojection/KoStarProjectionDeclarationForKoDeclarationCastProviderTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/type/kostarprojection/KoStarProjectionDeclarationForKoDeclarationCastProviderTest.kt
@@ -27,6 +27,10 @@ class KoStarProjectionDeclarationForKoDeclarationCastProviderTest {
             it?.isClass shouldBeEqualTo false
             it?.isObject shouldBeEqualTo false
             it?.isInterface shouldBeEqualTo false
+            it?.isClassOrObject shouldBeEqualTo false
+            it?.isClassOrInterface shouldBeEqualTo false
+            it?.isInterfaceOrObject shouldBeEqualTo false
+            it?.isClassOrInterfaceOrObject shouldBeEqualTo false
             it?.isTypeAlias shouldBeEqualTo false
             it?.isImportAlias shouldBeEqualTo false
             it?.isKotlinType shouldBeEqualTo false
@@ -46,6 +50,22 @@ class KoStarProjectionDeclarationForKoDeclarationCastProviderTest {
             it?.hasInterfaceDeclaration() shouldBeEqualTo false
             it?.hasInterfaceDeclaration { decl -> decl.name == "someName" } shouldBeEqualTo false
             it?.hasInterfaceDeclarationOf(SampleType::class) shouldBeEqualTo false
+            it?.asClassOrObjectDeclaration() shouldBeEqualTo null
+            it?.hasClassOrObjectDeclaration() shouldBeEqualTo false
+            it?.hasClassOrObjectDeclaration { decl -> decl.name == "someName" } shouldBeEqualTo false
+            it?.hasClassOrObjectDeclarationOf(SampleClass::class) shouldBeEqualTo false
+            it?.asClassOrInterfaceDeclaration() shouldBeEqualTo null
+            it?.hasClassOrInterfaceDeclaration() shouldBeEqualTo false
+            it?.hasClassOrInterfaceDeclaration { decl -> decl.name == "someName" } shouldBeEqualTo false
+            it?.hasClassOrInterfaceDeclarationOf(SampleClass::class) shouldBeEqualTo false
+            it?.asInterfaceOrObjectDeclaration() shouldBeEqualTo null
+            it?.hasInterfaceOrObjectDeclaration() shouldBeEqualTo false
+            it?.hasInterfaceOrObjectDeclaration { decl -> decl.name == "someName" } shouldBeEqualTo false
+            it?.hasInterfaceOrObjectDeclarationOf(SampleClass::class) shouldBeEqualTo false
+            it?.asClassOrInterfaceOrObjectDeclaration() shouldBeEqualTo null
+            it?.hasClassOrInterfaceOrObjectDeclaration() shouldBeEqualTo false
+            it?.hasClassOrInterfaceOrObjectDeclaration { decl -> decl.name == "someName" } shouldBeEqualTo false
+            it?.hasClassOrInterfaceOrObjectDeclarationOf(SampleClass::class) shouldBeEqualTo false
             it?.asTypeAliasDeclaration() shouldBeEqualTo null
             it?.hasTypeAliasDeclaration() shouldBeEqualTo false
             it?.hasTypeAliasDeclaration { decl -> decl.name == "someName" } shouldBeEqualTo false

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/type/kotype/KoTypeDeclarationForKoDeclarationCastProviderTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/type/kotype/KoTypeDeclarationForKoDeclarationCastProviderTest.kt
@@ -40,6 +40,10 @@ class KoTypeDeclarationForKoDeclarationCastProviderTest {
             it?.isClass shouldBeEqualTo true
             it?.isObject shouldBeEqualTo false
             it?.isInterface shouldBeEqualTo false
+            it?.isClassOrObject shouldBeEqualTo true
+            it?.isClassOrInterface shouldBeEqualTo true
+            it?.isInterfaceOrObject shouldBeEqualTo false
+            it?.isClassOrInterfaceOrObject shouldBeEqualTo true
             it?.isTypeAlias shouldBeEqualTo false
             it?.isImportAlias shouldBeEqualTo false
             it?.isKotlinType shouldBeEqualTo false
@@ -60,6 +64,28 @@ class KoTypeDeclarationForKoDeclarationCastProviderTest {
             it?.asInterfaceDeclaration() shouldBeEqualTo null
             it?.hasInterfaceDeclaration() shouldBeEqualTo false
             it?.hasInterfaceDeclarationOf(SampleType::class) shouldBeEqualTo false
+            it?.asClassOrObjectDeclaration() shouldBeInstanceOf KoClassDeclaration::class
+            it?.hasClassOrObjectDeclaration() shouldBeEqualTo true
+            it?.hasClassOrObjectDeclaration { decl -> decl.name == "SampleType" } shouldBeEqualTo true
+            it?.hasClassOrObjectDeclaration { decl -> decl.name == "SampleObject" } shouldBeEqualTo false
+            it?.hasClassOrObjectDeclarationOf(SampleType::class) shouldBeEqualTo true
+            it?.hasClassOrObjectDeclarationOf(SampleClass::class) shouldBeEqualTo false
+            it?.asClassOrInterfaceDeclaration() shouldBeInstanceOf KoClassDeclaration::class
+            it?.hasClassOrInterfaceDeclaration() shouldBeEqualTo true
+            it?.hasClassOrInterfaceDeclaration { decl -> decl.name == "SampleType" } shouldBeEqualTo true
+            it?.hasClassOrInterfaceDeclaration { decl -> decl.name == "SampleInterface" } shouldBeEqualTo false
+            it?.hasClassOrInterfaceDeclarationOf(SampleType::class) shouldBeEqualTo true
+            it?.hasClassOrInterfaceDeclarationOf(SampleClass::class) shouldBeEqualTo false
+            it?.asInterfaceOrObjectDeclaration() shouldBeEqualTo null
+            it?.hasInterfaceOrObjectDeclaration() shouldBeEqualTo false
+            it?.hasInterfaceOrObjectDeclaration { decl -> decl.name == "someName" } shouldBeEqualTo false
+            it?.hasInterfaceOrObjectDeclarationOf(SampleClass::class) shouldBeEqualTo false
+            it?.asClassOrInterfaceOrObjectDeclaration() shouldBeInstanceOf KoClassDeclaration::class
+            it?.hasClassOrInterfaceOrObjectDeclaration() shouldBeEqualTo true
+            it?.hasClassOrInterfaceOrObjectDeclaration { decl -> decl.name == "SampleType" } shouldBeEqualTo true
+            it?.hasClassOrInterfaceOrObjectDeclaration { decl -> decl.name == "SampleInterface" } shouldBeEqualTo false
+            it?.hasClassOrInterfaceOrObjectDeclarationOf(SampleType::class) shouldBeEqualTo true
+            it?.hasClassOrInterfaceOrObjectDeclarationOf(SampleClass::class) shouldBeEqualTo false
             it?.asTypeAliasDeclaration() shouldBeEqualTo null
             it?.hasTypeAliasDeclaration() shouldBeEqualTo false
             it?.asImportAliasDeclaration() shouldBeEqualTo null
@@ -97,6 +123,10 @@ class KoTypeDeclarationForKoDeclarationCastProviderTest {
             it?.isClass shouldBeEqualTo true
             it?.isObject shouldBeEqualTo false
             it?.isInterface shouldBeEqualTo false
+            it?.isClassOrObject shouldBeEqualTo true
+            it?.isClassOrInterface shouldBeEqualTo true
+            it?.isInterfaceOrObject shouldBeEqualTo false
+            it?.isClassOrInterfaceOrObject shouldBeEqualTo true
             it?.isTypeAlias shouldBeEqualTo false
             it?.isImportAlias shouldBeEqualTo false
             it?.isKotlinType shouldBeEqualTo false
@@ -117,6 +147,28 @@ class KoTypeDeclarationForKoDeclarationCastProviderTest {
             it?.asInterfaceDeclaration() shouldBeEqualTo null
             it?.hasInterfaceDeclaration() shouldBeEqualTo false
             it?.hasInterfaceDeclarationOf(SampleType::class) shouldBeEqualTo false
+            it?.asClassOrObjectDeclaration() shouldBeInstanceOf KoClassDeclaration::class
+            it?.hasClassOrObjectDeclaration() shouldBeEqualTo true
+            it?.hasClassOrObjectDeclaration { decl -> decl.name == "SampleType" } shouldBeEqualTo true
+            it?.hasClassOrObjectDeclaration { decl -> decl.name == "SampleObject" } shouldBeEqualTo false
+            it?.hasClassOrObjectDeclarationOf(SampleType::class) shouldBeEqualTo true
+            it?.hasClassOrObjectDeclarationOf(SampleClass::class) shouldBeEqualTo false
+            it?.asClassOrInterfaceDeclaration() shouldBeInstanceOf KoClassDeclaration::class
+            it?.hasClassOrInterfaceDeclaration() shouldBeEqualTo true
+            it?.hasClassOrInterfaceDeclaration { decl -> decl.name == "SampleType" } shouldBeEqualTo true
+            it?.hasClassOrInterfaceDeclaration { decl -> decl.name == "SampleInterface" } shouldBeEqualTo false
+            it?.hasClassOrInterfaceDeclarationOf(SampleType::class) shouldBeEqualTo true
+            it?.hasClassOrInterfaceDeclarationOf(SampleClass::class) shouldBeEqualTo false
+            it?.asInterfaceOrObjectDeclaration() shouldBeEqualTo null
+            it?.hasInterfaceOrObjectDeclaration() shouldBeEqualTo false
+            it?.hasInterfaceOrObjectDeclaration { decl -> decl.name == "someName" } shouldBeEqualTo false
+            it?.hasInterfaceOrObjectDeclarationOf(SampleClass::class) shouldBeEqualTo false
+            it?.asClassOrInterfaceOrObjectDeclaration() shouldBeInstanceOf KoClassDeclaration::class
+            it?.hasClassOrInterfaceOrObjectDeclaration() shouldBeEqualTo true
+            it?.hasClassOrInterfaceOrObjectDeclaration { decl -> decl.name == "SampleType" } shouldBeEqualTo true
+            it?.hasClassOrInterfaceOrObjectDeclaration { decl -> decl.name == "SampleInterface" } shouldBeEqualTo false
+            it?.hasClassOrInterfaceOrObjectDeclarationOf(SampleType::class) shouldBeEqualTo true
+            it?.hasClassOrInterfaceOrObjectDeclarationOf(SampleClass::class) shouldBeEqualTo false
             it?.asTypeAliasDeclaration() shouldBeEqualTo null
             it?.hasTypeAliasDeclaration() shouldBeEqualTo false
             it?.asImportAliasDeclaration() shouldBeEqualTo null
@@ -154,6 +206,10 @@ class KoTypeDeclarationForKoDeclarationCastProviderTest {
             it?.isClass shouldBeEqualTo false
             it?.isObject shouldBeEqualTo true
             it?.isInterface shouldBeEqualTo false
+            it?.isClassOrObject shouldBeEqualTo true
+            it?.isClassOrInterface shouldBeEqualTo false
+            it?.isInterfaceOrObject shouldBeEqualTo true
+            it?.isClassOrInterfaceOrObject shouldBeEqualTo true
             it?.isTypeAlias shouldBeEqualTo false
             it?.isImportAlias shouldBeEqualTo false
             it?.isKotlinType shouldBeEqualTo false
@@ -174,6 +230,28 @@ class KoTypeDeclarationForKoDeclarationCastProviderTest {
             it?.asInterfaceDeclaration() shouldBeEqualTo null
             it?.hasInterfaceDeclaration() shouldBeEqualTo false
             it?.hasInterfaceDeclarationOf(SampleObject::class) shouldBeEqualTo false
+            it?.asClassOrObjectDeclaration() shouldBeInstanceOf KoObjectDeclaration::class
+            it?.hasClassOrObjectDeclaration() shouldBeEqualTo true
+            it?.hasClassOrObjectDeclaration { decl -> decl.name == "SampleObject" } shouldBeEqualTo true
+            it?.hasClassOrObjectDeclaration { decl -> decl.name == "SampleClass" } shouldBeEqualTo false
+            it?.hasClassOrObjectDeclarationOf(SampleObject::class) shouldBeEqualTo true
+            it?.hasClassOrObjectDeclarationOf(SampleClass::class) shouldBeEqualTo false
+            it?.asClassOrInterfaceDeclaration() shouldBeEqualTo null
+            it?.hasClassOrInterfaceDeclaration() shouldBeEqualTo false
+            it?.hasClassOrInterfaceDeclaration { decl -> decl.name == "SampleObject" } shouldBeEqualTo false
+            it?.hasClassOrInterfaceDeclarationOf(SampleObject::class) shouldBeEqualTo false
+            it?.asInterfaceOrObjectDeclaration() shouldBeInstanceOf KoObjectDeclaration::class
+            it?.hasInterfaceOrObjectDeclaration() shouldBeEqualTo true
+            it?.hasInterfaceOrObjectDeclaration { decl -> decl.name == "SampleObject" } shouldBeEqualTo true
+            it?.hasInterfaceOrObjectDeclaration { decl -> decl.name == "SampleInterface" } shouldBeEqualTo false
+            it?.hasInterfaceOrObjectDeclarationOf(SampleObject::class) shouldBeEqualTo true
+            it?.hasInterfaceOrObjectDeclarationOf(SampleInterface::class) shouldBeEqualTo false
+            it?.asClassOrInterfaceOrObjectDeclaration() shouldBeInstanceOf KoObjectDeclaration::class
+            it?.hasClassOrInterfaceOrObjectDeclaration() shouldBeEqualTo true
+            it?.hasClassOrInterfaceOrObjectDeclaration { decl -> decl.name == "SampleObject" } shouldBeEqualTo true
+            it?.hasClassOrInterfaceOrObjectDeclaration { decl -> decl.name == "SampleClass" } shouldBeEqualTo false
+            it?.hasClassOrInterfaceOrObjectDeclarationOf(SampleObject::class) shouldBeEqualTo true
+            it?.hasClassOrInterfaceOrObjectDeclarationOf(SampleClass::class) shouldBeEqualTo false
             it?.asTypeAliasDeclaration() shouldBeEqualTo null
             it?.hasTypeAliasDeclaration() shouldBeEqualTo false
             it?.asImportAliasDeclaration() shouldBeEqualTo null
@@ -211,6 +289,10 @@ class KoTypeDeclarationForKoDeclarationCastProviderTest {
             it?.isClass shouldBeEqualTo false
             it?.isObject shouldBeEqualTo true
             it?.isInterface shouldBeEqualTo false
+            it?.isClassOrObject shouldBeEqualTo true
+            it?.isClassOrInterface shouldBeEqualTo false
+            it?.isInterfaceOrObject shouldBeEqualTo true
+            it?.isClassOrInterfaceOrObject shouldBeEqualTo true
             it?.isTypeAlias shouldBeEqualTo false
             it?.isImportAlias shouldBeEqualTo false
             it?.isKotlinType shouldBeEqualTo false
@@ -231,6 +313,28 @@ class KoTypeDeclarationForKoDeclarationCastProviderTest {
             it?.asInterfaceDeclaration() shouldBeEqualTo null
             it?.hasInterfaceDeclaration() shouldBeEqualTo false
             it?.hasInterfaceDeclarationOf(SampleObject::class) shouldBeEqualTo false
+            it?.asClassOrObjectDeclaration() shouldBeInstanceOf KoObjectDeclaration::class
+            it?.hasClassOrObjectDeclaration() shouldBeEqualTo true
+            it?.hasClassOrObjectDeclaration { decl -> decl.name == "SampleObject" } shouldBeEqualTo true
+            it?.hasClassOrObjectDeclaration { decl -> decl.name == "SampleClass" } shouldBeEqualTo false
+            it?.hasClassOrObjectDeclarationOf(SampleObject::class) shouldBeEqualTo true
+            it?.hasClassOrObjectDeclarationOf(SampleClass::class) shouldBeEqualTo false
+            it?.asClassOrInterfaceDeclaration() shouldBeEqualTo null
+            it?.hasClassOrInterfaceDeclaration() shouldBeEqualTo false
+            it?.hasClassOrInterfaceDeclaration { decl -> decl.name == "SampleObject" } shouldBeEqualTo false
+            it?.hasClassOrInterfaceDeclarationOf(SampleObject::class) shouldBeEqualTo false
+            it?.asInterfaceOrObjectDeclaration() shouldBeInstanceOf KoObjectDeclaration::class
+            it?.hasInterfaceOrObjectDeclaration() shouldBeEqualTo true
+            it?.hasInterfaceOrObjectDeclaration { decl -> decl.name == "SampleObject" } shouldBeEqualTo true
+            it?.hasInterfaceOrObjectDeclaration { decl -> decl.name == "SampleInterface" } shouldBeEqualTo false
+            it?.hasInterfaceOrObjectDeclarationOf(SampleObject::class) shouldBeEqualTo true
+            it?.hasInterfaceOrObjectDeclarationOf(SampleInterface::class) shouldBeEqualTo false
+            it?.asClassOrInterfaceOrObjectDeclaration() shouldBeInstanceOf KoObjectDeclaration::class
+            it?.hasClassOrInterfaceOrObjectDeclaration() shouldBeEqualTo true
+            it?.hasClassOrInterfaceOrObjectDeclaration { decl -> decl.name == "SampleObject" } shouldBeEqualTo true
+            it?.hasClassOrInterfaceOrObjectDeclaration { decl -> decl.name == "SampleClass" } shouldBeEqualTo false
+            it?.hasClassOrInterfaceOrObjectDeclarationOf(SampleObject::class) shouldBeEqualTo true
+            it?.hasClassOrInterfaceOrObjectDeclarationOf(SampleClass::class) shouldBeEqualTo false
             it?.asTypeAliasDeclaration() shouldBeEqualTo null
             it?.hasTypeAliasDeclaration() shouldBeEqualTo false
             it?.asImportAliasDeclaration() shouldBeEqualTo null
@@ -268,6 +372,10 @@ class KoTypeDeclarationForKoDeclarationCastProviderTest {
             it?.isClass shouldBeEqualTo false
             it?.isObject shouldBeEqualTo false
             it?.isInterface shouldBeEqualTo true
+            it?.isClassOrObject shouldBeEqualTo false
+            it?.isClassOrInterface shouldBeEqualTo true
+            it?.isInterfaceOrObject shouldBeEqualTo true
+            it?.isClassOrInterfaceOrObject shouldBeEqualTo true
             it?.isTypeAlias shouldBeEqualTo false
             it?.isImportAlias shouldBeEqualTo false
             it?.isKotlinType shouldBeEqualTo false
@@ -282,6 +390,28 @@ class KoTypeDeclarationForKoDeclarationCastProviderTest {
             it?.hasInterfaceDeclaration { declaration -> declaration.name == "OtherName" } shouldBeEqualTo false
             it?.hasInterfaceDeclarationOf(SampleInterface::class) shouldBeEqualTo true
             it?.hasInterfaceDeclarationOf(SampleClass::class) shouldBeEqualTo false
+            it?.asClassOrObjectDeclaration() shouldBeEqualTo null
+            it?.hasClassOrObjectDeclaration() shouldBeEqualTo false
+            it?.hasClassOrObjectDeclaration { decl -> decl.name == "SampleInterface" } shouldBeEqualTo false
+            it?.hasClassOrObjectDeclarationOf(SampleInterface::class) shouldBeEqualTo false
+            it?.asClassOrInterfaceDeclaration() shouldBeInstanceOf KoInterfaceDeclaration::class
+            it?.hasClassOrInterfaceDeclaration() shouldBeEqualTo true
+            it?.hasClassOrInterfaceDeclaration { decl -> decl.name == "SampleInterface" } shouldBeEqualTo true
+            it?.hasClassOrInterfaceDeclaration { decl -> decl.name == "SampleClass" } shouldBeEqualTo false
+            it?.hasClassOrInterfaceDeclarationOf(SampleInterface::class) shouldBeEqualTo true
+            it?.hasClassOrInterfaceDeclarationOf(SampleClass::class) shouldBeEqualTo false
+            it?.asInterfaceOrObjectDeclaration() shouldBeInstanceOf KoInterfaceDeclaration::class
+            it?.hasInterfaceOrObjectDeclaration() shouldBeEqualTo true
+            it?.hasInterfaceOrObjectDeclaration { decl -> decl.name == "SampleInterface" } shouldBeEqualTo true
+            it?.hasInterfaceOrObjectDeclaration { decl -> decl.name == "SampleObject" } shouldBeEqualTo false
+            it?.hasInterfaceOrObjectDeclarationOf(SampleInterface::class) shouldBeEqualTo true
+            it?.hasInterfaceOrObjectDeclarationOf(SampleObject::class) shouldBeEqualTo false
+            it?.asClassOrInterfaceOrObjectDeclaration() shouldBeInstanceOf KoInterfaceDeclaration::class
+            it?.hasClassOrInterfaceOrObjectDeclaration() shouldBeEqualTo true
+            it?.hasClassOrInterfaceOrObjectDeclaration { decl -> decl.name == "SampleInterface" } shouldBeEqualTo true
+            it?.hasClassOrInterfaceOrObjectDeclaration { decl -> decl.name == "SampleClass" } shouldBeEqualTo false
+            it?.hasClassOrInterfaceOrObjectDeclarationOf(SampleInterface::class) shouldBeEqualTo true
+            it?.hasClassOrInterfaceOrObjectDeclarationOf(SampleClass::class) shouldBeEqualTo false
             it?.asClassDeclaration() shouldBeEqualTo null
             it?.hasClassDeclaration() shouldBeEqualTo false
             it?.hasClassDeclarationOf(SampleInterface::class) shouldBeEqualTo false
@@ -325,6 +455,10 @@ class KoTypeDeclarationForKoDeclarationCastProviderTest {
             it?.isClass shouldBeEqualTo false
             it?.isObject shouldBeEqualTo false
             it?.isInterface shouldBeEqualTo true
+            it?.isClassOrObject shouldBeEqualTo false
+            it?.isClassOrInterface shouldBeEqualTo true
+            it?.isInterfaceOrObject shouldBeEqualTo true
+            it?.isClassOrInterfaceOrObject shouldBeEqualTo true
             it?.isTypeAlias shouldBeEqualTo false
             it?.isImportAlias shouldBeEqualTo false
             it?.isKotlinType shouldBeEqualTo false
@@ -339,6 +473,28 @@ class KoTypeDeclarationForKoDeclarationCastProviderTest {
             it?.hasInterfaceDeclaration { declaration -> declaration.name == "OtherName" } shouldBeEqualTo false
             it?.hasInterfaceDeclarationOf(SampleInterface::class) shouldBeEqualTo true
             it?.hasInterfaceDeclarationOf(SampleClass::class) shouldBeEqualTo false
+            it?.asClassOrObjectDeclaration() shouldBeEqualTo null
+            it?.hasClassOrObjectDeclaration() shouldBeEqualTo false
+            it?.hasClassOrObjectDeclaration { decl -> decl.name == "SampleInterface" } shouldBeEqualTo false
+            it?.hasClassOrObjectDeclarationOf(SampleInterface::class) shouldBeEqualTo false
+            it?.asClassOrInterfaceDeclaration() shouldBeInstanceOf KoInterfaceDeclaration::class
+            it?.hasClassOrInterfaceDeclaration() shouldBeEqualTo true
+            it?.hasClassOrInterfaceDeclaration { decl -> decl.name == "SampleInterface" } shouldBeEqualTo true
+            it?.hasClassOrInterfaceDeclaration { decl -> decl.name == "SampleClass" } shouldBeEqualTo false
+            it?.hasClassOrInterfaceDeclarationOf(SampleInterface::class) shouldBeEqualTo true
+            it?.hasClassOrInterfaceDeclarationOf(SampleClass::class) shouldBeEqualTo false
+            it?.asInterfaceOrObjectDeclaration() shouldBeInstanceOf KoInterfaceDeclaration::class
+            it?.hasInterfaceOrObjectDeclaration() shouldBeEqualTo true
+            it?.hasInterfaceOrObjectDeclaration { decl -> decl.name == "SampleInterface" } shouldBeEqualTo true
+            it?.hasInterfaceOrObjectDeclaration { decl -> decl.name == "SampleObject" } shouldBeEqualTo false
+            it?.hasInterfaceOrObjectDeclarationOf(SampleInterface::class) shouldBeEqualTo true
+            it?.hasInterfaceOrObjectDeclarationOf(SampleObject::class) shouldBeEqualTo false
+            it?.asClassOrInterfaceOrObjectDeclaration() shouldBeInstanceOf KoInterfaceDeclaration::class
+            it?.hasClassOrInterfaceOrObjectDeclaration() shouldBeEqualTo true
+            it?.hasClassOrInterfaceOrObjectDeclaration { decl -> decl.name == "SampleInterface" } shouldBeEqualTo true
+            it?.hasClassOrInterfaceOrObjectDeclaration { decl -> decl.name == "SampleClass" } shouldBeEqualTo false
+            it?.hasClassOrInterfaceOrObjectDeclarationOf(SampleInterface::class) shouldBeEqualTo true
+            it?.hasClassOrInterfaceOrObjectDeclarationOf(SampleClass::class) shouldBeEqualTo false
             it?.asClassDeclaration() shouldBeEqualTo null
             it?.hasClassDeclaration() shouldBeEqualTo false
             it?.hasClassDeclarationOf(SampleInterface::class) shouldBeEqualTo false
@@ -382,6 +538,10 @@ class KoTypeDeclarationForKoDeclarationCastProviderTest {
             it?.isClass shouldBeEqualTo false
             it?.isObject shouldBeEqualTo false
             it?.isInterface shouldBeEqualTo false
+            it?.isClassOrObject shouldBeEqualTo false
+            it?.isClassOrInterface shouldBeEqualTo false
+            it?.isInterfaceOrObject shouldBeEqualTo false
+            it?.isClassOrInterfaceOrObject shouldBeEqualTo false
             it?.isTypeAlias shouldBeEqualTo false
             it?.isImportAlias shouldBeEqualTo true
             it?.isKotlinType shouldBeEqualTo false
@@ -434,6 +594,10 @@ class KoTypeDeclarationForKoDeclarationCastProviderTest {
             it?.isClass shouldBeEqualTo false
             it?.isObject shouldBeEqualTo false
             it?.isInterface shouldBeEqualTo false
+            it?.isClassOrObject shouldBeEqualTo false
+            it?.isClassOrInterface shouldBeEqualTo false
+            it?.isInterfaceOrObject shouldBeEqualTo false
+            it?.isClassOrInterfaceOrObject shouldBeEqualTo false
             it?.isTypeAlias shouldBeEqualTo true
             it?.isImportAlias shouldBeEqualTo false
             it?.isKotlinType shouldBeEqualTo false
@@ -486,6 +650,10 @@ class KoTypeDeclarationForKoDeclarationCastProviderTest {
             it?.isClass shouldBeEqualTo false
             it?.isObject shouldBeEqualTo false
             it?.isInterface shouldBeEqualTo false
+            it?.isClassOrObject shouldBeEqualTo false
+            it?.isClassOrInterface shouldBeEqualTo false
+            it?.isInterfaceOrObject shouldBeEqualTo false
+            it?.isClassOrInterfaceOrObject shouldBeEqualTo false
             it?.isTypeAlias shouldBeEqualTo false
             it?.isImportAlias shouldBeEqualTo true
             it?.isKotlinType shouldBeEqualTo false
@@ -538,6 +706,10 @@ class KoTypeDeclarationForKoDeclarationCastProviderTest {
             it?.isClass shouldBeEqualTo false
             it?.isObject shouldBeEqualTo false
             it?.isInterface shouldBeEqualTo false
+            it?.isClassOrObject shouldBeEqualTo false
+            it?.isClassOrInterface shouldBeEqualTo false
+            it?.isInterfaceOrObject shouldBeEqualTo false
+            it?.isClassOrInterfaceOrObject shouldBeEqualTo false
             it?.isTypeAlias shouldBeEqualTo false
             it?.isImportAlias shouldBeEqualTo false
             it?.isKotlinType shouldBeEqualTo false
@@ -590,6 +762,10 @@ class KoTypeDeclarationForKoDeclarationCastProviderTest {
             it?.isClass shouldBeEqualTo false
             it?.isObject shouldBeEqualTo false
             it?.isInterface shouldBeEqualTo false
+            it?.isClassOrObject shouldBeEqualTo false
+            it?.isClassOrInterface shouldBeEqualTo false
+            it?.isInterfaceOrObject shouldBeEqualTo false
+            it?.isClassOrInterfaceOrObject shouldBeEqualTo false
             it?.isTypeAlias shouldBeEqualTo false
             it?.isImportAlias shouldBeEqualTo false
             it?.isKotlinType shouldBeEqualTo false
@@ -642,6 +818,10 @@ class KoTypeDeclarationForKoDeclarationCastProviderTest {
             it?.isClass shouldBeEqualTo false
             it?.isObject shouldBeEqualTo false
             it?.isInterface shouldBeEqualTo false
+            it?.isClassOrObject shouldBeEqualTo false
+            it?.isClassOrInterface shouldBeEqualTo false
+            it?.isInterfaceOrObject shouldBeEqualTo false
+            it?.isClassOrInterfaceOrObject shouldBeEqualTo false
             it?.isTypeAlias shouldBeEqualTo true
             it?.isImportAlias shouldBeEqualTo false
             it?.isKotlinType shouldBeEqualTo false
@@ -694,6 +874,10 @@ class KoTypeDeclarationForKoDeclarationCastProviderTest {
             it?.isClass shouldBeEqualTo false
             it?.isObject shouldBeEqualTo false
             it?.isInterface shouldBeEqualTo false
+            it?.isClassOrObject shouldBeEqualTo false
+            it?.isClassOrInterface shouldBeEqualTo false
+            it?.isInterfaceOrObject shouldBeEqualTo false
+            it?.isClassOrInterfaceOrObject shouldBeEqualTo false
             it?.isTypeAlias shouldBeEqualTo false
             it?.isImportAlias shouldBeEqualTo false
             it?.isKotlinType shouldBeEqualTo true
@@ -727,6 +911,22 @@ class KoTypeDeclarationForKoDeclarationCastProviderTest {
             it?.asInterfaceDeclaration() shouldBeEqualTo null
             it?.hasInterfaceDeclaration() shouldBeEqualTo false
             it?.hasInterfaceDeclarationOf(String::class) shouldBeEqualTo false
+            it?.asClassOrObjectDeclaration() shouldBeEqualTo null
+            it?.hasClassOrObjectDeclaration() shouldBeEqualTo false
+            it?.hasClassOrObjectDeclaration { decl -> decl.name == "someName" } shouldBeEqualTo false
+            it?.hasClassOrObjectDeclarationOf(SampleClass::class) shouldBeEqualTo false
+            it?.asClassOrInterfaceDeclaration() shouldBeEqualTo null
+            it?.hasClassOrInterfaceDeclaration() shouldBeEqualTo false
+            it?.hasClassOrInterfaceDeclaration { decl -> decl.name == "someName" } shouldBeEqualTo false
+            it?.hasClassOrInterfaceDeclarationOf(SampleClass::class) shouldBeEqualTo false
+            it?.asInterfaceOrObjectDeclaration() shouldBeEqualTo null
+            it?.hasInterfaceOrObjectDeclaration() shouldBeEqualTo false
+            it?.hasInterfaceOrObjectDeclaration { decl -> decl.name == "someName" } shouldBeEqualTo false
+            it?.hasInterfaceOrObjectDeclarationOf(SampleClass::class) shouldBeEqualTo false
+            it?.asClassOrInterfaceOrObjectDeclaration() shouldBeEqualTo null
+            it?.hasClassOrInterfaceOrObjectDeclaration() shouldBeEqualTo false
+            it?.hasClassOrInterfaceOrObjectDeclaration { decl -> decl.name == "someName" } shouldBeEqualTo false
+            it?.hasClassOrInterfaceOrObjectDeclarationOf(SampleClass::class) shouldBeEqualTo false
             it?.asTypeAliasDeclaration() shouldBeEqualTo null
             it?.hasTypeAliasDeclaration() shouldBeEqualTo false
             it?.asImportAliasDeclaration() shouldBeEqualTo null
@@ -756,6 +956,10 @@ class KoTypeDeclarationForKoDeclarationCastProviderTest {
             it?.isClass shouldBeEqualTo false
             it?.isObject shouldBeEqualTo false
             it?.isInterface shouldBeEqualTo false
+            it?.isClassOrObject shouldBeEqualTo false
+            it?.isClassOrInterface shouldBeEqualTo false
+            it?.isInterfaceOrObject shouldBeEqualTo false
+            it?.isClassOrInterfaceOrObject shouldBeEqualTo false
             it?.isTypeAlias shouldBeEqualTo false
             it?.isImportAlias shouldBeEqualTo false
             it?.isKotlinType shouldBeEqualTo true
@@ -789,6 +993,22 @@ class KoTypeDeclarationForKoDeclarationCastProviderTest {
             it?.asInterfaceDeclaration() shouldBeEqualTo null
             it?.hasInterfaceDeclaration() shouldBeEqualTo false
             it?.hasInterfaceDeclarationOf(String::class) shouldBeEqualTo false
+            it?.asClassOrObjectDeclaration() shouldBeEqualTo null
+            it?.hasClassOrObjectDeclaration() shouldBeEqualTo false
+            it?.hasClassOrObjectDeclaration { decl -> decl.name == "someName" } shouldBeEqualTo false
+            it?.hasClassOrObjectDeclarationOf(SampleClass::class) shouldBeEqualTo false
+            it?.asClassOrInterfaceDeclaration() shouldBeEqualTo null
+            it?.hasClassOrInterfaceDeclaration() shouldBeEqualTo false
+            it?.hasClassOrInterfaceDeclaration { decl -> decl.name == "someName" } shouldBeEqualTo false
+            it?.hasClassOrInterfaceDeclarationOf(SampleClass::class) shouldBeEqualTo false
+            it?.asInterfaceOrObjectDeclaration() shouldBeEqualTo null
+            it?.hasInterfaceOrObjectDeclaration() shouldBeEqualTo false
+            it?.hasInterfaceOrObjectDeclaration { decl -> decl.name == "someName" } shouldBeEqualTo false
+            it?.hasInterfaceOrObjectDeclarationOf(SampleClass::class) shouldBeEqualTo false
+            it?.asClassOrInterfaceOrObjectDeclaration() shouldBeEqualTo null
+            it?.hasClassOrInterfaceOrObjectDeclaration() shouldBeEqualTo false
+            it?.hasClassOrInterfaceOrObjectDeclaration { decl -> decl.name == "someName" } shouldBeEqualTo false
+            it?.hasClassOrInterfaceOrObjectDeclarationOf(SampleClass::class) shouldBeEqualTo false
             it?.asTypeAliasDeclaration() shouldBeEqualTo null
             it?.hasTypeAliasDeclaration() shouldBeEqualTo false
             it?.asImportAliasDeclaration() shouldBeEqualTo null
@@ -818,6 +1038,10 @@ class KoTypeDeclarationForKoDeclarationCastProviderTest {
             it?.isClass shouldBeEqualTo false
             it?.isObject shouldBeEqualTo false
             it?.isInterface shouldBeEqualTo false
+            it?.isClassOrObject shouldBeEqualTo false
+            it?.isClassOrInterface shouldBeEqualTo false
+            it?.isInterfaceOrObject shouldBeEqualTo false
+            it?.isClassOrInterfaceOrObject shouldBeEqualTo false
             it?.isTypeAlias shouldBeEqualTo false
             it?.isImportAlias shouldBeEqualTo false
             it?.isKotlinType shouldBeEqualTo false
@@ -867,6 +1091,10 @@ class KoTypeDeclarationForKoDeclarationCastProviderTest {
             it?.isClass shouldBeEqualTo false
             it?.isObject shouldBeEqualTo false
             it?.isInterface shouldBeEqualTo false
+            it?.isClassOrObject shouldBeEqualTo false
+            it?.isClassOrInterface shouldBeEqualTo false
+            it?.isInterfaceOrObject shouldBeEqualTo false
+            it?.isClassOrInterfaceOrObject shouldBeEqualTo false
             it?.isTypeAlias shouldBeEqualTo false
             it?.isImportAlias shouldBeEqualTo false
             it?.isKotlinType shouldBeEqualTo false
@@ -916,6 +1144,10 @@ class KoTypeDeclarationForKoDeclarationCastProviderTest {
             it?.isClass shouldBeEqualTo true
             it?.isObject shouldBeEqualTo false
             it?.isInterface shouldBeEqualTo false
+            it?.isClassOrObject shouldBeEqualTo true
+            it?.isClassOrInterface shouldBeEqualTo true
+            it?.isInterfaceOrObject shouldBeEqualTo false
+            it?.isClassOrInterfaceOrObject shouldBeEqualTo true
             it?.isTypeAlias shouldBeEqualTo false
             it?.isImportAlias shouldBeEqualTo false
             it?.isKotlinType shouldBeEqualTo false
@@ -936,6 +1168,28 @@ class KoTypeDeclarationForKoDeclarationCastProviderTest {
             it?.asInterfaceDeclaration() shouldBeEqualTo null
             it?.hasInterfaceDeclaration() shouldBeEqualTo false
             it?.hasInterfaceDeclarationOf(SampleCollection1::class) shouldBeEqualTo false
+            it?.asClassOrObjectDeclaration() shouldBeInstanceOf KoClassDeclaration::class
+            it?.hasClassOrObjectDeclaration() shouldBeEqualTo true
+            it?.hasClassOrObjectDeclaration { decl -> decl.name == "SampleCollection1" } shouldBeEqualTo true
+            it?.hasClassOrObjectDeclaration { decl -> decl.name == "SampleObject" } shouldBeEqualTo false
+            it?.hasClassOrObjectDeclarationOf(SampleCollection1::class) shouldBeEqualTo true
+            it?.hasClassOrObjectDeclarationOf(SampleClass::class) shouldBeEqualTo false
+            it?.asClassOrInterfaceDeclaration() shouldBeInstanceOf KoClassDeclaration::class
+            it?.hasClassOrInterfaceDeclaration() shouldBeEqualTo true
+            it?.hasClassOrInterfaceDeclaration { decl -> decl.name == "SampleCollection1" } shouldBeEqualTo true
+            it?.hasClassOrInterfaceDeclaration { decl -> decl.name == "SampleInterface" } shouldBeEqualTo false
+            it?.hasClassOrInterfaceDeclarationOf(SampleCollection1::class) shouldBeEqualTo true
+            it?.hasClassOrInterfaceDeclarationOf(SampleClass::class) shouldBeEqualTo false
+            it?.asInterfaceOrObjectDeclaration() shouldBeEqualTo null
+            it?.hasInterfaceOrObjectDeclaration() shouldBeEqualTo false
+            it?.hasInterfaceOrObjectDeclaration { decl -> decl.name == "someName" } shouldBeEqualTo false
+            it?.hasInterfaceOrObjectDeclarationOf(SampleClass::class) shouldBeEqualTo false
+            it?.asClassOrInterfaceOrObjectDeclaration() shouldBeInstanceOf KoClassDeclaration::class
+            it?.hasClassOrInterfaceOrObjectDeclaration() shouldBeEqualTo true
+            it?.hasClassOrInterfaceOrObjectDeclaration { decl -> decl.name == "SampleCollection1" } shouldBeEqualTo true
+            it?.hasClassOrInterfaceOrObjectDeclaration { decl -> decl.name == "SampleInterface" } shouldBeEqualTo false
+            it?.hasClassOrInterfaceOrObjectDeclarationOf(SampleCollection1::class) shouldBeEqualTo true
+            it?.hasClassOrInterfaceOrObjectDeclarationOf(SampleClass::class) shouldBeEqualTo false
             it?.asTypeAliasDeclaration() shouldBeEqualTo null
             it?.hasTypeAliasDeclaration() shouldBeEqualTo false
             it?.asImportAliasDeclaration() shouldBeEqualTo null
@@ -973,6 +1227,10 @@ class KoTypeDeclarationForKoDeclarationCastProviderTest {
             it?.isClass shouldBeEqualTo true
             it?.isObject shouldBeEqualTo false
             it?.isInterface shouldBeEqualTo false
+            it?.isClassOrObject shouldBeEqualTo true
+            it?.isClassOrInterface shouldBeEqualTo true
+            it?.isInterfaceOrObject shouldBeEqualTo false
+            it?.isClassOrInterfaceOrObject shouldBeEqualTo true
             it?.isTypeAlias shouldBeEqualTo false
             it?.isImportAlias shouldBeEqualTo false
             it?.isKotlinType shouldBeEqualTo false
@@ -993,6 +1251,28 @@ class KoTypeDeclarationForKoDeclarationCastProviderTest {
             it?.asInterfaceDeclaration() shouldBeEqualTo null
             it?.hasInterfaceDeclaration() shouldBeEqualTo false
             it?.hasInterfaceDeclarationOf(SampleCollection1::class) shouldBeEqualTo false
+            it?.asClassOrObjectDeclaration() shouldBeInstanceOf KoClassDeclaration::class
+            it?.hasClassOrObjectDeclaration() shouldBeEqualTo true
+            it?.hasClassOrObjectDeclaration { decl -> decl.name == "SampleCollection1" } shouldBeEqualTo true
+            it?.hasClassOrObjectDeclaration { decl -> decl.name == "SampleObject" } shouldBeEqualTo false
+            it?.hasClassOrObjectDeclarationOf(SampleCollection1::class) shouldBeEqualTo true
+            it?.hasClassOrObjectDeclarationOf(SampleClass::class) shouldBeEqualTo false
+            it?.asClassOrInterfaceDeclaration() shouldBeInstanceOf KoClassDeclaration::class
+            it?.hasClassOrInterfaceDeclaration() shouldBeEqualTo true
+            it?.hasClassOrInterfaceDeclaration { decl -> decl.name == "SampleCollection1" } shouldBeEqualTo true
+            it?.hasClassOrInterfaceDeclaration { decl -> decl.name == "SampleInterface" } shouldBeEqualTo false
+            it?.hasClassOrInterfaceDeclarationOf(SampleCollection1::class) shouldBeEqualTo true
+            it?.hasClassOrInterfaceDeclarationOf(SampleClass::class) shouldBeEqualTo false
+            it?.asInterfaceOrObjectDeclaration() shouldBeEqualTo null
+            it?.hasInterfaceOrObjectDeclaration() shouldBeEqualTo false
+            it?.hasInterfaceOrObjectDeclaration { decl -> decl.name == "someName" } shouldBeEqualTo false
+            it?.hasInterfaceOrObjectDeclarationOf(SampleClass::class) shouldBeEqualTo false
+            it?.asClassOrInterfaceOrObjectDeclaration() shouldBeInstanceOf KoClassDeclaration::class
+            it?.hasClassOrInterfaceOrObjectDeclaration() shouldBeEqualTo true
+            it?.hasClassOrInterfaceOrObjectDeclaration { decl -> decl.name == "SampleCollection1" } shouldBeEqualTo true
+            it?.hasClassOrInterfaceOrObjectDeclaration { decl -> decl.name == "SampleInterface" } shouldBeEqualTo false
+            it?.hasClassOrInterfaceOrObjectDeclarationOf(SampleCollection1::class) shouldBeEqualTo true
+            it?.hasClassOrInterfaceOrObjectDeclarationOf(SampleClass::class) shouldBeEqualTo false
             it?.asTypeAliasDeclaration() shouldBeEqualTo null
             it?.hasTypeAliasDeclaration() shouldBeEqualTo false
             it?.asImportAliasDeclaration() shouldBeEqualTo null
@@ -1030,6 +1310,10 @@ class KoTypeDeclarationForKoDeclarationCastProviderTest {
             it?.isClass shouldBeEqualTo false
             it?.isObject shouldBeEqualTo false
             it?.isInterface shouldBeEqualTo false
+            it?.isClassOrObject shouldBeEqualTo false
+            it?.isClassOrInterface shouldBeEqualTo false
+            it?.isInterfaceOrObject shouldBeEqualTo false
+            it?.isClassOrInterfaceOrObject shouldBeEqualTo false
             it?.isTypeAlias shouldBeEqualTo false
             it?.isImportAlias shouldBeEqualTo false
             it?.isKotlinType shouldBeEqualTo false
@@ -1053,6 +1337,22 @@ class KoTypeDeclarationForKoDeclarationCastProviderTest {
             it?.asInterfaceDeclaration() shouldBeEqualTo null
             it?.hasInterfaceDeclaration() shouldBeEqualTo false
             it?.hasInterfaceDeclarationOf(SampleExternalClass::class) shouldBeEqualTo false
+            it?.asClassOrObjectDeclaration() shouldBeEqualTo null
+            it?.hasClassOrObjectDeclaration() shouldBeEqualTo false
+            it?.hasClassOrObjectDeclaration { decl -> decl.name == "someName" } shouldBeEqualTo false
+            it?.hasClassOrObjectDeclarationOf(SampleClass::class) shouldBeEqualTo false
+            it?.asClassOrInterfaceDeclaration() shouldBeEqualTo null
+            it?.hasClassOrInterfaceDeclaration() shouldBeEqualTo false
+            it?.hasClassOrInterfaceDeclaration { decl -> decl.name == "someName" } shouldBeEqualTo false
+            it?.hasClassOrInterfaceDeclarationOf(SampleClass::class) shouldBeEqualTo false
+            it?.asInterfaceOrObjectDeclaration() shouldBeEqualTo null
+            it?.hasInterfaceOrObjectDeclaration() shouldBeEqualTo false
+            it?.hasInterfaceOrObjectDeclaration { decl -> decl.name == "someName" } shouldBeEqualTo false
+            it?.hasInterfaceOrObjectDeclarationOf(SampleClass::class) shouldBeEqualTo false
+            it?.asClassOrInterfaceOrObjectDeclaration() shouldBeEqualTo null
+            it?.hasClassOrInterfaceOrObjectDeclaration() shouldBeEqualTo false
+            it?.hasClassOrInterfaceOrObjectDeclaration { decl -> decl.name == "someName" } shouldBeEqualTo false
+            it?.hasClassOrInterfaceOrObjectDeclarationOf(SampleClass::class) shouldBeEqualTo false
             it?.asTypeAliasDeclaration() shouldBeEqualTo null
             it?.hasTypeAliasDeclaration() shouldBeEqualTo false
             it?.asImportAliasDeclaration() shouldBeEqualTo null
@@ -1088,6 +1388,10 @@ class KoTypeDeclarationForKoDeclarationCastProviderTest {
             it?.isClass shouldBeEqualTo false
             it?.isObject shouldBeEqualTo false
             it?.isInterface shouldBeEqualTo false
+            it?.isClassOrObject shouldBeEqualTo false
+            it?.isClassOrInterface shouldBeEqualTo false
+            it?.isInterfaceOrObject shouldBeEqualTo false
+            it?.isClassOrInterfaceOrObject shouldBeEqualTo false
             it?.isTypeAlias shouldBeEqualTo false
             it?.isImportAlias shouldBeEqualTo false
             it?.isKotlinType shouldBeEqualTo false
@@ -1111,6 +1415,22 @@ class KoTypeDeclarationForKoDeclarationCastProviderTest {
             it?.asInterfaceDeclaration() shouldBeEqualTo null
             it?.hasInterfaceDeclaration() shouldBeEqualTo false
             it?.hasInterfaceDeclarationOf(SampleExternalClass::class) shouldBeEqualTo false
+            it?.asClassOrObjectDeclaration() shouldBeEqualTo null
+            it?.hasClassOrObjectDeclaration() shouldBeEqualTo false
+            it?.hasClassOrObjectDeclaration { decl -> decl.name == "someName" } shouldBeEqualTo false
+            it?.hasClassOrObjectDeclarationOf(SampleClass::class) shouldBeEqualTo false
+            it?.asClassOrInterfaceDeclaration() shouldBeEqualTo null
+            it?.hasClassOrInterfaceDeclaration() shouldBeEqualTo false
+            it?.hasClassOrInterfaceDeclaration { decl -> decl.name == "someName" } shouldBeEqualTo false
+            it?.hasClassOrInterfaceDeclarationOf(SampleClass::class) shouldBeEqualTo false
+            it?.asInterfaceOrObjectDeclaration() shouldBeEqualTo null
+            it?.hasInterfaceOrObjectDeclaration() shouldBeEqualTo false
+            it?.hasInterfaceOrObjectDeclaration { decl -> decl.name == "someName" } shouldBeEqualTo false
+            it?.hasInterfaceOrObjectDeclarationOf(SampleClass::class) shouldBeEqualTo false
+            it?.asClassOrInterfaceOrObjectDeclaration() shouldBeEqualTo null
+            it?.hasClassOrInterfaceOrObjectDeclaration() shouldBeEqualTo false
+            it?.hasClassOrInterfaceOrObjectDeclaration { decl -> decl.name == "someName" } shouldBeEqualTo false
+            it?.hasClassOrInterfaceOrObjectDeclarationOf(SampleClass::class) shouldBeEqualTo false
             it?.asTypeAliasDeclaration() shouldBeEqualTo null
             it?.hasTypeAliasDeclaration() shouldBeEqualTo false
             it?.asImportAliasDeclaration() shouldBeEqualTo null
@@ -1149,6 +1469,10 @@ class KoTypeDeclarationForKoDeclarationCastProviderTest {
             it?.isClass shouldBeEqualTo false
             it?.isObject shouldBeEqualTo false
             it?.isInterface shouldBeEqualTo false
+            it?.isClassOrObject shouldBeEqualTo false
+            it?.isClassOrInterface shouldBeEqualTo false
+            it?.isInterfaceOrObject shouldBeEqualTo false
+            it?.isClassOrInterfaceOrObject shouldBeEqualTo false
             it?.isTypeAlias shouldBeEqualTo false
             it?.isImportAlias shouldBeEqualTo false
             it?.isKotlinType shouldBeEqualTo false

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/type/kotype/KoTypeDeclarationForKoDeclarationCastProviderTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/type/kotype/KoTypeDeclarationForKoDeclarationCastProviderTest.kt
@@ -21,7 +21,7 @@ import org.amshove.kluent.shouldBeEqualTo
 import org.amshove.kluent.shouldBeInstanceOf
 import org.junit.jupiter.api.Test
 
-@Suppress("detekt.LargeClass")
+@Suppress("detekt.LargeClass", "detekt.LongMethod")
 class KoTypeDeclarationForKoDeclarationCastProviderTest {
     @Test
     fun `nullable-class-type`() {

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/api/ext/list/KoDeclarationCastProviderListExt.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/api/ext/list/KoDeclarationCastProviderListExt.kt
@@ -9,6 +9,10 @@ import com.lemonappdev.konsist.api.declaration.KoInterfaceDeclaration
 import com.lemonappdev.konsist.api.declaration.KoObjectDeclaration
 import com.lemonappdev.konsist.api.declaration.KoTypeAliasDeclaration
 import com.lemonappdev.konsist.api.declaration.KoTypeParameterDeclaration
+import com.lemonappdev.konsist.api.declaration.combined.KoClassAndInterfaceAndObjectDeclaration
+import com.lemonappdev.konsist.api.declaration.combined.KoClassAndInterfaceDeclaration
+import com.lemonappdev.konsist.api.declaration.combined.KoClassAndObjectDeclaration
+import com.lemonappdev.konsist.api.declaration.combined.KoInterfaceAndObjectDeclaration
 import com.lemonappdev.konsist.api.declaration.type.KoKotlinTypeDeclaration
 import com.lemonappdev.konsist.api.provider.KoDeclarationCastProvider
 import kotlin.reflect.KClass
@@ -103,6 +107,63 @@ fun <T : KoDeclarationCastProvider> List<T>.interfaceDeclarations(
 ): List<KoInterfaceDeclaration> =
     filter { it.hasInterfaceDeclaration(predicate) }
         .mapNotNull { it.asInterfaceDeclaration() }
+
+/**
+ * List containing class and object declarations associated with declarations.
+ *
+ * @param predicate A function that defines the condition to be met by the class and object declaration.
+ *                  If null, all class and object declarations are included.
+ * @return A list of class and object declarations that match the provided predicate, or all class and object
+ * declarations if no predicate is provided.
+ */
+fun <T : KoDeclarationCastProvider> List<T>.classAndObjectDeclarations(
+    predicate: ((KoClassAndObjectDeclaration) -> Boolean)? = null,
+): List<KoClassAndObjectDeclaration> =
+    filter { it.hasClassOrObjectDeclaration(predicate) }
+        .mapNotNull { it.asClassOrObjectDeclaration() }
+
+/**
+ * List containing class and interface declarations associated with declarations.
+ *
+ * @param predicate A function that defines the condition to be met by the class and interface declaration.
+ *                  If null, all class and interface declarations are included.
+ * @return A list of class and interface declarations that match the provided predicate, or all class and interface
+ * declarations if no predicate is provided.
+ */
+fun <T : KoDeclarationCastProvider> List<T>.classAndInterfaceDeclarations(
+    predicate: ((KoClassAndInterfaceDeclaration) -> Boolean)? = null,
+): List<KoClassAndInterfaceDeclaration> =
+    filter { it.hasClassOrInterfaceDeclaration(predicate) }
+        .mapNotNull { it.asClassOrInterfaceDeclaration() }
+
+/**
+ * List containing interface and object declarations associated with declarations.
+ *
+ * @param predicate A function that defines the condition to be met by the interface and object declaration.
+ *                  If null, all interface and object declarations are included.
+ * @return A list of interface and object declarations that match the provided predicate, or all interface and object
+ * declarations if no predicate is provided.
+ */
+fun <T : KoDeclarationCastProvider> List<T>.interfaceAndObjectDeclarations(
+    predicate: ((KoInterfaceAndObjectDeclaration) -> Boolean)? = null,
+): List<KoInterfaceAndObjectDeclaration> =
+    filter { it.hasInterfaceOrObjectDeclaration(predicate) }
+        .mapNotNull { it.asInterfaceOrObjectDeclaration() }
+
+/**
+ * List containing class, interface and object declarations associated with declarations.
+ *
+ * @param predicate A function that defines the condition to be met by the class, interface and object declaration.
+ *                  If null, all class, interface and object declarations are included.
+ * @return A list of class, interface and object declarations that match the provided predicate, or all class,
+ * interface and object declarations if no predicate
+ * is provided.
+ */
+fun <T : KoDeclarationCastProvider> List<T>.classAndInterfaceAndObjectDeclarations(
+    predicate: ((KoClassAndInterfaceAndObjectDeclaration) -> Boolean)? = null,
+): List<KoClassAndInterfaceAndObjectDeclaration> =
+    filter { it.hasClassOrInterfaceOrObjectDeclaration(predicate) }
+        .mapNotNull { it.asClassOrInterfaceOrObjectDeclaration() }
 
 /**
  * List containing type alias declarations associated with declarations.
@@ -212,7 +273,7 @@ fun <T : KoDeclarationCastProvider> List<T>.withClassDeclaration(predicate: ((Ko
     filter {
         when (predicate) {
             null -> it.isClass
-            else -> it.asClassDeclaration()?.let { classDeclaration -> predicate(classDeclaration) } ?: false
+            else -> it.asClassDeclaration()?.let { classDeclaration -> predicate(classDeclaration) } == true
         }
     }
 
@@ -226,7 +287,7 @@ fun <T : KoDeclarationCastProvider> List<T>.withoutClassDeclaration(predicate: (
     filterNot {
         when (predicate) {
             null -> it.isClass
-            else -> it.asClassDeclaration()?.let { classDeclaration -> predicate(classDeclaration) } ?: false
+            else -> it.asClassDeclaration()?.let { classDeclaration -> predicate(classDeclaration) } == true
         }
     }
 
@@ -292,7 +353,7 @@ fun <T : KoDeclarationCastProvider> List<T>.withObjectDeclaration(predicate: ((K
     filter {
         when (predicate) {
             null -> it.isObject
-            else -> it.asObjectDeclaration()?.let { objectDeclaration -> predicate(objectDeclaration) } ?: false
+            else -> it.asObjectDeclaration()?.let { objectDeclaration -> predicate(objectDeclaration) } == true
         }
     }
 
@@ -306,7 +367,7 @@ fun <T : KoDeclarationCastProvider> List<T>.withoutObjectDeclaration(predicate: 
     filterNot {
         when (predicate) {
             null -> it.isObject
-            else -> it.asObjectDeclaration()?.let { objectDeclaration -> predicate(objectDeclaration) } ?: false
+            else -> it.asObjectDeclaration()?.let { objectDeclaration -> predicate(objectDeclaration) } == true
         }
     }
 
@@ -373,8 +434,7 @@ fun <T : KoDeclarationCastProvider> List<T>.withInterfaceDeclaration(predicate: 
         when (predicate) {
             null -> it.isInterface
             else ->
-                it.asInterfaceDeclaration()?.let { interfaceDeclaration -> predicate(interfaceDeclaration) }
-                    ?: false
+                it.asInterfaceDeclaration()?.let { interfaceDeclaration -> predicate(interfaceDeclaration) } == true
         }
     }
 
@@ -389,8 +449,7 @@ fun <T : KoDeclarationCastProvider> List<T>.withoutInterfaceDeclaration(predicat
         when (predicate) {
             null -> it.isInterface
             else ->
-                it.asInterfaceDeclaration()?.let { interfaceDeclaration -> predicate(interfaceDeclaration) }
-                    ?: false
+                it.asInterfaceDeclaration()?.let { interfaceDeclaration -> predicate(interfaceDeclaration) } == true
         }
     }
 
@@ -447,6 +506,330 @@ fun <T : KoDeclarationCastProvider> List<T>.withoutInterfaceDeclarationOf(kClass
     }
 
 /**
+ * List containing declarations with the specified class or object declaration.
+ *
+ * @param predicate The predicate function to determine if a class or object declaration satisfies a condition.
+ * @return A list containing declarations with the specified class or object declaration.
+ */
+fun <T : KoDeclarationCastProvider> List<T>.withClassOrObjectDeclaration(predicate: ((KoClassAndObjectDeclaration) -> Boolean)? = null): List<T> =
+    filter {
+        when (predicate) {
+            null -> it.isClassOrObject
+            else -> it.asClassOrObjectDeclaration()?.let { declaration -> predicate(declaration) } == true
+        }
+    }
+
+/**
+ * List containing declarations without the specified class or object declaration.
+ *
+ * @param predicate The predicate function to determine if a class or object declaration satisfies a condition.
+ * @return A list containing declarations without the specified class or object declaration.
+ */
+fun <T : KoDeclarationCastProvider> List<T>.withoutClassOrObjectDeclaration(predicate: ((KoClassAndObjectDeclaration) -> Boolean)? = null): List<T> =
+    filterNot {
+        when (predicate) {
+            null -> it.isClassOrObject
+            else -> it.asClassOrObjectDeclaration()?.let { declaration -> predicate(declaration) } == true
+        }
+    }
+
+/**
+ * List containing declarations with class or object declaration of.
+ *
+ * @param kClass The Kotlin class representing the class or object declaration to include.
+ * @param kClasses The Kotlin class(es) representing the class or object declaration(s) to include.
+ * @return A list containing declarations with the class or object declaration of the specified Kotlin class(es).
+ */
+
+fun <T : KoDeclarationCastProvider> List<T>.withClassOrObjectDeclarationOf(
+    kClass: KClass<*>,
+    vararg kClasses: KClass<*>,
+): List<T> = withClassOrObjectDeclarationOf(listOf(kClass, *kClasses))
+
+/**
+ * List containing declarations with class or object declaration of.
+ *
+ * @param kClasses The Kotlin class(es) representing the class or object declaration(s) to include.
+ * @return A list containing declarations with the class or object declaration of the specified Kotlin class(es).
+ */
+fun <T : KoDeclarationCastProvider> List<T>.withClassOrObjectDeclarationOf(kClasses: Collection<KClass<*>>): List<T> =
+    filter {
+        when {
+            kClasses.isEmpty() -> it.hasClassOrObjectDeclaration()
+            else -> kClasses.any { kClass -> it.hasClassOrObjectDeclarationOf(kClass) }
+        }
+    }
+
+/**
+ * List containing declarations without class or object declaration of.
+ *
+ * @param kClass The Kotlin class representing the class or object declaration to exclude.
+ * @param kClasses The Kotlin class(es) representing the class or object declaration(s) to exclude.
+ * @return A list containing declarations without class or object declaration of the specified Kotlin class(es).
+ */
+fun <T : KoDeclarationCastProvider> List<T>.withoutClassOrObjectDeclarationOf(
+    kClass: KClass<*>,
+    vararg kClasses: KClass<*>,
+): List<T> = withoutClassOrObjectDeclarationOf(listOf(kClass, *kClasses))
+
+/**
+ * List containing declarations without class or object declaration of.
+ *
+ * @param kClasses The Kotlin class(es) representing the class or object declaration(s) to exclude.
+ * @return A list containing declarations without class or object declaration of the specified Kotlin class(es).
+ */
+fun <T : KoDeclarationCastProvider> List<T>.withoutClassOrObjectDeclarationOf(kClasses: Collection<KClass<*>>): List<T> =
+    filterNot {
+        when {
+            kClasses.isEmpty() -> it.hasClassOrObjectDeclaration()
+            else -> kClasses.any { kClass -> it.hasClassOrObjectDeclarationOf(kClass) }
+        }
+    }
+
+/**
+ * List containing declarations with the specified class or interface declaration.
+ *
+ * @param predicate The predicate function to determine if a class or interface declaration satisfies a condition.
+ * @return A list containing declarations with the specified class or interface declaration.
+ */
+fun <T : KoDeclarationCastProvider> List<T>.withClassOrInterfaceDeclaration(predicate: ((KoClassAndInterfaceDeclaration) -> Boolean)? = null): List<T> =
+    filter {
+        when (predicate) {
+            null -> it.isClassOrInterface
+            else -> it.asClassOrInterfaceDeclaration()?.let { declaration -> predicate(declaration) } == true
+        }
+    }
+
+/**
+ * List containing declarations without the specified class or interface declaration.
+ *
+ * @param predicate The predicate function to determine if a class or interface declaration satisfies a condition.
+ * @return A list containing declarations without the specified class or interface declaration.
+ */
+fun <T : KoDeclarationCastProvider> List<T>.withoutClassOrInterfaceDeclaration(predicate: ((KoClassAndInterfaceDeclaration) -> Boolean)? = null): List<T> =
+    filterNot {
+        when (predicate) {
+            null -> it.isClassOrInterface
+            else -> it.asClassOrInterfaceDeclaration()?.let { declaration -> predicate(declaration) } == true
+        }
+    }
+
+/**
+ * List containing declarations with class or interface declaration of.
+ *
+ * @param kClass The Kotlin class representing the class or interface declaration to include.
+ * @param kClasses The Kotlin class(es) representing the class or interface declaration(s) to include.
+ * @return A list containing declarations with the class or interface declaration of the specified Kotlin class(es).
+ */
+
+fun <T : KoDeclarationCastProvider> List<T>.withClassOrInterfaceDeclarationOf(
+    kClass: KClass<*>,
+    vararg kClasses: KClass<*>,
+): List<T> = withClassOrInterfaceDeclarationOf(listOf(kClass, *kClasses))
+
+/**
+ * List containing declarations with class or interface declaration of.
+ *
+ * @param kClasses The Kotlin class(es) representing the class or interface declaration(s) to include.
+ * @return A list containing declarations with the class or interface declaration of the specified Kotlin class(es).
+ */
+fun <T : KoDeclarationCastProvider> List<T>.withClassOrInterfaceDeclarationOf(kClasses: Collection<KClass<*>>): List<T> =
+    filter {
+        when {
+            kClasses.isEmpty() -> it.hasClassOrInterfaceDeclaration()
+            else -> kClasses.any { kClass -> it.hasClassOrInterfaceDeclarationOf(kClass) }
+        }
+    }
+
+/**
+ * List containing declarations without class or interface declaration of.
+ *
+ * @param kClass The Kotlin class representing the class or interface declaration to exclude.
+ * @param kClasses The Kotlin class(es) representing the class or interface declaration(s) to exclude.
+ * @return A list containing declarations without class or interface declaration of the specified Kotlin class(es).
+ */
+fun <T : KoDeclarationCastProvider> List<T>.withoutClassOrInterfaceDeclarationOf(
+    kClass: KClass<*>,
+    vararg kClasses: KClass<*>,
+): List<T> = withoutClassOrInterfaceDeclarationOf(listOf(kClass, *kClasses))
+
+/**
+ * List containing declarations without class or interface declaration of.
+ *
+ * @param kClasses The Kotlin class(es) representing the class or interface declaration(s) to exclude.
+ * @return A list containing declarations without class or interface declaration of the specified Kotlin class(es).
+ */
+fun <T : KoDeclarationCastProvider> List<T>.withoutClassOrInterfaceDeclarationOf(kClasses: Collection<KClass<*>>): List<T> =
+    filterNot {
+        when {
+            kClasses.isEmpty() -> it.hasClassOrInterfaceDeclaration()
+            else -> kClasses.any { kClass -> it.hasClassOrInterfaceDeclarationOf(kClass) }
+        }
+    }
+
+/**
+ * List containing declarations with the specified interface or object declaration.
+ *
+ * @param predicate The predicate function to determine if a interface or object declaration satisfies a condition.
+ * @return A list containing declarations with the specified interface or object declaration.
+ */
+fun <T : KoDeclarationCastProvider> List<T>.withInterfaceOrObjectDeclaration(predicate: ((KoInterfaceAndObjectDeclaration) -> Boolean)? = null): List<T> =
+    filter {
+        when (predicate) {
+            null -> it.isInterfaceOrObject
+            else -> it.asInterfaceOrObjectDeclaration()?.let { declaration -> predicate(declaration) } == true
+        }
+    }
+
+/**
+ * List containing declarations without the specified interface or object declaration.
+ *
+ * @param predicate The predicate function to determine if a interface or object declaration satisfies a condition.
+ * @return A list containing declarations without the specified interface or object declaration.
+ */
+fun <T : KoDeclarationCastProvider> List<T>.withoutInterfaceOrObjectDeclaration(predicate: ((KoInterfaceAndObjectDeclaration) -> Boolean)? = null): List<T> =
+    filterNot {
+        when (predicate) {
+            null -> it.isInterfaceOrObject
+            else -> it.asInterfaceOrObjectDeclaration()?.let { declaration -> predicate(declaration) } == true
+        }
+    }
+
+/**
+ * List containing declarations with interface or object declaration of.
+ *
+ * @param kClass The Kotlin class representing the interface or object declaration to include.
+ * @param kClasses The Kotlin class(es) representing the interface or object declaration(s) to include.
+ * @return A list containing declarations with the interface or object declaration of the specified Kotlin class(es).
+ */
+
+fun <T : KoDeclarationCastProvider> List<T>.withInterfaceOrObjectDeclarationOf(
+    kClass: KClass<*>,
+    vararg kClasses: KClass<*>,
+): List<T> = withInterfaceOrObjectDeclarationOf(listOf(kClass, *kClasses))
+
+/**
+ * List containing declarations with interface or object declaration of.
+ *
+ * @param kClasses The Kotlin class(es) representing the interface or object declaration(s) to include.
+ * @return A list containing declarations with the interface or object declaration of the specified Kotlin class(es).
+ */
+fun <T : KoDeclarationCastProvider> List<T>.withInterfaceOrObjectDeclarationOf(kClasses: Collection<KClass<*>>): List<T> =
+    filter {
+        when {
+            kClasses.isEmpty() -> it.hasInterfaceOrObjectDeclaration()
+            else -> kClasses.any { kClass -> it.hasInterfaceOrObjectDeclarationOf(kClass) }
+        }
+    }
+
+/**
+ * List containing declarations without interface or object declaration of.
+ *
+ * @param kClass The Kotlin class representing the interface or object declaration to exclude.
+ * @param kClasses The Kotlin class(es) representing the interface or object declaration(s) to exclude.
+ * @return A list containing declarations without interface or object declaration of the specified Kotlin class(es).
+ */
+fun <T : KoDeclarationCastProvider> List<T>.withoutInterfaceOrObjectDeclarationOf(
+    kClass: KClass<*>,
+    vararg kClasses: KClass<*>,
+): List<T> = withoutInterfaceOrObjectDeclarationOf(listOf(kClass, *kClasses))
+
+/**
+ * List containing declarations without interface or object declaration of.
+ *
+ * @param kClasses The Kotlin class(es) representing the interface or object declaration(s) to exclude.
+ * @return A list containing declarations without interface or object declaration of the specified Kotlin class(es).
+ */
+fun <T : KoDeclarationCastProvider> List<T>.withoutInterfaceOrObjectDeclarationOf(kClasses: Collection<KClass<*>>): List<T> =
+    filterNot {
+        when {
+            kClasses.isEmpty() -> it.hasInterfaceOrObjectDeclaration()
+            else -> kClasses.any { kClass -> it.hasInterfaceOrObjectDeclarationOf(kClass) }
+        }
+    }
+
+/**
+ * List containing declarations with the specified class, interface or object declaration.
+ *
+ * @param predicate The predicate function to determine if an class, interface or object declaration satisfies a condition.
+ * @return A list containing declarations with the specified class, interface or object declaration.
+ */
+fun <T : KoDeclarationCastProvider> List<T>.withClassOrInterfaceOrObjectDeclaration(predicate: ((KoClassAndInterfaceAndObjectDeclaration) -> Boolean)? = null): List<T> =
+    filter {
+        when (predicate) {
+            null -> it.isClassOrInterfaceOrObject
+            else -> it.asClassOrInterfaceOrObjectDeclaration()?.let { declaration -> predicate(declaration) } == true
+        }
+    }
+
+/**
+ * List containing declarations without the specified class, interface or object declaration.
+ *
+ * @param predicate The predicate function to determine if a class, interface or object declaration satisfies a condition.
+ * @return A list containing declarations without the specified class, interface or object declaration.
+ */
+fun <T : KoDeclarationCastProvider> List<T>.withoutClassOrInterfaceOrObjectDeclaration(predicate: ((KoClassAndInterfaceAndObjectDeclaration) -> Boolean)? = null): List<T> =
+    filterNot {
+        when (predicate) {
+            null -> it.isClassOrInterfaceOrObject
+            else -> it.asClassOrInterfaceOrObjectDeclaration()?.let { declaration -> predicate(declaration) } == true
+        }
+    }
+
+/**
+ * List containing declarations with class, interface or object declaration of.
+ *
+ * @param kClass The Kotlin class representing the class, interface or object declaration to include.
+ * @param kClasses The Kotlin class(es) representing the class, interface or object declaration(s) to include.
+ * @return A list containing declarations with the class, interface or object declaration of the specified Kotlin class(es).
+ */
+
+fun <T : KoDeclarationCastProvider> List<T>.withClassOrInterfaceOrObjectDeclarationOf(
+    kClass: KClass<*>,
+    vararg kClasses: KClass<*>,
+): List<T> = withClassOrInterfaceOrObjectDeclarationOf(listOf(kClass, *kClasses))
+
+/**
+ * List containing declarations with class, interface or object declaration of.
+ *
+ * @param kClasses The Kotlin class(es) representing the class, interface or object declaration(s) to include.
+ * @return A list containing declarations with the class, interface or object declaration of the specified Kotlin class(es).
+ */
+fun <T : KoDeclarationCastProvider> List<T>.withClassOrInterfaceOrObjectDeclarationOf(kClasses: Collection<KClass<*>>): List<T> =
+    filter {
+        when {
+            kClasses.isEmpty() -> it.hasClassOrInterfaceOrObjectDeclaration()
+            else -> kClasses.any { kClass -> it.hasClassOrInterfaceOrObjectDeclarationOf(kClass) }
+        }
+    }
+
+/**
+ * List containing declarations without class, interface or object declaration of.
+ *
+ * @param kClass The Kotlin class representing the class, interface or object declaration to exclude.
+ * @param kClasses The Kotlin class(es) representing the class, interface or object declaration(s) to exclude.
+ * @return A list containing declarations without class, interface or object declaration of the specified Kotlin class(es).
+ */
+fun <T : KoDeclarationCastProvider> List<T>.withoutClassOrInterfaceOrObjectDeclarationOf(
+    kClass: KClass<*>,
+    vararg kClasses: KClass<*>,
+): List<T> = withoutClassOrInterfaceOrObjectDeclarationOf(listOf(kClass, *kClasses))
+
+/**
+ * List containing declarations without class, interface or object declaration of.
+ *
+ * @param kClasses The Kotlin class(es) representing the class, interface or object declaration(s) to exclude.
+ * @return A list containing declarations without class, interface or object declaration of the specified Kotlin class(es).
+ */
+fun <T : KoDeclarationCastProvider> List<T>.withoutClassOrInterfaceOrObjectDeclarationOf(kClasses: Collection<KClass<*>>): List<T> =
+    filterNot {
+        when {
+            kClasses.isEmpty() -> it.hasClassOrInterfaceOrObjectDeclaration()
+            else -> kClasses.any { kClass -> it.hasClassOrInterfaceOrObjectDeclarationOf(kClass) }
+        }
+    }
+
+/**
  * List containing declarations with the specified type alias declaration.
  *
  * @param predicate The predicate function to determine if a type alias declaration satisfies a condition.
@@ -457,8 +840,7 @@ fun <T : KoDeclarationCastProvider> List<T>.withTypeAliasDeclaration(predicate: 
         when (predicate) {
             null -> it.isTypeAlias
             else ->
-                it.asTypeAliasDeclaration()?.let { typeAliasDeclaration -> predicate(typeAliasDeclaration) }
-                    ?: false
+                it.asTypeAliasDeclaration()?.let { typeAliasDeclaration -> predicate(typeAliasDeclaration) } == true
         }
     }
 
@@ -473,8 +855,7 @@ fun <T : KoDeclarationCastProvider> List<T>.withoutTypeAliasDeclaration(predicat
         when (predicate) {
             null -> it.isTypeAlias
             else ->
-                it.asTypeAliasDeclaration()?.let { typeAliasDeclaration -> predicate(typeAliasDeclaration) }
-                    ?: false
+                it.asTypeAliasDeclaration()?.let { typeAliasDeclaration -> predicate(typeAliasDeclaration) } == true
         }
     }
 
@@ -491,8 +872,7 @@ fun <T : KoDeclarationCastProvider> List<T>.withImportAliasDeclaration(
         when (predicate) {
             null -> it.isImportAlias
             else ->
-                it.asImportAliasDeclaration()?.let { importAliasDeclaration -> predicate(importAliasDeclaration) }
-                    ?: false
+                it.asImportAliasDeclaration()?.let { importAliasDeclaration -> predicate(importAliasDeclaration) } == true
         }
     }
 
@@ -509,8 +889,7 @@ fun <T : KoDeclarationCastProvider> List<T>.withoutImportAliasDeclaration(
         when (predicate) {
             null -> it.isImportAlias
             else ->
-                it.asImportAliasDeclaration()?.let { importAliasDeclaration -> predicate(importAliasDeclaration) }
-                    ?: false
+                it.asImportAliasDeclaration()?.let { importAliasDeclaration -> predicate(importAliasDeclaration) } == true
         }
     }
 
@@ -525,8 +904,7 @@ fun <T : KoDeclarationCastProvider> List<T>.withKotlinTypeDeclaration(predicate:
         when (predicate) {
             null -> it.isKotlinType
             else ->
-                it.asKotlinTypeDeclaration()?.let { kotlinTypeDeclaration -> predicate(kotlinTypeDeclaration) }
-                    ?: false
+                it.asKotlinTypeDeclaration()?.let { kotlinTypeDeclaration -> predicate(kotlinTypeDeclaration) } == true
         }
     }
 
@@ -543,8 +921,7 @@ fun <T : KoDeclarationCastProvider> List<T>.withoutKotlinTypeDeclaration(
         when (predicate) {
             null -> it.isKotlinType
             else ->
-                it.asKotlinTypeDeclaration()?.let { kotlinTypeDeclaration -> predicate(kotlinTypeDeclaration) }
-                    ?: false
+                it.asKotlinTypeDeclaration()?.let { kotlinTypeDeclaration -> predicate(kotlinTypeDeclaration) } == true
         }
     }
 
@@ -613,8 +990,7 @@ fun <T : KoDeclarationCastProvider> List<T>.withKotlinBasicTypeDeclaration(
         when (predicate) {
             null -> it.isKotlinBasicType
             else ->
-                it.asKotlinBasicTypeDeclaration()?.let { kotlinTypeDeclaration -> predicate(kotlinTypeDeclaration) }
-                    ?: false
+                it.asKotlinBasicTypeDeclaration()?.let { kotlinTypeDeclaration -> predicate(kotlinTypeDeclaration) } == true
         }
     }
 
@@ -631,8 +1007,7 @@ fun <T : KoDeclarationCastProvider> List<T>.withoutKotlinBasicTypeDeclaration(
         when (predicate) {
             null -> it.isKotlinBasicType
             else ->
-                it.asKotlinBasicTypeDeclaration()?.let { kotlinTypeDeclaration -> predicate(kotlinTypeDeclaration) }
-                    ?: false
+                it.asKotlinBasicTypeDeclaration()?.let { kotlinTypeDeclaration -> predicate(kotlinTypeDeclaration) } == true
         }
     }
 
@@ -701,8 +1076,7 @@ fun <T : KoDeclarationCastProvider> List<T>.withKotlinCollectionTypeDeclaration(
         when (predicate) {
             null -> it.isKotlinCollectionType
             else ->
-                it.asKotlinCollectionTypeDeclaration()?.let { kotlinTypeDeclaration -> predicate(kotlinTypeDeclaration) }
-                    ?: false
+                it.asKotlinCollectionTypeDeclaration()?.let { kotlinTypeDeclaration -> predicate(kotlinTypeDeclaration) } == true
         }
     }
 
@@ -719,8 +1093,7 @@ fun <T : KoDeclarationCastProvider> List<T>.withoutKotlinCollectionTypeDeclarati
         when (predicate) {
             null -> it.isKotlinCollectionType
             else ->
-                it.asKotlinCollectionTypeDeclaration()?.let { kotlinTypeDeclaration -> predicate(kotlinTypeDeclaration) }
-                    ?: false
+                it.asKotlinCollectionTypeDeclaration()?.let { kotlinTypeDeclaration -> predicate(kotlinTypeDeclaration) } == true
         }
     }
 
@@ -791,7 +1164,7 @@ fun <T : KoDeclarationCastProvider> List<T>.withTypeParameterDeclaration(
             else ->
                 it
                     .asTypeParameterDeclaration()
-                    ?.let { typeParameter -> predicate(typeParameter) } ?: false
+                    ?.let { typeParameter -> predicate(typeParameter) } == true
         }
     }
 
@@ -810,7 +1183,7 @@ fun <T : KoDeclarationCastProvider> List<T>.withoutTypeParameterDeclaration(
             else ->
                 it
                     .asTypeParameterDeclaration()
-                    ?.let { typeParameter -> predicate(typeParameter) } ?: false
+                    ?.let { typeParameter -> predicate(typeParameter) } == true
         }
     }
 
@@ -827,7 +1200,7 @@ fun <T : KoDeclarationCastProvider> List<T>.withExternalDeclaration(predicate: (
             else ->
                 it
                     .asExternalDeclaration()
-                    ?.let { externalDeclaration -> predicate(externalDeclaration) } ?: false
+                    ?.let { externalDeclaration -> predicate(externalDeclaration) } == true
         }
     }
 
@@ -844,7 +1217,7 @@ fun <T : KoDeclarationCastProvider> List<T>.withoutExternalDeclaration(predicate
             else ->
                 it
                     .asExternalDeclaration()
-                    ?.let { externalDeclaration -> predicate(externalDeclaration) } ?: false
+                    ?.let { externalDeclaration -> predicate(externalDeclaration) } == true
         }
     }
 
@@ -914,7 +1287,7 @@ fun <T : KoDeclarationCastProvider> List<T>.withExternalTypeDeclaration(predicat
             else ->
                 it
                     .asExternalTypeDeclaration()
-                    ?.let { externalDeclaration -> predicate(externalDeclaration) } ?: false
+                    ?.let { externalDeclaration -> predicate(externalDeclaration) } == true
         }
     }
 
@@ -934,7 +1307,7 @@ fun <T : KoDeclarationCastProvider> List<T>.withoutExternalTypeDeclaration(
             else ->
                 it
                     .asExternalTypeDeclaration()
-                    ?.let { externalDeclaration -> predicate(externalDeclaration) } ?: false
+                    ?.let { externalDeclaration -> predicate(externalDeclaration) } == true
         }
     }
 

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/api/ext/list/KoDeclarationCastProviderListExt.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/api/ext/list/KoDeclarationCastProviderListExt.kt
@@ -511,7 +511,9 @@ fun <T : KoDeclarationCastProvider> List<T>.withoutInterfaceDeclarationOf(kClass
  * @param predicate The predicate function to determine if a class or object declaration satisfies a condition.
  * @return A list containing declarations with the specified class or object declaration.
  */
-fun <T : KoDeclarationCastProvider> List<T>.withClassOrObjectDeclaration(predicate: ((KoClassAndObjectDeclaration) -> Boolean)? = null): List<T> =
+fun <T : KoDeclarationCastProvider> List<T>.withClassOrObjectDeclaration(
+    predicate: ((KoClassAndObjectDeclaration) -> Boolean)? = null,
+): List<T> =
     filter {
         when (predicate) {
             null -> it.isClassOrObject
@@ -525,7 +527,9 @@ fun <T : KoDeclarationCastProvider> List<T>.withClassOrObjectDeclaration(predica
  * @param predicate The predicate function to determine if a class or object declaration satisfies a condition.
  * @return A list containing declarations without the specified class or object declaration.
  */
-fun <T : KoDeclarationCastProvider> List<T>.withoutClassOrObjectDeclaration(predicate: ((KoClassAndObjectDeclaration) -> Boolean)? = null): List<T> =
+fun <T : KoDeclarationCastProvider> List<T>.withoutClassOrObjectDeclaration(
+    predicate: ((KoClassAndObjectDeclaration) -> Boolean)? = null,
+): List<T> =
     filterNot {
         when (predicate) {
             null -> it.isClassOrObject
@@ -592,7 +596,9 @@ fun <T : KoDeclarationCastProvider> List<T>.withoutClassOrObjectDeclarationOf(kC
  * @param predicate The predicate function to determine if a class or interface declaration satisfies a condition.
  * @return A list containing declarations with the specified class or interface declaration.
  */
-fun <T : KoDeclarationCastProvider> List<T>.withClassOrInterfaceDeclaration(predicate: ((KoClassAndInterfaceDeclaration) -> Boolean)? = null): List<T> =
+fun <T : KoDeclarationCastProvider> List<T>.withClassOrInterfaceDeclaration(
+    predicate: ((KoClassAndInterfaceDeclaration) -> Boolean)? = null,
+): List<T> =
     filter {
         when (predicate) {
             null -> it.isClassOrInterface
@@ -606,7 +612,9 @@ fun <T : KoDeclarationCastProvider> List<T>.withClassOrInterfaceDeclaration(pred
  * @param predicate The predicate function to determine if a class or interface declaration satisfies a condition.
  * @return A list containing declarations without the specified class or interface declaration.
  */
-fun <T : KoDeclarationCastProvider> List<T>.withoutClassOrInterfaceDeclaration(predicate: ((KoClassAndInterfaceDeclaration) -> Boolean)? = null): List<T> =
+fun <T : KoDeclarationCastProvider> List<T>.withoutClassOrInterfaceDeclaration(
+    predicate: ((KoClassAndInterfaceDeclaration) -> Boolean)? = null,
+): List<T> =
     filterNot {
         when (predicate) {
             null -> it.isClassOrInterface
@@ -673,7 +681,9 @@ fun <T : KoDeclarationCastProvider> List<T>.withoutClassOrInterfaceDeclarationOf
  * @param predicate The predicate function to determine if a interface or object declaration satisfies a condition.
  * @return A list containing declarations with the specified interface or object declaration.
  */
-fun <T : KoDeclarationCastProvider> List<T>.withInterfaceOrObjectDeclaration(predicate: ((KoInterfaceAndObjectDeclaration) -> Boolean)? = null): List<T> =
+fun <T : KoDeclarationCastProvider> List<T>.withInterfaceOrObjectDeclaration(
+    predicate: ((KoInterfaceAndObjectDeclaration) -> Boolean)? = null,
+): List<T> =
     filter {
         when (predicate) {
             null -> it.isInterfaceOrObject
@@ -687,7 +697,9 @@ fun <T : KoDeclarationCastProvider> List<T>.withInterfaceOrObjectDeclaration(pre
  * @param predicate The predicate function to determine if a interface or object declaration satisfies a condition.
  * @return A list containing declarations without the specified interface or object declaration.
  */
-fun <T : KoDeclarationCastProvider> List<T>.withoutInterfaceOrObjectDeclaration(predicate: ((KoInterfaceAndObjectDeclaration) -> Boolean)? = null): List<T> =
+fun <T : KoDeclarationCastProvider> List<T>.withoutInterfaceOrObjectDeclaration(
+    predicate: ((KoInterfaceAndObjectDeclaration) -> Boolean)? = null,
+): List<T> =
     filterNot {
         when (predicate) {
             null -> it.isInterfaceOrObject
@@ -754,7 +766,9 @@ fun <T : KoDeclarationCastProvider> List<T>.withoutInterfaceOrObjectDeclarationO
  * @param predicate The predicate function to determine if an class, interface or object declaration satisfies a condition.
  * @return A list containing declarations with the specified class, interface or object declaration.
  */
-fun <T : KoDeclarationCastProvider> List<T>.withClassOrInterfaceOrObjectDeclaration(predicate: ((KoClassAndInterfaceAndObjectDeclaration) -> Boolean)? = null): List<T> =
+fun <T : KoDeclarationCastProvider> List<T>.withClassOrInterfaceOrObjectDeclaration(
+    predicate: ((KoClassAndInterfaceAndObjectDeclaration) -> Boolean)? = null,
+): List<T> =
     filter {
         when (predicate) {
             null -> it.isClassOrInterfaceOrObject
@@ -768,7 +782,9 @@ fun <T : KoDeclarationCastProvider> List<T>.withClassOrInterfaceOrObjectDeclarat
  * @param predicate The predicate function to determine if a class, interface or object declaration satisfies a condition.
  * @return A list containing declarations without the specified class, interface or object declaration.
  */
-fun <T : KoDeclarationCastProvider> List<T>.withoutClassOrInterfaceOrObjectDeclaration(predicate: ((KoClassAndInterfaceAndObjectDeclaration) -> Boolean)? = null): List<T> =
+fun <T : KoDeclarationCastProvider> List<T>.withoutClassOrInterfaceOrObjectDeclaration(
+    predicate: ((KoClassAndInterfaceAndObjectDeclaration) -> Boolean)? = null,
+): List<T> =
     filterNot {
         when (predicate) {
             null -> it.isClassOrInterfaceOrObject
@@ -872,7 +888,9 @@ fun <T : KoDeclarationCastProvider> List<T>.withImportAliasDeclaration(
         when (predicate) {
             null -> it.isImportAlias
             else ->
-                it.asImportAliasDeclaration()?.let { importAliasDeclaration -> predicate(importAliasDeclaration) } == true
+                it
+                    .asImportAliasDeclaration()
+                    ?.let { importAliasDeclaration -> predicate(importAliasDeclaration) } == true
         }
     }
 
@@ -889,7 +907,9 @@ fun <T : KoDeclarationCastProvider> List<T>.withoutImportAliasDeclaration(
         when (predicate) {
             null -> it.isImportAlias
             else ->
-                it.asImportAliasDeclaration()?.let { importAliasDeclaration -> predicate(importAliasDeclaration) } == true
+                it
+                    .asImportAliasDeclaration()
+                    ?.let { importAliasDeclaration -> predicate(importAliasDeclaration) } == true
         }
     }
 
@@ -990,7 +1010,9 @@ fun <T : KoDeclarationCastProvider> List<T>.withKotlinBasicTypeDeclaration(
         when (predicate) {
             null -> it.isKotlinBasicType
             else ->
-                it.asKotlinBasicTypeDeclaration()?.let { kotlinTypeDeclaration -> predicate(kotlinTypeDeclaration) } == true
+                it
+                    .asKotlinBasicTypeDeclaration()
+                    ?.let { kotlinTypeDeclaration -> predicate(kotlinTypeDeclaration) } == true
         }
     }
 
@@ -1007,7 +1029,9 @@ fun <T : KoDeclarationCastProvider> List<T>.withoutKotlinBasicTypeDeclaration(
         when (predicate) {
             null -> it.isKotlinBasicType
             else ->
-                it.asKotlinBasicTypeDeclaration()?.let { kotlinTypeDeclaration -> predicate(kotlinTypeDeclaration) } == true
+                it
+                    .asKotlinBasicTypeDeclaration()
+                    ?.let { kotlinTypeDeclaration -> predicate(kotlinTypeDeclaration) } == true
         }
     }
 
@@ -1076,7 +1100,9 @@ fun <T : KoDeclarationCastProvider> List<T>.withKotlinCollectionTypeDeclaration(
         when (predicate) {
             null -> it.isKotlinCollectionType
             else ->
-                it.asKotlinCollectionTypeDeclaration()?.let { kotlinTypeDeclaration -> predicate(kotlinTypeDeclaration) } == true
+                it
+                    .asKotlinCollectionTypeDeclaration()
+                    ?.let { kotlinTypeDeclaration -> predicate(kotlinTypeDeclaration) } == true
         }
     }
 
@@ -1093,7 +1119,9 @@ fun <T : KoDeclarationCastProvider> List<T>.withoutKotlinCollectionTypeDeclarati
         when (predicate) {
             null -> it.isKotlinCollectionType
             else ->
-                it.asKotlinCollectionTypeDeclaration()?.let { kotlinTypeDeclaration -> predicate(kotlinTypeDeclaration) } == true
+                it
+                    .asKotlinCollectionTypeDeclaration()
+                    ?.let { kotlinTypeDeclaration -> predicate(kotlinTypeDeclaration) } == true
         }
     }
 

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/api/provider/KoDeclarationCastProvider.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/api/provider/KoDeclarationCastProvider.kt
@@ -7,6 +7,10 @@ import com.lemonappdev.konsist.api.declaration.KoInterfaceDeclaration
 import com.lemonappdev.konsist.api.declaration.KoObjectDeclaration
 import com.lemonappdev.konsist.api.declaration.KoTypeAliasDeclaration
 import com.lemonappdev.konsist.api.declaration.KoTypeParameterDeclaration
+import com.lemonappdev.konsist.api.declaration.combined.KoClassAndInterfaceAndObjectDeclaration
+import com.lemonappdev.konsist.api.declaration.combined.KoClassAndInterfaceDeclaration
+import com.lemonappdev.konsist.api.declaration.combined.KoClassAndObjectDeclaration
+import com.lemonappdev.konsist.api.declaration.combined.KoInterfaceAndObjectDeclaration
 import com.lemonappdev.konsist.api.declaration.type.KoKotlinTypeDeclaration
 import kotlin.reflect.KClass
 
@@ -26,9 +30,29 @@ interface KoDeclarationCastProvider : KoBaseProvider {
     val isObject: Boolean
 
     /**
-     * Determines whatever declaration is a interface.
+     * Determines whatever declaration is an interface.
      */
     val isInterface: Boolean
+
+    /**
+     * Determines whatever declaration is a class or an object.
+     */
+    val isClassOrObject: Boolean
+
+    /**
+     * Determines whatever declaration is a class or an interface.
+     */
+    val isClassOrInterface: Boolean
+
+    /**
+     * Determines whatever declaration is an interface or an object.
+     */
+    val isInterfaceOrObject: Boolean
+
+    /**
+     * Determines whatever declaration is a class, an interface or an object.
+     */
+    val isClassOrInterfaceOrObject: Boolean
 
     /**
      * Determines whatever declaration is a type alias.
@@ -97,6 +121,34 @@ interface KoDeclarationCastProvider : KoBaseProvider {
      * @return the interface declaration associated with this declaration.
      */
     fun asInterfaceDeclaration(): KoInterfaceDeclaration?
+
+    /**
+     * Represents the class or object declaration associated with this declaration.
+     *
+     * @return the class or object declaration associated with this declaration.
+     */
+    fun asClassOrObjectDeclaration(): KoClassAndObjectDeclaration?
+
+    /**
+     * Represents the class or interface declaration associated with this declaration.
+     *
+     * @return the class or interface declaration associated with this declaration.
+     */
+    fun asClassOrInterfaceDeclaration(): KoClassAndInterfaceDeclaration?
+
+    /**
+     * Represents the interface or object declaration associated with this declaration.
+     *
+     * @return the interface or object declaration associated with this declaration.
+     */
+    fun asInterfaceOrObjectDeclaration(): KoInterfaceAndObjectDeclaration?
+
+    /**
+     * Represents the class, interface or object declaration associated with this declaration.
+     *
+     * @return the class, interface or object declaration associated with this declaration.
+     */
+    fun asClassOrInterfaceOrObjectDeclaration(): KoClassAndInterfaceAndObjectDeclaration?
 
     /**
      * Represents the declaration alias declaration associated with this declaration.
@@ -194,19 +246,87 @@ interface KoDeclarationCastProvider : KoBaseProvider {
     /**
      * Whether declaration has a specified interface declaration.
      *
-     * @param predicate The predicate function used to determine if a interface declaration satisfies a condition.
+     * @param predicate The predicate function used to determine if an interface declaration satisfies a condition.
      * @return `true` if the declaration has the specified interface declaration (or any interface declaration if [predicate] is `null`),
      * `false` otherwise.
      */
     fun hasInterfaceDeclaration(predicate: ((KoInterfaceDeclaration) -> Boolean)? = null): Boolean
 
     /**
-     * Whether declaration has a interface declaration of the specified Kotlin class.
+     * Whether declaration has an interface declaration of the specified Kotlin class.
      *
      * @param kClass The Kotlin class representing the interface declaration to check for.
-     * @return `true` if the declaration has a interface declaration matching the specified KClass, `false` otherwise.
+     * @return `true` if the declaration has an interface declaration matching the specified KClass, `false` otherwise.
      */
     fun hasInterfaceDeclarationOf(kClass: KClass<*>): Boolean
+
+    /**
+     * Whether declaration has a specified class or object declaration.
+     *
+     * @param predicate The predicate function used to determine if class or object declaration satisfies a condition.
+     * @return `true` if the declaration has the specified class or object declaration (or any class or object declaration if [predicate] is `null`),
+     * `false` otherwise.
+     */
+    fun hasClassOrObjectDeclaration(predicate: ((KoClassAndObjectDeclaration) -> Boolean)? = null): Boolean
+
+    /**
+     * Whether declaration has a class or an object declaration of the specified Kotlin class.
+     *
+     * @param kClass The Kotlin class representing the class or object declaration to check for.
+     * @return `true` if the declaration has a class or an object declaration matching the specified KClass, `false` otherwise.
+     */
+    fun hasClassOrObjectDeclarationOf(kClass: KClass<*>): Boolean
+
+    /**
+     * Whether declaration has a specified class or interface declaration.
+     *
+     * @param predicate The predicate function used to determine if class or interface declaration satisfies a condition.
+     * @return `true` if the declaration has the specified class or interface declaration (or any class or interface declaration if [predicate] is `null`),
+     * `false` otherwise.
+     */
+    fun hasClassOrInterfaceDeclaration(predicate: ((KoClassAndInterfaceDeclaration) -> Boolean)? = null): Boolean
+
+    /**
+     * Whether declaration has a class or an interface declaration of the specified Kotlin class.
+     *
+     * @param kClass The Kotlin class representing the class or interface declaration to check for.
+     * @return `true` if the declaration has a class or an interface declaration matching the specified KClass, `false` otherwise.
+     */
+    fun hasClassOrInterfaceDeclarationOf(kClass: KClass<*>): Boolean
+
+    /**
+     * Whether declaration has a specified interface or object declaration.
+     *
+     * @param predicate The predicate function used to determine if interface or object declaration satisfies a condition.
+     * @return `true` if the declaration has the specified interface or object declaration (or any interface or object declaration if [predicate] is `null`),
+     * `false` otherwise.
+     */
+    fun hasInterfaceOrObjectDeclaration(predicate: ((KoInterfaceAndObjectDeclaration) -> Boolean)? = null): Boolean
+
+    /**
+     * Whether declaration has an interface or an object declaration of the specified Kotlin class.
+     *
+     * @param kClass The Kotlin class representing the interface or object declaration to check for.
+     * @return `true` if the declaration has an interface or an object declaration matching the specified KClass, `false` otherwise.
+     */
+    fun hasInterfaceOrObjectDeclarationOf(kClass: KClass<*>): Boolean
+
+    /**
+     * Whether declaration has a specified class, interface or object declaration.
+     *
+     * @param predicate The predicate function used to determine if class, interface or object declaration satisfies a condition.
+     * @return `true` if the declaration has the specified class, interface or object declaration (or any class, interface or object declaration if [predicate] is `null`),
+     * `false` otherwise.
+     */
+    fun hasClassOrInterfaceOrObjectDeclaration(predicate: ((KoClassAndInterfaceAndObjectDeclaration) -> Boolean)? = null): Boolean
+
+    /**
+     * Whether declaration has a class, an interface or an object declaration of the specified Kotlin class.
+     *
+     * @param kClass The Kotlin class representing the class, interface or object declaration to check for.
+     * @return `true` if the declaration has a class, an interface  or an object declaration matching the specified KClass, `false` otherwise.
+     */
+    fun hasClassOrInterfaceOrObjectDeclarationOf(kClass: KClass<*>): Boolean
 
     /**
      * Whether declaration has a specified type alias declaration.

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/api/provider/KoDeclarationCastProvider.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/api/provider/KoDeclarationCastProvider.kt
@@ -264,7 +264,8 @@ interface KoDeclarationCastProvider : KoBaseProvider {
      * Whether declaration has a specified class or object declaration.
      *
      * @param predicate The predicate function used to determine if class or object declaration satisfies a condition.
-     * @return `true` if the declaration has the specified class or object declaration (or any class or object declaration if [predicate] is `null`),
+     * @return `true` if the declaration has the specified class or object declaration (or any class or object
+     * declaration if [predicate] is `null`),
      * `false` otherwise.
      */
     fun hasClassOrObjectDeclaration(predicate: ((KoClassAndObjectDeclaration) -> Boolean)? = null): Boolean
@@ -281,7 +282,8 @@ interface KoDeclarationCastProvider : KoBaseProvider {
      * Whether declaration has a specified class or interface declaration.
      *
      * @param predicate The predicate function used to determine if class or interface declaration satisfies a condition.
-     * @return `true` if the declaration has the specified class or interface declaration (or any class or interface declaration if [predicate] is `null`),
+     * @return `true` if the declaration has the specified class or interface declaration (or any class or interface
+     * declaration if [predicate] is `null`),
      * `false` otherwise.
      */
     fun hasClassOrInterfaceDeclaration(predicate: ((KoClassAndInterfaceDeclaration) -> Boolean)? = null): Boolean
@@ -298,7 +300,8 @@ interface KoDeclarationCastProvider : KoBaseProvider {
      * Whether declaration has a specified interface or object declaration.
      *
      * @param predicate The predicate function used to determine if interface or object declaration satisfies a condition.
-     * @return `true` if the declaration has the specified interface or object declaration (or any interface or object declaration if [predicate] is `null`),
+     * @return `true` if the declaration has the specified interface or object declaration (or any interface or object
+     * declaration if [predicate] is `null`),
      * `false` otherwise.
      */
     fun hasInterfaceOrObjectDeclaration(predicate: ((KoInterfaceAndObjectDeclaration) -> Boolean)? = null): Boolean
@@ -315,7 +318,8 @@ interface KoDeclarationCastProvider : KoBaseProvider {
      * Whether declaration has a specified class, interface or object declaration.
      *
      * @param predicate The predicate function used to determine if class, interface or object declaration satisfies a condition.
-     * @return `true` if the declaration has the specified class, interface or object declaration (or any class, interface or object declaration if [predicate] is `null`),
+     * @return `true` if the declaration has the specified class, interface or object declaration (or any class,
+     * interface or object declaration if [predicate] is `null`),
      * `false` otherwise.
      */
     fun hasClassOrInterfaceOrObjectDeclaration(predicate: ((KoClassAndInterfaceAndObjectDeclaration) -> Boolean)? = null): Boolean
@@ -324,7 +328,8 @@ interface KoDeclarationCastProvider : KoBaseProvider {
      * Whether declaration has a class, an interface or an object declaration of the specified Kotlin class.
      *
      * @param kClass The Kotlin class representing the class, interface or object declaration to check for.
-     * @return `true` if the declaration has a class, an interface  or an object declaration matching the specified KClass, `false` otherwise.
+     * @return `true` if the declaration has a class, an interface  or an object declaration matching the specified
+     * KClass, `false` otherwise.
      */
     fun hasClassOrInterfaceOrObjectDeclarationOf(kClass: KClass<*>): Boolean
 

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/KoDeclarationCastProviderCore.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/KoDeclarationCastProviderCore.kt
@@ -63,7 +63,7 @@ internal interface KoDeclarationCastProviderCore :
     override val isKotlinType: Boolean
         get() =
             koDeclarationCastProviderDeclaration is KoKotlinTypeDeclaration ||
-                    koDeclarationCastProviderDeclaration?.name?.let { TypeUtil.isKotlinType(it) } == true
+                koDeclarationCastProviderDeclaration?.name?.let { TypeUtil.isKotlinType(it) } == true
 
     override val isTypeParameter: Boolean
         get() = koDeclarationCastProviderDeclaration is KoTypeParameterDeclaration
@@ -77,32 +77,24 @@ internal interface KoDeclarationCastProviderCore :
 
     override fun asClassDeclaration(): KoClassDeclaration? = koDeclarationCastProviderDeclaration as? KoClassDeclaration
 
-    override fun asObjectDeclaration(): KoObjectDeclaration? =
-        koDeclarationCastProviderDeclaration as? KoObjectDeclaration
+    override fun asObjectDeclaration(): KoObjectDeclaration? = koDeclarationCastProviderDeclaration as? KoObjectDeclaration
 
-    override fun asInterfaceDeclaration(): KoInterfaceDeclaration? =
-        koDeclarationCastProviderDeclaration as? KoInterfaceDeclaration
+    override fun asInterfaceDeclaration(): KoInterfaceDeclaration? = koDeclarationCastProviderDeclaration as? KoInterfaceDeclaration
 
-    override fun asClassOrObjectDeclaration(): KoClassAndObjectDeclaration? =
-        asClassDeclaration() ?: asObjectDeclaration()
+    override fun asClassOrObjectDeclaration(): KoClassAndObjectDeclaration? = asClassDeclaration() ?: asObjectDeclaration()
 
-    override fun asClassOrInterfaceDeclaration(): KoClassAndInterfaceDeclaration? =
-        asClassDeclaration() ?: asInterfaceDeclaration()
+    override fun asClassOrInterfaceDeclaration(): KoClassAndInterfaceDeclaration? = asClassDeclaration() ?: asInterfaceDeclaration()
 
-    override fun asInterfaceOrObjectDeclaration(): KoInterfaceAndObjectDeclaration? =
-        asInterfaceDeclaration() ?: asObjectDeclaration()
+    override fun asInterfaceOrObjectDeclaration(): KoInterfaceAndObjectDeclaration? = asInterfaceDeclaration() ?: asObjectDeclaration()
 
     override fun asClassOrInterfaceOrObjectDeclaration(): KoClassAndInterfaceAndObjectDeclaration? =
         asClassDeclaration() ?: asInterfaceDeclaration() ?: asObjectDeclaration()
 
-    override fun asTypeAliasDeclaration(): KoTypeAliasDeclaration? =
-        koDeclarationCastProviderDeclaration as? KoTypeAliasDeclaration
+    override fun asTypeAliasDeclaration(): KoTypeAliasDeclaration? = koDeclarationCastProviderDeclaration as? KoTypeAliasDeclaration
 
-    override fun asImportAliasDeclaration(): KoImportAliasDeclaration? =
-        koDeclarationCastProviderDeclaration as? KoImportAliasDeclaration
+    override fun asImportAliasDeclaration(): KoImportAliasDeclaration? = koDeclarationCastProviderDeclaration as? KoImportAliasDeclaration
 
-    override fun asKotlinTypeDeclaration(): KoKotlinTypeDeclaration? =
-        koDeclarationCastProviderDeclaration as? KoKotlinTypeDeclaration
+    override fun asKotlinTypeDeclaration(): KoKotlinTypeDeclaration? = koDeclarationCastProviderDeclaration as? KoKotlinTypeDeclaration
 
     override fun asKotlinBasicTypeDeclaration(): KoKotlinTypeDeclaration? =
         if (koDeclarationCastProviderDeclaration?.isKotlinBasicType == true) asKotlinTypeDeclaration() else null
@@ -113,8 +105,7 @@ internal interface KoDeclarationCastProviderCore :
     override fun asTypeParameterDeclaration(): KoTypeParameterDeclaration? =
         koDeclarationCastProviderDeclaration as? KoTypeParameterDeclaration
 
-    override fun asExternalDeclaration(): KoExternalDeclaration? =
-        koDeclarationCastProviderDeclaration as? KoExternalDeclaration
+    override fun asExternalDeclaration(): KoExternalDeclaration? = koDeclarationCastProviderDeclaration as? KoExternalDeclaration
 
     @Deprecated("Will be removed in version 0.19.0", ReplaceWith("asExternalDeclaration"))
     override fun asExternalTypeDeclaration(): KoExternalDeclaration? = asExternalDeclaration()
@@ -125,8 +116,7 @@ internal interface KoDeclarationCastProviderCore :
             else -> asClassDeclaration()?.let { predicate(it) } ?: false
         }
 
-    override fun hasClassDeclarationOf(kClass: KClass<*>): Boolean =
-        kClass.qualifiedName == asClassDeclaration()?.fullyQualifiedName
+    override fun hasClassDeclarationOf(kClass: KClass<*>): Boolean = kClass.qualifiedName == asClassDeclaration()?.fullyQualifiedName
 
     override fun hasObjectDeclaration(predicate: ((KoObjectDeclaration) -> Boolean)?): Boolean =
         when (predicate) {
@@ -134,8 +124,7 @@ internal interface KoDeclarationCastProviderCore :
             else -> asObjectDeclaration()?.let { predicate(it) } ?: false
         }
 
-    override fun hasObjectDeclarationOf(kClass: KClass<*>): Boolean =
-        kClass.qualifiedName == asObjectDeclaration()?.fullyQualifiedName
+    override fun hasObjectDeclarationOf(kClass: KClass<*>): Boolean = kClass.qualifiedName == asObjectDeclaration()?.fullyQualifiedName
 
     override fun hasInterfaceDeclaration(predicate: ((KoInterfaceDeclaration) -> Boolean)?): Boolean =
         when (predicate) {
@@ -149,8 +138,7 @@ internal interface KoDeclarationCastProviderCore :
     override fun hasClassOrObjectDeclaration(predicate: ((KoClassAndObjectDeclaration) -> Boolean)?): Boolean =
         hasClassDeclaration(predicate) || hasObjectDeclaration(predicate)
 
-    override fun hasClassOrObjectDeclarationOf(kClass: KClass<*>): Boolean =
-        hasClassDeclarationOf(kClass) || hasObjectDeclarationOf(kClass)
+    override fun hasClassOrObjectDeclarationOf(kClass: KClass<*>): Boolean = hasClassDeclarationOf(kClass) || hasObjectDeclarationOf(kClass)
 
     override fun hasClassOrInterfaceDeclaration(predicate: ((KoClassAndInterfaceDeclaration) -> Boolean)?): Boolean =
         hasClassDeclaration(predicate) || hasInterfaceDeclaration(predicate)
@@ -221,12 +209,10 @@ internal interface KoDeclarationCastProviderCore :
             else -> asExternalDeclaration()?.let { predicate(it) } ?: false
         }
 
-    override fun hasExternalDeclarationOf(kClass: KClass<*>): Boolean =
-        kClass.qualifiedName == asExternalDeclaration()?.fullyQualifiedName
+    override fun hasExternalDeclarationOf(kClass: KClass<*>): Boolean = kClass.qualifiedName == asExternalDeclaration()?.fullyQualifiedName
 
     @Deprecated("Will be removed in version 0.19.0", ReplaceWith("hasExternalDeclaration"))
-    override fun hasExternalTypeDeclaration(predicate: ((KoExternalDeclaration) -> Boolean)?): Boolean =
-        hasExternalDeclaration()
+    override fun hasExternalTypeDeclaration(predicate: ((KoExternalDeclaration) -> Boolean)?): Boolean = hasExternalDeclaration()
 
     @Deprecated("Will be removed in version 0.19.0", ReplaceWith("hasExternalDeclarationOf"))
     override fun hasExternalTypeDeclarationOf(kClass: KClass<*>): Boolean = hasExternalDeclarationOf(kClass)

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/KoDeclarationCastProviderCore.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/KoDeclarationCastProviderCore.kt
@@ -8,6 +8,10 @@ import com.lemonappdev.konsist.api.declaration.KoObjectDeclaration
 import com.lemonappdev.konsist.api.declaration.KoSourceDeclaration
 import com.lemonappdev.konsist.api.declaration.KoTypeAliasDeclaration
 import com.lemonappdev.konsist.api.declaration.KoTypeParameterDeclaration
+import com.lemonappdev.konsist.api.declaration.combined.KoClassAndInterfaceAndObjectDeclaration
+import com.lemonappdev.konsist.api.declaration.combined.KoClassAndInterfaceDeclaration
+import com.lemonappdev.konsist.api.declaration.combined.KoClassAndObjectDeclaration
+import com.lemonappdev.konsist.api.declaration.combined.KoInterfaceAndObjectDeclaration
 import com.lemonappdev.konsist.api.declaration.type.KoKotlinTypeDeclaration
 import com.lemonappdev.konsist.api.provider.KoDeclarationCastProvider
 import com.lemonappdev.konsist.core.util.TypeUtil
@@ -38,6 +42,18 @@ internal interface KoDeclarationCastProviderCore :
     override val isInterface: Boolean
         get() = koDeclarationCastProviderDeclaration is KoInterfaceDeclaration
 
+    override val isClassOrObject: Boolean
+        get() = isClass || isObject
+
+    override val isClassOrInterface: Boolean
+        get() = isClass || isInterface
+
+    override val isInterfaceOrObject: Boolean
+        get() = isInterface || isObject
+
+    override val isClassOrInterfaceOrObject: Boolean
+        get() = isClass || isInterface || isObject
+
     override val isTypeAlias: Boolean
         get() = koDeclarationCastProviderDeclaration is KoTypeAliasDeclaration
 
@@ -47,7 +63,7 @@ internal interface KoDeclarationCastProviderCore :
     override val isKotlinType: Boolean
         get() =
             koDeclarationCastProviderDeclaration is KoKotlinTypeDeclaration ||
-                koDeclarationCastProviderDeclaration?.name?.let { TypeUtil.isKotlinType(it) } == true
+                    koDeclarationCastProviderDeclaration?.name?.let { TypeUtil.isKotlinType(it) } == true
 
     override val isTypeParameter: Boolean
         get() = koDeclarationCastProviderDeclaration is KoTypeParameterDeclaration
@@ -61,15 +77,32 @@ internal interface KoDeclarationCastProviderCore :
 
     override fun asClassDeclaration(): KoClassDeclaration? = koDeclarationCastProviderDeclaration as? KoClassDeclaration
 
-    override fun asObjectDeclaration(): KoObjectDeclaration? = koDeclarationCastProviderDeclaration as? KoObjectDeclaration
+    override fun asObjectDeclaration(): KoObjectDeclaration? =
+        koDeclarationCastProviderDeclaration as? KoObjectDeclaration
 
-    override fun asInterfaceDeclaration(): KoInterfaceDeclaration? = koDeclarationCastProviderDeclaration as? KoInterfaceDeclaration
+    override fun asInterfaceDeclaration(): KoInterfaceDeclaration? =
+        koDeclarationCastProviderDeclaration as? KoInterfaceDeclaration
 
-    override fun asTypeAliasDeclaration(): KoTypeAliasDeclaration? = koDeclarationCastProviderDeclaration as? KoTypeAliasDeclaration
+    override fun asClassOrObjectDeclaration(): KoClassAndObjectDeclaration? =
+        asClassDeclaration() ?: asObjectDeclaration()
 
-    override fun asImportAliasDeclaration(): KoImportAliasDeclaration? = koDeclarationCastProviderDeclaration as? KoImportAliasDeclaration
+    override fun asClassOrInterfaceDeclaration(): KoClassAndInterfaceDeclaration? =
+        asClassDeclaration() ?: asInterfaceDeclaration()
 
-    override fun asKotlinTypeDeclaration(): KoKotlinTypeDeclaration? = koDeclarationCastProviderDeclaration as? KoKotlinTypeDeclaration
+    override fun asInterfaceOrObjectDeclaration(): KoInterfaceAndObjectDeclaration? =
+        asInterfaceDeclaration() ?: asObjectDeclaration()
+
+    override fun asClassOrInterfaceOrObjectDeclaration(): KoClassAndInterfaceAndObjectDeclaration? =
+        asClassDeclaration() ?: asInterfaceDeclaration() ?: asObjectDeclaration()
+
+    override fun asTypeAliasDeclaration(): KoTypeAliasDeclaration? =
+        koDeclarationCastProviderDeclaration as? KoTypeAliasDeclaration
+
+    override fun asImportAliasDeclaration(): KoImportAliasDeclaration? =
+        koDeclarationCastProviderDeclaration as? KoImportAliasDeclaration
+
+    override fun asKotlinTypeDeclaration(): KoKotlinTypeDeclaration? =
+        koDeclarationCastProviderDeclaration as? KoKotlinTypeDeclaration
 
     override fun asKotlinBasicTypeDeclaration(): KoKotlinTypeDeclaration? =
         if (koDeclarationCastProviderDeclaration?.isKotlinBasicType == true) asKotlinTypeDeclaration() else null
@@ -80,7 +113,8 @@ internal interface KoDeclarationCastProviderCore :
     override fun asTypeParameterDeclaration(): KoTypeParameterDeclaration? =
         koDeclarationCastProviderDeclaration as? KoTypeParameterDeclaration
 
-    override fun asExternalDeclaration(): KoExternalDeclaration? = koDeclarationCastProviderDeclaration as? KoExternalDeclaration
+    override fun asExternalDeclaration(): KoExternalDeclaration? =
+        koDeclarationCastProviderDeclaration as? KoExternalDeclaration
 
     @Deprecated("Will be removed in version 0.19.0", ReplaceWith("asExternalDeclaration"))
     override fun asExternalTypeDeclaration(): KoExternalDeclaration? = asExternalDeclaration()
@@ -91,7 +125,8 @@ internal interface KoDeclarationCastProviderCore :
             else -> asClassDeclaration()?.let { predicate(it) } ?: false
         }
 
-    override fun hasClassDeclarationOf(kClass: KClass<*>): Boolean = kClass.qualifiedName == asClassDeclaration()?.fullyQualifiedName
+    override fun hasClassDeclarationOf(kClass: KClass<*>): Boolean =
+        kClass.qualifiedName == asClassDeclaration()?.fullyQualifiedName
 
     override fun hasObjectDeclaration(predicate: ((KoObjectDeclaration) -> Boolean)?): Boolean =
         when (predicate) {
@@ -99,7 +134,8 @@ internal interface KoDeclarationCastProviderCore :
             else -> asObjectDeclaration()?.let { predicate(it) } ?: false
         }
 
-    override fun hasObjectDeclarationOf(kClass: KClass<*>): Boolean = kClass.qualifiedName == asObjectDeclaration()?.fullyQualifiedName
+    override fun hasObjectDeclarationOf(kClass: KClass<*>): Boolean =
+        kClass.qualifiedName == asObjectDeclaration()?.fullyQualifiedName
 
     override fun hasInterfaceDeclaration(predicate: ((KoInterfaceDeclaration) -> Boolean)?): Boolean =
         when (predicate) {
@@ -109,6 +145,30 @@ internal interface KoDeclarationCastProviderCore :
 
     override fun hasInterfaceDeclarationOf(kClass: KClass<*>): Boolean =
         kClass.qualifiedName == asInterfaceDeclaration()?.fullyQualifiedName
+
+    override fun hasClassOrObjectDeclaration(predicate: ((KoClassAndObjectDeclaration) -> Boolean)?): Boolean =
+        hasClassDeclaration(predicate) || hasObjectDeclaration(predicate)
+
+    override fun hasClassOrObjectDeclarationOf(kClass: KClass<*>): Boolean =
+        hasClassDeclarationOf(kClass) || hasObjectDeclarationOf(kClass)
+
+    override fun hasClassOrInterfaceDeclaration(predicate: ((KoClassAndInterfaceDeclaration) -> Boolean)?): Boolean =
+        hasClassDeclaration(predicate) || hasInterfaceDeclaration(predicate)
+
+    override fun hasClassOrInterfaceDeclarationOf(kClass: KClass<*>): Boolean =
+        hasClassDeclarationOf(kClass) || hasInterfaceDeclarationOf(kClass)
+
+    override fun hasInterfaceOrObjectDeclaration(predicate: ((KoInterfaceAndObjectDeclaration) -> Boolean)?): Boolean =
+        hasInterfaceDeclaration(predicate) || hasObjectDeclaration(predicate)
+
+    override fun hasInterfaceOrObjectDeclarationOf(kClass: KClass<*>): Boolean =
+        hasInterfaceDeclarationOf(kClass) || hasObjectDeclarationOf(kClass)
+
+    override fun hasClassOrInterfaceOrObjectDeclaration(predicate: ((KoClassAndInterfaceAndObjectDeclaration) -> Boolean)?): Boolean =
+        hasClassDeclaration(predicate) || hasInterfaceDeclaration(predicate) || hasObjectDeclaration(predicate)
+
+    override fun hasClassOrInterfaceOrObjectDeclarationOf(kClass: KClass<*>): Boolean =
+        hasClassDeclarationOf(kClass) || hasInterfaceDeclarationOf(kClass) || hasObjectDeclarationOf(kClass)
 
     override fun hasTypeAliasDeclaration(predicate: ((KoTypeAliasDeclaration) -> Boolean)?): Boolean =
         when (predicate) {
@@ -161,10 +221,12 @@ internal interface KoDeclarationCastProviderCore :
             else -> asExternalDeclaration()?.let { predicate(it) } ?: false
         }
 
-    override fun hasExternalDeclarationOf(kClass: KClass<*>): Boolean = kClass.qualifiedName == asExternalDeclaration()?.fullyQualifiedName
+    override fun hasExternalDeclarationOf(kClass: KClass<*>): Boolean =
+        kClass.qualifiedName == asExternalDeclaration()?.fullyQualifiedName
 
     @Deprecated("Will be removed in version 0.19.0", ReplaceWith("hasExternalDeclaration"))
-    override fun hasExternalTypeDeclaration(predicate: ((KoExternalDeclaration) -> Boolean)?): Boolean = hasExternalDeclaration()
+    override fun hasExternalTypeDeclaration(predicate: ((KoExternalDeclaration) -> Boolean)?): Boolean =
+        hasExternalDeclaration()
 
     @Deprecated("Will be removed in version 0.19.0", ReplaceWith("hasExternalDeclarationOf"))
     override fun hasExternalTypeDeclarationOf(kClass: KClass<*>): Boolean = hasExternalDeclarationOf(kClass)

--- a/lib/src/test/kotlin/com/lemonappdev/konsist/api/ext/list/KoDeclarationCastProviderListExtTest.kt
+++ b/lib/src/test/kotlin/com/lemonappdev/konsist/api/ext/list/KoDeclarationCastProviderListExtTest.kt
@@ -2002,7 +2002,6 @@ class KoDeclarationCastProviderListExtTest {
         sut shouldBeEqualTo listOf(declaration3)
     }
 
-
     @Test
     fun `withClassOrObjectDeclaration() returns declaration with class or object`() {
         // given
@@ -2396,7 +2395,6 @@ class KoDeclarationCastProviderListExtTest {
         // then
         sut shouldBeEqualTo listOf(declaration3)
     }
-
 
     @Test
     fun `withClassOrInterfaceDeclaration() returns declaration with class or interface`() {
@@ -2792,7 +2790,6 @@ class KoDeclarationCastProviderListExtTest {
         sut shouldBeEqualTo listOf(declaration3)
     }
 
-
     @Test
     fun `withInterfaceOrObjectDeclaration() returns declaration with interface or object`() {
         // given
@@ -3187,7 +3184,6 @@ class KoDeclarationCastProviderListExtTest {
         sut shouldBeEqualTo listOf(declaration3)
     }
 
-
     @Test
     fun `withClassOrInterfaceOrObjectDeclaration() returns declaration with class, interface or object`() {
         // given
@@ -3424,7 +3420,7 @@ class KoDeclarationCastProviderListExtTest {
     }
 
     @Test
-    fun `withClassOrInterfaceOrObjectDeclarationOf(list of KClass) returns declarations with one of given classes, interfaces or objects`() {
+    fun `withClassOrInterfaceOrObjectDeclarationOf(list of KClass) returns declarations with one of given declaration`() {
         // given
         val declaration1: KoDeclarationCastProvider =
             mockk {
@@ -3527,7 +3523,7 @@ class KoDeclarationCastProviderListExtTest {
     }
 
     @Test
-    fun `withoutClassOrInterfaceOrObjectDeclarationOf(list of KClass) returns declaration without any of given classes, interfaces or objects`() {
+    fun `withoutClassOrInterfaceOrObjectDeclarationOf(list of KClass) returns declaration without any of given declaration`() {
         // given
         val declaration1: KoDeclarationCastProvider =
             mockk {
@@ -3555,7 +3551,7 @@ class KoDeclarationCastProviderListExtTest {
     }
 
     @Test
-    fun `withoutClassOrInterfaceOrObjectDeclarationOf(set of KClass) returns declaration without any of given classes, interfaces or objects`() {
+    fun `withoutClassOrInterfaceOrObjectDeclarationOf(set of KClass) returns declaration without any of given declaration`() {
         // given
         val declaration1: KoDeclarationCastProvider =
             mockk {
@@ -3581,7 +3577,6 @@ class KoDeclarationCastProviderListExtTest {
         // then
         sut shouldBeEqualTo listOf(declaration3)
     }
-
 
     @Test
     fun `withTypeAliasDeclaration() returns declaration with type alias`() {

--- a/lib/src/test/kotlin/com/lemonappdev/konsist/api/ext/list/KoDeclarationCastProviderListExtTest.kt
+++ b/lib/src/test/kotlin/com/lemonappdev/konsist/api/ext/list/KoDeclarationCastProviderListExtTest.kt
@@ -7,6 +7,10 @@ import com.lemonappdev.konsist.api.declaration.KoInterfaceDeclaration
 import com.lemonappdev.konsist.api.declaration.KoObjectDeclaration
 import com.lemonappdev.konsist.api.declaration.KoTypeAliasDeclaration
 import com.lemonappdev.konsist.api.declaration.KoTypeParameterDeclaration
+import com.lemonappdev.konsist.api.declaration.combined.KoClassAndInterfaceAndObjectDeclaration
+import com.lemonappdev.konsist.api.declaration.combined.KoClassAndInterfaceDeclaration
+import com.lemonappdev.konsist.api.declaration.combined.KoClassAndObjectDeclaration
+import com.lemonappdev.konsist.api.declaration.combined.KoInterfaceAndObjectDeclaration
 import com.lemonappdev.konsist.api.declaration.type.KoKotlinTypeDeclaration
 import com.lemonappdev.konsist.api.provider.KoDeclarationCastProvider
 import com.lemonappdev.konsist.testdata.SampleType1
@@ -184,6 +188,234 @@ class KoDeclarationCastProviderListExtTest {
 
         // when
         val sut = declarations.interfaceDeclarations(predicate)
+
+        // then
+        sut shouldBeEqualTo listOf(sourceDeclaration1)
+    }
+
+    @Test
+    fun `classAndObjectDeclarations returns classes and objects from all declarations`() {
+        // given
+        val sourceDeclaration1: KoClassAndObjectDeclaration = mockk()
+        val sourceDeclaration2: KoClassAndObjectDeclaration = mockk()
+        val declaration1: KoDeclarationCastProvider =
+            mockk {
+                every { asClassOrObjectDeclaration() } returns sourceDeclaration1
+                every { hasClassOrObjectDeclaration() } returns true
+            }
+        val declaration2: KoDeclarationCastProvider =
+            mockk {
+                every { asClassOrObjectDeclaration() } returns sourceDeclaration2
+                every { hasClassOrObjectDeclaration() } returns true
+            }
+        val declaration3: KoDeclarationCastProvider =
+            mockk {
+                every { hasClassOrObjectDeclaration() } returns false
+            }
+        val declarations = listOf(declaration1, declaration2, declaration3)
+
+        // when
+        val sut = declarations.classAndObjectDeclarations()
+
+        // then
+        sut shouldBeEqualTo listOf(sourceDeclaration1, sourceDeclaration2)
+    }
+
+    @Test
+    fun `classAndObjectDeclarations returns classes and objects from all declarations which satisfies predicate`() {
+        // given
+        val predicate: (KoClassAndObjectDeclaration) -> Boolean = { it.hasNameContaining("SomeObject") }
+        val sourceDeclaration1: KoClassAndObjectDeclaration = mockk()
+        val sourceDeclaration2: KoClassAndObjectDeclaration = mockk()
+        val declaration1: KoDeclarationCastProvider =
+            mockk {
+                every { asClassOrObjectDeclaration() } returns sourceDeclaration1
+                every { hasClassOrObjectDeclaration(predicate) } returns true
+            }
+        val declaration2: KoDeclarationCastProvider =
+            mockk {
+                every { asClassOrObjectDeclaration() } returns sourceDeclaration2
+                every { hasClassOrObjectDeclaration(predicate) } returns false
+            }
+        val declaration3: KoDeclarationCastProvider =
+            mockk {
+                every { hasClassOrObjectDeclaration(predicate) } returns false
+            }
+        val declarations = listOf(declaration1, declaration2, declaration3)
+
+        // when
+        val sut = declarations.classAndObjectDeclarations(predicate)
+
+        // then
+        sut shouldBeEqualTo listOf(sourceDeclaration1)
+    }
+
+    @Test
+    fun `classAndInterfaceDeclarations returns classes and interfaces from all declarations`() {
+        // given
+        val sourceDeclaration1: KoClassAndInterfaceDeclaration = mockk()
+        val sourceDeclaration2: KoClassAndInterfaceDeclaration = mockk()
+        val declaration1: KoDeclarationCastProvider =
+            mockk {
+                every { asClassOrInterfaceDeclaration() } returns sourceDeclaration1
+                every { hasClassOrInterfaceDeclaration() } returns true
+            }
+        val declaration2: KoDeclarationCastProvider =
+            mockk {
+                every { asClassOrInterfaceDeclaration() } returns sourceDeclaration2
+                every { hasClassOrInterfaceDeclaration() } returns true
+            }
+        val declaration3: KoDeclarationCastProvider =
+            mockk {
+                every { hasClassOrInterfaceDeclaration() } returns false
+            }
+        val declarations = listOf(declaration1, declaration2, declaration3)
+
+        // when
+        val sut = declarations.classAndInterfaceDeclarations()
+
+        // then
+        sut shouldBeEqualTo listOf(sourceDeclaration1, sourceDeclaration2)
+    }
+
+    @Test
+    fun `classAndInterfaceDeclarations returns classes and interfaces from all declarations which satisfies predicate`() {
+        // given
+        val predicate: (KoClassAndInterfaceDeclaration) -> Boolean = { it.hasNameContaining("SomeInterface") }
+        val sourceDeclaration1: KoClassAndInterfaceDeclaration = mockk()
+        val sourceDeclaration2: KoClassAndInterfaceDeclaration = mockk()
+        val declaration1: KoDeclarationCastProvider =
+            mockk {
+                every { asClassOrInterfaceDeclaration() } returns sourceDeclaration1
+                every { hasClassOrInterfaceDeclaration(predicate) } returns true
+            }
+        val declaration2: KoDeclarationCastProvider =
+            mockk {
+                every { asClassOrInterfaceDeclaration() } returns sourceDeclaration2
+                every { hasClassOrInterfaceDeclaration(predicate) } returns false
+            }
+        val declaration3: KoDeclarationCastProvider =
+            mockk {
+                every { hasClassOrInterfaceDeclaration(predicate) } returns false
+            }
+        val declarations = listOf(declaration1, declaration2, declaration3)
+
+        // when
+        val sut = declarations.classAndInterfaceDeclarations(predicate)
+
+        // then
+        sut shouldBeEqualTo listOf(sourceDeclaration1)
+    }
+
+    @Test
+    fun `interfaceAndObjectDeclarations returns interfaces and objects from all declarations`() {
+        // given
+        val sourceDeclaration1: KoInterfaceAndObjectDeclaration = mockk()
+        val sourceDeclaration2: KoInterfaceAndObjectDeclaration = mockk()
+        val declaration1: KoDeclarationCastProvider =
+            mockk {
+                every { asInterfaceOrObjectDeclaration() } returns sourceDeclaration1
+                every { hasInterfaceOrObjectDeclaration() } returns true
+            }
+        val declaration2: KoDeclarationCastProvider =
+            mockk {
+                every { asInterfaceOrObjectDeclaration() } returns sourceDeclaration2
+                every { hasInterfaceOrObjectDeclaration() } returns true
+            }
+        val declaration3: KoDeclarationCastProvider =
+            mockk {
+                every { hasInterfaceOrObjectDeclaration() } returns false
+            }
+        val declarations = listOf(declaration1, declaration2, declaration3)
+
+        // when
+        val sut = declarations.interfaceAndObjectDeclarations()
+
+        // then
+        sut shouldBeEqualTo listOf(sourceDeclaration1, sourceDeclaration2)
+    }
+
+    @Test
+    fun `interfaceAndObjectDeclarations returns interfaces and objects from all declarations which satisfies predicate`() {
+        // given
+        val predicate: (KoInterfaceAndObjectDeclaration) -> Boolean = { it.hasNameContaining("SomeInterface") }
+        val sourceDeclaration1: KoInterfaceAndObjectDeclaration = mockk()
+        val sourceDeclaration2: KoInterfaceAndObjectDeclaration = mockk()
+        val declaration1: KoDeclarationCastProvider =
+            mockk {
+                every { asInterfaceOrObjectDeclaration() } returns sourceDeclaration1
+                every { hasInterfaceOrObjectDeclaration(predicate) } returns true
+            }
+        val declaration2: KoDeclarationCastProvider =
+            mockk {
+                every { asInterfaceOrObjectDeclaration() } returns sourceDeclaration2
+                every { hasInterfaceOrObjectDeclaration(predicate) } returns false
+            }
+        val declaration3: KoDeclarationCastProvider =
+            mockk {
+                every { hasInterfaceOrObjectDeclaration(predicate) } returns false
+            }
+        val declarations = listOf(declaration1, declaration2, declaration3)
+
+        // when
+        val sut = declarations.interfaceAndObjectDeclarations(predicate)
+
+        // then
+        sut shouldBeEqualTo listOf(sourceDeclaration1)
+    }
+
+    @Test
+    fun `classAndInterfaceAndObjectDeclarations returns classes, interfaces and objects from all declarations`() {
+        // given
+        val sourceDeclaration1: KoClassAndInterfaceAndObjectDeclaration = mockk()
+        val sourceDeclaration2: KoClassAndInterfaceAndObjectDeclaration = mockk()
+        val declaration1: KoDeclarationCastProvider =
+            mockk {
+                every { asClassOrInterfaceOrObjectDeclaration() } returns sourceDeclaration1
+                every { hasClassOrInterfaceOrObjectDeclaration() } returns true
+            }
+        val declaration2: KoDeclarationCastProvider =
+            mockk {
+                every { asClassOrInterfaceOrObjectDeclaration() } returns sourceDeclaration2
+                every { hasClassOrInterfaceOrObjectDeclaration() } returns true
+            }
+        val declaration3: KoDeclarationCastProvider =
+            mockk {
+                every { hasClassOrInterfaceOrObjectDeclaration() } returns false
+            }
+        val declarations = listOf(declaration1, declaration2, declaration3)
+
+        // when
+        val sut = declarations.classAndInterfaceAndObjectDeclarations()
+
+        // then
+        sut shouldBeEqualTo listOf(sourceDeclaration1, sourceDeclaration2)
+    }
+
+    @Test
+    fun `classAndInterfaceAndObjectDeclarations returns classes, interfaces and objects from all declarations which satisfies predicate`() {
+        // given
+        val predicate: (KoClassAndInterfaceAndObjectDeclaration) -> Boolean = { it.hasNameContaining("SomeObject") }
+        val sourceDeclaration1: KoClassAndInterfaceAndObjectDeclaration = mockk()
+        val sourceDeclaration2: KoClassAndInterfaceAndObjectDeclaration = mockk()
+        val declaration1: KoDeclarationCastProvider =
+            mockk {
+                every { asClassOrInterfaceOrObjectDeclaration() } returns sourceDeclaration1
+                every { hasClassOrInterfaceOrObjectDeclaration(predicate) } returns true
+            }
+        val declaration2: KoDeclarationCastProvider =
+            mockk {
+                every { asClassOrInterfaceOrObjectDeclaration() } returns sourceDeclaration2
+                every { hasClassOrInterfaceOrObjectDeclaration(predicate) } returns false
+            }
+        val declaration3: KoDeclarationCastProvider =
+            mockk {
+                every { hasClassOrInterfaceOrObjectDeclaration(predicate) } returns false
+            }
+        val declarations = listOf(declaration1, declaration2, declaration3)
+
+        // when
+        val sut = declarations.classAndInterfaceAndObjectDeclarations(predicate)
 
         // then
         sut shouldBeEqualTo listOf(sourceDeclaration1)
@@ -1769,6 +2001,1587 @@ class KoDeclarationCastProviderListExtTest {
         // then
         sut shouldBeEqualTo listOf(declaration3)
     }
+
+
+    @Test
+    fun `withClassOrObjectDeclaration() returns declaration with class or object`() {
+        // given
+        val declaration1: KoDeclarationCastProvider =
+            mockk {
+                every { isClassOrObject } returns true
+            }
+        val declaration2: KoDeclarationCastProvider =
+            mockk {
+                every { isClassOrObject } returns false
+            }
+        val declarations = listOf(declaration1, declaration2)
+
+        // when
+        val sut = declarations.withClassOrObjectDeclaration()
+
+        // then
+        sut shouldBeEqualTo listOf(declaration1)
+    }
+
+    @Test
+    fun `withClassOrObjectDeclarationOf(empty list) returns declaration with class or object`() {
+        // given
+        val declaration1: KoDeclarationCastProvider =
+            mockk {
+                every { hasClassOrObjectDeclaration() } returns true
+            }
+        val declaration2: KoDeclarationCastProvider =
+            mockk {
+                every { hasClassOrObjectDeclaration() } returns false
+            }
+        val declarations = listOf(declaration1, declaration2)
+
+        // when
+        val sut = declarations.withClassOrObjectDeclarationOf(emptyList())
+
+        // then
+        sut shouldBeEqualTo listOf(declaration1)
+    }
+
+    @Test
+    fun `withClassOrObjectDeclarationOf(empty set) returns declaration with class or object`() {
+        // given
+        val declaration1: KoDeclarationCastProvider =
+            mockk {
+                every { hasClassOrObjectDeclaration() } returns true
+            }
+        val declaration2: KoDeclarationCastProvider =
+            mockk {
+                every { hasClassOrObjectDeclaration() } returns false
+            }
+        val declarations = listOf(declaration1, declaration2)
+
+        // when
+        val sut = declarations.withClassOrObjectDeclarationOf(emptySet())
+
+        // then
+        sut shouldBeEqualTo listOf(declaration1)
+    }
+
+    @Test
+    fun `withClassOrObjectDeclaration{} returns declaration which satisfy predicate`() {
+        // given
+        val name1 = "name1"
+        val name2 = "name2"
+        val sourceObject1: KoClassAndObjectDeclaration =
+            mockk {
+                every { name } returns name1
+            }
+        val sourceObject2: KoClassAndObjectDeclaration =
+            mockk {
+                every { name } returns name2
+            }
+        val declaration1: KoDeclarationCastProvider =
+            mockk {
+                every { asClassOrObjectDeclaration() } returns sourceObject1
+            }
+        val declaration2: KoDeclarationCastProvider =
+            mockk {
+                every { asClassOrObjectDeclaration() } returns sourceObject2
+            }
+        val declaration3: KoDeclarationCastProvider =
+            mockk {
+                every { asClassOrObjectDeclaration() } returns null
+            }
+        val declarations = listOf(declaration1, declaration2, declaration3)
+
+        // when
+        val sut = declarations.withClassOrObjectDeclaration { it.name == name1 }
+
+        // then
+        sut shouldBeEqualTo listOf(declaration1)
+    }
+
+    @Test
+    fun `withoutClassOrObjectDeclaration() returns declaration without class or object`() {
+        // given
+        val declaration1: KoDeclarationCastProvider =
+            mockk {
+                every { isClassOrObject } returns true
+            }
+        val declaration2: KoDeclarationCastProvider =
+            mockk {
+                every { isClassOrObject } returns false
+            }
+        val declarations = listOf(declaration1, declaration2)
+
+        // when
+        val sut = declarations.withoutClassOrObjectDeclaration()
+
+        // then
+        sut shouldBeEqualTo listOf(declaration2)
+    }
+
+    @Test
+    fun `withoutClassOrObjectDeclarationOf(empty list) returns declaration without class or object`() {
+        // given
+        val declaration1: KoDeclarationCastProvider =
+            mockk {
+                every { hasClassOrObjectDeclaration() } returns true
+            }
+        val declaration2: KoDeclarationCastProvider =
+            mockk {
+                every { hasClassOrObjectDeclaration() } returns false
+            }
+        val declarations = listOf(declaration1, declaration2)
+
+        // when
+        val sut = declarations.withoutClassOrObjectDeclarationOf(emptyList())
+
+        // then
+        sut shouldBeEqualTo listOf(declaration2)
+    }
+
+    @Test
+    fun `withoutClassOrObjectDeclarationOf(empty set) returns declaration without class or object`() {
+        // given
+        val declaration1: KoDeclarationCastProvider =
+            mockk {
+                every { hasClassOrObjectDeclaration() } returns true
+            }
+        val declaration2: KoDeclarationCastProvider =
+            mockk {
+                every { hasClassOrObjectDeclaration() } returns false
+            }
+        val declarations = listOf(declaration1, declaration2)
+
+        // when
+        val sut = declarations.withoutClassOrObjectDeclarationOf(emptySet())
+
+        // then
+        sut shouldBeEqualTo listOf(declaration2)
+    }
+
+    @Test
+    fun `withoutClassOrObjectDeclaration{} returns declarations which not satisfy predicate`() {
+        // given
+        val name1 = "name1"
+        val name2 = "name2"
+        val sourceObject1: KoClassAndObjectDeclaration =
+            mockk {
+                every { name } returns name1
+            }
+        val sourceObject2: KoClassAndObjectDeclaration =
+            mockk {
+                every { name } returns name2
+            }
+        val declaration1: KoDeclarationCastProvider =
+            mockk {
+                every { asClassOrObjectDeclaration() } returns sourceObject1
+            }
+        val declaration2: KoDeclarationCastProvider =
+            mockk {
+                every { asClassOrObjectDeclaration() } returns sourceObject2
+            }
+        val declaration3: KoDeclarationCastProvider =
+            mockk {
+                every { asClassOrObjectDeclaration() } returns null
+            }
+        val declarations = listOf(declaration1, declaration2, declaration3)
+
+        // when
+        val sut = declarations.withoutClassOrObjectDeclaration { it.name == name1 }
+
+        // then
+        sut shouldBeEqualTo listOf(declaration2, declaration3)
+    }
+
+    @Test
+    fun `withClassOrObjectDeclarationOf(KClass) returns declaration with given class or object`() {
+        // given
+        val declaration1: KoDeclarationCastProvider =
+            mockk {
+                every { hasClassOrObjectDeclarationOf(SampleType1::class) } returns true
+            }
+        val declaration2: KoDeclarationCastProvider =
+            mockk {
+                every { hasClassOrObjectDeclarationOf(SampleType1::class) } returns false
+            }
+        val declarations = listOf(declaration1, declaration2)
+
+        // when
+        val sut = declarations.withClassOrObjectDeclarationOf(SampleType1::class)
+
+        // then
+        sut shouldBeEqualTo listOf(declaration1)
+    }
+
+    @Test
+    fun `withClassOrObjectDeclarationOf(KClass) returns declarations with one of given classes or objects`() {
+        // given
+        val declaration1: KoDeclarationCastProvider =
+            mockk {
+                every { hasClassOrObjectDeclarationOf(SampleType1::class) } returns true
+                every { hasClassOrObjectDeclarationOf(SampleType2::class) } returns false
+            }
+        val declaration2: KoDeclarationCastProvider =
+            mockk {
+                every { hasClassOrObjectDeclarationOf(SampleType1::class) } returns false
+                every { hasClassOrObjectDeclarationOf(SampleType2::class) } returns true
+            }
+        val declaration3: KoDeclarationCastProvider =
+            mockk {
+                every { hasClassOrObjectDeclarationOf(SampleType1::class) } returns false
+                every { hasClassOrObjectDeclarationOf(SampleType2::class) } returns false
+            }
+        val declarations = listOf(declaration1, declaration2, declaration3)
+
+        // when
+        val sut = declarations.withClassOrObjectDeclarationOf(SampleType1::class, SampleType2::class)
+
+        // then
+        sut shouldBeEqualTo listOf(declaration1, declaration2)
+    }
+
+    @Test
+    fun `withClassOrObjectDeclarationOf(list of KClass) returns declarations with one of given classes or objects`() {
+        // given
+        val declaration1: KoDeclarationCastProvider =
+            mockk {
+                every { hasClassOrObjectDeclarationOf(SampleType1::class) } returns true
+                every { hasClassOrObjectDeclarationOf(SampleType2::class) } returns false
+            }
+        val declaration2: KoDeclarationCastProvider =
+            mockk {
+                every { hasClassOrObjectDeclarationOf(SampleType1::class) } returns false
+                every { hasClassOrObjectDeclarationOf(SampleType2::class) } returns true
+            }
+        val declaration3: KoDeclarationCastProvider =
+            mockk {
+                every { hasClassOrObjectDeclarationOf(SampleType1::class) } returns false
+                every { hasClassOrObjectDeclarationOf(SampleType2::class) } returns false
+            }
+        val declarations = listOf(declaration1, declaration2, declaration3)
+        val kClasses = listOf(SampleType1::class, SampleType2::class)
+
+        // when
+        val sut = declarations.withClassOrObjectDeclarationOf(kClasses)
+
+        // then
+        sut shouldBeEqualTo listOf(declaration1, declaration2)
+    }
+
+    @Test
+    fun `withClassOrObjectDeclarationOf(set of KClass) returns declarations with one of given classes or objects`() {
+        // given
+        val declaration1: KoDeclarationCastProvider =
+            mockk {
+                every { hasClassOrObjectDeclarationOf(SampleType1::class) } returns true
+                every { hasClassOrObjectDeclarationOf(SampleType2::class) } returns false
+            }
+        val declaration2: KoDeclarationCastProvider =
+            mockk {
+                every { hasClassOrObjectDeclarationOf(SampleType1::class) } returns false
+                every { hasClassOrObjectDeclarationOf(SampleType2::class) } returns true
+            }
+        val declaration3: KoDeclarationCastProvider =
+            mockk {
+                every { hasClassOrObjectDeclarationOf(SampleType1::class) } returns false
+                every { hasClassOrObjectDeclarationOf(SampleType2::class) } returns false
+            }
+        val declarations = listOf(declaration1, declaration2, declaration3)
+        val kClasses = setOf(SampleType1::class, SampleType2::class)
+
+        // when
+        val sut = declarations.withClassOrObjectDeclarationOf(kClasses)
+
+        // then
+        sut shouldBeEqualTo listOf(declaration1, declaration2)
+    }
+
+    @Test
+    fun `withoutClassOrObjectDeclarationOf(KClass) returns declaration without given class or object`() {
+        // given
+        val declaration1: KoDeclarationCastProvider =
+            mockk {
+                every { hasClassOrObjectDeclarationOf(SampleType1::class) } returns true
+            }
+        val declaration2: KoDeclarationCastProvider =
+            mockk {
+                every { hasClassOrObjectDeclarationOf(SampleType1::class) } returns false
+            }
+        val declarations = listOf(declaration1, declaration2)
+
+        // when
+        val sut = declarations.withoutClassOrObjectDeclarationOf(SampleType1::class)
+
+        // then
+        sut shouldBeEqualTo listOf(declaration2)
+    }
+
+    @Test
+    fun `withoutClassOrObjectDeclarationOf(KClass) returns declaration without any of given classes or objects`() {
+        // given
+        val declaration1: KoDeclarationCastProvider =
+            mockk {
+                every { hasClassOrObjectDeclarationOf(SampleType1::class) } returns true
+                every { hasClassOrObjectDeclarationOf(SampleType2::class) } returns false
+            }
+        val declaration2: KoDeclarationCastProvider =
+            mockk {
+                every { hasClassOrObjectDeclarationOf(SampleType1::class) } returns false
+                every { hasClassOrObjectDeclarationOf(SampleType2::class) } returns true
+            }
+        val declaration3: KoDeclarationCastProvider =
+            mockk {
+                every { hasClassOrObjectDeclarationOf(SampleType1::class) } returns false
+                every { hasClassOrObjectDeclarationOf(SampleType2::class) } returns false
+            }
+        val declarations = listOf(declaration1, declaration2, declaration3)
+
+        // when
+        val sut = declarations.withoutClassOrObjectDeclarationOf(SampleType1::class, SampleType2::class)
+
+        // then
+        sut shouldBeEqualTo listOf(declaration3)
+    }
+
+    @Test
+    fun `withoutClassOrObjectDeclarationOf(list of KClass) returns declaration without any of given classes or objects`() {
+        // given
+        val declaration1: KoDeclarationCastProvider =
+            mockk {
+                every { hasClassOrObjectDeclarationOf(SampleType1::class) } returns true
+                every { hasClassOrObjectDeclarationOf(SampleType2::class) } returns false
+            }
+        val declaration2: KoDeclarationCastProvider =
+            mockk {
+                every { hasClassOrObjectDeclarationOf(SampleType1::class) } returns false
+                every { hasClassOrObjectDeclarationOf(SampleType2::class) } returns true
+            }
+        val declaration3: KoDeclarationCastProvider =
+            mockk {
+                every { hasClassOrObjectDeclarationOf(SampleType1::class) } returns false
+                every { hasClassOrObjectDeclarationOf(SampleType2::class) } returns false
+            }
+        val declarations = listOf(declaration1, declaration2, declaration3)
+        val kClasses = listOf(SampleType1::class, SampleType2::class)
+
+        // when
+        val sut = declarations.withoutClassOrObjectDeclarationOf(kClasses)
+
+        // then
+        sut shouldBeEqualTo listOf(declaration3)
+    }
+
+    @Test
+    fun `withoutClassOrObjectDeclarationOf(set of KClass) returns declaration without any of given classes or objects`() {
+        // given
+        val declaration1: KoDeclarationCastProvider =
+            mockk {
+                every { hasClassOrObjectDeclarationOf(SampleType1::class) } returns true
+                every { hasClassOrObjectDeclarationOf(SampleType2::class) } returns false
+            }
+        val declaration2: KoDeclarationCastProvider =
+            mockk {
+                every { hasClassOrObjectDeclarationOf(SampleType1::class) } returns false
+                every { hasClassOrObjectDeclarationOf(SampleType2::class) } returns true
+            }
+        val declaration3: KoDeclarationCastProvider =
+            mockk {
+                every { hasClassOrObjectDeclarationOf(SampleType1::class) } returns false
+                every { hasClassOrObjectDeclarationOf(SampleType2::class) } returns false
+            }
+        val declarations = listOf(declaration1, declaration2, declaration3)
+        val kClasses = setOf(SampleType1::class, SampleType2::class)
+
+        // when
+        val sut = declarations.withoutClassOrObjectDeclarationOf(kClasses)
+
+        // then
+        sut shouldBeEqualTo listOf(declaration3)
+    }
+
+
+    @Test
+    fun `withClassOrInterfaceDeclaration() returns declaration with class or interface`() {
+        // given
+        val declaration1: KoDeclarationCastProvider =
+            mockk {
+                every { isClassOrInterface } returns true
+            }
+        val declaration2: KoDeclarationCastProvider =
+            mockk {
+                every { isClassOrInterface } returns false
+            }
+        val declarations = listOf(declaration1, declaration2)
+
+        // when
+        val sut = declarations.withClassOrInterfaceDeclaration()
+
+        // then
+        sut shouldBeEqualTo listOf(declaration1)
+    }
+
+    @Test
+    fun `withClassOrInterfaceDeclarationOf(empty list) returns declaration with class or interface`() {
+        // given
+        val declaration1: KoDeclarationCastProvider =
+            mockk {
+                every { hasClassOrInterfaceDeclaration() } returns true
+            }
+        val declaration2: KoDeclarationCastProvider =
+            mockk {
+                every { hasClassOrInterfaceDeclaration() } returns false
+            }
+        val declarations = listOf(declaration1, declaration2)
+
+        // when
+        val sut = declarations.withClassOrInterfaceDeclarationOf(emptyList())
+
+        // then
+        sut shouldBeEqualTo listOf(declaration1)
+    }
+
+    @Test
+    fun `withClassOrInterfaceDeclarationOf(empty set) returns declaration with class or interface`() {
+        // given
+        val declaration1: KoDeclarationCastProvider =
+            mockk {
+                every { hasClassOrInterfaceDeclaration() } returns true
+            }
+        val declaration2: KoDeclarationCastProvider =
+            mockk {
+                every { hasClassOrInterfaceDeclaration() } returns false
+            }
+        val declarations = listOf(declaration1, declaration2)
+
+        // when
+        val sut = declarations.withClassOrInterfaceDeclarationOf(emptySet())
+
+        // then
+        sut shouldBeEqualTo listOf(declaration1)
+    }
+
+    @Test
+    fun `withClassOrInterfaceDeclaration{} returns declaration which satisfy predicate`() {
+        // given
+        val name1 = "name1"
+        val name2 = "name2"
+        val sourceInterface1: KoClassAndInterfaceDeclaration =
+            mockk {
+                every { name } returns name1
+            }
+        val sourceInterface2: KoClassAndInterfaceDeclaration =
+            mockk {
+                every { name } returns name2
+            }
+        val declaration1: KoDeclarationCastProvider =
+            mockk {
+                every { asClassOrInterfaceDeclaration() } returns sourceInterface1
+            }
+        val declaration2: KoDeclarationCastProvider =
+            mockk {
+                every { asClassOrInterfaceDeclaration() } returns sourceInterface2
+            }
+        val declaration3: KoDeclarationCastProvider =
+            mockk {
+                every { asClassOrInterfaceDeclaration() } returns null
+            }
+        val declarations = listOf(declaration1, declaration2, declaration3)
+
+        // when
+        val sut = declarations.withClassOrInterfaceDeclaration { it.name == name1 }
+
+        // then
+        sut shouldBeEqualTo listOf(declaration1)
+    }
+
+    @Test
+    fun `withoutClassOrInterfaceDeclaration() returns declaration without class or interface`() {
+        // given
+        val declaration1: KoDeclarationCastProvider =
+            mockk {
+                every { isClassOrInterface } returns true
+            }
+        val declaration2: KoDeclarationCastProvider =
+            mockk {
+                every { isClassOrInterface } returns false
+            }
+        val declarations = listOf(declaration1, declaration2)
+
+        // when
+        val sut = declarations.withoutClassOrInterfaceDeclaration()
+
+        // then
+        sut shouldBeEqualTo listOf(declaration2)
+    }
+
+    @Test
+    fun `withoutClassOrInterfaceDeclarationOf(empty list) returns declaration without class or interface`() {
+        // given
+        val declaration1: KoDeclarationCastProvider =
+            mockk {
+                every { hasClassOrInterfaceDeclaration() } returns true
+            }
+        val declaration2: KoDeclarationCastProvider =
+            mockk {
+                every { hasClassOrInterfaceDeclaration() } returns false
+            }
+        val declarations = listOf(declaration1, declaration2)
+
+        // when
+        val sut = declarations.withoutClassOrInterfaceDeclarationOf(emptyList())
+
+        // then
+        sut shouldBeEqualTo listOf(declaration2)
+    }
+
+    @Test
+    fun `withoutClassOrInterfaceDeclarationOf(empty set) returns declaration without class or interface`() {
+        // given
+        val declaration1: KoDeclarationCastProvider =
+            mockk {
+                every { hasClassOrInterfaceDeclaration() } returns true
+            }
+        val declaration2: KoDeclarationCastProvider =
+            mockk {
+                every { hasClassOrInterfaceDeclaration() } returns false
+            }
+        val declarations = listOf(declaration1, declaration2)
+
+        // when
+        val sut = declarations.withoutClassOrInterfaceDeclarationOf(emptySet())
+
+        // then
+        sut shouldBeEqualTo listOf(declaration2)
+    }
+
+    @Test
+    fun `withoutClassOrInterfaceDeclaration{} returns declarations which not satisfy predicate`() {
+        // given
+        val name1 = "name1"
+        val name2 = "name2"
+        val sourceInterface1: KoClassAndInterfaceDeclaration =
+            mockk {
+                every { name } returns name1
+            }
+        val sourceInterface2: KoClassAndInterfaceDeclaration =
+            mockk {
+                every { name } returns name2
+            }
+        val declaration1: KoDeclarationCastProvider =
+            mockk {
+                every { asClassOrInterfaceDeclaration() } returns sourceInterface1
+            }
+        val declaration2: KoDeclarationCastProvider =
+            mockk {
+                every { asClassOrInterfaceDeclaration() } returns sourceInterface2
+            }
+        val declaration3: KoDeclarationCastProvider =
+            mockk {
+                every { asClassOrInterfaceDeclaration() } returns null
+            }
+        val declarations = listOf(declaration1, declaration2, declaration3)
+
+        // when
+        val sut = declarations.withoutClassOrInterfaceDeclaration { it.name == name1 }
+
+        // then
+        sut shouldBeEqualTo listOf(declaration2, declaration3)
+    }
+
+    @Test
+    fun `withClassOrInterfaceDeclarationOf(KClass) returns declaration with given class or interface`() {
+        // given
+        val declaration1: KoDeclarationCastProvider =
+            mockk {
+                every { hasClassOrInterfaceDeclarationOf(SampleType1::class) } returns true
+            }
+        val declaration2: KoDeclarationCastProvider =
+            mockk {
+                every { hasClassOrInterfaceDeclarationOf(SampleType1::class) } returns false
+            }
+        val declarations = listOf(declaration1, declaration2)
+
+        // when
+        val sut = declarations.withClassOrInterfaceDeclarationOf(SampleType1::class)
+
+        // then
+        sut shouldBeEqualTo listOf(declaration1)
+    }
+
+    @Test
+    fun `withClassOrInterfaceDeclarationOf(KClass) returns declarations with one of given classes or interfaces`() {
+        // given
+        val declaration1: KoDeclarationCastProvider =
+            mockk {
+                every { hasClassOrInterfaceDeclarationOf(SampleType1::class) } returns true
+                every { hasClassOrInterfaceDeclarationOf(SampleType2::class) } returns false
+            }
+        val declaration2: KoDeclarationCastProvider =
+            mockk {
+                every { hasClassOrInterfaceDeclarationOf(SampleType1::class) } returns false
+                every { hasClassOrInterfaceDeclarationOf(SampleType2::class) } returns true
+            }
+        val declaration3: KoDeclarationCastProvider =
+            mockk {
+                every { hasClassOrInterfaceDeclarationOf(SampleType1::class) } returns false
+                every { hasClassOrInterfaceDeclarationOf(SampleType2::class) } returns false
+            }
+        val declarations = listOf(declaration1, declaration2, declaration3)
+
+        // when
+        val sut = declarations.withClassOrInterfaceDeclarationOf(SampleType1::class, SampleType2::class)
+
+        // then
+        sut shouldBeEqualTo listOf(declaration1, declaration2)
+    }
+
+    @Test
+    fun `withClassOrInterfaceDeclarationOf(list of KClass) returns declarations with one of given classes or interfaces`() {
+        // given
+        val declaration1: KoDeclarationCastProvider =
+            mockk {
+                every { hasClassOrInterfaceDeclarationOf(SampleType1::class) } returns true
+                every { hasClassOrInterfaceDeclarationOf(SampleType2::class) } returns false
+            }
+        val declaration2: KoDeclarationCastProvider =
+            mockk {
+                every { hasClassOrInterfaceDeclarationOf(SampleType1::class) } returns false
+                every { hasClassOrInterfaceDeclarationOf(SampleType2::class) } returns true
+            }
+        val declaration3: KoDeclarationCastProvider =
+            mockk {
+                every { hasClassOrInterfaceDeclarationOf(SampleType1::class) } returns false
+                every { hasClassOrInterfaceDeclarationOf(SampleType2::class) } returns false
+            }
+        val declarations = listOf(declaration1, declaration2, declaration3)
+        val kClasses = listOf(SampleType1::class, SampleType2::class)
+
+        // when
+        val sut = declarations.withClassOrInterfaceDeclarationOf(kClasses)
+
+        // then
+        sut shouldBeEqualTo listOf(declaration1, declaration2)
+    }
+
+    @Test
+    fun `withClassOrInterfaceDeclarationOf(set of KClass) returns declarations with one of given classes or interfaces`() {
+        // given
+        val declaration1: KoDeclarationCastProvider =
+            mockk {
+                every { hasClassOrInterfaceDeclarationOf(SampleType1::class) } returns true
+                every { hasClassOrInterfaceDeclarationOf(SampleType2::class) } returns false
+            }
+        val declaration2: KoDeclarationCastProvider =
+            mockk {
+                every { hasClassOrInterfaceDeclarationOf(SampleType1::class) } returns false
+                every { hasClassOrInterfaceDeclarationOf(SampleType2::class) } returns true
+            }
+        val declaration3: KoDeclarationCastProvider =
+            mockk {
+                every { hasClassOrInterfaceDeclarationOf(SampleType1::class) } returns false
+                every { hasClassOrInterfaceDeclarationOf(SampleType2::class) } returns false
+            }
+        val declarations = listOf(declaration1, declaration2, declaration3)
+        val kClasses = setOf(SampleType1::class, SampleType2::class)
+
+        // when
+        val sut = declarations.withClassOrInterfaceDeclarationOf(kClasses)
+
+        // then
+        sut shouldBeEqualTo listOf(declaration1, declaration2)
+    }
+
+    @Test
+    fun `withoutClassOrInterfaceDeclarationOf(KClass) returns declaration without given class or interface`() {
+        // given
+        val declaration1: KoDeclarationCastProvider =
+            mockk {
+                every { hasClassOrInterfaceDeclarationOf(SampleType1::class) } returns true
+            }
+        val declaration2: KoDeclarationCastProvider =
+            mockk {
+                every { hasClassOrInterfaceDeclarationOf(SampleType1::class) } returns false
+            }
+        val declarations = listOf(declaration1, declaration2)
+
+        // when
+        val sut = declarations.withoutClassOrInterfaceDeclarationOf(SampleType1::class)
+
+        // then
+        sut shouldBeEqualTo listOf(declaration2)
+    }
+
+    @Test
+    fun `withoutClassOrInterfaceDeclarationOf(KClass) returns declaration without any of given classes or interfaces`() {
+        // given
+        val declaration1: KoDeclarationCastProvider =
+            mockk {
+                every { hasClassOrInterfaceDeclarationOf(SampleType1::class) } returns true
+                every { hasClassOrInterfaceDeclarationOf(SampleType2::class) } returns false
+            }
+        val declaration2: KoDeclarationCastProvider =
+            mockk {
+                every { hasClassOrInterfaceDeclarationOf(SampleType1::class) } returns false
+                every { hasClassOrInterfaceDeclarationOf(SampleType2::class) } returns true
+            }
+        val declaration3: KoDeclarationCastProvider =
+            mockk {
+                every { hasClassOrInterfaceDeclarationOf(SampleType1::class) } returns false
+                every { hasClassOrInterfaceDeclarationOf(SampleType2::class) } returns false
+            }
+        val declarations = listOf(declaration1, declaration2, declaration3)
+
+        // when
+        val sut = declarations.withoutClassOrInterfaceDeclarationOf(SampleType1::class, SampleType2::class)
+
+        // then
+        sut shouldBeEqualTo listOf(declaration3)
+    }
+
+    @Test
+    fun `withoutClassOrInterfaceDeclarationOf(list of KClass) returns declaration without any of given classes or interfaces`() {
+        // given
+        val declaration1: KoDeclarationCastProvider =
+            mockk {
+                every { hasClassOrInterfaceDeclarationOf(SampleType1::class) } returns true
+                every { hasClassOrInterfaceDeclarationOf(SampleType2::class) } returns false
+            }
+        val declaration2: KoDeclarationCastProvider =
+            mockk {
+                every { hasClassOrInterfaceDeclarationOf(SampleType1::class) } returns false
+                every { hasClassOrInterfaceDeclarationOf(SampleType2::class) } returns true
+            }
+        val declaration3: KoDeclarationCastProvider =
+            mockk {
+                every { hasClassOrInterfaceDeclarationOf(SampleType1::class) } returns false
+                every { hasClassOrInterfaceDeclarationOf(SampleType2::class) } returns false
+            }
+        val declarations = listOf(declaration1, declaration2, declaration3)
+        val kClasses = listOf(SampleType1::class, SampleType2::class)
+
+        // when
+        val sut = declarations.withoutClassOrInterfaceDeclarationOf(kClasses)
+
+        // then
+        sut shouldBeEqualTo listOf(declaration3)
+    }
+
+    @Test
+    fun `withoutClassOrInterfaceDeclarationOf(set of KClass) returns declaration without any of given classes or interfaces`() {
+        // given
+        val declaration1: KoDeclarationCastProvider =
+            mockk {
+                every { hasClassOrInterfaceDeclarationOf(SampleType1::class) } returns true
+                every { hasClassOrInterfaceDeclarationOf(SampleType2::class) } returns false
+            }
+        val declaration2: KoDeclarationCastProvider =
+            mockk {
+                every { hasClassOrInterfaceDeclarationOf(SampleType1::class) } returns false
+                every { hasClassOrInterfaceDeclarationOf(SampleType2::class) } returns true
+            }
+        val declaration3: KoDeclarationCastProvider =
+            mockk {
+                every { hasClassOrInterfaceDeclarationOf(SampleType1::class) } returns false
+                every { hasClassOrInterfaceDeclarationOf(SampleType2::class) } returns false
+            }
+        val declarations = listOf(declaration1, declaration2, declaration3)
+        val kClasses = setOf(SampleType1::class, SampleType2::class)
+
+        // when
+        val sut = declarations.withoutClassOrInterfaceDeclarationOf(kClasses)
+
+        // then
+        sut shouldBeEqualTo listOf(declaration3)
+    }
+
+
+    @Test
+    fun `withInterfaceOrObjectDeclaration() returns declaration with interface or object`() {
+        // given
+        val declaration1: KoDeclarationCastProvider =
+            mockk {
+                every { isInterfaceOrObject } returns true
+            }
+        val declaration2: KoDeclarationCastProvider =
+            mockk {
+                every { isInterfaceOrObject } returns false
+            }
+        val declarations = listOf(declaration1, declaration2)
+
+        // when
+        val sut = declarations.withInterfaceOrObjectDeclaration()
+
+        // then
+        sut shouldBeEqualTo listOf(declaration1)
+    }
+
+    @Test
+    fun `withInterfaceOrObjectDeclarationOf(empty list) returns declaration with interface or object`() {
+        // given
+        val declaration1: KoDeclarationCastProvider =
+            mockk {
+                every { hasInterfaceOrObjectDeclaration() } returns true
+            }
+        val declaration2: KoDeclarationCastProvider =
+            mockk {
+                every { hasInterfaceOrObjectDeclaration() } returns false
+            }
+        val declarations = listOf(declaration1, declaration2)
+
+        // when
+        val sut = declarations.withInterfaceOrObjectDeclarationOf(emptyList())
+
+        // then
+        sut shouldBeEqualTo listOf(declaration1)
+    }
+
+    @Test
+    fun `withInterfaceOrObjectDeclarationOf(empty set) returns declaration with interface or object`() {
+        // given
+        val declaration1: KoDeclarationCastProvider =
+            mockk {
+                every { hasInterfaceOrObjectDeclaration() } returns true
+            }
+        val declaration2: KoDeclarationCastProvider =
+            mockk {
+                every { hasInterfaceOrObjectDeclaration() } returns false
+            }
+        val declarations = listOf(declaration1, declaration2)
+
+        // when
+        val sut = declarations.withInterfaceOrObjectDeclarationOf(emptySet())
+
+        // then
+        sut shouldBeEqualTo listOf(declaration1)
+    }
+
+    @Test
+    fun `withInterfaceOrObjectDeclaration{} returns declaration which satisfy predicate`() {
+        // given
+        val name1 = "name1"
+        val name2 = "name2"
+        val sourceObject1: KoInterfaceAndObjectDeclaration =
+            mockk {
+                every { name } returns name1
+            }
+        val sourceObject2: KoInterfaceAndObjectDeclaration =
+            mockk {
+                every { name } returns name2
+            }
+        val declaration1: KoDeclarationCastProvider =
+            mockk {
+                every { asInterfaceOrObjectDeclaration() } returns sourceObject1
+            }
+        val declaration2: KoDeclarationCastProvider =
+            mockk {
+                every { asInterfaceOrObjectDeclaration() } returns sourceObject2
+            }
+        val declaration3: KoDeclarationCastProvider =
+            mockk {
+                every { asInterfaceOrObjectDeclaration() } returns null
+            }
+        val declarations = listOf(declaration1, declaration2, declaration3)
+
+        // when
+        val sut = declarations.withInterfaceOrObjectDeclaration { it.name == name1 }
+
+        // then
+        sut shouldBeEqualTo listOf(declaration1)
+    }
+
+    @Test
+    fun `withoutInterfaceOrObjectDeclaration() returns declaration without interface or object`() {
+        // given
+        val declaration1: KoDeclarationCastProvider =
+            mockk {
+                every { isInterfaceOrObject } returns true
+            }
+        val declaration2: KoDeclarationCastProvider =
+            mockk {
+                every { isInterfaceOrObject } returns false
+            }
+        val declarations = listOf(declaration1, declaration2)
+
+        // when
+        val sut = declarations.withoutInterfaceOrObjectDeclaration()
+
+        // then
+        sut shouldBeEqualTo listOf(declaration2)
+    }
+
+    @Test
+    fun `withoutInterfaceOrObjectDeclarationOf(empty list) returns declaration without interface or object`() {
+        // given
+        val declaration1: KoDeclarationCastProvider =
+            mockk {
+                every { hasInterfaceOrObjectDeclaration() } returns true
+            }
+        val declaration2: KoDeclarationCastProvider =
+            mockk {
+                every { hasInterfaceOrObjectDeclaration() } returns false
+            }
+        val declarations = listOf(declaration1, declaration2)
+
+        // when
+        val sut = declarations.withoutInterfaceOrObjectDeclarationOf(emptyList())
+
+        // then
+        sut shouldBeEqualTo listOf(declaration2)
+    }
+
+    @Test
+    fun `withoutInterfaceOrObjectDeclarationOf(empty set) returns declaration without interface or object`() {
+        // given
+        val declaration1: KoDeclarationCastProvider =
+            mockk {
+                every { hasInterfaceOrObjectDeclaration() } returns true
+            }
+        val declaration2: KoDeclarationCastProvider =
+            mockk {
+                every { hasInterfaceOrObjectDeclaration() } returns false
+            }
+        val declarations = listOf(declaration1, declaration2)
+
+        // when
+        val sut = declarations.withoutInterfaceOrObjectDeclarationOf(emptySet())
+
+        // then
+        sut shouldBeEqualTo listOf(declaration2)
+    }
+
+    @Test
+    fun `withoutInterfaceOrObjectDeclaration{} returns declarations which not satisfy predicate`() {
+        // given
+        val name1 = "name1"
+        val name2 = "name2"
+        val sourceObject1: KoInterfaceAndObjectDeclaration =
+            mockk {
+                every { name } returns name1
+            }
+        val sourceObject2: KoInterfaceAndObjectDeclaration =
+            mockk {
+                every { name } returns name2
+            }
+        val declaration1: KoDeclarationCastProvider =
+            mockk {
+                every { asInterfaceOrObjectDeclaration() } returns sourceObject1
+            }
+        val declaration2: KoDeclarationCastProvider =
+            mockk {
+                every { asInterfaceOrObjectDeclaration() } returns sourceObject2
+            }
+        val declaration3: KoDeclarationCastProvider =
+            mockk {
+                every { asInterfaceOrObjectDeclaration() } returns null
+            }
+        val declarations = listOf(declaration1, declaration2, declaration3)
+
+        // when
+        val sut = declarations.withoutInterfaceOrObjectDeclaration { it.name == name1 }
+
+        // then
+        sut shouldBeEqualTo listOf(declaration2, declaration3)
+    }
+
+    @Test
+    fun `withInterfaceOrObjectDeclarationOf(KClass) returns declaration with given interface or object`() {
+        // given
+        val declaration1: KoDeclarationCastProvider =
+            mockk {
+                every { hasInterfaceOrObjectDeclarationOf(SampleType1::class) } returns true
+            }
+        val declaration2: KoDeclarationCastProvider =
+            mockk {
+                every { hasInterfaceOrObjectDeclarationOf(SampleType1::class) } returns false
+            }
+        val declarations = listOf(declaration1, declaration2)
+
+        // when
+        val sut = declarations.withInterfaceOrObjectDeclarationOf(SampleType1::class)
+
+        // then
+        sut shouldBeEqualTo listOf(declaration1)
+    }
+
+    @Test
+    fun `withInterfaceOrObjectDeclarationOf(KClass) returns declarations with one of given interfaces or objects`() {
+        // given
+        val declaration1: KoDeclarationCastProvider =
+            mockk {
+                every { hasInterfaceOrObjectDeclarationOf(SampleType1::class) } returns true
+                every { hasInterfaceOrObjectDeclarationOf(SampleType2::class) } returns false
+            }
+        val declaration2: KoDeclarationCastProvider =
+            mockk {
+                every { hasInterfaceOrObjectDeclarationOf(SampleType1::class) } returns false
+                every { hasInterfaceOrObjectDeclarationOf(SampleType2::class) } returns true
+            }
+        val declaration3: KoDeclarationCastProvider =
+            mockk {
+                every { hasInterfaceOrObjectDeclarationOf(SampleType1::class) } returns false
+                every { hasInterfaceOrObjectDeclarationOf(SampleType2::class) } returns false
+            }
+        val declarations = listOf(declaration1, declaration2, declaration3)
+
+        // when
+        val sut = declarations.withInterfaceOrObjectDeclarationOf(SampleType1::class, SampleType2::class)
+
+        // then
+        sut shouldBeEqualTo listOf(declaration1, declaration2)
+    }
+
+    @Test
+    fun `withInterfaceOrObjectDeclarationOf(list of KClass) returns declarations with one of given interfaces or objects`() {
+        // given
+        val declaration1: KoDeclarationCastProvider =
+            mockk {
+                every { hasInterfaceOrObjectDeclarationOf(SampleType1::class) } returns true
+                every { hasInterfaceOrObjectDeclarationOf(SampleType2::class) } returns false
+            }
+        val declaration2: KoDeclarationCastProvider =
+            mockk {
+                every { hasInterfaceOrObjectDeclarationOf(SampleType1::class) } returns false
+                every { hasInterfaceOrObjectDeclarationOf(SampleType2::class) } returns true
+            }
+        val declaration3: KoDeclarationCastProvider =
+            mockk {
+                every { hasInterfaceOrObjectDeclarationOf(SampleType1::class) } returns false
+                every { hasInterfaceOrObjectDeclarationOf(SampleType2::class) } returns false
+            }
+        val declarations = listOf(declaration1, declaration2, declaration3)
+        val kClasses = listOf(SampleType1::class, SampleType2::class)
+
+        // when
+        val sut = declarations.withInterfaceOrObjectDeclarationOf(kClasses)
+
+        // then
+        sut shouldBeEqualTo listOf(declaration1, declaration2)
+    }
+
+    @Test
+    fun `withInterfaceOrObjectDeclarationOf(set of KClass) returns declarations with one of given interfaces or objects`() {
+        // given
+        val declaration1: KoDeclarationCastProvider =
+            mockk {
+                every { hasInterfaceOrObjectDeclarationOf(SampleType1::class) } returns true
+                every { hasInterfaceOrObjectDeclarationOf(SampleType2::class) } returns false
+            }
+        val declaration2: KoDeclarationCastProvider =
+            mockk {
+                every { hasInterfaceOrObjectDeclarationOf(SampleType1::class) } returns false
+                every { hasInterfaceOrObjectDeclarationOf(SampleType2::class) } returns true
+            }
+        val declaration3: KoDeclarationCastProvider =
+            mockk {
+                every { hasInterfaceOrObjectDeclarationOf(SampleType1::class) } returns false
+                every { hasInterfaceOrObjectDeclarationOf(SampleType2::class) } returns false
+            }
+        val declarations = listOf(declaration1, declaration2, declaration3)
+        val kClasses = setOf(SampleType1::class, SampleType2::class)
+
+        // when
+        val sut = declarations.withInterfaceOrObjectDeclarationOf(kClasses)
+
+        // then
+        sut shouldBeEqualTo listOf(declaration1, declaration2)
+    }
+
+    @Test
+    fun `withoutInterfaceOrObjectDeclarationOf(KClass) returns declaration without given interface or object`() {
+        // given
+        val declaration1: KoDeclarationCastProvider =
+            mockk {
+                every { hasInterfaceOrObjectDeclarationOf(SampleType1::class) } returns true
+            }
+        val declaration2: KoDeclarationCastProvider =
+            mockk {
+                every { hasInterfaceOrObjectDeclarationOf(SampleType1::class) } returns false
+            }
+        val declarations = listOf(declaration1, declaration2)
+
+        // when
+        val sut = declarations.withoutInterfaceOrObjectDeclarationOf(SampleType1::class)
+
+        // then
+        sut shouldBeEqualTo listOf(declaration2)
+    }
+
+    @Test
+    fun `withoutInterfaceOrObjectDeclarationOf(KClass) returns declaration without any of given interfaces or objects`() {
+        // given
+        val declaration1: KoDeclarationCastProvider =
+            mockk {
+                every { hasInterfaceOrObjectDeclarationOf(SampleType1::class) } returns true
+                every { hasInterfaceOrObjectDeclarationOf(SampleType2::class) } returns false
+            }
+        val declaration2: KoDeclarationCastProvider =
+            mockk {
+                every { hasInterfaceOrObjectDeclarationOf(SampleType1::class) } returns false
+                every { hasInterfaceOrObjectDeclarationOf(SampleType2::class) } returns true
+            }
+        val declaration3: KoDeclarationCastProvider =
+            mockk {
+                every { hasInterfaceOrObjectDeclarationOf(SampleType1::class) } returns false
+                every { hasInterfaceOrObjectDeclarationOf(SampleType2::class) } returns false
+            }
+        val declarations = listOf(declaration1, declaration2, declaration3)
+
+        // when
+        val sut = declarations.withoutInterfaceOrObjectDeclarationOf(SampleType1::class, SampleType2::class)
+
+        // then
+        sut shouldBeEqualTo listOf(declaration3)
+    }
+
+    @Test
+    fun `withoutInterfaceOrObjectDeclarationOf(list of KClass) returns declaration without any of given interfaces or objects`() {
+        // given
+        val declaration1: KoDeclarationCastProvider =
+            mockk {
+                every { hasInterfaceOrObjectDeclarationOf(SampleType1::class) } returns true
+                every { hasInterfaceOrObjectDeclarationOf(SampleType2::class) } returns false
+            }
+        val declaration2: KoDeclarationCastProvider =
+            mockk {
+                every { hasInterfaceOrObjectDeclarationOf(SampleType1::class) } returns false
+                every { hasInterfaceOrObjectDeclarationOf(SampleType2::class) } returns true
+            }
+        val declaration3: KoDeclarationCastProvider =
+            mockk {
+                every { hasInterfaceOrObjectDeclarationOf(SampleType1::class) } returns false
+                every { hasInterfaceOrObjectDeclarationOf(SampleType2::class) } returns false
+            }
+        val declarations = listOf(declaration1, declaration2, declaration3)
+        val kClasses = listOf(SampleType1::class, SampleType2::class)
+
+        // when
+        val sut = declarations.withoutInterfaceOrObjectDeclarationOf(kClasses)
+
+        // then
+        sut shouldBeEqualTo listOf(declaration3)
+    }
+
+    @Test
+    fun `withoutInterfaceOrObjectDeclarationOf(set of KClass) returns declaration without any of given interfaces or objects`() {
+        // given
+        val declaration1: KoDeclarationCastProvider =
+            mockk {
+                every { hasInterfaceOrObjectDeclarationOf(SampleType1::class) } returns true
+                every { hasInterfaceOrObjectDeclarationOf(SampleType2::class) } returns false
+            }
+        val declaration2: KoDeclarationCastProvider =
+            mockk {
+                every { hasInterfaceOrObjectDeclarationOf(SampleType1::class) } returns false
+                every { hasInterfaceOrObjectDeclarationOf(SampleType2::class) } returns true
+            }
+        val declaration3: KoDeclarationCastProvider =
+            mockk {
+                every { hasInterfaceOrObjectDeclarationOf(SampleType1::class) } returns false
+                every { hasInterfaceOrObjectDeclarationOf(SampleType2::class) } returns false
+            }
+        val declarations = listOf(declaration1, declaration2, declaration3)
+        val kClasses = setOf(SampleType1::class, SampleType2::class)
+
+        // when
+        val sut = declarations.withoutInterfaceOrObjectDeclarationOf(kClasses)
+
+        // then
+        sut shouldBeEqualTo listOf(declaration3)
+    }
+
+
+    @Test
+    fun `withClassOrInterfaceOrObjectDeclaration() returns declaration with class, interface or object`() {
+        // given
+        val declaration1: KoDeclarationCastProvider =
+            mockk {
+                every { isClassOrInterfaceOrObject } returns true
+            }
+        val declaration2: KoDeclarationCastProvider =
+            mockk {
+                every { isClassOrInterfaceOrObject } returns false
+            }
+        val declarations = listOf(declaration1, declaration2)
+
+        // when
+        val sut = declarations.withClassOrInterfaceOrObjectDeclaration()
+
+        // then
+        sut shouldBeEqualTo listOf(declaration1)
+    }
+
+    @Test
+    fun `withClassOrInterfaceOrObjectDeclarationOf(empty list) returns declaration with class, interface or object`() {
+        // given
+        val declaration1: KoDeclarationCastProvider =
+            mockk {
+                every { hasClassOrInterfaceOrObjectDeclaration() } returns true
+            }
+        val declaration2: KoDeclarationCastProvider =
+            mockk {
+                every { hasClassOrInterfaceOrObjectDeclaration() } returns false
+            }
+        val declarations = listOf(declaration1, declaration2)
+
+        // when
+        val sut = declarations.withClassOrInterfaceOrObjectDeclarationOf(emptyList())
+
+        // then
+        sut shouldBeEqualTo listOf(declaration1)
+    }
+
+    @Test
+    fun `withClassOrInterfaceOrObjectDeclarationOf(empty set) returns declaration with class, interface or object`() {
+        // given
+        val declaration1: KoDeclarationCastProvider =
+            mockk {
+                every { hasClassOrInterfaceOrObjectDeclaration() } returns true
+            }
+        val declaration2: KoDeclarationCastProvider =
+            mockk {
+                every { hasClassOrInterfaceOrObjectDeclaration() } returns false
+            }
+        val declarations = listOf(declaration1, declaration2)
+
+        // when
+        val sut = declarations.withClassOrInterfaceOrObjectDeclarationOf(emptySet())
+
+        // then
+        sut shouldBeEqualTo listOf(declaration1)
+    }
+
+    @Test
+    fun `withClassOrInterfaceOrObjectDeclaration{} returns declaration which satisfy predicate`() {
+        // given
+        val name1 = "name1"
+        val name2 = "name2"
+        val sourceObject1: KoClassAndInterfaceAndObjectDeclaration =
+            mockk {
+                every { name } returns name1
+            }
+        val sourceObject2: KoClassAndInterfaceAndObjectDeclaration =
+            mockk {
+                every { name } returns name2
+            }
+        val declaration1: KoDeclarationCastProvider =
+            mockk {
+                every { asClassOrInterfaceOrObjectDeclaration() } returns sourceObject1
+            }
+        val declaration2: KoDeclarationCastProvider =
+            mockk {
+                every { asClassOrInterfaceOrObjectDeclaration() } returns sourceObject2
+            }
+        val declaration3: KoDeclarationCastProvider =
+            mockk {
+                every { asClassOrInterfaceOrObjectDeclaration() } returns null
+            }
+        val declarations = listOf(declaration1, declaration2, declaration3)
+
+        // when
+        val sut = declarations.withClassOrInterfaceOrObjectDeclaration { it.name == name1 }
+
+        // then
+        sut shouldBeEqualTo listOf(declaration1)
+    }
+
+    @Test
+    fun `withoutClassOrInterfaceOrObjectDeclaration() returns declaration without class, interface or object`() {
+        // given
+        val declaration1: KoDeclarationCastProvider =
+            mockk {
+                every { isClassOrInterfaceOrObject } returns true
+            }
+        val declaration2: KoDeclarationCastProvider =
+            mockk {
+                every { isClassOrInterfaceOrObject } returns false
+            }
+        val declarations = listOf(declaration1, declaration2)
+
+        // when
+        val sut = declarations.withoutClassOrInterfaceOrObjectDeclaration()
+
+        // then
+        sut shouldBeEqualTo listOf(declaration2)
+    }
+
+    @Test
+    fun `withoutClassOrInterfaceOrObjectDeclarationOf(empty list) returns declaration without class, interface or object`() {
+        // given
+        val declaration1: KoDeclarationCastProvider =
+            mockk {
+                every { hasClassOrInterfaceOrObjectDeclaration() } returns true
+            }
+        val declaration2: KoDeclarationCastProvider =
+            mockk {
+                every { hasClassOrInterfaceOrObjectDeclaration() } returns false
+            }
+        val declarations = listOf(declaration1, declaration2)
+
+        // when
+        val sut = declarations.withoutClassOrInterfaceOrObjectDeclarationOf(emptyList())
+
+        // then
+        sut shouldBeEqualTo listOf(declaration2)
+    }
+
+    @Test
+    fun `withoutClassOrInterfaceOrObjectDeclarationOf(empty set) returns declaration without class, interface or object`() {
+        // given
+        val declaration1: KoDeclarationCastProvider =
+            mockk {
+                every { hasClassOrInterfaceOrObjectDeclaration() } returns true
+            }
+        val declaration2: KoDeclarationCastProvider =
+            mockk {
+                every { hasClassOrInterfaceOrObjectDeclaration() } returns false
+            }
+        val declarations = listOf(declaration1, declaration2)
+
+        // when
+        val sut = declarations.withoutClassOrInterfaceOrObjectDeclarationOf(emptySet())
+
+        // then
+        sut shouldBeEqualTo listOf(declaration2)
+    }
+
+    @Test
+    fun `withoutClassOrInterfaceOrObjectDeclaration{} returns declarations which not satisfy predicate`() {
+        // given
+        val name1 = "name1"
+        val name2 = "name2"
+        val sourceObject1: KoClassAndInterfaceAndObjectDeclaration =
+            mockk {
+                every { name } returns name1
+            }
+        val sourceObject2: KoClassAndInterfaceAndObjectDeclaration =
+            mockk {
+                every { name } returns name2
+            }
+        val declaration1: KoDeclarationCastProvider =
+            mockk {
+                every { asClassOrInterfaceOrObjectDeclaration() } returns sourceObject1
+            }
+        val declaration2: KoDeclarationCastProvider =
+            mockk {
+                every { asClassOrInterfaceOrObjectDeclaration() } returns sourceObject2
+            }
+        val declaration3: KoDeclarationCastProvider =
+            mockk {
+                every { asClassOrInterfaceOrObjectDeclaration() } returns null
+            }
+        val declarations = listOf(declaration1, declaration2, declaration3)
+
+        // when
+        val sut = declarations.withoutClassOrInterfaceOrObjectDeclaration { it.name == name1 }
+
+        // then
+        sut shouldBeEqualTo listOf(declaration2, declaration3)
+    }
+
+    @Test
+    fun `withClassOrInterfaceOrObjectDeclarationOf(KClass) returns declaration with given class, interface or object`() {
+        // given
+        val declaration1: KoDeclarationCastProvider =
+            mockk {
+                every { hasClassOrInterfaceOrObjectDeclarationOf(SampleType1::class) } returns true
+            }
+        val declaration2: KoDeclarationCastProvider =
+            mockk {
+                every { hasClassOrInterfaceOrObjectDeclarationOf(SampleType1::class) } returns false
+            }
+        val declarations = listOf(declaration1, declaration2)
+
+        // when
+        val sut = declarations.withClassOrInterfaceOrObjectDeclarationOf(SampleType1::class)
+
+        // then
+        sut shouldBeEqualTo listOf(declaration1)
+    }
+
+    @Test
+    fun `withClassOrInterfaceOrObjectDeclarationOf(KClass) returns declarations with one of given classes, interfaces or objects`() {
+        // given
+        val declaration1: KoDeclarationCastProvider =
+            mockk {
+                every { hasClassOrInterfaceOrObjectDeclarationOf(SampleType1::class) } returns true
+                every { hasClassOrInterfaceOrObjectDeclarationOf(SampleType2::class) } returns false
+            }
+        val declaration2: KoDeclarationCastProvider =
+            mockk {
+                every { hasClassOrInterfaceOrObjectDeclarationOf(SampleType1::class) } returns false
+                every { hasClassOrInterfaceOrObjectDeclarationOf(SampleType2::class) } returns true
+            }
+        val declaration3: KoDeclarationCastProvider =
+            mockk {
+                every { hasClassOrInterfaceOrObjectDeclarationOf(SampleType1::class) } returns false
+                every { hasClassOrInterfaceOrObjectDeclarationOf(SampleType2::class) } returns false
+            }
+        val declarations = listOf(declaration1, declaration2, declaration3)
+
+        // when
+        val sut = declarations.withClassOrInterfaceOrObjectDeclarationOf(SampleType1::class, SampleType2::class)
+
+        // then
+        sut shouldBeEqualTo listOf(declaration1, declaration2)
+    }
+
+    @Test
+    fun `withClassOrInterfaceOrObjectDeclarationOf(list of KClass) returns declarations with one of given classes, interfaces or objects`() {
+        // given
+        val declaration1: KoDeclarationCastProvider =
+            mockk {
+                every { hasClassOrInterfaceOrObjectDeclarationOf(SampleType1::class) } returns true
+                every { hasClassOrInterfaceOrObjectDeclarationOf(SampleType2::class) } returns false
+            }
+        val declaration2: KoDeclarationCastProvider =
+            mockk {
+                every { hasClassOrInterfaceOrObjectDeclarationOf(SampleType1::class) } returns false
+                every { hasClassOrInterfaceOrObjectDeclarationOf(SampleType2::class) } returns true
+            }
+        val declaration3: KoDeclarationCastProvider =
+            mockk {
+                every { hasClassOrInterfaceOrObjectDeclarationOf(SampleType1::class) } returns false
+                every { hasClassOrInterfaceOrObjectDeclarationOf(SampleType2::class) } returns false
+            }
+        val declarations = listOf(declaration1, declaration2, declaration3)
+        val kClasses = listOf(SampleType1::class, SampleType2::class)
+
+        // when
+        val sut = declarations.withClassOrInterfaceOrObjectDeclarationOf(kClasses)
+
+        // then
+        sut shouldBeEqualTo listOf(declaration1, declaration2)
+    }
+
+    @Test
+    fun `withClassOrInterfaceOrObjectDeclarationOf(set of KClass) returns declarations with one of given classes, interfaces or objects`() {
+        // given
+        val declaration1: KoDeclarationCastProvider =
+            mockk {
+                every { hasClassOrInterfaceOrObjectDeclarationOf(SampleType1::class) } returns true
+                every { hasClassOrInterfaceOrObjectDeclarationOf(SampleType2::class) } returns false
+            }
+        val declaration2: KoDeclarationCastProvider =
+            mockk {
+                every { hasClassOrInterfaceOrObjectDeclarationOf(SampleType1::class) } returns false
+                every { hasClassOrInterfaceOrObjectDeclarationOf(SampleType2::class) } returns true
+            }
+        val declaration3: KoDeclarationCastProvider =
+            mockk {
+                every { hasClassOrInterfaceOrObjectDeclarationOf(SampleType1::class) } returns false
+                every { hasClassOrInterfaceOrObjectDeclarationOf(SampleType2::class) } returns false
+            }
+        val declarations = listOf(declaration1, declaration2, declaration3)
+        val kClasses = setOf(SampleType1::class, SampleType2::class)
+
+        // when
+        val sut = declarations.withClassOrInterfaceOrObjectDeclarationOf(kClasses)
+
+        // then
+        sut shouldBeEqualTo listOf(declaration1, declaration2)
+    }
+
+    @Test
+    fun `withoutClassOrInterfaceOrObjectDeclarationOf(KClass) returns declaration without given class, interface or object`() {
+        // given
+        val declaration1: KoDeclarationCastProvider =
+            mockk {
+                every { hasClassOrInterfaceOrObjectDeclarationOf(SampleType1::class) } returns true
+            }
+        val declaration2: KoDeclarationCastProvider =
+            mockk {
+                every { hasClassOrInterfaceOrObjectDeclarationOf(SampleType1::class) } returns false
+            }
+        val declarations = listOf(declaration1, declaration2)
+
+        // when
+        val sut = declarations.withoutClassOrInterfaceOrObjectDeclarationOf(SampleType1::class)
+
+        // then
+        sut shouldBeEqualTo listOf(declaration2)
+    }
+
+    @Test
+    fun `withoutClassOrInterfaceOrObjectDeclarationOf(KClass) returns declaration without any of given classes, interfaces or objects`() {
+        // given
+        val declaration1: KoDeclarationCastProvider =
+            mockk {
+                every { hasClassOrInterfaceOrObjectDeclarationOf(SampleType1::class) } returns true
+                every { hasClassOrInterfaceOrObjectDeclarationOf(SampleType2::class) } returns false
+            }
+        val declaration2: KoDeclarationCastProvider =
+            mockk {
+                every { hasClassOrInterfaceOrObjectDeclarationOf(SampleType1::class) } returns false
+                every { hasClassOrInterfaceOrObjectDeclarationOf(SampleType2::class) } returns true
+            }
+        val declaration3: KoDeclarationCastProvider =
+            mockk {
+                every { hasClassOrInterfaceOrObjectDeclarationOf(SampleType1::class) } returns false
+                every { hasClassOrInterfaceOrObjectDeclarationOf(SampleType2::class) } returns false
+            }
+        val declarations = listOf(declaration1, declaration2, declaration3)
+
+        // when
+        val sut = declarations.withoutClassOrInterfaceOrObjectDeclarationOf(SampleType1::class, SampleType2::class)
+
+        // then
+        sut shouldBeEqualTo listOf(declaration3)
+    }
+
+    @Test
+    fun `withoutClassOrInterfaceOrObjectDeclarationOf(list of KClass) returns declaration without any of given classes, interfaces or objects`() {
+        // given
+        val declaration1: KoDeclarationCastProvider =
+            mockk {
+                every { hasClassOrInterfaceOrObjectDeclarationOf(SampleType1::class) } returns true
+                every { hasClassOrInterfaceOrObjectDeclarationOf(SampleType2::class) } returns false
+            }
+        val declaration2: KoDeclarationCastProvider =
+            mockk {
+                every { hasClassOrInterfaceOrObjectDeclarationOf(SampleType1::class) } returns false
+                every { hasClassOrInterfaceOrObjectDeclarationOf(SampleType2::class) } returns true
+            }
+        val declaration3: KoDeclarationCastProvider =
+            mockk {
+                every { hasClassOrInterfaceOrObjectDeclarationOf(SampleType1::class) } returns false
+                every { hasClassOrInterfaceOrObjectDeclarationOf(SampleType2::class) } returns false
+            }
+        val declarations = listOf(declaration1, declaration2, declaration3)
+        val kClasses = listOf(SampleType1::class, SampleType2::class)
+
+        // when
+        val sut = declarations.withoutClassOrInterfaceOrObjectDeclarationOf(kClasses)
+
+        // then
+        sut shouldBeEqualTo listOf(declaration3)
+    }
+
+    @Test
+    fun `withoutClassOrInterfaceOrObjectDeclarationOf(set of KClass) returns declaration without any of given classes, interfaces or objects`() {
+        // given
+        val declaration1: KoDeclarationCastProvider =
+            mockk {
+                every { hasClassOrInterfaceOrObjectDeclarationOf(SampleType1::class) } returns true
+                every { hasClassOrInterfaceOrObjectDeclarationOf(SampleType2::class) } returns false
+            }
+        val declaration2: KoDeclarationCastProvider =
+            mockk {
+                every { hasClassOrInterfaceOrObjectDeclarationOf(SampleType1::class) } returns false
+                every { hasClassOrInterfaceOrObjectDeclarationOf(SampleType2::class) } returns true
+            }
+        val declaration3: KoDeclarationCastProvider =
+            mockk {
+                every { hasClassOrInterfaceOrObjectDeclarationOf(SampleType1::class) } returns false
+                every { hasClassOrInterfaceOrObjectDeclarationOf(SampleType2::class) } returns false
+            }
+        val declarations = listOf(declaration1, declaration2, declaration3)
+        val kClasses = setOf(SampleType1::class, SampleType2::class)
+
+        // when
+        val sut = declarations.withoutClassOrInterfaceOrObjectDeclarationOf(kClasses)
+
+        // then
+        sut shouldBeEqualTo listOf(declaration3)
+    }
+
 
     @Test
     fun `withTypeAliasDeclaration() returns declaration with type alias`() {


### PR DESCRIPTION
This PR introduces a comprehensive set of functionalities to enhance type handling within `KoDeclarationCastProvider`, focusing on combined types like classes, interfaces, and objects. The changes aim to improve the clarity, usability, and flexibility of declarations, making it easier to work with complex type combinations in Kotlin.

### Summary of Changes:
1. **New Properties**:  
   Added Boolean properties such as `isClassOrObject`, `isClassOrInterface`, and similar, to allow quick identification of declarations that belong to combined type categories (e.g., whether a declaration is either a class or an object).

2. **New Methods for Casting**:  
   Introduced methods like `asClassOrObjectDeclaration()` or `asClassOrInterfaceDeclaration()` that enable safe casting to specific combined types. This ensures clear and consistent handling of declarations based on their type composition.

3. **Type Predicate Methods**:  
   Added methods like `hasClassOrObjectDeclaration(predicate)` to verify specific conditions on combined types. These allow for flexible filtering and validation based on predicates.

4. **Extensions for Lists**:  
   Introduced extension functions for lists of `KoDeclarationCastProvider` to support filtering and mapping based on the newly added properties and methods. Examples include:
   - `classAndObjectDeclarations()` for extracting all class or object declarations.
   - `withClassOrInterfaceDeclaration(predicate)` to filter elements matching specific criteria for combined types.
   - `withoutInterfaceOrObjectDeclarationOf()` to exclude declarations of certain types.

### Purpose:
This update fills a gap in the `KoDeclarationCastProvider` API by adding essential support for combined type operations. It enables developers to seamlessly:
- Distinguish between classes, objects, and interfaces in various combinations.
- Cast or transform declarations to desired combined types.
- Filter or map lists of declarations using intuitive, high-level abstractions.

### Use Case:
For example, a developer working with a mixed collection of declarations can now easily retrieve all class-and-interface declarations that match a specific condition, avoiding manual type checks and improving code readability.
