### PR TITLE
KON-693 Add ASCII tree to missing methods like assertNotEmpty

### DIFF
--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/verify/kodeclarationassert/assertempty/AssertEmptyOnDeclarationListTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/verify/kodeclarationassert/assertempty/AssertEmptyOnDeclarationListTest.kt
@@ -99,13 +99,13 @@ class AssertEmptyOnDeclarationListTest {
         } catch (e: Exception) {
             val filepath =
                 "file://$rootPath/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/verify/kodeclarationassert/" +
-                        "assertempty/snippet/declaration-assert-empty-error-on-list-containing-non-null-values.kt"
+                    "assertempty/snippet/declaration-assert-empty-error-on-list-containing-non-null-values.kt"
 
             e.message?.shouldContain(
                 "Assert 'declaration-assert-empty-error-on-list-containing-non-null-values' failed. " +
                     "Declaration list is not empty. It contains values:\n" +
-                        "├── Class SampleClass1 $filepath:1:1\n" +
-                        "└── Class SampleClass2 $filepath:3:1"
+                    "├── Class SampleClass1 $filepath:1:1\n" +
+                    "└── Class SampleClass2 $filepath:3:1",
             )
                 ?: throw e
         }
@@ -125,12 +125,12 @@ class AssertEmptyOnDeclarationListTest {
         } catch (e: Exception) {
             val filepath =
                 "file://$rootPath/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/verify/kodeclarationassert/" +
-                        "assertempty/snippet/declaration-assert-empty-error-on-list-containing-null-and-non-null-values.kt:1:24"
+                    "assertempty/snippet/declaration-assert-empty-error-on-list-containing-null-and-non-null-values.kt:1:24"
 
             e.message?.shouldContain(
                 "Assert 'declaration-assert-empty-error-on-list-containing-null-and-non-null-values' failed. " +
                     "Declaration list is not empty. It contains 1 null value and values:\n" +
-                        "└── Type Int $filepath",
+                    "└── Type Int $filepath",
             )
                 ?: throw e
         }
@@ -150,12 +150,12 @@ class AssertEmptyOnDeclarationListTest {
         } catch (e: Exception) {
             val filepath =
                 "file://$rootPath/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/verify/kodeclarationassert/" +
-                        "assertempty/snippet/declaration-assert-empty-error-with-custom-message.kt:1:1"
+                    "assertempty/snippet/declaration-assert-empty-error-with-custom-message.kt:1:1"
 
             e.message?.shouldContain(
                 "Assert 'declaration-assert-empty-error-with-custom-message' failed.\n$message\n" +
                     "Declaration list is not empty. It contains values:\n" +
-                        "└── Class SampleClass $filepath",
+                    "└── Class SampleClass $filepath",
             )
                 ?: throw e
         }
@@ -175,12 +175,12 @@ class AssertEmptyOnDeclarationListTest {
         } catch (e: Exception) {
             val filepath =
                 "file://$rootPath/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/verify/kodeclarationassert/" +
-                        "assertempty/snippet/declaration-assert-empty-error-with-custom-message-and-strict-set-to-true.kt:1:1"
+                    "assertempty/snippet/declaration-assert-empty-error-with-custom-message-and-strict-set-to-true.kt:1:1"
 
             e.message?.shouldContain(
                 "Assert 'declaration-assert-empty-error-with-custom-message-and-strict-set-to-true' failed.\n$message\n" +
                     "Declaration list is not empty. It contains values:\n" +
-                        "└── Class SampleClass $filepath",
+                    "└── Class SampleClass $filepath",
             )
                 ?: throw e
         }

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/verify/kodeclarationassert/assertempty/AssertEmptyOnDeclarationListTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/verify/kodeclarationassert/assertempty/AssertEmptyOnDeclarationListTest.kt
@@ -1,15 +1,17 @@
 package com.lemonappdev.konsist.core.verify.kodeclarationassert.assertempty
 
 import com.lemonappdev.konsist.TestSnippetProvider
-import com.lemonappdev.konsist.api.ext.list.classes
 import com.lemonappdev.konsist.api.verify.assertEmpty
 import com.lemonappdev.konsist.api.verify.assertNotEmpty
 import com.lemonappdev.konsist.core.exception.KoAssertionFailedException
+import com.lemonappdev.konsist.core.filesystem.PathProvider
 import org.amshove.kluent.shouldContain
 import org.amshove.kluent.shouldThrow
 import org.junit.jupiter.api.Test
 
 class AssertEmptyOnDeclarationListTest {
+    private val rootPath = PathProvider.rootProjectPath
+
     @Test
     fun `declaration-assert-test-method-name-derived-from-junit-method-name`() {
         // given
@@ -95,9 +97,15 @@ class AssertEmptyOnDeclarationListTest {
         try {
             sut.assertEmpty()
         } catch (e: Exception) {
+            val filepath =
+                "file://$rootPath/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/verify/kodeclarationassert/" +
+                        "assertempty/snippet/declaration-assert-empty-error-on-list-containing-non-null-values.kt"
+
             e.message?.shouldContain(
                 "Assert 'declaration-assert-empty-error-on-list-containing-non-null-values' failed. " +
-                    "Declaration list is not empty. It contains values:\nSampleClass1,\nSampleClass2.",
+                    "Declaration list is not empty. It contains values:\n" +
+                        "├── Class SampleClass1 $filepath:1:1\n" +
+                        "└── Class SampleClass2 $filepath:3:1"
             )
                 ?: throw e
         }
@@ -115,9 +123,14 @@ class AssertEmptyOnDeclarationListTest {
         try {
             sut.assertEmpty()
         } catch (e: Exception) {
+            val filepath =
+                "file://$rootPath/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/verify/kodeclarationassert/" +
+                        "assertempty/snippet/declaration-assert-empty-error-on-list-containing-null-and-non-null-values.kt:1:24"
+
             e.message?.shouldContain(
                 "Assert 'declaration-assert-empty-error-on-list-containing-null-and-non-null-values' failed. " +
-                    "Declaration list is not empty. It contains 1 null value and values:\nInt.",
+                    "Declaration list is not empty. It contains 1 null value and values:\n" +
+                        "└── Type Int $filepath",
             )
                 ?: throw e
         }
@@ -135,9 +148,14 @@ class AssertEmptyOnDeclarationListTest {
         try {
             sut.assertEmpty(additionalMessage = message)
         } catch (e: Exception) {
+            val filepath =
+                "file://$rootPath/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/verify/kodeclarationassert/" +
+                        "assertempty/snippet/declaration-assert-empty-error-with-custom-message.kt:1:1"
+
             e.message?.shouldContain(
                 "Assert 'declaration-assert-empty-error-with-custom-message' failed.\n$message\n" +
-                    "Declaration list is not empty. It contains values:\nSampleClass.",
+                    "Declaration list is not empty. It contains values:\n" +
+                        "└── Class SampleClass $filepath",
             )
                 ?: throw e
         }
@@ -155,9 +173,14 @@ class AssertEmptyOnDeclarationListTest {
         try {
             sut.assertEmpty(strict = true, additionalMessage = message)
         } catch (e: Exception) {
+            val filepath =
+                "file://$rootPath/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/verify/kodeclarationassert/" +
+                        "assertempty/snippet/declaration-assert-empty-error-with-custom-message-and-strict-set-to-true.kt:1:1"
+
             e.message?.shouldContain(
                 "Assert 'declaration-assert-empty-error-with-custom-message-and-strict-set-to-true' failed.\n$message\n" +
-                    "Declaration list is not empty. It contains values:\nSampleClass.",
+                    "Declaration list is not empty. It contains values:\n" +
+                        "└── Class SampleClass $filepath",
             )
                 ?: throw e
         }

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/verify/kodeclarationassert/assertempty/AssertEmptyOnDeclarationSequenceTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/verify/kodeclarationassert/assertempty/AssertEmptyOnDeclarationSequenceTest.kt
@@ -1,15 +1,17 @@
 package com.lemonappdev.konsist.core.verify.kodeclarationassert.assertempty
 
 import com.lemonappdev.konsist.TestSnippetProvider
-import com.lemonappdev.konsist.api.ext.list.classes
 import com.lemonappdev.konsist.api.verify.assertEmpty
 import com.lemonappdev.konsist.api.verify.assertNotEmpty
 import com.lemonappdev.konsist.core.exception.KoAssertionFailedException
+import com.lemonappdev.konsist.core.filesystem.PathProvider
 import org.amshove.kluent.shouldContain
 import org.amshove.kluent.shouldThrow
 import org.junit.jupiter.api.Test
 
 class AssertEmptyOnDeclarationSequenceTest {
+    private val rootPath = PathProvider.rootProjectPath
+
     @Test
     fun `declaration-assert-test-method-name-derived-from-junit-method-name`() {
         // given
@@ -100,9 +102,15 @@ class AssertEmptyOnDeclarationSequenceTest {
         try {
             sut.assertEmpty()
         } catch (e: Exception) {
+            val filepath =
+                "file://$rootPath/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/verify/kodeclarationassert/" +
+                        "assertempty/snippet/declaration-assert-empty-error-on-list-containing-non-null-values.kt"
+
             e.message?.shouldContain(
                 "Assert 'declaration-assert-empty-error-on-list-containing-non-null-values' failed. " +
-                    "Declaration list is not empty. It contains values:\nSampleClass1,\nSampleClass2.",
+                    "Declaration list is not empty. It contains values:\n" +
+                        "├── Class SampleClass1 $filepath:1:1\n" +
+                        "└── Class SampleClass2 $filepath:3:1",
             )
                 ?: throw e
         }
@@ -121,9 +129,14 @@ class AssertEmptyOnDeclarationSequenceTest {
         try {
             sut.assertEmpty()
         } catch (e: Exception) {
+            val filepath =
+                "file://$rootPath/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/verify/kodeclarationassert/" +
+                        "assertempty/snippet/declaration-assert-empty-error-on-list-containing-null-and-non-null-values.kt:1:24"
+
             e.message?.shouldContain(
                 "Assert 'declaration-assert-empty-error-on-list-containing-null-and-non-null-values' failed. " +
-                    "Declaration list is not empty. It contains 1 null value and values:\nInt.",
+                    "Declaration list is not empty. It contains 1 null value and values:\n" +
+                        "└── Type Int $filepath",
             )
                 ?: throw e
         }
@@ -142,9 +155,14 @@ class AssertEmptyOnDeclarationSequenceTest {
         try {
             sut.assertEmpty(additionalMessage = message)
         } catch (e: Exception) {
+            val filepath =
+                "file://$rootPath/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/verify/kodeclarationassert/" +
+                        "assertempty/snippet/declaration-assert-empty-error-with-custom-message.kt:1:1"
+
             e.message?.shouldContain(
                 "Assert 'declaration-assert-empty-error-with-custom-message' failed.\n$message\n" +
-                    "Declaration list is not empty. It contains values:\nSampleClass.",
+                    "Declaration list is not empty. It contains values:\n" +
+                        "└── Class SampleClass $filepath",
             )
                 ?: throw e
         }
@@ -163,9 +181,14 @@ class AssertEmptyOnDeclarationSequenceTest {
         try {
             sut.assertEmpty(strict = true, additionalMessage = message)
         } catch (e: Exception) {
+            val filepath =
+                "file://$rootPath/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/verify/kodeclarationassert/" +
+                        "assertempty/snippet/declaration-assert-empty-error-with-custom-message-and-strict-set-to-true.kt:1:1"
+
             e.message?.shouldContain(
                 "Assert 'declaration-assert-empty-error-with-custom-message-and-strict-set-to-true' failed.\n$message\n" +
-                    "Declaration list is not empty. It contains values:\nSampleClass.",
+                    "Declaration list is not empty. It contains values:\n" +
+                        "└── Class SampleClass $filepath",
             )
                 ?: throw e
         }

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/verify/kodeclarationassert/assertempty/AssertEmptyOnDeclarationSequenceTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/verify/kodeclarationassert/assertempty/AssertEmptyOnDeclarationSequenceTest.kt
@@ -104,13 +104,13 @@ class AssertEmptyOnDeclarationSequenceTest {
         } catch (e: Exception) {
             val filepath =
                 "file://$rootPath/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/verify/kodeclarationassert/" +
-                        "assertempty/snippet/declaration-assert-empty-error-on-list-containing-non-null-values.kt"
+                    "assertempty/snippet/declaration-assert-empty-error-on-list-containing-non-null-values.kt"
 
             e.message?.shouldContain(
                 "Assert 'declaration-assert-empty-error-on-list-containing-non-null-values' failed. " +
                     "Declaration list is not empty. It contains values:\n" +
-                        "├── Class SampleClass1 $filepath:1:1\n" +
-                        "└── Class SampleClass2 $filepath:3:1",
+                    "├── Class SampleClass1 $filepath:1:1\n" +
+                    "└── Class SampleClass2 $filepath:3:1",
             )
                 ?: throw e
         }
@@ -131,12 +131,12 @@ class AssertEmptyOnDeclarationSequenceTest {
         } catch (e: Exception) {
             val filepath =
                 "file://$rootPath/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/verify/kodeclarationassert/" +
-                        "assertempty/snippet/declaration-assert-empty-error-on-list-containing-null-and-non-null-values.kt:1:24"
+                    "assertempty/snippet/declaration-assert-empty-error-on-list-containing-null-and-non-null-values.kt:1:24"
 
             e.message?.shouldContain(
                 "Assert 'declaration-assert-empty-error-on-list-containing-null-and-non-null-values' failed. " +
                     "Declaration list is not empty. It contains 1 null value and values:\n" +
-                        "└── Type Int $filepath",
+                    "└── Type Int $filepath",
             )
                 ?: throw e
         }
@@ -157,12 +157,12 @@ class AssertEmptyOnDeclarationSequenceTest {
         } catch (e: Exception) {
             val filepath =
                 "file://$rootPath/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/verify/kodeclarationassert/" +
-                        "assertempty/snippet/declaration-assert-empty-error-with-custom-message.kt:1:1"
+                    "assertempty/snippet/declaration-assert-empty-error-with-custom-message.kt:1:1"
 
             e.message?.shouldContain(
                 "Assert 'declaration-assert-empty-error-with-custom-message' failed.\n$message\n" +
                     "Declaration list is not empty. It contains values:\n" +
-                        "└── Class SampleClass $filepath",
+                    "└── Class SampleClass $filepath",
             )
                 ?: throw e
         }
@@ -183,12 +183,12 @@ class AssertEmptyOnDeclarationSequenceTest {
         } catch (e: Exception) {
             val filepath =
                 "file://$rootPath/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/verify/kodeclarationassert/" +
-                        "assertempty/snippet/declaration-assert-empty-error-with-custom-message-and-strict-set-to-true.kt:1:1"
+                    "assertempty/snippet/declaration-assert-empty-error-with-custom-message-and-strict-set-to-true.kt:1:1"
 
             e.message?.shouldContain(
                 "Assert 'declaration-assert-empty-error-with-custom-message-and-strict-set-to-true' failed.\n$message\n" +
                     "Declaration list is not empty. It contains values:\n" +
-                        "└── Class SampleClass $filepath",
+                    "└── Class SampleClass $filepath",
             )
                 ?: throw e
         }

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/verify/koproviderassert/assertempty/AssertEmptyOnProviderListTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/verify/koproviderassert/assertempty/AssertEmptyOnProviderListTest.kt
@@ -8,11 +8,14 @@ import com.lemonappdev.konsist.api.provider.KoSourceAndAliasTypeProvider
 import com.lemonappdev.konsist.api.verify.assertEmpty
 import com.lemonappdev.konsist.api.verify.assertNotEmpty
 import com.lemonappdev.konsist.core.exception.KoAssertionFailedException
+import com.lemonappdev.konsist.core.filesystem.PathProvider
 import org.amshove.kluent.shouldContain
 import org.amshove.kluent.shouldThrow
 import org.junit.jupiter.api.Test
 
 class AssertEmptyOnProviderListTest {
+    private val rootPath = PathProvider.rootProjectPath
+
     @Test
     fun `provider-assert-test-method-name-derived-from-junit-method-name`() {
         // given
@@ -101,9 +104,15 @@ class AssertEmptyOnProviderListTest {
         try {
             sut.assertEmpty()
         } catch (e: Exception) {
+                       val filepath =
+                "file://$rootPath/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/verify/koproviderassert/" +
+                        "assertempty/snippet/provider-assert-empty-error-on-list-containing-non-null-values.kt"
+
             e.message?.shouldContain(
                 "Assert 'provider-assert-empty-error-on-list-containing-non-null-values' failed. " +
-                    "Declaration list is not empty. It contains values:\nSampleClass1,\nSampleClass2.",
+                    "Declaration list is not empty. It contains values:\n" +
+                        "├── Class SampleClass1 $filepath:1:1\n" +
+                        "└── Class SampleClass2 $filepath:3:1",
             )
                 ?: throw e
         }
@@ -122,9 +131,14 @@ class AssertEmptyOnProviderListTest {
         try {
             sut.assertEmpty()
         } catch (e: Exception) {
+                       val filepath =
+                "file://$rootPath/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/verify/koproviderassert/" +
+                        "assertempty/snippet/provider-assert-empty-error-on-list-containing-null-and-non-null-values.kt:1:1"
+
             e.message?.shouldContain(
                 "Assert 'provider-assert-empty-error-on-list-containing-null-and-non-null-values' failed. " +
-                    "Declaration list is not empty. It contains 1 null value and values:\nsampleFunction.",
+                    "Declaration list is not empty. It contains 1 null value and values:\n" +
+                        "└── Function sampleFunction $filepath",
             )
                 ?: throw e
         }
@@ -144,9 +158,14 @@ class AssertEmptyOnProviderListTest {
         try {
             sut.assertEmpty(additionalMessage = message)
         } catch (e: Exception) {
+            val filepath =
+                "file://$rootPath/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/verify/koproviderassert/" +
+                        "assertempty/snippet/provider-assert-empty-error-with-custom-message.kt:1:1"
+
             e.message?.shouldContain(
                 "Assert 'provider-assert-empty-error-with-custom-message' failed.\n$message\n" +
-                    "Declaration list is not empty. It contains values:\nSampleClass.",
+                    "Declaration list is not empty. It contains values:\n" +
+                        "└── Class SampleClass $filepath",
             )
                 ?: throw e
         }
@@ -166,9 +185,14 @@ class AssertEmptyOnProviderListTest {
         try {
             sut.assertEmpty(strict = true, additionalMessage = message)
         } catch (e: Exception) {
+            val filepath =
+                "file://$rootPath/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/verify/koproviderassert/" +
+                        "assertempty/snippet/provider-assert-empty-error-with-custom-message-and-strict-set-to-true.kt:1:1"
+
             e.message?.shouldContain(
                 "Assert 'provider-assert-empty-error-with-custom-message-and-strict-set-to-true' failed.\n$message\n" +
-                    "Declaration list is not empty. It contains values:\nSampleClass.",
+                    "Declaration list is not empty. It contains values:\n" +
+                        "└── Class SampleClass $filepath",
             )
                 ?: throw e
         }

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/verify/koproviderassert/assertempty/AssertEmptyOnProviderListTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/verify/koproviderassert/assertempty/AssertEmptyOnProviderListTest.kt
@@ -104,15 +104,15 @@ class AssertEmptyOnProviderListTest {
         try {
             sut.assertEmpty()
         } catch (e: Exception) {
-                       val filepath =
+            val filepath =
                 "file://$rootPath/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/verify/koproviderassert/" +
-                        "assertempty/snippet/provider-assert-empty-error-on-list-containing-non-null-values.kt"
+                    "assertempty/snippet/provider-assert-empty-error-on-list-containing-non-null-values.kt"
 
             e.message?.shouldContain(
                 "Assert 'provider-assert-empty-error-on-list-containing-non-null-values' failed. " +
                     "Declaration list is not empty. It contains values:\n" +
-                        "├── Class SampleClass1 $filepath:1:1\n" +
-                        "└── Class SampleClass2 $filepath:3:1",
+                    "├── Class SampleClass1 $filepath:1:1\n" +
+                    "└── Class SampleClass2 $filepath:3:1",
             )
                 ?: throw e
         }
@@ -131,14 +131,14 @@ class AssertEmptyOnProviderListTest {
         try {
             sut.assertEmpty()
         } catch (e: Exception) {
-                       val filepath =
+            val filepath =
                 "file://$rootPath/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/verify/koproviderassert/" +
-                        "assertempty/snippet/provider-assert-empty-error-on-list-containing-null-and-non-null-values.kt:1:1"
+                    "assertempty/snippet/provider-assert-empty-error-on-list-containing-null-and-non-null-values.kt:1:1"
 
             e.message?.shouldContain(
                 "Assert 'provider-assert-empty-error-on-list-containing-null-and-non-null-values' failed. " +
                     "Declaration list is not empty. It contains 1 null value and values:\n" +
-                        "└── Function sampleFunction $filepath",
+                    "└── Function sampleFunction $filepath",
             )
                 ?: throw e
         }
@@ -160,12 +160,12 @@ class AssertEmptyOnProviderListTest {
         } catch (e: Exception) {
             val filepath =
                 "file://$rootPath/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/verify/koproviderassert/" +
-                        "assertempty/snippet/provider-assert-empty-error-with-custom-message.kt:1:1"
+                    "assertempty/snippet/provider-assert-empty-error-with-custom-message.kt:1:1"
 
             e.message?.shouldContain(
                 "Assert 'provider-assert-empty-error-with-custom-message' failed.\n$message\n" +
                     "Declaration list is not empty. It contains values:\n" +
-                        "└── Class SampleClass $filepath",
+                    "└── Class SampleClass $filepath",
             )
                 ?: throw e
         }
@@ -187,12 +187,12 @@ class AssertEmptyOnProviderListTest {
         } catch (e: Exception) {
             val filepath =
                 "file://$rootPath/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/verify/koproviderassert/" +
-                        "assertempty/snippet/provider-assert-empty-error-with-custom-message-and-strict-set-to-true.kt:1:1"
+                    "assertempty/snippet/provider-assert-empty-error-with-custom-message-and-strict-set-to-true.kt:1:1"
 
             e.message?.shouldContain(
                 "Assert 'provider-assert-empty-error-with-custom-message-and-strict-set-to-true' failed.\n$message\n" +
                     "Declaration list is not empty. It contains values:\n" +
-                        "└── Class SampleClass $filepath",
+                    "└── Class SampleClass $filepath",
             )
                 ?: throw e
         }

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/verify/koproviderassert/assertempty/AssertEmptyOnProviderSequenceTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/verify/koproviderassert/assertempty/AssertEmptyOnProviderSequenceTest.kt
@@ -8,11 +8,14 @@ import com.lemonappdev.konsist.api.provider.KoSourceAndAliasTypeProvider
 import com.lemonappdev.konsist.api.verify.assertEmpty
 import com.lemonappdev.konsist.api.verify.assertNotEmpty
 import com.lemonappdev.konsist.core.exception.KoAssertionFailedException
+import com.lemonappdev.konsist.core.filesystem.PathProvider
 import org.amshove.kluent.shouldContain
 import org.amshove.kluent.shouldThrow
 import org.junit.jupiter.api.Test
 
 class AssertEmptyOnProviderSequenceTest {
+    private val rootPath = PathProvider.rootProjectPath
+
     @Test
     fun `provider-assert-test-method-name-derived-from-junit-method-name`() {
         // given
@@ -106,9 +109,15 @@ class AssertEmptyOnProviderSequenceTest {
         try {
             sut.assertEmpty()
         } catch (e: Exception) {
+            val filepath =
+                "file://$rootPath/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/verify/koproviderassert/" +
+                        "assertempty/snippet/provider-assert-empty-error-on-list-containing-non-null-values.kt:1:1"
+
             e.message?.shouldContain(
                 "Assert 'provider-assert-empty-error-on-list-containing-non-null-values' failed. " +
-                    "Declaration list is not empty. It contains values:\nSampleClass1,\nSampleClass2.",
+                    "Declaration list is not empty. It contains values:" +
+                        "└── Class SampleClass1 $filepath" +
+                        "└── Class SampleClass2 $filepath",
             )
                 ?: throw e
         }
@@ -128,9 +137,14 @@ class AssertEmptyOnProviderSequenceTest {
         try {
             sut.assertEmpty()
         } catch (e: Exception) {
+            val filepath =
+                "file://$rootPath/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/verify/koproviderassert/" +
+                        "assertempty/snippet/rovider-assert-empty-error-on-list-containing-null-and-non-null-values.kt:1:1"
+
             e.message?.shouldContain(
                 "Assert 'provider-assert-empty-error-on-list-containing-null-and-non-null-values' failed. " +
-                    "Declaration list is not empty. It contains 1 null value and values:\nsampleFunction.",
+                    "Declaration list is not empty. It contains 1 null value and values:\n" +
+                        "└── Function sampleFunction $filepath",
             )
                 ?: throw e
         }
@@ -151,9 +165,14 @@ class AssertEmptyOnProviderSequenceTest {
         try {
             sut.assertEmpty(additionalMessage = message)
         } catch (e: Exception) {
+            val filepath =
+                "file://$rootPath/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/verify/koproviderassert/" +
+                        "assertempty/snippet/provider-assert-empty-error-with-custom-message.kt:1:1"
+
             e.message?.shouldContain(
                 "Assert 'provider-assert-empty-error-with-custom-message' failed.\n$message\n" +
-                    "Declaration list is not empty. It contains values:\nSampleClass.",
+                    "Declaration list is not empty. It contains values:\n" +
+                        "└── Class SampleClass $filepath",
             )
                 ?: throw e
         }
@@ -174,9 +193,14 @@ class AssertEmptyOnProviderSequenceTest {
         try {
             sut.assertEmpty(strict = true, additionalMessage = message)
         } catch (e: Exception) {
+            val filepath =
+                "file://$rootPath/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/verify/koproviderassert/" +
+                        "assertempty/snippet/provider-assert-empty-error-with-custom-message-and-strict-set-to-true.kt:1:1"
+
             e.message?.shouldContain(
                 "Assert 'provider-assert-empty-error-with-custom-message-and-strict-set-to-true' failed.\n$message\n" +
-                    "Declaration list is not empty. It contains values:\nSampleClass.",
+                    "Declaration list is not empty. It contains values:\n" +
+                        "└── Class SampleClass $filepath",
             )
                 ?: throw e
         }

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/verify/koproviderassert/assertempty/AssertEmptyOnProviderSequenceTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/verify/koproviderassert/assertempty/AssertEmptyOnProviderSequenceTest.kt
@@ -111,13 +111,13 @@ class AssertEmptyOnProviderSequenceTest {
         } catch (e: Exception) {
             val filepath =
                 "file://$rootPath/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/verify/koproviderassert/" +
-                        "assertempty/snippet/provider-assert-empty-error-on-list-containing-non-null-values.kt:1:1"
+                        "assertempty/snippet/provider-assert-empty-error-on-list-containing-non-null-values.kt"
 
             e.message?.shouldContain(
                 "Assert 'provider-assert-empty-error-on-list-containing-non-null-values' failed. " +
-                    "Declaration list is not empty. It contains values:" +
-                        "└── Class SampleClass1 $filepath" +
-                        "└── Class SampleClass2 $filepath",
+                    "Declaration list is not empty. It contains values:\n" +
+                        "├── Class SampleClass1 $filepath:1:1\n" +
+                        "└── Class SampleClass2 $filepath:3:1",
             )
                 ?: throw e
         }
@@ -139,7 +139,7 @@ class AssertEmptyOnProviderSequenceTest {
         } catch (e: Exception) {
             val filepath =
                 "file://$rootPath/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/verify/koproviderassert/" +
-                        "assertempty/snippet/rovider-assert-empty-error-on-list-containing-null-and-non-null-values.kt:1:1"
+                        "assertempty/snippet/provider-assert-empty-error-on-list-containing-null-and-non-null-values.kt:1:1"
 
             e.message?.shouldContain(
                 "Assert 'provider-assert-empty-error-on-list-containing-null-and-non-null-values' failed. " +

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/verify/koproviderassert/assertempty/AssertEmptyOnProviderSequenceTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/verify/koproviderassert/assertempty/AssertEmptyOnProviderSequenceTest.kt
@@ -111,13 +111,13 @@ class AssertEmptyOnProviderSequenceTest {
         } catch (e: Exception) {
             val filepath =
                 "file://$rootPath/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/verify/koproviderassert/" +
-                        "assertempty/snippet/provider-assert-empty-error-on-list-containing-non-null-values.kt"
+                    "assertempty/snippet/provider-assert-empty-error-on-list-containing-non-null-values.kt"
 
             e.message?.shouldContain(
                 "Assert 'provider-assert-empty-error-on-list-containing-non-null-values' failed. " +
                     "Declaration list is not empty. It contains values:\n" +
-                        "├── Class SampleClass1 $filepath:1:1\n" +
-                        "└── Class SampleClass2 $filepath:3:1",
+                    "├── Class SampleClass1 $filepath:1:1\n" +
+                    "└── Class SampleClass2 $filepath:3:1",
             )
                 ?: throw e
         }
@@ -139,12 +139,12 @@ class AssertEmptyOnProviderSequenceTest {
         } catch (e: Exception) {
             val filepath =
                 "file://$rootPath/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/verify/koproviderassert/" +
-                        "assertempty/snippet/provider-assert-empty-error-on-list-containing-null-and-non-null-values.kt:1:1"
+                    "assertempty/snippet/provider-assert-empty-error-on-list-containing-null-and-non-null-values.kt:1:1"
 
             e.message?.shouldContain(
                 "Assert 'provider-assert-empty-error-on-list-containing-null-and-non-null-values' failed. " +
                     "Declaration list is not empty. It contains 1 null value and values:\n" +
-                        "└── Function sampleFunction $filepath",
+                    "└── Function sampleFunction $filepath",
             )
                 ?: throw e
         }
@@ -167,12 +167,12 @@ class AssertEmptyOnProviderSequenceTest {
         } catch (e: Exception) {
             val filepath =
                 "file://$rootPath/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/verify/koproviderassert/" +
-                        "assertempty/snippet/provider-assert-empty-error-with-custom-message.kt:1:1"
+                    "assertempty/snippet/provider-assert-empty-error-with-custom-message.kt:1:1"
 
             e.message?.shouldContain(
                 "Assert 'provider-assert-empty-error-with-custom-message' failed.\n$message\n" +
                     "Declaration list is not empty. It contains values:\n" +
-                        "└── Class SampleClass $filepath",
+                    "└── Class SampleClass $filepath",
             )
                 ?: throw e
         }
@@ -195,12 +195,12 @@ class AssertEmptyOnProviderSequenceTest {
         } catch (e: Exception) {
             val filepath =
                 "file://$rootPath/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/verify/koproviderassert/" +
-                        "assertempty/snippet/provider-assert-empty-error-with-custom-message-and-strict-set-to-true.kt:1:1"
+                    "assertempty/snippet/provider-assert-empty-error-with-custom-message-and-strict-set-to-true.kt:1:1"
 
             e.message?.shouldContain(
                 "Assert 'provider-assert-empty-error-with-custom-message-and-strict-set-to-true' failed.\n$message\n" +
                     "Declaration list is not empty. It contains values:\n" +
-                        "└── Class SampleClass $filepath",
+                    "└── Class SampleClass $filepath",
             )
                 ?: throw e
         }

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/core/verify/KoDeclarationAndProviderAssertCore.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/core/verify/KoDeclarationAndProviderAssertCore.kt
@@ -114,12 +114,12 @@ fun checkIfLocalListHasOnlyNullElements(
     if (hasOnlyNUllElements && (localList.size > 1)) {
         throw KoPreconditionFailedException(
             "Declaration list contains only null elements. Please make sure that list of declarations contain items " +
-                    "before calling the '$testMethodName' method.",
+                "before calling the '$testMethodName' method.",
         )
     } else if (hasOnlyNUllElements && (localList.size == 1)) {
         throw KoPreconditionFailedException(
             "Method '$testMethodName' was called on a null value. Please ensure that the declaration is not null before " +
-                    "calling this method.",
+                "calling this method.",
         )
     }
 }
@@ -131,7 +131,7 @@ fun checkIfLocalListIsEmpty(
     if (localList.isEmpty()) {
         throw KoPreconditionFailedException(
             "Declaration list is empty. Please make sure that list of declarations contain items " +
-                    "before calling the '$testMethodName' method.",
+                "before calling the '$testMethodName' method.",
         )
     }
 }
@@ -146,13 +146,12 @@ private fun <E : KoBaseProvider> checkIfAnnotatedWithSuppress(
     localList
         .filterNot {
             it is KoAnnotationDeclaration &&
-                    (
-                            it.name == "Suppress" &&
-                                    it.hasTextContaining("\"konsist.$suppressName\"") ||
-                                    it.hasTextContaining("\"$suppressName\"")
-                            )
-        }
-        .forEach { declarations[it] = checkIfDeclarationIsAnnotatedWithSuppress(it as KoBaseDeclaration, suppressName) }
+                (
+                    it.name == "Suppress" &&
+                        it.hasTextContaining("\"konsist.$suppressName\"") ||
+                        it.hasTextContaining("\"$suppressName\"")
+                )
+        }.forEach { declarations[it] = checkIfDeclarationIsAnnotatedWithSuppress(it as KoBaseDeclaration, suppressName) }
 
     val withoutSuppress = mutableListOf<E>()
 
@@ -172,7 +171,7 @@ private fun checkIfDeclarationIsAnnotatedWithSuppress(
 
         is KoAnnotationProvider -> {
             checkIfSuppressed(declaration, testMethodName) ||
-                    checkIfParentIsAnnotatedWithSuppress(declaration, testMethodName)
+                checkIfParentIsAnnotatedWithSuppress(declaration, testMethodName)
         }
 
         else -> {
@@ -238,7 +237,7 @@ private fun getCheckFailedMessage(
 
     val getRootMessage =
         "Assert '$testName' was violated (${failedItems.size} $times).$customMessage" +
-                "Invalid $types:"
+            "Invalid $types:"
 
     val failedDeclarationAsciiTreeNodes = failedDeclarationsMessage.map { AsciiTreeNode(it, emptyList()) }
 
@@ -290,6 +289,7 @@ private fun getFailedNameWithDeclarationType(
     declarationType: String?,
 ) = if (name != null) "$declarationType $name" else "$declarationType"
 
+@Suppress("detekt.CyclomaticComplexMethod")
 private fun getEmptyResult(
     items: List<*>,
     additionalMessage: String?,
@@ -328,18 +328,22 @@ private fun getEmptyResult(
         val getRootMessage =
             "Assert '$testMethodName' failed.${customMessage}Declaration list is$negation empty.$values"
 
-        val failedDeclarationAsciiTreeNodes = items
-            .filterNotNull()
-            .mapNotNull { it: Any ->
-                it.createErrorOutput()?.let { string -> AsciiTreeNode(string, emptyList()) }
-            }
+        val failedDeclarationAsciiTreeNodes =
+            items
+                .filterNotNull()
+                .mapNotNull {
+                    it
+                        .createErrorOutput()
+                        ?.let { string -> AsciiTreeNode(string, emptyList()) }
+                }
 
-        val message = AsciiTreeCreator().invoke(
-            AsciiTreeNode(
-                getRootMessage,
-                failedDeclarationAsciiTreeNodes,
-            ),
-        )
+        val message =
+            AsciiTreeCreator().invoke(
+                AsciiTreeNode(
+                    getRootMessage,
+                    failedDeclarationAsciiTreeNodes,
+                ),
+            )
         throw KoAssertionFailedException(message)
     }
 }
@@ -356,7 +360,6 @@ private fun <E : Any> E?.createErrorOutput(): String? {
 
     return null
 }
-
 
 private fun getNullResult(
     item: Any?,
@@ -377,14 +380,15 @@ private fun getNullResult(
         val failedDeclarationAsciiTreeNode: AsciiTreeNode? =
             item.createErrorOutput()?.let { string -> AsciiTreeNode(string, emptyList()) }
 
-        val message = failedDeclarationAsciiTreeNode?.let {
-            AsciiTreeCreator().invoke(
-                AsciiTreeNode(
-                    getRootMessage,
-                    listOf(failedDeclarationAsciiTreeNode),
-                ),
-            )
-        } ?: getRootMessage
+        val message =
+            failedDeclarationAsciiTreeNode?.let {
+                AsciiTreeCreator().invoke(
+                    AsciiTreeNode(
+                        getRootMessage,
+                        listOf(failedDeclarationAsciiTreeNode),
+                    ),
+                )
+            } ?: getRootMessage
 
         throw KoAssertionFailedException(message)
     }

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/core/verify/KoDeclarationAndProviderAssertCore.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/core/verify/KoDeclarationAndProviderAssertCore.kt
@@ -114,12 +114,12 @@ fun checkIfLocalListHasOnlyNullElements(
     if (hasOnlyNUllElements && (localList.size > 1)) {
         throw KoPreconditionFailedException(
             "Declaration list contains only null elements. Please make sure that list of declarations contain items " +
-                "before calling the '$testMethodName' method.",
+                    "before calling the '$testMethodName' method.",
         )
     } else if (hasOnlyNUllElements && (localList.size == 1)) {
         throw KoPreconditionFailedException(
             "Method '$testMethodName' was called on a null value. Please ensure that the declaration is not null before " +
-                "calling this method.",
+                    "calling this method.",
         )
     }
 }
@@ -131,7 +131,7 @@ fun checkIfLocalListIsEmpty(
     if (localList.isEmpty()) {
         throw KoPreconditionFailedException(
             "Declaration list is empty. Please make sure that list of declarations contain items " +
-                "before calling the '$testMethodName' method.",
+                    "before calling the '$testMethodName' method.",
         )
     }
 }
@@ -146,12 +146,13 @@ private fun <E : KoBaseProvider> checkIfAnnotatedWithSuppress(
     localList
         .filterNot {
             it is KoAnnotationDeclaration &&
-                (
-                    it.name == "Suppress" &&
-                        it.hasTextContaining("\"konsist.$suppressName\"") ||
-                        it.hasTextContaining("\"$suppressName\"")
-                )
-        }.forEach { declarations[it] = checkIfDeclarationIsAnnotatedWithSuppress(it as KoBaseDeclaration, suppressName) }
+                    (
+                            it.name == "Suppress" &&
+                                    it.hasTextContaining("\"konsist.$suppressName\"") ||
+                                    it.hasTextContaining("\"$suppressName\"")
+                            )
+        }
+        .forEach { declarations[it] = checkIfDeclarationIsAnnotatedWithSuppress(it as KoBaseDeclaration, suppressName) }
 
     val withoutSuppress = mutableListOf<E>()
 
@@ -171,7 +172,7 @@ private fun checkIfDeclarationIsAnnotatedWithSuppress(
 
         is KoAnnotationProvider -> {
             checkIfSuppressed(declaration, testMethodName) ||
-                checkIfParentIsAnnotatedWithSuppress(declaration, testMethodName)
+                    checkIfParentIsAnnotatedWithSuppress(declaration, testMethodName)
         }
 
         else -> {
@@ -237,7 +238,7 @@ private fun getCheckFailedMessage(
 
     val getRootMessage =
         "Assert '$testName' was violated (${failedItems.size} $times).$customMessage" +
-            "Invalid $types:"
+                "Invalid $types:"
 
     val failedDeclarationAsciiTreeNodes = failedDeclarationsMessage.map { AsciiTreeNode(it, emptyList()) }
 
@@ -370,7 +371,21 @@ private fun getNullResult(
         val value = if (isNull) ": $item" else ""
         val customMessage = if (additionalMessage != null) "\n${additionalMessage}\n" else " "
 
-        val message = "Assert `$testMethodName` failed.${customMessage}Declaration has$negation null value$value."
+        val getRootMessage =
+            "Assert `$testMethodName` failed.${customMessage}Declaration has$negation null value$value."
+
+        val failedDeclarationAsciiTreeNode: AsciiTreeNode? =
+            item.createErrorOutput()?.let { string -> AsciiTreeNode(string, emptyList()) }
+
+        val message = failedDeclarationAsciiTreeNode?.let {
+            AsciiTreeCreator().invoke(
+                AsciiTreeNode(
+                    getRootMessage,
+                    listOf(failedDeclarationAsciiTreeNode),
+                ),
+            )
+        } ?: getRootMessage
+
         throw KoAssertionFailedException(message)
     }
 }


### PR DESCRIPTION
**Enhancements** - Added ASCII tree and hyperlinks to improve error messages for missing methods.  

**Updated Methods** - `assertNotEmpty`, `assertEmpty`, `assertNull`, `assertNotNull`

**Before:**
![image](https://github.com/user-attachments/assets/1ae97c55-19ef-462f-a0b1-52867d591faf)

**After:**
![image](https://github.com/user-attachments/assets/4dac3a12-4889-4c0c-9d1a-234835f7d101)
