### PR TITLE
KON-695 Add missing providers for `KoEnumContantDeclaration`

### DIFF
--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koclass/KoClassDeclarationForKoDeclarationProviderTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koclass/KoClassDeclarationForKoDeclarationProviderTest.kt
@@ -7,7 +7,7 @@ import org.amshove.kluent.assertSoftly
 import org.amshove.kluent.shouldBeEqualTo
 import org.junit.jupiter.api.Test
 
-class KoClassDeclarationForKoFileDeclarationProviderTest {
+class KoClassDeclarationForKoDeclarationProviderTest {
     @Test
     fun `class-has-no-declarations`() {
         // given

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koenumconstant/KoEnumConstantDeclarationForKoClassProviderTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koenumconstant/KoEnumConstantDeclarationForKoClassProviderTest.kt
@@ -1,0 +1,86 @@
+package com.lemonappdev.konsist.core.declaration.koenumconstant
+
+import com.lemonappdev.konsist.TestSnippetProvider.getSnippetKoScope
+import com.lemonappdev.konsist.api.ext.list.enumConstants
+import org.amshove.kluent.assertSoftly
+import org.amshove.kluent.shouldBeEqualTo
+import org.junit.jupiter.api.Test
+
+class KoEnumConstantDeclarationForKoClassProviderTest {
+    @Test
+    fun `enum-constant-contains-no-classes`() {
+        // given
+        val sut =
+            getSnippetFile("enum-constant-contains-no-classes")
+                .classes()
+                .enumConstants
+                .first()
+
+        // then
+        assertSoftly(sut) {
+            classes() shouldBeEqualTo emptyList()
+            numClasses() shouldBeEqualTo 0
+            countClasses { it.name == "SampleInnerClass" } shouldBeEqualTo 0
+            hasClasses() shouldBeEqualTo false
+            hasClassWithName(emptyList()) shouldBeEqualTo false
+            hasClassWithName(emptySet()) shouldBeEqualTo false
+            hasClassesWithAllNames(emptyList()) shouldBeEqualTo false
+            hasClassesWithAllNames(emptySet()) shouldBeEqualTo false
+            hasClassWithName("SampleInnerClass") shouldBeEqualTo false
+            hasClassWithName(listOf("SampleInnerClass")) shouldBeEqualTo false
+            hasClassWithName(setOf("SampleInnerClass")) shouldBeEqualTo false
+            hasClassesWithAllNames("SampleInnerClass1", "SampleInnerClass2") shouldBeEqualTo false
+            hasClassesWithAllNames(listOf("SampleInnerClass1", "SampleInnerClass2")) shouldBeEqualTo false
+            hasClassesWithAllNames(setOf("SampleInnerClass1", "SampleInnerClass2")) shouldBeEqualTo false
+            hasClass { it.name == "SampleInnerClass" } shouldBeEqualTo false
+            hasAllClasses { it.name == "SampleInnerClass" } shouldBeEqualTo true
+        }
+    }
+
+    @Test
+    fun `enum-constant-contains-class`() {
+        // given
+        val sut =
+            getSnippetFile("enum-constant-contains-class")
+                .classes()
+                .enumConstants
+                .first()
+
+        // then
+        assertSoftly(sut) {
+            classes().map { it.name } shouldBeEqualTo listOf("SampleInnerClass1", "SampleInnerClass2")
+            numClasses() shouldBeEqualTo 2
+            countClasses { it.name == "SampleInnerClass1" } shouldBeEqualTo 1
+            hasClasses() shouldBeEqualTo true
+            hasClassWithName(emptyList()) shouldBeEqualTo true
+            hasClassWithName(emptySet()) shouldBeEqualTo true
+            hasClassesWithAllNames(emptyList()) shouldBeEqualTo true
+            hasClassesWithAllNames(emptySet()) shouldBeEqualTo true
+            hasClassWithName("SampleInnerClass1") shouldBeEqualTo true
+            hasClassWithName("OtherClass") shouldBeEqualTo false
+            hasClassWithName("SampleInnerClass1", "OtherClass") shouldBeEqualTo true
+            hasClassWithName(listOf("SampleInnerClass1")) shouldBeEqualTo true
+            hasClassWithName(listOf("OtherClass")) shouldBeEqualTo false
+            hasClassWithName(listOf("SampleInnerClass1", "OtherClass")) shouldBeEqualTo true
+            hasClassWithName(setOf("SampleInnerClass1")) shouldBeEqualTo true
+            hasClassWithName(setOf("OtherClass")) shouldBeEqualTo false
+            hasClassWithName(setOf("SampleInnerClass1", "OtherClass")) shouldBeEqualTo true
+            hasClassesWithAllNames("SampleInnerClass1") shouldBeEqualTo true
+            hasClassesWithAllNames("SampleInnerClass1", "SampleInnerClass2") shouldBeEqualTo true
+            hasClassesWithAllNames("SampleInnerClass1", "OtherClass") shouldBeEqualTo false
+            hasClassesWithAllNames(listOf("SampleInnerClass1")) shouldBeEqualTo true
+            hasClassesWithAllNames(listOf("SampleInnerClass1", "SampleInnerClass2")) shouldBeEqualTo true
+            hasClassesWithAllNames(listOf("SampleInnerClass1", "OtherClass")) shouldBeEqualTo false
+            hasClassesWithAllNames(setOf("SampleInnerClass1")) shouldBeEqualTo true
+            hasClassesWithAllNames(setOf("SampleInnerClass1", "SampleInnerClass2")) shouldBeEqualTo true
+            hasClassesWithAllNames(setOf("SampleInnerClass1", "OtherClass")) shouldBeEqualTo false
+            hasClass { it.name == "SampleInnerClass1" } shouldBeEqualTo true
+            hasClass { it.name == "OtherClass" } shouldBeEqualTo false
+            hasAllClasses { it.name.endsWith("2") || it.name == "SampleInnerClass1" } shouldBeEqualTo true
+            hasAllClasses { it.name.endsWith("2") } shouldBeEqualTo false
+        }
+    }
+
+    private fun getSnippetFile(fileName: String) =
+        getSnippetKoScope("core/declaration/koenumconstant/snippet/forkoclassprovider/", fileName)
+}

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koenumconstant/KoEnumConstantDeclarationForKoDeclarationProviderTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koenumconstant/KoEnumConstantDeclarationForKoDeclarationProviderTest.kt
@@ -1,0 +1,64 @@
+package com.lemonappdev.konsist.core.declaration.koenumconstant
+
+import com.lemonappdev.konsist.TestSnippetProvider.getSnippetKoScope
+import com.lemonappdev.konsist.api.ext.list.enumConstants
+import com.lemonappdev.konsist.api.provider.KoNameProvider
+import org.amshove.kluent.assertSoftly
+import org.amshove.kluent.shouldBeEqualTo
+import org.junit.jupiter.api.Test
+
+class KoEnumConstantDeclarationForKoDeclarationProviderTest {
+    @Test
+    fun `enum-constant-contains-no-declarations`() {
+        // given
+        val sut =
+            getSnippetFile("enum-constant-contains-no-declarations")
+                .classes()
+                .enumConstants
+                .first()
+
+        // then
+        assertSoftly(sut) {
+            declarations() shouldBeEqualTo emptyList()
+            numDeclarations() shouldBeEqualTo 0
+            countDeclarations { (it as KoNameProvider).name == "sampleProperty" } shouldBeEqualTo 0
+            hasDeclarations() shouldBeEqualTo false
+            hasDeclaration { (it as KoNameProvider).name == "SampleDeclaration" } shouldBeEqualTo false
+            hasAllDeclarations { (it as KoNameProvider).name == "SampleDeclaration" } shouldBeEqualTo true
+        }
+    }
+
+    @Test
+    fun `enum-constant-contains-declarations`() {
+        // given
+        val sut =
+            getSnippetFile("enum-constant-contains-declarations")
+                .classes()
+                .enumConstants
+                .first()
+
+        // then
+        assertSoftly(sut) {
+            numDeclarations() shouldBeEqualTo 3
+            countDeclarations { (it as KoNameProvider).hasNameStartingWith("sample") } shouldBeEqualTo 2
+            hasDeclarations() shouldBeEqualTo true
+            hasDeclaration { (it as KoNameProvider).name == "sampleProperty" } shouldBeEqualTo true
+            hasDeclaration { (it as KoNameProvider).name == "otherProperty" } shouldBeEqualTo false
+            hasAllDeclarations { (it as KoNameProvider).hasNameContaining("") } shouldBeEqualTo true
+            hasAllDeclarations { (it as KoNameProvider).hasNameStartingWith("sample") } shouldBeEqualTo false
+            declarations()
+                .filterIsInstance<KoNameProvider>()
+                .map { it.name }
+                .shouldBeEqualTo(
+                    listOf(
+                        "sampleProperty",
+                        "sampleFunction",
+                        "SampleInnerClass",
+                    ),
+                )
+        }
+    }
+
+    private fun getSnippetFile(fileName: String) =
+        getSnippetKoScope("core/declaration/koenumconstant/snippet/forkodeclarationprovider/", fileName)
+}

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koenumconstant/KoEnumConstantDeclarationForKoDeclarationProviderTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koenumconstant/KoEnumConstantDeclarationForKoDeclarationProviderTest.kt
@@ -44,7 +44,7 @@ class KoEnumConstantDeclarationForKoDeclarationProviderTest {
             hasDeclarations() shouldBeEqualTo true
             hasDeclaration { (it as KoNameProvider).name == "sampleProperty" } shouldBeEqualTo true
             hasDeclaration { (it as KoNameProvider).name == "otherProperty" } shouldBeEqualTo false
-            hasAllDeclarations { (it as KoNameProvider).hasNameContaining("") } shouldBeEqualTo true
+            hasAllDeclarations { (it as KoNameProvider).hasNameContaining("ample") } shouldBeEqualTo true
             hasAllDeclarations { (it as KoNameProvider).hasNameStartingWith("sample") } shouldBeEqualTo false
             declarations()
                 .filterIsInstance<KoNameProvider>()
@@ -58,6 +58,193 @@ class KoEnumConstantDeclarationForKoDeclarationProviderTest {
                 )
         }
     }
+
+    @Test
+    fun `enum-constant-contains-nested-and-local-declarations includeLocal=true`() {
+        // given
+        val sut =
+            getSnippetFile("enum-constant-contains-nested-and-local-declarations")
+                .classes()
+                .enumConstants
+                .first()
+
+        // then
+        assertSoftly(sut) {
+            numDeclarations(includeLocal = true, includeNested = false) shouldBeEqualTo 6
+
+            countDeclarations(
+                includeLocal = true,
+                includeNested = false
+            ) { (it as KoNameProvider).hasNameStartingWith("sampleLocal") }
+                .shouldBeEqualTo(2)
+
+            hasDeclarations(includeLocal = true, includeNested = false) shouldBeEqualTo true
+            hasDeclaration(
+                includeLocal = true,
+                includeNested = false
+            ) { (it as KoNameProvider).name == "sampleLocalProperty" }
+                .shouldBeEqualTo(true)
+
+            hasDeclaration(
+                includeLocal = true,
+                includeNested = false
+            ) { (it as KoNameProvider).name == "otherLocalProperty" }
+                .shouldBeEqualTo(false)
+
+            hasAllDeclarations(
+                includeLocal = true,
+                includeNested = false
+            ) { (it as KoNameProvider).hasNameContaining("ample") }
+                .shouldBeEqualTo(true)
+
+            hasAllDeclarations(includeLocal = true, includeNested = false) {
+                (it as KoNameProvider).hasNameStartingWith(
+                    "sample"
+                )
+            }
+                .shouldBeEqualTo(false)
+
+            declarations(includeLocal = true, includeNested = false)
+                .filterIsInstance<KoNameProvider>()
+                .map { it.name }
+                .shouldBeEqualTo(
+                    listOf(
+                        "sampleProperty",
+                        "sampleFunction",
+                        "sampleLocalProperty",
+                        "sampleLocalFunction",
+                        "SampleLocalClass",
+                        "SampleInnerClass",
+                    ),
+                )
+        }
+    }
+
+    @Test
+    fun `enum-constant-contains-nested-and-local-declarations includeNested=true`() {
+        // given
+        val sut =
+            getSnippetFile("enum-constant-contains-nested-and-local-declarations")
+                .classes()
+                .enumConstants
+                .first()
+
+        // then
+        assertSoftly(sut) {
+            numDeclarations(includeLocal = false, includeNested = true) shouldBeEqualTo 6
+
+            countDeclarations(
+                includeLocal = false,
+                includeNested = true
+            ) { (it as KoNameProvider).hasNameStartingWith("sampleNested") }
+                .shouldBeEqualTo(2)
+
+            hasDeclarations(includeLocal = false, includeNested = true) shouldBeEqualTo true
+            hasDeclaration(
+                includeLocal = false,
+                includeNested = true
+            ) { (it as KoNameProvider).name == "sampleNestedProperty" }
+                .shouldBeEqualTo(true)
+
+            hasDeclaration(
+                includeLocal = false,
+                includeNested = true
+            ) { (it as KoNameProvider).name == "otherNestedProperty" }
+                .shouldBeEqualTo(false)
+
+            hasAllDeclarations(
+                includeLocal = false,
+                includeNested = true
+            ) { (it as KoNameProvider).hasNameContaining("ample") }
+                .shouldBeEqualTo(true)
+
+            hasAllDeclarations(includeLocal = false, includeNested = true) {
+                (it as KoNameProvider).hasNameStartingWith(
+                    "sample"
+                )
+            }
+                .shouldBeEqualTo(false)
+
+            declarations(includeLocal = false, includeNested = true)
+                .filterIsInstance<KoNameProvider>()
+                .map { it.name }
+                .shouldBeEqualTo(
+                    listOf(
+                        "sampleProperty",
+                        "sampleFunction",
+                        "SampleInnerClass",
+                        "sampleNestedProperty",
+                        "sampleNestedFunction",
+                        "SampleNestedClass",
+                    ),
+                )
+        }
+    }
+
+    @Test
+    fun `enum-constant-contains-nested-and-local-declarations includeLocal=true and includeNested=true`() {
+        // given
+        val sut =
+            getSnippetFile("enum-constant-contains-nested-and-local-declarations")
+                .classes()
+                .enumConstants
+                .first()
+
+        // then
+        assertSoftly(sut) {
+            numDeclarations(includeLocal = true, includeNested = true) shouldBeEqualTo 9
+
+            countDeclarations(
+                includeLocal = true,
+                includeNested = true
+            ) { (it as KoNameProvider).hasNameStartingWith("sample") }
+                .shouldBeEqualTo(6)
+
+            hasDeclarations(includeLocal = true, includeNested = true) shouldBeEqualTo true
+            hasDeclaration(
+                includeLocal = true,
+                includeNested = true
+            ) { (it as KoNameProvider).name == "sampleLocalProperty" }
+                .shouldBeEqualTo(true)
+
+            hasDeclaration(
+                includeLocal = true,
+                includeNested = true
+            ) { (it as KoNameProvider).name == "otherLocalProperty" }
+                .shouldBeEqualTo(false)
+
+            hasAllDeclarations(
+                includeLocal = true,
+                includeNested = true
+            ) { (it as KoNameProvider).hasNameContaining("ample") }
+                .shouldBeEqualTo(true)
+
+            hasAllDeclarations(includeLocal = true, includeNested = true) {
+                (it as KoNameProvider).hasNameStartingWith(
+                    "sample"
+                )
+            }
+                .shouldBeEqualTo(false)
+
+            declarations(includeLocal = true, includeNested = true)
+                .filterIsInstance<KoNameProvider>()
+                .map { it.name }
+                .shouldBeEqualTo(
+                    listOf(
+                        "sampleProperty",
+                        "sampleFunction",
+                        "sampleLocalProperty",
+                        "sampleLocalFunction",
+                        "SampleLocalClass",
+                        "SampleInnerClass",
+                        "sampleNestedProperty",
+                        "sampleNestedFunction",
+                        "SampleNestedClass",
+                    ),
+                )
+        }
+    }
+
 
     private fun getSnippetFile(fileName: String) =
         getSnippetKoScope("core/declaration/koenumconstant/snippet/forkodeclarationprovider/", fileName)

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koenumconstant/KoEnumConstantDeclarationForKoDeclarationProviderTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koenumconstant/KoEnumConstantDeclarationForKoDeclarationProviderTest.kt
@@ -74,35 +74,34 @@ class KoEnumConstantDeclarationForKoDeclarationProviderTest {
 
             countDeclarations(
                 includeLocal = true,
-                includeNested = false
+                includeNested = false,
             ) { (it as KoNameProvider).hasNameStartingWith("sampleLocal") }
                 .shouldBeEqualTo(2)
 
             hasDeclarations(includeLocal = true, includeNested = false) shouldBeEqualTo true
             hasDeclaration(
                 includeLocal = true,
-                includeNested = false
+                includeNested = false,
             ) { (it as KoNameProvider).name == "sampleLocalProperty" }
                 .shouldBeEqualTo(true)
 
             hasDeclaration(
                 includeLocal = true,
-                includeNested = false
+                includeNested = false,
             ) { (it as KoNameProvider).name == "otherLocalProperty" }
                 .shouldBeEqualTo(false)
 
             hasAllDeclarations(
                 includeLocal = true,
-                includeNested = false
+                includeNested = false,
             ) { (it as KoNameProvider).hasNameContaining("ample") }
                 .shouldBeEqualTo(true)
 
             hasAllDeclarations(includeLocal = true, includeNested = false) {
                 (it as KoNameProvider).hasNameStartingWith(
-                    "sample"
+                    "sample",
                 )
-            }
-                .shouldBeEqualTo(false)
+            }.shouldBeEqualTo(false)
 
             declarations(includeLocal = true, includeNested = false)
                 .filterIsInstance<KoNameProvider>()
@@ -135,35 +134,34 @@ class KoEnumConstantDeclarationForKoDeclarationProviderTest {
 
             countDeclarations(
                 includeLocal = false,
-                includeNested = true
+                includeNested = true,
             ) { (it as KoNameProvider).hasNameStartingWith("sampleNested") }
                 .shouldBeEqualTo(2)
 
             hasDeclarations(includeLocal = false, includeNested = true) shouldBeEqualTo true
             hasDeclaration(
                 includeLocal = false,
-                includeNested = true
+                includeNested = true,
             ) { (it as KoNameProvider).name == "sampleNestedProperty" }
                 .shouldBeEqualTo(true)
 
             hasDeclaration(
                 includeLocal = false,
-                includeNested = true
+                includeNested = true,
             ) { (it as KoNameProvider).name == "otherNestedProperty" }
                 .shouldBeEqualTo(false)
 
             hasAllDeclarations(
                 includeLocal = false,
-                includeNested = true
+                includeNested = true,
             ) { (it as KoNameProvider).hasNameContaining("ample") }
                 .shouldBeEqualTo(true)
 
             hasAllDeclarations(includeLocal = false, includeNested = true) {
                 (it as KoNameProvider).hasNameStartingWith(
-                    "sample"
+                    "sample",
                 )
-            }
-                .shouldBeEqualTo(false)
+            }.shouldBeEqualTo(false)
 
             declarations(includeLocal = false, includeNested = true)
                 .filterIsInstance<KoNameProvider>()
@@ -196,35 +194,34 @@ class KoEnumConstantDeclarationForKoDeclarationProviderTest {
 
             countDeclarations(
                 includeLocal = true,
-                includeNested = true
+                includeNested = true,
             ) { (it as KoNameProvider).hasNameStartingWith("sample") }
                 .shouldBeEqualTo(6)
 
             hasDeclarations(includeLocal = true, includeNested = true) shouldBeEqualTo true
             hasDeclaration(
                 includeLocal = true,
-                includeNested = true
+                includeNested = true,
             ) { (it as KoNameProvider).name == "sampleLocalProperty" }
                 .shouldBeEqualTo(true)
 
             hasDeclaration(
                 includeLocal = true,
-                includeNested = true
+                includeNested = true,
             ) { (it as KoNameProvider).name == "otherLocalProperty" }
                 .shouldBeEqualTo(false)
 
             hasAllDeclarations(
                 includeLocal = true,
-                includeNested = true
+                includeNested = true,
             ) { (it as KoNameProvider).hasNameContaining("ample") }
                 .shouldBeEqualTo(true)
 
             hasAllDeclarations(includeLocal = true, includeNested = true) {
                 (it as KoNameProvider).hasNameStartingWith(
-                    "sample"
+                    "sample",
                 )
-            }
-                .shouldBeEqualTo(false)
+            }.shouldBeEqualTo(false)
 
             declarations(includeLocal = true, includeNested = true)
                 .filterIsInstance<KoNameProvider>()
@@ -244,7 +241,6 @@ class KoEnumConstantDeclarationForKoDeclarationProviderTest {
                 )
         }
     }
-
 
     private fun getSnippetFile(fileName: String) =
         getSnippetKoScope("core/declaration/koenumconstant/snippet/forkodeclarationprovider/", fileName)

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koenumconstant/KoEnumConstantDeclarationForKoFunctionProviderTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koenumconstant/KoEnumConstantDeclarationForKoFunctionProviderTest.kt
@@ -1,0 +1,89 @@
+package com.lemonappdev.konsist.core.declaration.koenumconstant
+
+import com.lemonappdev.konsist.TestSnippetProvider.getSnippetKoScope
+import com.lemonappdev.konsist.api.ext.list.enumConstants
+import org.amshove.kluent.assertSoftly
+import org.amshove.kluent.shouldBeEqualTo
+import org.junit.jupiter.api.Test
+import sun.security.pkcs11.wrapper.Functions
+
+class KoEnumConstantDeclarationForKoFunctionProviderTest {
+    @Test
+    fun `enum-constant-contains-no-function`() {
+        // given
+        val sut =
+            getSnippetFile("enum-constant-contains-no-function")
+                .classes()
+                .enumConstants
+                .first()
+
+        // then
+        assertSoftly(sut) {
+            functions() shouldBeEqualTo emptyList()
+            numFunctions() shouldBeEqualTo 0
+            countFunctions { it.name == "sampleFunction" } shouldBeEqualTo 0
+            hasFunctions() shouldBeEqualTo false
+            hasFunctionWithName(emptyList()) shouldBeEqualTo false
+            hasFunctionWithName(emptySet()) shouldBeEqualTo false
+            hasFunctionsWithAllNames(emptyList()) shouldBeEqualTo false
+            hasFunctionsWithAllNames(emptySet()) shouldBeEqualTo false
+            hasFunctionWithName("sampleFunction") shouldBeEqualTo false
+            hasFunctionWithName(listOf("sampleFunction")) shouldBeEqualTo false
+            hasFunctionWithName(setOf("sampleFunction")) shouldBeEqualTo false
+            hasFunctionsWithAllNames("sampleFunction1", "sampleFunction2") shouldBeEqualTo false
+            hasFunctionsWithAllNames(listOf("sampleFunction1", "sampleFunction2")) shouldBeEqualTo false
+            hasFunctionsWithAllNames(setOf("sampleFunction1", "sampleFunction2")) shouldBeEqualTo false
+            hasFunction { it.name == "sampleFunction" } shouldBeEqualTo false
+            hasAllFunctions { it.name == "sampleFunction" } shouldBeEqualTo true
+        }
+    }
+
+    @Test
+    fun `enum-constant-contains-function`() {
+        // given
+        val sut =
+            getSnippetFile("enum-constant-contains-function")
+                .classes()
+                .enumConstants
+                .first()
+
+        // then
+        assertSoftly(sut) {
+            numFunctions() shouldBeEqualTo 2
+            countFunctions { it.name == "sampleFunction1" } shouldBeEqualTo 1
+            hasFunctions() shouldBeEqualTo true
+            hasFunctionWithName(emptyList()) shouldBeEqualTo true
+            hasFunctionWithName(emptySet()) shouldBeEqualTo true
+            hasFunctionsWithAllNames(emptyList()) shouldBeEqualTo true
+            hasFunctionsWithAllNames(emptySet()) shouldBeEqualTo true
+            hasFunctionWithName("sampleFunction1") shouldBeEqualTo true
+            hasFunctionWithName("otherFunction") shouldBeEqualTo false
+            hasFunctionWithName("sampleFunction1", "otherFunction") shouldBeEqualTo true
+            hasFunctionWithName(listOf("sampleFunction1")) shouldBeEqualTo true
+            hasFunctionWithName(listOf("otherFunction")) shouldBeEqualTo false
+            hasFunctionWithName(listOf("sampleFunction1", "otherFunction")) shouldBeEqualTo true
+            hasFunctionWithName(setOf("sampleFunction1")) shouldBeEqualTo true
+            hasFunctionWithName(setOf("otherFunction")) shouldBeEqualTo false
+            hasFunctionWithName(setOf("sampleFunction1", "otherFunction")) shouldBeEqualTo true
+            hasFunctionsWithAllNames("sampleFunction1") shouldBeEqualTo true
+            hasFunctionsWithAllNames("sampleFunction1", "sampleFunction2") shouldBeEqualTo true
+            hasFunctionsWithAllNames("sampleFunction1", "otherFunction") shouldBeEqualTo false
+            hasFunctionsWithAllNames(listOf("sampleFunction1")) shouldBeEqualTo true
+            hasFunctionsWithAllNames(listOf("sampleFunction1", "sampleFunction2")) shouldBeEqualTo true
+            hasFunctionsWithAllNames(listOf("sampleFunction1", "otherFunction")) shouldBeEqualTo false
+            hasFunctionsWithAllNames(setOf("sampleFunction1")) shouldBeEqualTo true
+            hasFunctionsWithAllNames(setOf("sampleFunction1", "sampleFunction2")) shouldBeEqualTo true
+            hasFunctionsWithAllNames(setOf("sampleFunction1", "otherFunction")) shouldBeEqualTo false
+            hasFunction { it.name == "sampleFunction1" } shouldBeEqualTo true
+            hasFunction { it.name == "otherFunction" } shouldBeEqualTo false
+            hasAllFunctions { it.name.endsWith("2") || it.name == "sampleFunction1" } shouldBeEqualTo true
+            hasAllFunctions { it.name.endsWith("2") } shouldBeEqualTo false
+            functions()
+                .map { it.name }
+                .shouldBeEqualTo(listOf("sampleFunction1", "sampleFunction2"))
+        }
+    }
+
+    private fun getSnippetFile(fileName: String) =
+        getSnippetKoScope("core/declaration/koenumconstant/snippet/forkofunctionprovider/", fileName)
+}

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koenumconstant/KoEnumConstantDeclarationForKoFunctionProviderTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koenumconstant/KoEnumConstantDeclarationForKoFunctionProviderTest.kt
@@ -5,7 +5,6 @@ import com.lemonappdev.konsist.api.ext.list.enumConstants
 import org.amshove.kluent.assertSoftly
 import org.amshove.kluent.shouldBeEqualTo
 import org.junit.jupiter.api.Test
-import sun.security.pkcs11.wrapper.Functions
 
 class KoEnumConstantDeclarationForKoFunctionProviderTest {
     @Test

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koenumconstant/KoEnumConstantDeclarationForKoPropertyProviderTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koenumconstant/KoEnumConstantDeclarationForKoPropertyProviderTest.kt
@@ -1,0 +1,133 @@
+package com.lemonappdev.konsist.core.declaration.koenumconstant
+
+import com.lemonappdev.konsist.TestSnippetProvider
+import com.lemonappdev.konsist.api.ext.list.enumConstants
+import org.amshove.kluent.assertSoftly
+import org.amshove.kluent.shouldBeEqualTo
+import org.junit.jupiter.api.Test
+
+class KoEnumConstantDeclarationForKoPropertyProviderTest {
+    @Test
+    fun `enum-constant-has-no-properties`() {
+        // given
+        val sut =
+            getSnippetFile("enum-constant-has-no-properties")
+                .classes()
+                .enumConstants
+                .first()
+
+        // then
+        assertSoftly(sut) {
+            properties() shouldBeEqualTo emptyList()
+            hasProperties() shouldBeEqualTo false
+            hasPropertyWithName(emptyList()) shouldBeEqualTo false
+            hasPropertyWithName(emptySet()) shouldBeEqualTo false
+            hasPropertiesWithAllNames(emptyList()) shouldBeEqualTo false
+            hasPropertiesWithAllNames(emptySet()) shouldBeEqualTo false
+            hasPropertyWithName("sampleProperty") shouldBeEqualTo false
+            hasPropertyWithName(listOf("sampleProperty")) shouldBeEqualTo false
+            hasPropertyWithName(setOf("sampleProperty")) shouldBeEqualTo false
+            hasPropertiesWithAllNames("sampleProperty1", "sampleProperty2") shouldBeEqualTo false
+            hasPropertiesWithAllNames(listOf("sampleProperty1", "sampleProperty2")) shouldBeEqualTo false
+            hasPropertiesWithAllNames(setOf("sampleProperty1", "sampleProperty2")) shouldBeEqualTo false
+            hasProperty { it.name == "sampleProperty" } shouldBeEqualTo false
+            hasAllProperties { it.hasNameStartingWith("sample") } shouldBeEqualTo true
+        }
+    }
+
+    @Test
+    fun `enum-constant-has-two-properties`() {
+        // given
+        val sut =
+            getSnippetFile("enum-constant-has-two-properties")
+                .classes()
+                .enumConstants
+                .first()
+
+        // then
+        assertSoftly(sut) {
+            hasProperties() shouldBeEqualTo true
+            hasPropertyWithName(emptyList()) shouldBeEqualTo true
+            hasPropertyWithName(emptySet()) shouldBeEqualTo true
+            hasPropertiesWithAllNames(emptyList()) shouldBeEqualTo true
+            hasPropertiesWithAllNames(emptySet()) shouldBeEqualTo true
+            hasPropertyWithName("sampleProperty1") shouldBeEqualTo true
+            hasPropertyWithName("sampleProperty1", "otherProperty") shouldBeEqualTo true
+            hasPropertyWithName(listOf("sampleProperty1")) shouldBeEqualTo true
+            hasPropertyWithName(listOf("sampleProperty1", "otherProperty")) shouldBeEqualTo true
+            hasPropertyWithName(setOf("sampleProperty1")) shouldBeEqualTo true
+            hasPropertyWithName(setOf("sampleProperty1", "otherProperty")) shouldBeEqualTo true
+            hasPropertiesWithAllNames("sampleProperty1") shouldBeEqualTo true
+            hasPropertiesWithAllNames("sampleProperty1", "sampleProperty2") shouldBeEqualTo true
+            hasPropertiesWithAllNames("sampleProperty1", "otherProperty") shouldBeEqualTo false
+            hasPropertiesWithAllNames(listOf("sampleProperty1")) shouldBeEqualTo true
+            hasPropertiesWithAllNames(listOf("sampleProperty1", "sampleProperty2")) shouldBeEqualTo true
+            hasPropertiesWithAllNames(listOf("sampleProperty1", "otherProperty")) shouldBeEqualTo false
+            hasPropertiesWithAllNames(setOf("sampleProperty1")) shouldBeEqualTo true
+            hasPropertiesWithAllNames(setOf("sampleProperty1", "sampleProperty2")) shouldBeEqualTo true
+            hasPropertiesWithAllNames(setOf("sampleProperty1", "otherProperty")) shouldBeEqualTo false
+            hasProperty { it.name == "sampleProperty1" } shouldBeEqualTo true
+            hasProperty { it.hasNameEndingWith("Property1") } shouldBeEqualTo true
+            hasAllProperties { it.hasNameStartingWith("sample") } shouldBeEqualTo true
+            hasAllProperties { it.hasNameEndingWith("Class1") } shouldBeEqualTo false
+        }
+    }
+
+    @Test
+    fun `enum-constant-contains-nested-properties includeNested true`() {
+        // given
+        val sut =
+            getSnippetFile("enum-constant-contains-nested-properties")
+                .classes()
+                .enumConstants
+                .first()
+
+        // then
+        val expected = listOf("sampleProperty1", "sampleInnerProperty")
+
+        sut
+            .properties(includeNested = true)
+            .map { it.name }
+            .shouldBeEqualTo(expected)
+    }
+
+    @Test
+    fun `enum-constant-contains-nested-properties includeNested false`() {
+        // given
+        val sut =
+            getSnippetFile("enum-constant-contains-nested-properties")
+                .classes()
+                .enumConstants
+                .first()
+
+        // then
+        val expected = listOf("sampleProperty1")
+
+        sut
+            .properties(includeNested = false)
+            .map { it.name }
+            .shouldBeEqualTo(expected)
+    }
+
+    @Test
+    fun `count-properties`() {
+        // given
+        val sut =
+            getSnippetFile("count-properties")
+                .classes()
+                .enumConstants
+                .first()
+
+        // then
+        assertSoftly(sut) {
+            numProperties(includeNested = true) shouldBeEqualTo 2
+            numProperties(includeNested = false) shouldBeEqualTo 1
+            countProperties(includeNested = false) { it.isVal } shouldBeEqualTo 1
+            countProperties { it.isVal } shouldBeEqualTo 2
+            countProperties { it.name == "sampleProperty" && it.isVar } shouldBeEqualTo 0
+        }
+    }
+
+    private fun getSnippetFile(fileName: String) =
+        TestSnippetProvider.getSnippetKoScope("core/declaration/koenumconstant/snippet/forkopropertyprovider/", fileName)
+}

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koenumconstant/snippet/forkoclassprovider/enum-constant-contains-class.kttest
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koenumconstant/snippet/forkoclassprovider/enum-constant-contains-class.kttest
@@ -1,0 +1,6 @@
+enum class SampleClass {
+    SAMPLE_CONSTANT_1 {
+        inner class SampleInnerClass1
+        inner class SampleInnerClass2
+    };
+}

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koenumconstant/snippet/forkoclassprovider/enum-constant-contains-no-classes.kttest
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koenumconstant/snippet/forkoclassprovider/enum-constant-contains-no-classes.kttest
@@ -1,0 +1,3 @@
+enum class SampleClass {
+    SAMPLE_CONSTANT_1
+}

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koenumconstant/snippet/forkodeclarationprovider/enum-constant-contains-declarations.kttest
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koenumconstant/snippet/forkodeclarationprovider/enum-constant-contains-declarations.kttest
@@ -1,0 +1,10 @@
+enum class SampleClass {
+    SAMPLE_CONSTANT_1 {
+        val sampleProperty = 0
+        override fun sampleFunction() = 1
+
+        inner class SampleInnerClass
+    };
+
+    abstract fun sampleFunction(): Int
+}

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koenumconstant/snippet/forkodeclarationprovider/enum-constant-contains-nested-and-local-declarations.kttest
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koenumconstant/snippet/forkodeclarationprovider/enum-constant-contains-nested-and-local-declarations.kttest
@@ -1,0 +1,25 @@
+enum class SampleClass {
+    SAMPLE_CONSTANT_1 {
+        val sampleProperty = 0
+
+        override fun sampleFunction(): Int {
+            val sampleLocalProperty = 0
+
+            fun sampleLocalFunction() = 1
+
+            class SampleLocalClass
+
+            return 1
+        }
+
+        inner class SampleInnerClass {
+            val sampleNestedProperty = 0
+
+            fun sampleNestedFunction() = 1
+
+            inner class SampleNestedClass
+        }
+    };
+
+    abstract fun sampleFunction(): Int
+}

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koenumconstant/snippet/forkodeclarationprovider/enum-constant-contains-no-declarations.kttest
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koenumconstant/snippet/forkodeclarationprovider/enum-constant-contains-no-declarations.kttest
@@ -1,0 +1,3 @@
+enum class SampleClass {
+    SAMPLE_CONSTANT_1
+}

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koenumconstant/snippet/forkofunctionprovider/enum-constant-contains-function.kttest
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koenumconstant/snippet/forkofunctionprovider/enum-constant-contains-function.kttest
@@ -1,0 +1,11 @@
+enum class SampleClass {
+    SAMPLE_CONSTANT_1 {
+        override fun sampleFunction1() = 1
+
+        override fun sampleFunction2() = ""
+    };
+
+    abstract fun sampleFunction1(): Int
+
+    abstract fun sampleFunction2(): String
+}

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koenumconstant/snippet/forkofunctionprovider/enum-constant-contains-no-function.kttest
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koenumconstant/snippet/forkofunctionprovider/enum-constant-contains-no-function.kttest
@@ -1,0 +1,3 @@
+enum class SampleClass {
+    SAMPLE_CONSTANT_1
+}

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koenumconstant/snippet/forkopropertyprovider/count-properties.kttest
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koenumconstant/snippet/forkopropertyprovider/count-properties.kttest
@@ -1,0 +1,11 @@
+enum class SampleEnumClass {
+    SAMPLE_ENUM_CONSTANT {
+        override val sampleProperty1: String get() = "sample value"
+
+        inner class SampleInnerClass {
+            val sampleInnerProperty = 0
+        }
+    };
+
+    abstract val sampleProperty1: String
+}

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koenumconstant/snippet/forkopropertyprovider/enum-constant-contains-nested-properties.kttest
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koenumconstant/snippet/forkopropertyprovider/enum-constant-contains-nested-properties.kttest
@@ -1,0 +1,11 @@
+enum class SampleEnumClass {
+    SAMPLE_ENUM_CONSTANT {
+        override val sampleProperty1: String get() = "sample value"
+
+        inner class SampleInnerClass {
+            val sampleInnerProperty = 0
+        }
+    };
+
+    abstract val sampleProperty1: String
+}

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koenumconstant/snippet/forkopropertyprovider/enum-constant-has-no-properties.kttest
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koenumconstant/snippet/forkopropertyprovider/enum-constant-has-no-properties.kttest
@@ -1,0 +1,7 @@
+enum class SampleClass {
+    SAMPLE_CONSTANT_1 {
+        override fun sampleLocalFunction1() = 1
+    };
+
+    abstract fun sampleLocalFunction1(): Int
+}

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koenumconstant/snippet/forkopropertyprovider/enum-constant-has-two-properties.kttest
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koenumconstant/snippet/forkopropertyprovider/enum-constant-has-two-properties.kttest
@@ -1,0 +1,11 @@
+enum class SampleEnumClass {
+    SAMPLE_ENUM_CONSTANT {
+        override val sampleProperty1: String get() = "sample value"
+
+        override val sampleProperty2 = 0
+    };
+
+    abstract val sampleProperty1: String
+
+    internal abstract val sampleProperty2: Int
+}

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/kofile/KoFileDeclarationForKoDeclarationProviderTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/kofile/KoFileDeclarationForKoDeclarationProviderTest.kt
@@ -10,7 +10,7 @@ import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.Arguments.arguments
 import org.junit.jupiter.params.provider.MethodSource
 
-class KoFileDeclarationForKoFileDeclarationProviderTest {
+class KoFileDeclarationForKoDeclarationProviderTest {
     @Test
     fun `file-has-two-declarations`() {
         // given

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/kointerface/KoInterfaceDeclarationForKoDeclarationProviderTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/kointerface/KoInterfaceDeclarationForKoDeclarationProviderTest.kt
@@ -7,7 +7,7 @@ import org.amshove.kluent.assertSoftly
 import org.amshove.kluent.shouldBeEqualTo
 import org.junit.jupiter.api.Test
 
-class KoInterfaceDeclarationForKoFileDeclarationProviderTest {
+class KoInterfaceDeclarationForKoDeclarationProviderTest {
     @Test
     fun `interface-has-no-declarations`() {
         // given

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koobject/KoObjectDeclarationForKoDeclarationProviderTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koobject/KoObjectDeclarationForKoDeclarationProviderTest.kt
@@ -7,7 +7,7 @@ import org.amshove.kluent.assertSoftly
 import org.amshove.kluent.shouldBeEqualTo
 import org.junit.jupiter.api.Test
 
-class KoObjectDeclarationForKoFileDeclarationProviderTest {
+class KoObjectDeclarationForKoDeclarationProviderTest {
     @Test
     fun `object-has-no-declarations`() {
         // given

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/api/declaration/KoEnumConstantDeclaration.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/api/declaration/KoEnumConstantDeclaration.kt
@@ -16,6 +16,7 @@ import com.lemonappdev.konsist.api.provider.KoModuleProvider
 import com.lemonappdev.konsist.api.provider.KoNameProvider
 import com.lemonappdev.konsist.api.provider.KoPackageProvider
 import com.lemonappdev.konsist.api.provider.KoPathProvider
+import com.lemonappdev.konsist.api.provider.KoPropertyProvider
 import com.lemonappdev.konsist.api.provider.KoResideInPackageProvider
 import com.lemonappdev.konsist.api.provider.KoSourceSetProvider
 import com.lemonappdev.konsist.api.provider.KoTextProvider
@@ -39,6 +40,7 @@ interface KoEnumConstantDeclaration :
     KoLocalFunctionProvider,
     @RemoveInVersion("0.20.0")
     KoVariableProvider,
+    KoPropertyProvider,
     KoLocationProvider,
     KoNameProvider,
     KoPackageProvider,

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/api/declaration/KoEnumConstantDeclaration.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/api/declaration/KoEnumConstantDeclaration.kt
@@ -3,10 +3,13 @@ package com.lemonappdev.konsist.api.declaration
 import com.lemonappdev.konsist.api.provider.KoAnnotationProvider
 import com.lemonappdev.konsist.api.provider.KoArgumentProvider
 import com.lemonappdev.konsist.api.provider.KoBaseProvider
+import com.lemonappdev.konsist.api.provider.KoClassProvider
 import com.lemonappdev.konsist.api.provider.KoContainingDeclarationProvider
 import com.lemonappdev.konsist.api.provider.KoContainingFileProvider
+import com.lemonappdev.konsist.api.provider.KoDeclarationProvider
 import com.lemonappdev.konsist.api.provider.KoEnumNameProvider
 import com.lemonappdev.konsist.api.provider.KoFullyQualifiedNameProvider
+import com.lemonappdev.konsist.api.provider.KoFunctionProvider
 import com.lemonappdev.konsist.api.provider.KoKDocProvider
 import com.lemonappdev.konsist.api.provider.KoLocalClassProvider
 import com.lemonappdev.konsist.api.provider.KoLocalDeclarationProvider
@@ -43,6 +46,9 @@ interface KoEnumConstantDeclaration :
     KoLocalFunctionProvider,
     @RemoveInVersion("0.20.0")
     KoVariableProvider,
+    KoClassProvider,
+    KoDeclarationProvider,
+    KoFunctionProvider,
     KoPropertyProvider,
     KoLocationProvider,
     KoNameProvider,

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/api/declaration/KoEnumConstantDeclaration.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/api/declaration/KoEnumConstantDeclaration.kt
@@ -77,6 +77,12 @@ interface KoEnumConstantDeclaration :
     @Deprecated("Will be removed in version 0.20.0", ReplaceWith("numDeclarations()"))
     override val numLocalDeclarations: Int
 
+    @Deprecated("Will be removed in version 0.20.0", ReplaceWith("functions()"))
+    override val localFunctions: List<KoFunctionDeclaration>
+
+    @Deprecated("Will be removed in version 0.20.0", ReplaceWith("numFunctions()"))
+    override val numLocalFunctions: Int
+
     @Deprecated("Will be removed in version 0.20.0", ReplaceWith("countProperties()"))
     override fun countVariables(predicate: (KoVariableDeclaration) -> Boolean): Int
 
@@ -148,12 +154,6 @@ interface KoEnumConstantDeclaration :
 
     @Deprecated("Will be removed in version 0.20.0", ReplaceWith("hasAllDeclarations()"))
     override fun hasAllLocalDeclarations(predicate: (KoBaseDeclaration) -> Boolean): Boolean
-
-    @Deprecated("Will be removed in version 0.20.0", ReplaceWith("functions()"))
-    override val localFunctions: List<KoFunctionDeclaration>
-
-    @Deprecated("Will be removed in version 0.20.0", ReplaceWith("numFunctions()"))
-    override val numLocalFunctions: Int
 
     @Deprecated("Will be removed in version 0.20.0", ReplaceWith("countFunctions()"))
     override fun countLocalFunctions(predicate: (KoFunctionDeclaration) -> Boolean): Int

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/api/declaration/KoEnumConstantDeclaration.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/api/declaration/KoEnumConstantDeclaration.kt
@@ -29,6 +29,7 @@ import com.lemonappdev.konsist.core.annotation.RemoveInVersion
 /**
  * Represents a Kotlin enum constant declaration.
  */
+@Suppress("detekt.TooManyFunctions")
 interface KoEnumConstantDeclaration :
     KoBaseDeclaration,
     KoBaseProvider,

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/api/declaration/KoEnumConstantDeclaration.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/api/declaration/KoEnumConstantDeclaration.kt
@@ -20,6 +20,7 @@ import com.lemonappdev.konsist.api.provider.KoResideInPackageProvider
 import com.lemonappdev.konsist.api.provider.KoSourceSetProvider
 import com.lemonappdev.konsist.api.provider.KoTextProvider
 import com.lemonappdev.konsist.api.provider.KoVariableProvider
+import com.lemonappdev.konsist.core.annotation.RemoveInVersion
 
 /**
  * Represents a Kotlin enum constant declaration.
@@ -36,6 +37,7 @@ interface KoEnumConstantDeclaration :
     KoLocalClassProvider,
     KoLocalDeclarationProvider,
     KoLocalFunctionProvider,
+    @RemoveInVersion("0.20.0")
     KoVariableProvider,
     KoLocationProvider,
     KoNameProvider,
@@ -45,4 +47,40 @@ interface KoEnumConstantDeclaration :
     KoModuleProvider,
     KoSourceSetProvider,
     KoResideInPackageProvider,
-    KoTextProvider
+    KoTextProvider {
+    @Deprecated("Will be removed in version 0.20.0", ReplaceWith("properties()"))
+    override val variables: List<KoVariableDeclaration>
+
+    @Deprecated("Will be removed in version 0.20.0", ReplaceWith("numProperties()"))
+    override val numVariables: Int
+
+    @Deprecated("Will be removed in version 0.20.0", ReplaceWith("countProperties()"))
+    override fun countVariables(predicate: (KoVariableDeclaration) -> Boolean): Int
+
+    @Deprecated("Will be removed in version 0.20.0", ReplaceWith("hasProperties()"))
+    override fun hasVariables(): Boolean
+
+    @Deprecated("Will be removed in version 0.20.0", ReplaceWith("hasPropertyWithName()"))
+    override fun hasVariableWithName(
+        name: String,
+        vararg names: String,
+    ): Boolean
+
+    @Deprecated("Will be removed in version 0.20.0", ReplaceWith("hasPropertyWithName()"))
+    override fun hasVariableWithName(names: Collection<String>): Boolean
+
+    @Deprecated("Will be removed in version 0.20.0", ReplaceWith("hasPropertiesWithAllNames()"))
+    override fun hasVariablesWithAllNames(
+        name: String,
+        vararg names: String,
+    ): Boolean
+
+    @Deprecated("Will be removed in version 0.20.0", ReplaceWith("hasPropertiesWithAllNames()"))
+    override fun hasVariablesWithAllNames(names: Collection<String>): Boolean
+
+    @Deprecated("Will be removed in version 0.20.0", ReplaceWith("hasProperty()"))
+    override fun hasVariable(predicate: (KoVariableDeclaration) -> Boolean): Boolean
+
+    @Deprecated("Will be removed in version 0.20.0", ReplaceWith("hasAllProperties()"))
+    override fun hasAllVariables(predicate: (KoVariableDeclaration) -> Boolean): Boolean
+}

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/api/declaration/KoEnumConstantDeclaration.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/api/declaration/KoEnumConstantDeclaration.kt
@@ -35,8 +35,11 @@ interface KoEnumConstantDeclaration :
     KoEnumNameProvider,
     KoFullyQualifiedNameProvider,
     KoKDocProvider,
+    @RemoveInVersion("0.20.0")
     KoLocalClassProvider,
+    @RemoveInVersion("0.20.0")
     KoLocalDeclarationProvider,
+    @RemoveInVersion("0.20.0")
     KoLocalFunctionProvider,
     @RemoveInVersion("0.20.0")
     KoVariableProvider,
@@ -55,6 +58,18 @@ interface KoEnumConstantDeclaration :
 
     @Deprecated("Will be removed in version 0.20.0", ReplaceWith("numProperties()"))
     override val numVariables: Int
+
+    @Deprecated("Will be removed in version 0.20.0", ReplaceWith("classes()"))
+    override val localClasses: List<KoClassDeclaration>
+
+    @Deprecated("Will be removed in version 0.20.0", ReplaceWith("numClasses()"))
+    override val numLocalClasses: Int
+
+    @Deprecated("Will be removed in version 0.20.0", ReplaceWith("declarations()"))
+    override val localDeclarations: List<KoBaseDeclaration>
+
+    @Deprecated("Will be removed in version 0.20.0", ReplaceWith("numDeclarations()"))
+    override val numLocalDeclarations: Int
 
     @Deprecated("Will be removed in version 0.20.0", ReplaceWith("countProperties()"))
     override fun countVariables(predicate: (KoVariableDeclaration) -> Boolean): Int
@@ -85,4 +100,82 @@ interface KoEnumConstantDeclaration :
 
     @Deprecated("Will be removed in version 0.20.0", ReplaceWith("hasAllProperties()"))
     override fun hasAllVariables(predicate: (KoVariableDeclaration) -> Boolean): Boolean
+
+    @Deprecated("Will be removed in version 0.20.0", ReplaceWith("countClasses()"))
+    override fun countLocalClasses(predicate: (KoClassDeclaration) -> Boolean): Int
+
+    @Deprecated("Will be removed in version 0.20.0", ReplaceWith("hasClasses()"))
+    override fun hasLocalClasses(): Boolean
+
+    @Deprecated("Will be removed in version 0.20.0", ReplaceWith("hasClassWithName()"))
+    override fun hasLocalClassWithName(
+        name: String,
+        vararg names: String,
+    ): Boolean
+
+    @Deprecated("Will be removed in version 0.20.0", ReplaceWith("hasClassWithName()"))
+    override fun hasLocalClassWithName(names: Collection<String>): Boolean
+
+    @Deprecated("Will be removed in version 0.20.0", ReplaceWith("hasClassesWithAllNames()"))
+    override fun hasLocalClassesWithAllNames(
+        name: String,
+        vararg names: String,
+    ): Boolean
+
+    @Deprecated("Will be removed in version 0.20.0", ReplaceWith("hasClassesWithAllNames()"))
+    override fun hasLocalClassesWithAllNames(names: Collection<String>): Boolean
+
+    @Deprecated("Will be removed in version 0.20.0", ReplaceWith("hasClass()"))
+    override fun hasLocalClass(predicate: (KoClassDeclaration) -> Boolean): Boolean
+
+    @Deprecated("Will be removed in version 0.20.0", ReplaceWith("hasAllClasses()"))
+    override fun hasAllLocalClasses(predicate: (KoClassDeclaration) -> Boolean): Boolean
+
+    @Deprecated("Will be removed in version 0.20.0", ReplaceWith("countDeclarations()"))
+    override fun countLocalDeclarations(predicate: (KoBaseDeclaration) -> Boolean): Int
+
+    @Deprecated("Will be removed in version 0.20.0", ReplaceWith("hasDeclarations()"))
+    override fun hasLocalDeclarations(): Boolean
+
+    @Deprecated("Will be removed in version 0.20.0", ReplaceWith("hasDeclaration()"))
+    override fun hasLocalDeclaration(predicate: (KoBaseDeclaration) -> Boolean): Boolean
+
+    @Deprecated("Will be removed in version 0.20.0", ReplaceWith("hasAllDeclarations()"))
+    override fun hasAllLocalDeclarations(predicate: (KoBaseDeclaration) -> Boolean): Boolean
+
+    @Deprecated("Will be removed in version 0.20.0", ReplaceWith("functions()"))
+    override val localFunctions: List<KoFunctionDeclaration>
+
+    @Deprecated("Will be removed in version 0.20.0", ReplaceWith("numFunctions()"))
+    override val numLocalFunctions: Int
+
+    @Deprecated("Will be removed in version 0.20.0", ReplaceWith("countFunctions()"))
+    override fun countLocalFunctions(predicate: (KoFunctionDeclaration) -> Boolean): Int
+
+    @Deprecated("Will be removed in version 0.20.0", ReplaceWith("hasFunctions()"))
+    override fun hasLocalFunctions(): Boolean
+
+    @Deprecated("Will be removed in version 0.20.0", ReplaceWith("hasFunctionWithName()"))
+    override fun hasLocalFunctionWithName(
+        name: String,
+        vararg names: String,
+    ): Boolean
+
+    @Deprecated("Will be removed in version 0.20.0", ReplaceWith("hasFunctionWithName()"))
+    override fun hasLocalFunctionWithName(names: Collection<String>): Boolean
+
+    @Deprecated("Will be removed in version 0.20.0", ReplaceWith("hasFunctionsWithAllNames()"))
+    override fun hasLocalFunctionsWithAllNames(
+        name: String,
+        vararg names: String,
+    ): Boolean
+
+    @Deprecated("Will be removed in version 0.20.0", ReplaceWith("hasFunctionsWithAllNames()"))
+    override fun hasLocalFunctionsWithAllNames(names: Collection<String>): Boolean
+
+    @Deprecated("Will be removed in version 0.20.0", ReplaceWith("hasFunction()"))
+    override fun hasLocalFunction(predicate: (KoFunctionDeclaration) -> Boolean): Boolean
+
+    @Deprecated("Will be removed in version 0.20.0", ReplaceWith("hasAllFunctions()"))
+    override fun hasAllLocalFunctions(predicate: (KoFunctionDeclaration) -> Boolean): Boolean
 }

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/api/ext/list/DepracatedKoLocalClassProviderListExt.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/api/ext/list/DepracatedKoLocalClassProviderListExt.kt
@@ -1,0 +1,199 @@
+package com.lemonappdev.konsist.api.ext.list
+
+import com.lemonappdev.konsist.api.declaration.KoClassDeclaration
+import com.lemonappdev.konsist.api.declaration.KoEnumConstantDeclaration
+
+/**
+ * List containing local class declarations.
+ */
+@Deprecated("Will be removed in version 0.20.0", ReplaceWith("classes()"))
+val <T : KoEnumConstantDeclaration> List<T>.localClasses: List<KoClassDeclaration>
+    get() = flatMap { it.localClasses }
+
+/**
+ * List containing declarations with any local class.
+ *
+ * @return A list containing declarations with any local class.
+ */
+@Deprecated("Will be removed in version 0.20.0", ReplaceWith("withClasses()"))
+fun <T : KoEnumConstantDeclaration> List<T>.withLocalClasses(): List<T> = filter { it.hasLocalClasses() }
+
+/**
+ * List containing declarations with no local classes.
+ *
+ * @return A list containing declarations with no local classes.
+ */
+@Deprecated("Will be removed in version 0.20.0", ReplaceWith("withoutClasses()"))
+fun <T : KoEnumConstantDeclaration> List<T>.withoutLocalClasses(): List<T> = filterNot { it.hasLocalClasses() }
+
+/**
+ * List containing declarations that have at least one local class with the specified name(s).
+ *
+ * @param name The name of the local class to include.
+ * @param names The names of additional local classes to include.
+ * @return A list containing declarations with at least one of the specified local class(es).
+ */
+@Deprecated("Will be removed in version 0.20.0", ReplaceWith("withClassNamed()"))
+fun <T : KoEnumConstantDeclaration> List<T>.withLocalClassNamed(
+    name: String,
+    vararg names: String,
+): List<T> = withLocalClassNamed(listOf(name, *names))
+
+/**
+ * List containing declarations that have at least one local class with the specified name(s).
+ *
+ * @param names The names of additional local classes to include.
+ * @return A list containing declarations with at least one of the specified local class(es).
+ */
+@Deprecated("Will be removed in version 0.20.0", ReplaceWith("withClassNamed()"))
+fun <T : KoEnumConstantDeclaration> List<T>.withLocalClassNamed(names: Collection<String>): List<T> =
+    filter {
+        when {
+            names.isEmpty() -> it.hasLocalClasses()
+            else -> it.hasLocalClassWithName(names)
+        }
+    }
+
+/**
+ * List containing declarations without any of specified local classes.
+ *
+ * @param name The name of the local class to exclude.
+ * @param names The names of additional local classes to exclude.
+ * @return A list containing declarations without any of specified local classes.
+ */
+@Deprecated("Will be removed in version 0.20.0", ReplaceWith("withoutClassNamed()"))
+fun <T : KoEnumConstantDeclaration> List<T>.withoutLocalClassNamed(
+    name: String,
+    vararg names: String,
+): List<T> = withoutLocalClassNamed(listOf(name, *names))
+
+/**
+ * List containing declarations without any of specified local classes.
+ *
+ * @param names The names of additional local classes to exclude.
+ * @return A list containing declarations without any of specified local classes.
+ */
+@Deprecated("Will be removed in version 0.20.0", ReplaceWith("withoutClassNamed()"))
+fun <T : KoEnumConstantDeclaration> List<T>.withoutLocalClassNamed(names: Collection<String>): List<T> =
+    filterNot {
+        when {
+            names.isEmpty() -> it.hasLocalClasses()
+            else -> it.hasLocalClassWithName(names)
+        }
+    }
+
+/**
+ * List containing declarations that have all specified local classes.
+ *
+ * @param name The name of the local class to include.
+ * @param names The name(s) of the local class(es) to include.
+ * @return A list containing declarations with all specified local class(es).
+ */
+@Deprecated("Will be removed in version 0.20.0", ReplaceWith("withAllClassesNamed()"))
+fun <T : KoEnumConstantDeclaration> List<T>.withAllLocalClassesNamed(
+    name: String,
+    vararg names: String,
+): List<T> = withAllLocalClassesNamed(listOf(name, *names))
+
+/**
+ * List containing declarations that have all specified local classes.
+ *
+ * @param names The name(s) of the local class(es) to include.
+ * @return A list containing declarations with all specified local class(es).
+ */
+@Deprecated("Will be removed in version 0.20.0", ReplaceWith("withAllClassesNamed()"))
+fun <T : KoEnumConstantDeclaration> List<T>.withAllLocalClassesNamed(names: Collection<String>): List<T> =
+    filter {
+        when {
+            names.isEmpty() -> it.hasLocalClasses()
+            else -> it.hasLocalClassesWithAllNames(names)
+        }
+    }
+
+/**
+ * List containing declarations without all specified local classes.
+ *
+ * @param name The name of the local class to exclude.
+ * @param names The name(s) of the local class(es) to exclude.
+ * @return A list containing declarations without all specified local class(es).
+ */
+@Deprecated("Will be removed in version 0.20.0", ReplaceWith("withoutAllClassesNamed()"))
+fun <T : KoEnumConstantDeclaration> List<T>.withoutAllLocalClassesNamed(
+    name: String,
+    vararg names: String,
+): List<T> = withoutAllLocalClassesNamed(listOf(name, *names))
+
+/**
+ * List containing declarations without all specified local classes.
+ *
+ * @param names The name(s) of the local class(es) to exclude.
+ * @return A list containing declarations without all specified local class(es).
+ */
+@Deprecated("Will be removed in version 0.20.0", ReplaceWith("withoutAllClassesNamed()"))
+fun <T : KoEnumConstantDeclaration> List<T>.withoutAllLocalClassesNamed(names: Collection<String>): List<T> =
+    filterNot {
+        when {
+            names.isEmpty() -> it.hasLocalClasses()
+            else -> it.hasLocalClassesWithAllNames(names)
+        }
+    }
+
+/**
+ * List containing declarations that have at least one local class satisfying the provided predicate.
+ *
+ * @param predicate A function that defines the condition to be met by a local class declaration.
+ * @return A list containing declarations with at least one local class satisfying the predicate.
+ */
+@Deprecated("Will be removed in version 0.20.0", ReplaceWith("withClass()"))
+fun <T : KoEnumConstantDeclaration> List<T>.withLocalClass(predicate: (KoClassDeclaration) -> Boolean): List<T> =
+    filter { it.hasLocalClass(predicate) }
+
+/**
+ * List containing declarations that not have local class satisfying the provided predicate.
+ *
+ * @param predicate A function that defines the condition to be met by a local class declaration.
+ * @return A list containing declarations without local class satisfying the provided predicate.
+ */
+@Deprecated("Will be removed in version 0.20.0", ReplaceWith("withoutClass()"))
+fun <T : KoEnumConstantDeclaration> List<T>.withoutLocalClass(predicate: (KoClassDeclaration) -> Boolean): List<T> =
+    filterNot { it.hasLocalClass(predicate) }
+
+/**
+ * List containing declarations that have all local classes satisfying the provided predicate.
+ *
+ * @param predicate A function that defines the condition to be met by all local class declarations.
+ * @return A filtered list containing declarations with all local classes satisfying the predicate.
+ */
+@Deprecated("Will be removed in version 0.20.0", ReplaceWith("withAllClasses()"))
+fun <T : KoEnumConstantDeclaration> List<T>.withAllLocalClasses(predicate: (KoClassDeclaration) -> Boolean): List<T> =
+    filter { it.hasAllLocalClasses(predicate) }
+
+/**
+ * List containing declarations that have at least one local class not satisfying the provided predicate.
+ *
+ * @param predicate A function that defines the condition to be met by all local class declarations.
+ * @return A list containing declarations that have at least one local class not satisfying the provided predicate.
+ */
+@Deprecated("Will be removed in version 0.20.0", ReplaceWith("withoutAllClasses()"))
+fun <T : KoEnumConstantDeclaration> List<T>.withoutAllLocalClasses(predicate: (KoClassDeclaration) -> Boolean): List<T> =
+    filterNot { it.hasAllLocalClasses(predicate) }
+
+/**
+ * List containing declarations with local class declarations satisfying the predicate.
+ *
+ * @param predicate A function that defines the condition to be met by the list of local class declarations.
+ * @return A list containing declarations with local class declarations satisfying the predicate.
+ */
+@Deprecated("Will be removed in version 0.20.0", ReplaceWith("withClasses()"))
+fun <T : KoEnumConstantDeclaration> List<T>.withLocalClasses(predicate: (List<KoClassDeclaration>) -> Boolean): List<T> =
+    filter { predicate(it.localClasses) }
+
+/**
+ * List containing declarations without local class declarations satisfying the predicate.
+ *
+ * @param predicate A function that defines the condition to be met by the list of local class declarations.
+ * @return A list containing declarations without local class declarations satisfying the predicate.
+ */
+@Deprecated("Will be removed in version 0.20.0", ReplaceWith("withoutClasses()"))
+fun <T : KoEnumConstantDeclaration> List<T>.withoutLocalClasses(predicate: (List<KoClassDeclaration>) -> Boolean): List<T> =
+    filterNot { predicate(it.localClasses) }

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/api/ext/list/DeprecatedKoLocalDeclarationProviderListExt.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/api/ext/list/DeprecatedKoLocalDeclarationProviderListExt.kt
@@ -1,0 +1,91 @@
+package com.lemonappdev.konsist.api.ext.list
+
+import com.lemonappdev.konsist.api.declaration.KoBaseDeclaration
+import com.lemonappdev.konsist.api.declaration.KoEnumConstantDeclaration
+
+/**
+ * List containing local declarations.
+ */
+@Deprecated("Will be removed in version 0.20.0", ReplaceWith("declarations()"))
+val <T : KoEnumConstantDeclaration> List<T>.localDeclarations: List<KoBaseDeclaration>
+    get() = flatMap { it.localDeclarations }
+
+/**
+ * List containing declarations with any local declaration.
+ *
+ * @return A list containing declarations with any local declaration.
+ */
+@Deprecated("Will be removed in version 0.20.0", ReplaceWith("withDeclarations()"))
+fun <T : KoEnumConstantDeclaration> List<T>.withLocalDeclarations(): List<T> = filter { it.hasLocalDeclarations() }
+
+/**
+ * List containing declarations with no local declarations.
+ *
+ * @return A list containing declarations with no local declarations.
+ */
+@Deprecated("Will be removed in version 0.20.0", ReplaceWith("withoutDeclarations()"))
+fun <T : KoEnumConstantDeclaration> List<T>.withoutLocalDeclarations(): List<T> = filterNot { it.hasLocalDeclarations() }
+
+/**
+ * List containing declarations that have at least one local declaration satisfying the provided predicate.
+ *
+ * @param predicate A function that defines the condition to be met by a local declaration.
+ * @return A list containing declarations with at least one local declaration satisfying the predicate.
+ */
+@Deprecated("Will be removed in version 0.20.0", ReplaceWith("withDeclaration()"))
+fun <T : KoEnumConstantDeclaration> List<T>.withLocalDeclaration(predicate: (KoBaseDeclaration) -> Boolean): List<T> =
+    filter {
+        it.hasLocalDeclaration(predicate)
+    }
+
+/**
+ * List containing declarations that not have local declaration satisfying the provided predicate.
+ *
+ * @param predicate A function that defines the condition to be met by a local declaration.
+ * @return A list containing declarations without local declaration satisfying the provided predicate.
+ */
+@Deprecated("Will be removed in version 0.20.0", ReplaceWith("withoutDeclaration()"))
+fun <T : KoEnumConstantDeclaration> List<T>.withoutLocalDeclaration(predicate: (KoBaseDeclaration) -> Boolean): List<T> =
+    filterNot { it.hasLocalDeclaration(predicate) }
+
+/**
+ * List containing declarations that have all local declarations satisfying the provided predicate.
+ *
+ * @param predicate A function that defines the condition to be met by all local declarations.
+ * @return A filtered list containing declarations with all local declarations satisfying the predicate.
+ */
+@Deprecated("Will be removed in version 0.20.0", ReplaceWith("withAllDeclarations()"))
+fun <T : KoEnumConstantDeclaration> List<T>.withAllLocalDeclarations(predicate: (KoBaseDeclaration) -> Boolean): List<T> =
+    filter {
+        it.hasAllLocalDeclarations(predicate)
+    }
+
+/**
+ * List containing declarations that have at least one local declaration not satisfying the provided predicate.
+ *
+ * @param predicate A function that defines the condition to be met by all local declarations.
+ * @return A list containing declarations that have at least one local declaration not satisfying the provided predicate.
+ */
+@Deprecated("Will be removed in version 0.20.0", ReplaceWith("withoutAllDeclarations()"))
+fun <T : KoEnumConstantDeclaration> List<T>.withoutAllLocalDeclarations(predicate: (KoBaseDeclaration) -> Boolean): List<T> =
+    filterNot { it.hasAllLocalDeclarations(predicate) }
+
+/**
+ * List containing declarations with local declarations satisfying the predicate.
+ *
+ * @param predicate A function that defines the condition to be met by the list of local declarations.
+ * @return A list containing declarations with local declarations satisfying the predicate.
+ */
+@Deprecated("Will be removed in version 0.20.0", ReplaceWith("withDeclarations()"))
+fun <T : KoEnumConstantDeclaration> List<T>.withLocalDeclarations(predicate: (List<KoBaseDeclaration>) -> Boolean): List<T> =
+    filter { predicate(it.localDeclarations) }
+
+/**
+ * List containing declarations without local declarations satisfying the predicate.
+ *
+ * @param predicate A function that defines the condition to be met by the list of local declarations.
+ * @return A list containing declarations without local declarations satisfying the predicate.
+ */
+@Deprecated("Will be removed in version 0.20.0", ReplaceWith("withoutDeclarations()"))
+fun <T : KoEnumConstantDeclaration> List<T>.withoutLocalDeclarations(predicate: (List<KoBaseDeclaration>) -> Boolean): List<T> =
+    filterNot { predicate(it.localDeclarations) }

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/api/ext/list/DeprecatedKoLocalFunctionProviderListExt.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/api/ext/list/DeprecatedKoLocalFunctionProviderListExt.kt
@@ -2,7 +2,6 @@ package com.lemonappdev.konsist.api.ext.list
 
 import com.lemonappdev.konsist.api.declaration.KoEnumConstantDeclaration
 import com.lemonappdev.konsist.api.declaration.KoFunctionDeclaration
-import com.lemonappdev.konsist.api.provider.KoLocalFunctionProvider
 
 /**
  * List containing local function declarations.

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/api/ext/list/DeprecatedKoLocalFunctionProviderListExt.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/api/ext/list/DeprecatedKoLocalFunctionProviderListExt.kt
@@ -1,0 +1,200 @@
+package com.lemonappdev.konsist.api.ext.list
+
+import com.lemonappdev.konsist.api.declaration.KoEnumConstantDeclaration
+import com.lemonappdev.konsist.api.declaration.KoFunctionDeclaration
+import com.lemonappdev.konsist.api.provider.KoLocalFunctionProvider
+
+/**
+ * List containing local function declarations.
+ */
+@Deprecated("Will be removed in version 0.20.0", ReplaceWith("functions()"))
+val <T : KoEnumConstantDeclaration> List<T>.localFunctions: List<KoFunctionDeclaration>
+    get() = flatMap { it.localFunctions }
+
+/**
+ * List containing declarations with any local function.
+ *
+ * @return A list containing declarations with any local function.
+ */
+@Deprecated("Will be removed in version 0.20.0", ReplaceWith("withFunctions()"))
+fun <T : KoEnumConstantDeclaration> List<T>.withLocalFunctions(): List<T> = filter { it.hasLocalFunctions() }
+
+/**
+ * List containing declarations with no local functions.
+ *
+ * @return A list containing declarations with no local functions.
+ */
+@Deprecated("Will be removed in version 0.20.0", ReplaceWith("withoutFunctions()"))
+fun <T : KoEnumConstantDeclaration> List<T>.withoutLocalFunctions(): List<T> = filterNot { it.hasLocalFunctions() }
+
+/**
+ * List containing declarations that have at least one local function with the specified name(s).
+ *
+ * @param name The name of the local function to include.
+ * @param names The names of additional local functions to include.
+ * @return A list containing declarations with at least one of the specified local function(s).
+ */
+@Deprecated("Will be removed in version 0.20.0", ReplaceWith("withFunctionNamed()"))
+fun <T : KoEnumConstantDeclaration> List<T>.withLocalFunctionNamed(
+    name: String,
+    vararg names: String,
+): List<T> = withLocalFunctionNamed(listOf(name, *names))
+
+/**
+ * List containing declarations that have at least one local function with the specified name(s).
+ *
+ * @param names The names of additional local functions to include.
+ * @return A list containing declarations with at least one of the specified local function(s).
+ */
+@Deprecated("Will be removed in version 0.20.0", ReplaceWith("withFunctionNamed()"))
+fun <T : KoEnumConstantDeclaration> List<T>.withLocalFunctionNamed(names: Collection<String>): List<T> =
+    filter {
+        when {
+            names.isEmpty() -> it.hasLocalFunctions()
+            else -> it.hasLocalFunctionWithName(names)
+        }
+    }
+
+/**
+ * List containing declarations without any of specified local functions.
+ *
+ * @param name The name of the local function to exclude.
+ * @param names The names of additional local functions to exclude.
+ * @return A list containing declarations without any of specified local functions.
+ */
+@Deprecated("Will be removed in version 0.20.0", ReplaceWith("withoutFunctionNamed()"))
+fun <T : KoEnumConstantDeclaration> List<T>.withoutLocalFunctionNamed(
+    name: String,
+    vararg names: String,
+): List<T> = withoutLocalFunctionNamed(listOf(name, *names))
+
+/**
+ * List containing declarations without any of specified local functions.
+ *
+ * @param names The names of additional local functions to exclude.
+ * @return A list containing declarations without any of specified local functions.
+ */
+@Deprecated("Will be removed in version 0.20.0", ReplaceWith("withoutFunctionNamed()"))
+fun <T : KoEnumConstantDeclaration> List<T>.withoutLocalFunctionNamed(names: Collection<String>): List<T> =
+    filterNot {
+        when {
+            names.isEmpty() -> it.hasLocalFunctions()
+            else -> it.hasLocalFunctionWithName(names)
+        }
+    }
+
+/**
+ * List containing declarations that have all specified local functions.
+ *
+ * @param name The name of the local function to include.
+ * @param names The name(s) of the local function(s) to include.
+ * @return A list containing declarations with all specified local function(s).
+ */
+@Deprecated("Will be removed in version 0.20.0", ReplaceWith("withAllFunctionsNamed()"))
+fun <T : KoEnumConstantDeclaration> List<T>.withAllLocalFunctionsNamed(
+    name: String,
+    vararg names: String,
+): List<T> = withAllLocalFunctionsNamed(listOf(name, *names))
+
+/**
+ * List containing declarations that have all specified local functions.
+ *
+ * @param names The name(s) of the local function(s) to include.
+ * @return A list containing declarations with all specified local function(s).
+ */
+@Deprecated("Will be removed in version 0.20.0", ReplaceWith("withAllFunctionsNamed()"))
+fun <T : KoEnumConstantDeclaration> List<T>.withAllLocalFunctionsNamed(names: Collection<String>): List<T> =
+    filter {
+        when {
+            names.isEmpty() -> it.hasLocalFunctions()
+            else -> it.hasLocalFunctionsWithAllNames(names)
+        }
+    }
+
+/**
+ * List containing declarations without all specified local functions.
+ *
+ * @param name The name of the local function to exclude.
+ * @param names The name(s) of the local function(s) to exclude.
+ * @return A list containing declarations without all specified local function(s).
+ */
+@Deprecated("Will be removed in version 0.20.0", ReplaceWith("withoutAllFunctionsNamed()"))
+fun <T : KoEnumConstantDeclaration> List<T>.withoutAllLocalFunctionsNamed(
+    name: String,
+    vararg names: String,
+): List<T> = withoutAllLocalFunctionsNamed(listOf(name, *names))
+
+/**
+ * List containing declarations without all specified local functions.
+ *
+ * @param names The name(s) of the local function(s) to exclude.
+ * @return A list containing declarations without all specified local function(s).
+ */
+@Deprecated("Will be removed in version 0.20.0", ReplaceWith("withoutAllFunctionsNamed()"))
+fun <T : KoEnumConstantDeclaration> List<T>.withoutAllLocalFunctionsNamed(names: Collection<String>): List<T> =
+    filterNot {
+        when {
+            names.isEmpty() -> it.hasLocalFunctions()
+            else -> it.hasLocalFunctionsWithAllNames(names)
+        }
+    }
+
+/**
+ * List containing declarations that have at least one local function satisfying the provided predicate.
+ *
+ * @param predicate A function that defines the condition to be met by a local function declaration.
+ * @return A list containing declarations with at least one local function satisfying the predicate.
+ */
+@Deprecated("Will be removed in version 0.20.0", ReplaceWith("withFunction()"))
+fun <T : KoEnumConstantDeclaration> List<T>.withLocalFunction(predicate: (KoFunctionDeclaration) -> Boolean): List<T> =
+    filter { it.hasLocalFunction(predicate) }
+
+/**
+ * List containing declarations that not have local function satisfying the provided predicate.
+ *
+ * @param predicate A function that defines the condition to be met by a local function declaration.
+ * @return A list containing declarations without local function satisfying the provided predicate.
+ */
+@Deprecated("Will be removed in version 0.20.0", ReplaceWith("withoutFunction()"))
+fun <T : KoEnumConstantDeclaration> List<T>.withoutLocalFunction(predicate: (KoFunctionDeclaration) -> Boolean): List<T> =
+    filterNot { it.hasLocalFunction(predicate) }
+
+/**
+ * List containing declarations that have all local functions satisfying the provided predicate.
+ *
+ * @param predicate A function that defines the condition to be met by all local function declarations.
+ * @return A filtered list containing declarations with all local functions satisfying the predicate.
+ */
+@Deprecated("Will be removed in version 0.20.0", ReplaceWith("withAllFunctions()"))
+fun <T : KoEnumConstantDeclaration> List<T>.withAllLocalFunctions(predicate: (KoFunctionDeclaration) -> Boolean): List<T> =
+    filter { it.hasAllLocalFunctions(predicate) }
+
+/**
+ * List containing declarations that have at least one local function not satisfying the provided predicate.
+ *
+ * @param predicate A function that defines the condition to be met by all local function declarations.
+ * @return A list containing declarations that have at least one local function not satisfying the provided predicate.
+ */
+@Deprecated("Will be removed in version 0.20.0", ReplaceWith("withoutAllFunctions()"))
+fun <T : KoEnumConstantDeclaration> List<T>.withoutAllLocalFunctions(predicate: (KoFunctionDeclaration) -> Boolean): List<T> =
+    filterNot { it.hasAllLocalFunctions(predicate) }
+
+/**
+ * List containing declarations with local function declarations satisfying the predicate.
+ *
+ * @param predicate A function that defines the condition to be met by the list of local function declarations.
+ * @return A list containing declarations with local function declarations satisfying the predicate.
+ */
+@Deprecated("Will be removed in version 0.20.0", ReplaceWith("withFunctions()"))
+fun <T : KoEnumConstantDeclaration> List<T>.withLocalFunctions(predicate: (List<KoFunctionDeclaration>) -> Boolean): List<T> =
+    filter { predicate(it.localFunctions) }
+
+/**
+ * List containing declarations without local function declarations satisfying the predicate.
+ *
+ * @param predicate A function that defines the condition to be met by the list of local function declarations.
+ * @return A list containing declarations without local function declarations satisfying the predicate.
+ */
+@Deprecated("Will be removed in version 0.20.0", ReplaceWith("withoutFunctions()"))
+fun <T : KoEnumConstantDeclaration> List<T>.withoutLocalFunctions(predicate: (List<KoFunctionDeclaration>) -> Boolean): List<T> =
+    filterNot { predicate(it.localFunctions) }

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/core/declaration/KoEnumConstantDeclarationCore.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/core/declaration/KoEnumConstantDeclarationCore.kt
@@ -4,6 +4,7 @@ import com.lemonappdev.konsist.api.declaration.KoArgumentDeclaration
 import com.lemonappdev.konsist.api.declaration.KoBaseDeclaration
 import com.lemonappdev.konsist.api.declaration.KoEnumConstantDeclaration
 import com.lemonappdev.konsist.api.declaration.KoVariableDeclaration
+import com.lemonappdev.konsist.core.annotation.RemoveInVersion
 import com.lemonappdev.konsist.core.cache.KoDeclarationCache
 import com.lemonappdev.konsist.core.provider.KoAnnotationProviderCore
 import com.lemonappdev.konsist.core.provider.KoArgumentProviderCore
@@ -20,11 +21,13 @@ import com.lemonappdev.konsist.core.provider.KoLocationProviderCore
 import com.lemonappdev.konsist.core.provider.KoModuleProviderCore
 import com.lemonappdev.konsist.core.provider.KoNameProviderCore
 import com.lemonappdev.konsist.core.provider.KoPathProviderCore
+import com.lemonappdev.konsist.core.provider.KoPropertyProviderCore
 import com.lemonappdev.konsist.core.provider.KoResideInPackageProviderCore
 import com.lemonappdev.konsist.core.provider.KoSourceSetProviderCore
 import com.lemonappdev.konsist.core.provider.KoTextProviderCore
 import com.lemonappdev.konsist.core.provider.KoVariableProviderCore
 import com.lemonappdev.konsist.core.provider.packagee.KoPackageDeclarationProviderCore
+import com.lemonappdev.konsist.core.provider.util.KoDeclarationProviderCoreUtil
 import com.lemonappdev.konsist.core.provider.util.KoLocalDeclarationProviderCoreUtil
 import org.jetbrains.kotlin.com.intellij.psi.PsiElement
 import org.jetbrains.kotlin.psi.KtAnnotationEntry
@@ -47,7 +50,9 @@ internal class KoEnumConstantDeclarationCore private constructor(
     KoLocalClassProviderCore,
     KoLocalDeclarationProviderCore,
     KoLocalFunctionProviderCore,
+    @RemoveInVersion("0.20.0")
     KoVariableProviderCore,
+    KoPropertyProviderCore,
     KoLocationProviderCore,
     KoNameProviderCore,
     KoContainingDeclarationProviderCore,
@@ -74,6 +79,11 @@ internal class KoEnumConstantDeclarationCore private constructor(
 
         KoLocalDeclarationProviderCoreUtil.getKoLocalDeclarations(psiElements, this)
     }
+
+    override fun declarations(
+        includeNested: Boolean,
+        includeLocal: Boolean
+    ): List<KoBaseDeclaration> = KoDeclarationProviderCoreUtil.getKoDeclarations(ktEnumEntry, includeNested, includeLocal, this)
 
     override val arguments: List<KoArgumentDeclaration> by lazy {
         ktEnumEntry

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/core/declaration/KoEnumConstantDeclarationCore.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/core/declaration/KoEnumConstantDeclarationCore.kt
@@ -3,6 +3,7 @@ package com.lemonappdev.konsist.core.declaration
 import com.lemonappdev.konsist.api.declaration.KoArgumentDeclaration
 import com.lemonappdev.konsist.api.declaration.KoBaseDeclaration
 import com.lemonappdev.konsist.api.declaration.KoEnumConstantDeclaration
+import com.lemonappdev.konsist.api.declaration.KoVariableDeclaration
 import com.lemonappdev.konsist.core.cache.KoDeclarationCache
 import com.lemonappdev.konsist.core.provider.KoAnnotationProviderCore
 import com.lemonappdev.konsist.core.provider.KoArgumentProviderCore
@@ -89,6 +90,43 @@ internal class KoEnumConstantDeclarationCore private constructor(
     }
 
     override fun toString(): String = name
+
+    @Deprecated("Will be removed in version 0.20.0", replaceWith = ReplaceWith("properties()"))
+    override val variables: List<KoVariableDeclaration> by lazy { super<KoVariableProviderCore>.variables }
+
+    @Deprecated("Will be removed in version 0.20.0", replaceWith = ReplaceWith("numProperties()"))
+    override val numVariables: Int by lazy { super<KoVariableProviderCore>.numVariables }
+
+    @Deprecated("Will be removed in version 0.20.0", replaceWith = ReplaceWith("countProperties()"))
+    override fun countVariables(predicate: (KoVariableDeclaration) -> Boolean): Int =
+        super<KoVariableProviderCore>.countVariables(predicate)
+
+    @Deprecated("Will be removed in version 0.20.0", replaceWith = ReplaceWith("hasProperties()"))
+    override fun hasVariables(): Boolean = super<KoVariableProviderCore>.hasVariables()
+
+    @Deprecated("Will be removed in version 0.20.0", replaceWith = ReplaceWith("hasPropertyWithName()"))
+    override fun hasVariableWithName(name: String, vararg names: String): Boolean =
+        super<KoVariableProviderCore>.hasVariableWithName(name, *names)
+
+    @Deprecated("Will be removed in version 0.20.0", replaceWith = ReplaceWith("hasPropertyWithName()"))
+    override fun hasVariableWithName(names: Collection<String>): Boolean =
+        super<KoVariableProviderCore>.hasVariableWithName(names)
+
+    @Deprecated("Will be removed in version 0.20.0", replaceWith = ReplaceWith("hasPropertiesWithAllNames()"))
+    override fun hasVariablesWithAllNames(name: String, vararg names: String): Boolean =
+        super<KoVariableProviderCore>.hasVariablesWithAllNames(name, *names)
+
+    @Deprecated("Will be removed in version 0.20.0", replaceWith = ReplaceWith("hasPropertiesWithAllNames()"))
+    override fun hasVariablesWithAllNames(names: Collection<String>): Boolean =
+        super<KoVariableProviderCore>.hasVariablesWithAllNames(names)
+
+    @Deprecated("Will be removed in version 0.20.0", replaceWith = ReplaceWith("hasProperty()"))
+    override fun hasVariable(predicate: (KoVariableDeclaration) -> Boolean): Boolean =
+        super<KoVariableProviderCore>.hasVariable(predicate)
+
+    @Deprecated("Will be removed in version 0.20.0", replaceWith = ReplaceWith("hasAllProperties()"))
+    override fun hasAllVariables(predicate: (KoVariableDeclaration) -> Boolean): Boolean =
+        super<KoVariableProviderCore>.hasAllVariables(predicate)
 
     internal companion object {
         private val cache: KoDeclarationCache<KoEnumConstantDeclaration> = KoDeclarationCache()

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/core/declaration/KoEnumConstantDeclarationCore.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/core/declaration/KoEnumConstantDeclarationCore.kt
@@ -2,7 +2,9 @@ package com.lemonappdev.konsist.core.declaration
 
 import com.lemonappdev.konsist.api.declaration.KoArgumentDeclaration
 import com.lemonappdev.konsist.api.declaration.KoBaseDeclaration
+import com.lemonappdev.konsist.api.declaration.KoClassDeclaration
 import com.lemonappdev.konsist.api.declaration.KoEnumConstantDeclaration
+import com.lemonappdev.konsist.api.declaration.KoFunctionDeclaration
 import com.lemonappdev.konsist.api.declaration.KoVariableDeclaration
 import com.lemonappdev.konsist.core.annotation.RemoveInVersion
 import com.lemonappdev.konsist.core.cache.KoDeclarationCache
@@ -47,8 +49,11 @@ internal class KoEnumConstantDeclarationCore private constructor(
     KoContainingFileProviderCore,
     KoEnumNameProviderCore,
     KoKDocProviderCore,
+    @RemoveInVersion("0.20.0")
     KoLocalClassProviderCore,
+    @RemoveInVersion("0.20.0")
     KoLocalDeclarationProviderCore,
+    @RemoveInVersion("0.20.0")
     KoLocalFunctionProviderCore,
     @RemoveInVersion("0.20.0")
     KoVariableProviderCore,
@@ -70,15 +75,6 @@ internal class KoEnumConstantDeclarationCore private constructor(
     override val psiElement: PsiElement by lazy { ktEnumEntry }
 
     override val ktElement: KtElement by lazy { ktEnumEntry }
-
-    override val localDeclarations: List<KoBaseDeclaration> by lazy {
-        val psiElements =
-            ktEnumEntry
-                .body
-                ?.children
-
-        KoLocalDeclarationProviderCoreUtil.getKoLocalDeclarations(psiElements, this)
-    }
 
     override fun declarations(
         includeNested: Boolean,
@@ -106,6 +102,35 @@ internal class KoEnumConstantDeclarationCore private constructor(
 
     @Deprecated("Will be removed in version 0.20.0", replaceWith = ReplaceWith("numProperties()"))
     override val numVariables: Int by lazy { super<KoVariableProviderCore>.numVariables }
+
+    @Deprecated("Will be removed in version 0.20.0", replaceWith = ReplaceWith("declarations()"))
+    override val localDeclarations: List<KoBaseDeclaration> by lazy {
+        val psiElements =
+            ktEnumEntry
+                .body
+                ?.children
+
+        KoLocalDeclarationProviderCoreUtil.getKoLocalDeclarations(psiElements, this)
+    }
+    @Deprecated("Will be removed in version 0.20.0", replaceWith = ReplaceWith("numDeclarations()"))
+    override val numLocalDeclarations: Int
+        get() = super<KoLocalDeclarationProviderCore>.numLocalDeclarations
+
+    @Deprecated("Will be removed in version 0.20.0", replaceWith = ReplaceWith("classes()"))
+    override val localClasses: List<KoClassDeclaration>
+        get() = super<KoLocalClassProviderCore>.localClasses
+
+    @Deprecated("Will be removed in version 0.20.0", replaceWith = ReplaceWith("numClasses()"))
+    override val numLocalClasses: Int
+        get() = super<KoLocalClassProviderCore>.numLocalClasses
+
+    @Deprecated("Will be removed in version 0.20.0", replaceWith = ReplaceWith("functions()"))
+    override val localFunctions: List<KoFunctionDeclaration>
+        get() = super<KoLocalFunctionProviderCore>.localFunctions
+
+    @Deprecated("Will be removed in version 0.20.0", replaceWith = ReplaceWith("numFunctions()"))
+    override val numLocalFunctions: Int
+        get() = super<KoLocalFunctionProviderCore>.numLocalFunctions
 
     @Deprecated("Will be removed in version 0.20.0", replaceWith = ReplaceWith("countProperties()"))
     override fun countVariables(predicate: (KoVariableDeclaration) -> Boolean): Int =
@@ -137,6 +162,86 @@ internal class KoEnumConstantDeclarationCore private constructor(
     @Deprecated("Will be removed in version 0.20.0", replaceWith = ReplaceWith("hasAllProperties()"))
     override fun hasAllVariables(predicate: (KoVariableDeclaration) -> Boolean): Boolean =
         super<KoVariableProviderCore>.hasAllVariables(predicate)
+
+    @Deprecated("Will be removed in version 0.20.0", replaceWith = ReplaceWith("countClasses()"))
+    override fun countLocalClasses(predicate: (KoClassDeclaration) -> Boolean): Int =
+        super<KoLocalClassProviderCore>.countLocalClasses(predicate)
+
+    @Deprecated("Will be removed in version 0.20.0", replaceWith = ReplaceWith("hasClasses()"))
+    override fun hasLocalClasses(): Boolean =
+        super<KoLocalClassProviderCore>.hasLocalClasses()
+
+    @Deprecated("Will be removed in version 0.20.0", replaceWith = ReplaceWith("hasClassWithName()"))
+    override fun hasLocalClassWithName(name: String, vararg names: String): Boolean =
+        super<KoLocalClassProviderCore>.hasLocalClassWithName(name, *names)
+
+    @Deprecated("Will be removed in version 0.20.0", replaceWith = ReplaceWith("hasClassWithName()"))
+    override fun hasLocalClassWithName(names: Collection<String>): Boolean =
+        super<KoLocalClassProviderCore>.hasLocalClassWithName(names)
+
+    @Deprecated("Will be removed in version 0.20.0", replaceWith = ReplaceWith("hasClassesWithAllNames()"))
+    override fun hasLocalClassesWithAllNames(name: String, vararg names: String): Boolean =
+        super<KoLocalClassProviderCore>.hasLocalClassesWithAllNames(name, *names)
+
+    @Deprecated("Will be removed in version 0.20.0", replaceWith = ReplaceWith("hasClassesWithAllNames()"))
+    override fun hasLocalClassesWithAllNames(names: Collection<String>): Boolean =
+        super<KoLocalClassProviderCore>.hasLocalClassesWithAllNames(names)
+
+    @Deprecated("Will be removed in version 0.20.0", replaceWith = ReplaceWith("hasClass()"))
+    override fun hasLocalClass(predicate: (KoClassDeclaration) -> Boolean): Boolean =
+        super<KoLocalClassProviderCore>.hasLocalClass(predicate)
+
+    @Deprecated("Will be removed in version 0.20.0", replaceWith = ReplaceWith("hasAllClasses()"))
+    override fun hasAllLocalClasses(predicate: (KoClassDeclaration) -> Boolean): Boolean =
+        super<KoLocalClassProviderCore>.hasAllLocalClasses(predicate)
+
+    @Deprecated("Will be removed in version 0.20.0", replaceWith = ReplaceWith("countDeclarations()"))
+    override fun countLocalDeclarations(predicate: (KoBaseDeclaration) -> Boolean): Int =
+        super<KoLocalDeclarationProviderCore>.countLocalDeclarations(predicate)
+
+    @Deprecated("Will be removed in version 0.20.0", replaceWith = ReplaceWith("hasDeclarations()"))
+    override fun hasLocalDeclarations(): Boolean =
+        super<KoLocalDeclarationProviderCore>.hasLocalDeclarations()
+
+    @Deprecated("Will be removed in version 0.20.0", replaceWith = ReplaceWith("hasDeclaration()"))
+    override fun hasLocalDeclaration(predicate: (KoBaseDeclaration) -> Boolean): Boolean =
+        super<KoLocalDeclarationProviderCore>.hasLocalDeclaration(predicate)
+
+    @Deprecated("Will be removed in version 0.20.0", replaceWith = ReplaceWith("hasAllDeclarations()"))
+    override fun hasAllLocalDeclarations(predicate: (KoBaseDeclaration) -> Boolean): Boolean =
+        super<KoLocalDeclarationProviderCore>.hasAllLocalDeclarations(predicate)
+
+    @Deprecated("Will be removed in version 0.20.0", replaceWith = ReplaceWith("countFunctions()"))
+    override fun countLocalFunctions(predicate: (KoFunctionDeclaration) -> Boolean): Int =
+        super<KoLocalFunctionProviderCore>.countLocalFunctions(predicate)
+
+    @Deprecated("Will be removed in version 0.20.0", replaceWith = ReplaceWith("hasFunctions()"))
+    override fun hasLocalFunctions(): Boolean =
+        super<KoLocalFunctionProviderCore>.hasLocalFunctions()
+
+    @Deprecated("Will be removed in version 0.20.0", replaceWith = ReplaceWith("hasFunctionWithName()"))
+    override fun hasLocalFunctionWithName(name: String, vararg names: String): Boolean =
+        super<KoLocalFunctionProviderCore>.hasLocalFunctionWithName(name, *names)
+
+    @Deprecated("Will be removed in version 0.20.0", replaceWith = ReplaceWith("hasFunctionWithName()"))
+    override fun hasLocalFunctionWithName(names: Collection<String>): Boolean =
+        super<KoLocalFunctionProviderCore>.hasLocalFunctionWithName(names)
+
+    @Deprecated("Will be removed in version 0.20.0", replaceWith = ReplaceWith("hasFunctionsWithAllNames()"))
+    override fun hasLocalFunctionsWithAllNames(name: String, vararg names: String): Boolean =
+        super<KoLocalFunctionProviderCore>.hasLocalFunctionsWithAllNames(name, *names)
+
+    @Deprecated("Will be removed in version 0.20.0", replaceWith = ReplaceWith("hasFunctionsWithAllNames()"))
+    override fun hasLocalFunctionsWithAllNames(names: Collection<String>): Boolean =
+        super<KoLocalFunctionProviderCore>.hasLocalFunctionsWithAllNames(names)
+
+    @Deprecated("Will be removed in version 0.20.0", replaceWith = ReplaceWith("hasFunction()"))
+    override fun hasLocalFunction(predicate: (KoFunctionDeclaration) -> Boolean): Boolean =
+        super<KoLocalFunctionProviderCore>.hasLocalFunction(predicate)
+
+    @Deprecated("Will be removed in version 0.20.0", replaceWith = ReplaceWith("hasAllFunctions()"))
+    override fun hasAllLocalFunctions(predicate: (KoFunctionDeclaration) -> Boolean): Boolean =
+        super<KoLocalFunctionProviderCore>.hasAllLocalFunctions(predicate)
 
     internal companion object {
         private val cache: KoDeclarationCache<KoEnumConstantDeclaration> = KoDeclarationCache()

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/core/declaration/KoEnumConstantDeclarationCore.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/core/declaration/KoEnumConstantDeclarationCore.kt
@@ -122,24 +122,19 @@ internal class KoEnumConstantDeclarationCore private constructor(
         KoLocalDeclarationProviderCoreUtil.getKoLocalDeclarations(psiElements, this)
     }
     @Deprecated("Will be removed in version 0.20.0", replaceWith = ReplaceWith("numDeclarations()"))
-    override val numLocalDeclarations: Int
-        get() = super<KoLocalDeclarationProviderCore>.numLocalDeclarations
+    override val numLocalDeclarations: Int by lazy { super<KoLocalDeclarationProviderCore>.numLocalDeclarations }
 
     @Deprecated("Will be removed in version 0.20.0", replaceWith = ReplaceWith("classes()"))
-    override val localClasses: List<KoClassDeclaration>
-        get() = super<KoLocalClassProviderCore>.localClasses
+    override val localClasses: List<KoClassDeclaration> by lazy { super<KoLocalClassProviderCore>.localClasses }
 
     @Deprecated("Will be removed in version 0.20.0", replaceWith = ReplaceWith("numClasses()"))
-    override val numLocalClasses: Int
-        get() = super<KoLocalClassProviderCore>.numLocalClasses
+    override val numLocalClasses: Int by lazy { super<KoLocalClassProviderCore>.numLocalClasses }
 
     @Deprecated("Will be removed in version 0.20.0", replaceWith = ReplaceWith("functions()"))
-    override val localFunctions: List<KoFunctionDeclaration>
-        get() = super<KoLocalFunctionProviderCore>.localFunctions
+    override val localFunctions: List<KoFunctionDeclaration> by lazy { super<KoLocalFunctionProviderCore>.localFunctions }
 
     @Deprecated("Will be removed in version 0.20.0", replaceWith = ReplaceWith("numFunctions()"))
-    override val numLocalFunctions: Int
-        get() = super<KoLocalFunctionProviderCore>.numLocalFunctions
+    override val numLocalFunctions: Int by lazy { super<KoLocalFunctionProviderCore>.numLocalFunctions }
 
     @Deprecated("Will be removed in version 0.20.0", replaceWith = ReplaceWith("countProperties()"))
     override fun countVariables(predicate: (KoVariableDeclaration) -> Boolean): Int =

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/core/declaration/KoEnumConstantDeclarationCore.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/core/declaration/KoEnumConstantDeclarationCore.kt
@@ -6,9 +6,6 @@ import com.lemonappdev.konsist.api.declaration.KoClassDeclaration
 import com.lemonappdev.konsist.api.declaration.KoEnumConstantDeclaration
 import com.lemonappdev.konsist.api.declaration.KoFunctionDeclaration
 import com.lemonappdev.konsist.api.declaration.KoVariableDeclaration
-import com.lemonappdev.konsist.api.provider.KoClassProvider
-import com.lemonappdev.konsist.api.provider.KoDeclarationProvider
-import com.lemonappdev.konsist.api.provider.KoFunctionProvider
 import com.lemonappdev.konsist.core.annotation.RemoveInVersion
 import com.lemonappdev.konsist.core.cache.KoDeclarationCache
 import com.lemonappdev.konsist.core.provider.KoAnnotationProviderCore
@@ -45,6 +42,7 @@ import org.jetbrains.kotlin.psi.KtTypeParameterListOwner
 import org.jetbrains.kotlin.psi.KtValueArgument
 import org.jetbrains.kotlin.psi.KtValueArgumentList
 
+@Suppress("detekt.TooManyFunctions")
 internal class KoEnumConstantDeclarationCore private constructor(
     override val ktEnumEntry: KtEnumEntry,
     override val containingDeclaration: KoBaseDeclaration,
@@ -87,7 +85,7 @@ internal class KoEnumConstantDeclarationCore private constructor(
 
     override fun declarations(
         includeNested: Boolean,
-        includeLocal: Boolean
+        includeLocal: Boolean,
     ): List<KoBaseDeclaration> = KoDeclarationProviderCoreUtil.getKoDeclarations(ktEnumEntry, includeNested, includeLocal, this)
 
     override val arguments: List<KoArgumentDeclaration> by lazy {
@@ -121,6 +119,7 @@ internal class KoEnumConstantDeclarationCore private constructor(
 
         KoLocalDeclarationProviderCoreUtil.getKoLocalDeclarations(psiElements, this)
     }
+
     @Deprecated("Will be removed in version 0.20.0", replaceWith = ReplaceWith("numDeclarations()"))
     override val numLocalDeclarations: Int by lazy { super<KoLocalDeclarationProviderCore>.numLocalDeclarations }
 
@@ -144,24 +143,26 @@ internal class KoEnumConstantDeclarationCore private constructor(
     override fun hasVariables(): Boolean = super<KoVariableProviderCore>.hasVariables()
 
     @Deprecated("Will be removed in version 0.20.0", replaceWith = ReplaceWith("hasPropertyWithName()"))
-    override fun hasVariableWithName(name: String, vararg names: String): Boolean =
-        super<KoVariableProviderCore>.hasVariableWithName(name, *names)
+    override fun hasVariableWithName(
+        name: String,
+        vararg names: String,
+    ): Boolean = super<KoVariableProviderCore>.hasVariableWithName(name, *names)
 
     @Deprecated("Will be removed in version 0.20.0", replaceWith = ReplaceWith("hasPropertyWithName()"))
-    override fun hasVariableWithName(names: Collection<String>): Boolean =
-        super<KoVariableProviderCore>.hasVariableWithName(names)
+    override fun hasVariableWithName(names: Collection<String>): Boolean = super<KoVariableProviderCore>.hasVariableWithName(names)
 
     @Deprecated("Will be removed in version 0.20.0", replaceWith = ReplaceWith("hasPropertiesWithAllNames()"))
-    override fun hasVariablesWithAllNames(name: String, vararg names: String): Boolean =
-        super<KoVariableProviderCore>.hasVariablesWithAllNames(name, *names)
+    override fun hasVariablesWithAllNames(
+        name: String,
+        vararg names: String,
+    ): Boolean = super<KoVariableProviderCore>.hasVariablesWithAllNames(name, *names)
 
     @Deprecated("Will be removed in version 0.20.0", replaceWith = ReplaceWith("hasPropertiesWithAllNames()"))
     override fun hasVariablesWithAllNames(names: Collection<String>): Boolean =
         super<KoVariableProviderCore>.hasVariablesWithAllNames(names)
 
     @Deprecated("Will be removed in version 0.20.0", replaceWith = ReplaceWith("hasProperty()"))
-    override fun hasVariable(predicate: (KoVariableDeclaration) -> Boolean): Boolean =
-        super<KoVariableProviderCore>.hasVariable(predicate)
+    override fun hasVariable(predicate: (KoVariableDeclaration) -> Boolean): Boolean = super<KoVariableProviderCore>.hasVariable(predicate)
 
     @Deprecated("Will be removed in version 0.20.0", replaceWith = ReplaceWith("hasAllProperties()"))
     override fun hasAllVariables(predicate: (KoVariableDeclaration) -> Boolean): Boolean =
@@ -172,20 +173,22 @@ internal class KoEnumConstantDeclarationCore private constructor(
         super<KoLocalClassProviderCore>.countLocalClasses(predicate)
 
     @Deprecated("Will be removed in version 0.20.0", replaceWith = ReplaceWith("hasClasses()"))
-    override fun hasLocalClasses(): Boolean =
-        super<KoLocalClassProviderCore>.hasLocalClasses()
+    override fun hasLocalClasses(): Boolean = super<KoLocalClassProviderCore>.hasLocalClasses()
 
     @Deprecated("Will be removed in version 0.20.0", replaceWith = ReplaceWith("hasClassWithName()"))
-    override fun hasLocalClassWithName(name: String, vararg names: String): Boolean =
-        super<KoLocalClassProviderCore>.hasLocalClassWithName(name, *names)
+    override fun hasLocalClassWithName(
+        name: String,
+        vararg names: String,
+    ): Boolean = super<KoLocalClassProviderCore>.hasLocalClassWithName(name, *names)
 
     @Deprecated("Will be removed in version 0.20.0", replaceWith = ReplaceWith("hasClassWithName()"))
-    override fun hasLocalClassWithName(names: Collection<String>): Boolean =
-        super<KoLocalClassProviderCore>.hasLocalClassWithName(names)
+    override fun hasLocalClassWithName(names: Collection<String>): Boolean = super<KoLocalClassProviderCore>.hasLocalClassWithName(names)
 
     @Deprecated("Will be removed in version 0.20.0", replaceWith = ReplaceWith("hasClassesWithAllNames()"))
-    override fun hasLocalClassesWithAllNames(name: String, vararg names: String): Boolean =
-        super<KoLocalClassProviderCore>.hasLocalClassesWithAllNames(name, *names)
+    override fun hasLocalClassesWithAllNames(
+        name: String,
+        vararg names: String,
+    ): Boolean = super<KoLocalClassProviderCore>.hasLocalClassesWithAllNames(name, *names)
 
     @Deprecated("Will be removed in version 0.20.0", replaceWith = ReplaceWith("hasClassesWithAllNames()"))
     override fun hasLocalClassesWithAllNames(names: Collection<String>): Boolean =
@@ -204,8 +207,7 @@ internal class KoEnumConstantDeclarationCore private constructor(
         super<KoLocalDeclarationProviderCore>.countLocalDeclarations(predicate)
 
     @Deprecated("Will be removed in version 0.20.0", replaceWith = ReplaceWith("hasDeclarations()"))
-    override fun hasLocalDeclarations(): Boolean =
-        super<KoLocalDeclarationProviderCore>.hasLocalDeclarations()
+    override fun hasLocalDeclarations(): Boolean = super<KoLocalDeclarationProviderCore>.hasLocalDeclarations()
 
     @Deprecated("Will be removed in version 0.20.0", replaceWith = ReplaceWith("hasDeclaration()"))
     override fun hasLocalDeclaration(predicate: (KoBaseDeclaration) -> Boolean): Boolean =
@@ -220,20 +222,23 @@ internal class KoEnumConstantDeclarationCore private constructor(
         super<KoLocalFunctionProviderCore>.countLocalFunctions(predicate)
 
     @Deprecated("Will be removed in version 0.20.0", replaceWith = ReplaceWith("hasFunctions()"))
-    override fun hasLocalFunctions(): Boolean =
-        super<KoLocalFunctionProviderCore>.hasLocalFunctions()
+    override fun hasLocalFunctions(): Boolean = super<KoLocalFunctionProviderCore>.hasLocalFunctions()
 
     @Deprecated("Will be removed in version 0.20.0", replaceWith = ReplaceWith("hasFunctionWithName()"))
-    override fun hasLocalFunctionWithName(name: String, vararg names: String): Boolean =
-        super<KoLocalFunctionProviderCore>.hasLocalFunctionWithName(name, *names)
+    override fun hasLocalFunctionWithName(
+        name: String,
+        vararg names: String,
+    ): Boolean = super<KoLocalFunctionProviderCore>.hasLocalFunctionWithName(name, *names)
 
     @Deprecated("Will be removed in version 0.20.0", replaceWith = ReplaceWith("hasFunctionWithName()"))
     override fun hasLocalFunctionWithName(names: Collection<String>): Boolean =
         super<KoLocalFunctionProviderCore>.hasLocalFunctionWithName(names)
 
     @Deprecated("Will be removed in version 0.20.0", replaceWith = ReplaceWith("hasFunctionsWithAllNames()"))
-    override fun hasLocalFunctionsWithAllNames(name: String, vararg names: String): Boolean =
-        super<KoLocalFunctionProviderCore>.hasLocalFunctionsWithAllNames(name, *names)
+    override fun hasLocalFunctionsWithAllNames(
+        name: String,
+        vararg names: String,
+    ): Boolean = super<KoLocalFunctionProviderCore>.hasLocalFunctionsWithAllNames(name, *names)
 
     @Deprecated("Will be removed in version 0.20.0", replaceWith = ReplaceWith("hasFunctionsWithAllNames()"))
     override fun hasLocalFunctionsWithAllNames(names: Collection<String>): Boolean =

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/core/declaration/KoEnumConstantDeclarationCore.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/core/declaration/KoEnumConstantDeclarationCore.kt
@@ -6,15 +6,21 @@ import com.lemonappdev.konsist.api.declaration.KoClassDeclaration
 import com.lemonappdev.konsist.api.declaration.KoEnumConstantDeclaration
 import com.lemonappdev.konsist.api.declaration.KoFunctionDeclaration
 import com.lemonappdev.konsist.api.declaration.KoVariableDeclaration
+import com.lemonappdev.konsist.api.provider.KoClassProvider
+import com.lemonappdev.konsist.api.provider.KoDeclarationProvider
+import com.lemonappdev.konsist.api.provider.KoFunctionProvider
 import com.lemonappdev.konsist.core.annotation.RemoveInVersion
 import com.lemonappdev.konsist.core.cache.KoDeclarationCache
 import com.lemonappdev.konsist.core.provider.KoAnnotationProviderCore
 import com.lemonappdev.konsist.core.provider.KoArgumentProviderCore
 import com.lemonappdev.konsist.core.provider.KoBaseProviderCore
+import com.lemonappdev.konsist.core.provider.KoClassProviderCore
 import com.lemonappdev.konsist.core.provider.KoContainingDeclarationProviderCore
 import com.lemonappdev.konsist.core.provider.KoContainingFileProviderCore
 import com.lemonappdev.konsist.core.provider.KoDeclarationFullyQualifiedNameProviderCore
+import com.lemonappdev.konsist.core.provider.KoDeclarationProviderCore
 import com.lemonappdev.konsist.core.provider.KoEnumNameProviderCore
+import com.lemonappdev.konsist.core.provider.KoFunctionProviderCore
 import com.lemonappdev.konsist.core.provider.KoKDocProviderCore
 import com.lemonappdev.konsist.core.provider.KoLocalClassProviderCore
 import com.lemonappdev.konsist.core.provider.KoLocalDeclarationProviderCore
@@ -57,6 +63,9 @@ internal class KoEnumConstantDeclarationCore private constructor(
     KoLocalFunctionProviderCore,
     @RemoveInVersion("0.20.0")
     KoVariableProviderCore,
+    KoClassProviderCore,
+    KoDeclarationProviderCore,
+    KoFunctionProviderCore,
     KoPropertyProviderCore,
     KoLocationProviderCore,
     KoNameProviderCore,


### PR DESCRIPTION
**Changes:**  
- Deprecated support for variables and local declarations in `KoEnumConstantDeclaration`.  
- Added support for properties and other declarations in `KoEnumConstantDeclaration`.  

Previously, `KoEnumConstantDeclaration` provided access to properties, functions and extensions for variables, local declarations and local functions. However, this behaviour was incorrect and has now been deprecated. Instead, new providers have been introduced to access properties, functions and extensions specifically for declarations, properties, functions and classes.

Community: https://github.com/LemonAppDev/konsist/discussions/1596

**Examples:**
- Use `hasProperty { ... }` instead of `hasVariable { ... }`

	**Before:**
	```kotlin
	Konsist
	    .scopeFromProject()
	    .classes()
	    .enumConstants
	    .assertTrue { enumConst ->
	        enumConst.hasVariable { it.name == "sampleName" }
	    }
	```
	
	**After:**
	```kotlin
	Konsist
	    .scopeFromProject()
	    .classes()
	    .enumConstants
	    .assertTrue { enumConst ->
	        enumConst.hasProperty { it.name == "sampleName" }
	    }
	```

- It is now possible to write tests like this (variables do not support e.g. getter declarations).

	```kotlin
	Konsist
	    .scopeFromProject()
	    .classes()
	    .enumConstants
	    .assertTrue { enumConst ->
	        enumConst.hasProperty { it.hasGetter }
	    }
	```

- Use `hasFunction { ... }` instead of `hasLocalFunction { ... }`

	**Before:**
	```kotlin
	Konsist
	    .scopeFromProject()
	    .classes()
	    .enumConstants
	    .assertTrue { enumConst ->
	        enumConst.hasLocalFunction { it.hasReturnType() }
	    }
	```
	
	**After:**
	```kotlin
	Konsist
	    .scopeFromProject()
	    .classes()
	    .enumConstants
	    .assertTrue { enumConst ->
	        enumConst.hasFunction { it.hasReturnType() }
	    }
	```