### PR TITLE
KON-699 Restore Layer Package Validation

### DIFF
--- a/lib/src/main/kotlin/com/lemonappdev/konsist/api/architecture/Layer.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/api/architecture/Layer.kt
@@ -49,7 +49,7 @@ data class Layer(
         if (rootPackage == "..") {
             throw IllegalArgumentException(
                 "Invalid rootPackage definition for layer '$name'. " +
-                        "Package name cannot be empty. Current definition: $rootPackage",
+                    "Package name cannot be empty. Current definition: $rootPackage",
             )
         }
 
@@ -67,22 +67,23 @@ data class Layer(
         if (packageWithoutEndingDots.isEmpty()) {
             throw IllegalArgumentException(
                 "Invalid package definition for layer '$name'. " +
-                        "Package name cannot be empty. Current definition: $rootPackage",
+                    "Package name cannot be empty. Current definition: $rootPackage",
             )
         }
 
         // Special handling for packages starting with '..'
-        val effectivePackage = if (packageWithoutEndingDots.startsWith("..")) {
-            packageWithoutEndingDots.substring(2)
-        } else {
-            packageWithoutEndingDots
-        }
+        val effectivePackage =
+            if (packageWithoutEndingDots.startsWith("..")) {
+                packageWithoutEndingDots.substring(2)
+            } else {
+                packageWithoutEndingDots
+            }
 
         // Check for starting dot (but not ..)
         if (effectivePackage.startsWith(".") && !packageWithoutEndingDots.startsWith("..")) {
             throw IllegalArgumentException(
                 "Invalid package definition for layer '$name'. " +
-                        "Package cannot start with a dot. Current definition: $rootPackage",
+                    "Package cannot start with a dot. Current definition: $rootPackage",
             )
         }
 
@@ -90,23 +91,24 @@ data class Layer(
         if (effectivePackage.contains("..")) {
             throw IllegalArgumentException(
                 "Invalid package definition for layer '$name'. " +
-                        "Package can only end with '..'. Current definition: $rootPackage",
+                    "Package can only end with '..'. Current definition: $rootPackage",
             )
         }
 
         // Split and validate segments
-        val segments = effectivePackage
-            .split(".")
-            .filter { it.isNotEmpty() }
+        val segments =
+            effectivePackage
+                .split(".")
+                .filter { it.isNotEmpty() }
 
         // Validate each segment
         segments.forEachIndexed { index, segment ->
             if (!segment.matches(REGEX_VALID_PACKAGE_SEGMENT)) {
                 throw IllegalArgumentException(
                     "Invalid package definition for layer '$name'. " +
-                            "Invalid package segment '$segment' at position ${index + 1}. " +
-                            "Package segments must start with a lowercase letter and contain only " +
-                            "lowercase letters, numbers, or underscores. Current definition: $rootPackage",
+                        "Invalid package segment '$segment' at position ${index + 1}. " +
+                        "Package segments must start with a lowercase letter and contain only " +
+                        "lowercase letters, numbers, or underscores. Current definition: $rootPackage",
                 )
             }
         }
@@ -115,14 +117,14 @@ data class Layer(
     private fun endsWithExactlyTwoDots(): Boolean {
         val lastIndex = rootPackage.length - 1
         return lastIndex >= 1 &&
-                rootPackage[lastIndex] == '.' &&
-                rootPackage[lastIndex - 1] == '.' &&
-                (lastIndex < 2 || rootPackage[lastIndex - 2] != '.')
+            rootPackage[lastIndex] == '.' &&
+            rootPackage[lastIndex - 1] == '.' &&
+            (lastIndex < 2 || rootPackage[lastIndex - 2] != '.')
     }
 
     private fun buildPackageErrorMessage(): String =
         "Invalid package definition for layer '$name'. To include subpackages, " +
-                "the definition must end with '..'. Current definition: $rootPackage"
+            "the definition must end with '..'. Current definition: $rootPackage"
 
     private companion object {
         private val REGEX_VALID_PACKAGE_SEGMENT = Regex("^[a-z][a-z0-9_]*$")

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/api/architecture/Layer.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/api/architecture/Layer.kt
@@ -3,28 +3,36 @@ package com.lemonappdev.konsist.api.architecture
 /**
  * Represents an architectural layer within a software system.
  *
- * A layer is defined by its name and a root package path that determines which code belongs to this layer.
- * The root package path supports wildcards using ".." notation to include all subpackages.
+ * An architectural layer is defined by a name and a package path pattern that determines which code belongs to it.
+ * The package pattern supports wildcards using ".." to include all subpackages at that level.
  *
- * Example usage:
- * ```
+ * Usage:
+ * ```kotlin
+ * // Standard layer definitions (wildcards at the end)
  * val domainLayer = Layer("Domain", "com.example.domain..")
  * val presentationLayer = Layer("Presentation", "com.example.presentation..")
+ *
+ * // Wildcards layer definitions (wildcards at the start and at the end)
+ * val specificDomainLayer = Layer("Domain", "..domain..")  // matches any path ending with "domain"
  * ```
  *
- * Package naming rules:
- * - Must end with ".." to indicate inclusion of all subpackages
- * - Cannot be empty (just "..")
- * - Cannot start with a dot
- * - Each package segment must:
- *   - Start with a lowercase letter
- *   - Contain only lowercase letters, numbers, or underscores
- *   - Follow standard Java package naming conventions
- * - Intermediate ".." wildcards are allowed (e.g., "com..domain..")
+ * Package Pattern Rules:
+ * 1. Basic Structure
+ *    - Must end with ".." to indicate subpackage inclusion
+ *    - Cannot be empty (just "..")
+ *    - Can start with ".." for wildcard matching
  *
- * @property name The name of the layer. Must not be blank.
- * @property rootPackage The package path defining this layer. Must follow the package naming rules.
- * @throws IllegalArgumentException If name or rootPackage is blank
+ * 2. Package Segments
+ *    - Must start with a lowercase letter
+ *    - Can contain: lowercase letters, numbers, underscores
+ *
+ * 3. Wildcard Usage
+ *    - ".." is only allowed at start or end of pattern
+ *    - No consecutive dots except for wildcard notation
+ *
+ * @property name Layer identifier (non-blank)
+ * @property rootPackage Package pattern defining layer scope (must follow pattern rules)
+ * @throws IllegalArgumentException If name is blank or rootPackage violates pattern rules
  */
 @Suppress("detekt.ThrowsCount")
 data class Layer(
@@ -41,7 +49,7 @@ data class Layer(
         if (rootPackage == "..") {
             throw IllegalArgumentException(
                 "Invalid rootPackage definition for layer '$name'. " +
-                    "Package name cannot be empty. Current definition: $rootPackage",
+                        "Package name cannot be empty. Current definition: $rootPackage",
             )
         }
 
@@ -52,86 +60,69 @@ data class Layer(
             )
         }
 
-        // Check if there's more than one ".." in the package
-        if (countConsecutiveDoubleDots(rootPackage) > 1) {
-            throw IllegalArgumentException(
-                "Invalid package definition for layer '$name'. Package can only end with '..'. " +
-                    "Current definition: $rootPackage",
-            )
-        }
-
-        val packageWithoutDoubleDot = rootPackage.removeSuffix("..")
+        // Remove the ending '..' for further validation
+        val packageWithoutEndingDots = rootPackage.removeSuffix("..")
 
         // Empty package (just ..) is not valid
-        if (packageWithoutDoubleDot.isEmpty()) {
+        if (packageWithoutEndingDots.isEmpty()) {
             throw IllegalArgumentException(
                 "Invalid package definition for layer '$name'. " +
-                    "Package name cannot be empty. Current definition: $rootPackage",
+                        "Package name cannot be empty. Current definition: $rootPackage",
             )
         }
 
-        // Check for starting dot
-        if (packageWithoutDoubleDot.startsWith(".")) {
+        // Special handling for packages starting with '..'
+        val effectivePackage = if (packageWithoutEndingDots.startsWith("..")) {
+            packageWithoutEndingDots.substring(2)
+        } else {
+            packageWithoutEndingDots
+        }
+
+        // Check for starting dot (but not ..)
+        if (effectivePackage.startsWith(".") && !packageWithoutEndingDots.startsWith("..")) {
             throw IllegalArgumentException(
                 "Invalid package definition for layer '$name'. " +
-                    "Package cannot start with a dot. Current definition: $rootPackage",
+                        "Package cannot start with a dot. Current definition: $rootPackage",
             )
         }
 
-        // Validate each package segment
-        val segments =
-            packageWithoutDoubleDot
-                .split(".")
-                .filter { it.isNotEmpty() && it != "." } // Filter out empty segments and single dots
-                .map { if (it == ".") "" else it } // Handle any remaining dots
+        // Check for consecutive dots in middle (excluding the start and end ..)
+        if (effectivePackage.contains("..")) {
+            throw IllegalArgumentException(
+                "Invalid package definition for layer '$name'. " +
+                        "Package can only end with '..'. Current definition: $rootPackage",
+            )
+        }
 
+        // Split and validate segments
+        val segments = effectivePackage
+            .split(".")
+            .filter { it.isNotEmpty() }
+
+        // Validate each segment
         segments.forEachIndexed { index, segment ->
             if (!segment.matches(REGEX_VALID_PACKAGE_SEGMENT)) {
                 throw IllegalArgumentException(
                     "Invalid package definition for layer '$name'. " +
-                        "Invalid package segment '$segment' at position ${index + 1}. " +
-                        "Package segments must start with a lowercase letter and contain only " +
-                        "lowercase letters, numbers, or underscores. Current definition: $rootPackage",
+                            "Invalid package segment '$segment' at position ${index + 1}. " +
+                            "Package segments must start with a lowercase letter and contain only " +
+                            "lowercase letters, numbers, or underscores. Current definition: $rootPackage",
                 )
             }
         }
     }
 
-    /**
-     * Counts the number of ".." occurrences in the string.
-     * Looks for exactly two consecutive dots, not counting sequences of 3 or more dots.
-     *
-     * @param str The string to check
-     * @return The number of ".." occurrences
-     */
-    private fun countConsecutiveDoubleDots(str: String): Int {
-        var count = 0
-        var i = 0
-        while (i < str.length - 1) {
-            if (str[i] == '.' && str[i + 1] == '.') {
-                // Check if it's exactly two dots (not three or more)
-                if (i + 2 >= str.length || str[i + 2] != '.') {
-                    count++
-                }
-                i += 2
-            } else {
-                i++
-            }
-        }
-        return count
-    }
-
     private fun endsWithExactlyTwoDots(): Boolean {
         val lastIndex = rootPackage.length - 1
         return lastIndex >= 1 &&
-            rootPackage[lastIndex] == '.' &&
-            rootPackage[lastIndex - 1] == '.' &&
-            (lastIndex < 2 || rootPackage[lastIndex - 2] != '.')
+                rootPackage[lastIndex] == '.' &&
+                rootPackage[lastIndex - 1] == '.' &&
+                (lastIndex < 2 || rootPackage[lastIndex - 2] != '.')
     }
 
     private fun buildPackageErrorMessage(): String =
         "Invalid package definition for layer '$name'. To include subpackages, " +
-            "the definition must end with '..'. Current definition: $rootPackage"
+                "the definition must end with '..'. Current definition: $rootPackage"
 
     private companion object {
         private val REGEX_VALID_PACKAGE_SEGMENT = Regex("^[a-z][a-z0-9_]*$")

--- a/lib/src/test/kotlin/com/lemonappdev/konsist/api/architecture/LayerTest.kt
+++ b/lib/src/test/kotlin/com/lemonappdev/konsist/api/architecture/LayerTest.kt
@@ -1,5 +1,6 @@
 package com.lemonappdev.konsist.api.architecture
 
+import org.amshove.kluent.shouldNotThrow
 import org.amshove.kluent.shouldThrow
 import org.amshove.kluent.withMessage
 import org.junit.jupiter.api.Test
@@ -97,6 +98,17 @@ class LayerTest {
         // then
         func shouldThrow IllegalArgumentException::class withMessage
             "Invalid package definition for layer 'name'. Package can only end with '..'. Current definition: com..example.."
+    }
+
+    @Test
+    fun `create Layer with package starting with two dots should not throw exception`() {
+        // when
+        val func = {
+            Layer("Domain", "..domain..")
+        }
+
+        // then
+        func shouldNotThrow IllegalArgumentException::class
     }
 
     @Test


### PR DESCRIPTION
In Konsit 0.17.0  wildcards while defining Layer got broken.

Restore Konsist `0.16.1` behaviour allowing layer definition with two dots at the beginning

```kotlin
Layer("Domain", "..domain..")
```