### PR TITLE
Update layer package convention naming

### DIFF
--- a/lib/src/main/kotlin/com/lemonappdev/konsist/api/architecture/Layer.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/api/architecture/Layer.kt
@@ -100,7 +100,7 @@ data class Layer(
                     "Invalid package definition for layer '$name'. " +
                         "Invalid package segment '$segment' at position ${index + 1}. " +
                         "Package segments must start with a lowercase letter and contain only " +
-                        "lowercase letters, numbers, or underscores. Current definition: $rootPackage",
+                        "letters, numbers, or underscores. Current definition: $rootPackage",
                 )
             }
         }
@@ -119,6 +119,6 @@ data class Layer(
             "the definition must end with '..'. Current definition: $rootPackage"
 
     private companion object {
-        private val REGEX_VALID_PACKAGE_SEGMENT = Regex("^[a-z][a-z0-9_]*$")
+        private val REGEX_VALID_PACKAGE_SEGMENT = Regex("^[a-z][a-zA-Z0-9_]*$")
     }
 }

--- a/lib/src/test/kotlin/com/lemonappdev/konsist/api/architecture/LayerTest.kt
+++ b/lib/src/test/kotlin/com/lemonappdev/konsist/api/architecture/LayerTest.kt
@@ -56,7 +56,7 @@ class LayerTest {
     }
 
     @Test
-    fun `create Layer with uppercase package segment should throw exception`() {
+    fun `create Layer with Pascal case package segment should throw exception`() {
         // when
         val func = { Layer(name = "name", rootPackage = "Com.example..") }
 
@@ -111,6 +111,7 @@ class LayerTest {
                 "com.example.test..",
                 "com.example1.test2..",
                 "com.example_test..",
+                "com.exampleTest..",
             )
 
         // then

--- a/lib/src/test/kotlin/com/lemonappdev/konsist/api/architecture/LayerTest.kt
+++ b/lib/src/test/kotlin/com/lemonappdev/konsist/api/architecture/LayerTest.kt
@@ -63,7 +63,7 @@ class LayerTest {
         // then
         func shouldThrow IllegalArgumentException::class withMessage
             "Invalid package definition for layer 'name'. Invalid package segment 'Com' at position 1. Package segments must start with " +
-            "a lowercase letter and contain only lowercase letters, numbers, or underscores. Current definition: Com.example.."
+            "a lowercase letter and contain only letters, numbers, or underscores. Current definition: Com.example.."
     }
 
     @Test
@@ -74,7 +74,7 @@ class LayerTest {
         // then
         func shouldThrow IllegalArgumentException::class withMessage
             "Invalid package definition for layer 'name'. Invalid package segment '1example' at position 2. Package segments " +
-            "must start with a lowercase letter and contain only lowercase letters, numbers, or underscores. " +
+            "must start with a lowercase letter and contain only letters, numbers, or underscores. " +
             "Current definition: com.1example.."
     }
 
@@ -86,7 +86,7 @@ class LayerTest {
         // then
         func shouldThrow IllegalArgumentException::class withMessage
             "Invalid package definition for layer 'name'. Invalid package segment 'example\$#' at position 2. Package segments " +
-            "must start with a lowercase letter and contain only lowercase letters, numbers, or underscores. Current definition: " +
+            "must start with a lowercase letter and contain only letters, numbers, or underscores. Current definition: " +
             "com.example\$#.."
     }
 


### PR DESCRIPTION
Accept camelCase regarding Kotlin guidelines:

> Package and class naming rules in Kotlin are quite simple:
> 
> Names of packages are always lowercase and do not use underscores (org.example.project). Using multi-word names is generally discouraged, but if you do need to use multiple words, you can either just concatenate them together or use camel

https://kotlinlang.org/docs/coding-conventions.html#naming-rules