### PR TITLE
KON-701 Fix incorrect sourceDeclaration resolution for inner classes in parent declarations

### DIFF
--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koparent/KoParentDeclarationForKoSourceDeclarationProviderTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koparent/KoParentDeclarationForKoSourceDeclarationProviderTest.kt
@@ -316,6 +316,34 @@ class KoParentDeclarationForKoSourceDeclarationProviderTest {
                     null,
                     "com.samplepackage.SampleInterface.SampleName",
                 ),
+                arguments(
+                    "class-with-parent-interface-with-two-part-name-from-the-same-file",
+                    KoInterfaceDeclaration::class,
+                    KoClassDeclaration::class,
+                    null,
+                    "com.samplepackage.SampleInterface.SampleNestedInterface",
+                ),
+                arguments(
+                    "class-with-parent-class-with-two-part-name-from-the-same-file",
+                    KoClassDeclaration::class,
+                    KoInterfaceDeclaration::class,
+                    null,
+                    "com.samplepackage.SampleInterface.SampleNestedClass",
+                ),
+                arguments(
+                    "class-with-parent-interface-with-two-part-name-from-import",
+                    KoInterfaceDeclaration::class,
+                    KoClassDeclaration::class,
+                    null,
+                    "com.lemonappdev.konsist.testdata.SampleParentInterfaceWithNestedDeclarations.SampleNestedInterface",
+                ),
+                arguments(
+                    "class-with-parent-class-with-two-part-name-from-import",
+                    KoClassDeclaration::class,
+                    KoInterfaceDeclaration::class,
+                    null,
+                    "com.lemonappdev.konsist.testdata.SampleParentInterfaceWithNestedDeclarations.SampleNestedClass",
+                ),
             )
 
         @Suppress("unused", "detekt.LongMethod")
@@ -384,6 +412,20 @@ class KoParentDeclarationForKoSourceDeclarationProviderTest {
                     KoClassDeclaration::class,
                     null,
                     "com.samplepackage.SampleInterface.SampleName",
+                ),
+                arguments(
+                    "interface-with-parent-interface-with-two-part-name-from-the-same-file",
+                    KoInterfaceDeclaration::class,
+                    KoClassDeclaration::class,
+                    null,
+                    "com.samplepackage.SampleInterface.SampleNestedInterface",
+                ),
+                arguments(
+                    "interface-with-parent-interface-with-two-part-name-from-import",
+                    KoInterfaceDeclaration::class,
+                    KoClassDeclaration::class,
+                    null,
+                    "com.lemonappdev.konsist.testdata.SampleParentInterfaceWithNestedDeclarations.SampleNestedInterface",
                 ),
             )
 
@@ -544,6 +586,34 @@ class KoParentDeclarationForKoSourceDeclarationProviderTest {
                     KoInterfaceDeclaration::class,
                     null,
                     "com.samplepackage.SampleInterface.SampleName",
+                ),
+                arguments(
+                    "object-with-parent-interface-with-two-part-name-from-the-same-file",
+                    KoInterfaceDeclaration::class,
+                    KoClassDeclaration::class,
+                    null,
+                    "com.samplepackage.SampleInterface.SampleNestedInterface",
+                ),
+                arguments(
+                    "object-with-parent-class-with-two-part-name-from-the-same-file",
+                    KoClassDeclaration::class,
+                    KoInterfaceDeclaration::class,
+                    null,
+                    "com.samplepackage.SampleInterface.SampleNestedClass",
+                ),
+                arguments(
+                    "object-with-parent-interface-with-two-part-name-from-import",
+                    KoInterfaceDeclaration::class,
+                    KoClassDeclaration::class,
+                    null,
+                    "com.lemonappdev.konsist.testdata.SampleParentInterfaceWithNestedDeclarations.SampleNestedInterface",
+                ),
+                arguments(
+                    "object-with-parent-class-with-two-part-name-from-import",
+                    KoClassDeclaration::class,
+                    KoInterfaceDeclaration::class,
+                    null,
+                    "com.lemonappdev.konsist.testdata.SampleParentInterfaceWithNestedDeclarations.SampleNestedClass",
                 ),
             )
     }

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koparent/snippet/forkosourcedeclarationprovider/class-with-parent-class-with-two-part-name-from-import.kttest
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koparent/snippet/forkosourcedeclarationprovider/class-with-parent-class-with-two-part-name-from-import.kttest
@@ -1,0 +1,5 @@
+package com.samplepackage
+
+import com.lemonappdev.konsist.testdata.SampleParentInterfaceWithNestedDeclarations
+
+data class SampleName(val data: String) : SampleParentInterfaceWithNestedDeclarations.SampleNestedClass()

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koparent/snippet/forkosourcedeclarationprovider/class-with-parent-class-with-two-part-name-from-the-same-file.kttest
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koparent/snippet/forkosourcedeclarationprovider/class-with-parent-class-with-two-part-name-from-the-same-file.kttest
@@ -1,0 +1,7 @@
+package com.samplepackage
+
+data class SampleName(val data: String) : SampleInterface.SampleNestedClass()
+
+interface SampleInterface {
+    open class SampleNestedClass
+}

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koparent/snippet/forkosourcedeclarationprovider/class-with-parent-interface-with-two-part-name-from-import.kttest
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koparent/snippet/forkosourcedeclarationprovider/class-with-parent-interface-with-two-part-name-from-import.kttest
@@ -1,0 +1,5 @@
+package com.samplepackage
+
+import com.lemonappdev.konsist.testdata.SampleParentInterfaceWithNestedDeclarations
+
+data class SampleName(val data: String) : SampleParentInterfaceWithNestedDeclarations.SampleNestedInterface

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koparent/snippet/forkosourcedeclarationprovider/class-with-parent-interface-with-two-part-name-from-the-same-file.kttest
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koparent/snippet/forkosourcedeclarationprovider/class-with-parent-interface-with-two-part-name-from-the-same-file.kttest
@@ -1,0 +1,7 @@
+package com.samplepackage
+
+data class SampleName(val data: String) : SampleInterface.SampleNestedInterface
+
+interface SampleInterface {
+    interface SampleNestedInterface
+}

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koparent/snippet/forkosourcedeclarationprovider/interface-with-parent-interface-with-two-part-name-from-import.kttest
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koparent/snippet/forkosourcedeclarationprovider/interface-with-parent-interface-with-two-part-name-from-import.kttest
@@ -1,0 +1,5 @@
+package com.samplepackage
+
+import com.lemonappdev.konsist.testdata.SampleParentInterfaceWithNestedDeclarations
+
+interface SampleName : SampleParentInterfaceWithNestedDeclarations.SampleNestedInterface

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koparent/snippet/forkosourcedeclarationprovider/interface-with-parent-interface-with-two-part-name-from-the-same-file.kttest
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koparent/snippet/forkosourcedeclarationprovider/interface-with-parent-interface-with-two-part-name-from-the-same-file.kttest
@@ -1,0 +1,7 @@
+package com.samplepackage
+
+interface SampleName : SampleInterface.SampleNestedInterface
+
+interface SampleInterface {
+    interface SampleNestedInterface
+}

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koparent/snippet/forkosourcedeclarationprovider/object-with-parent-class-with-two-part-name-from-import.kttest
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koparent/snippet/forkosourcedeclarationprovider/object-with-parent-class-with-two-part-name-from-import.kttest
@@ -1,0 +1,5 @@
+package com.samplepackage
+
+import com.lemonappdev.konsist.testdata.SampleParentInterfaceWithNestedDeclarations
+
+object SampleName : SampleParentInterfaceWithNestedDeclarations.SampleNestedClass()

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koparent/snippet/forkosourcedeclarationprovider/object-with-parent-class-with-two-part-name-from-the-same-file.kttest
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koparent/snippet/forkosourcedeclarationprovider/object-with-parent-class-with-two-part-name-from-the-same-file.kttest
@@ -1,0 +1,7 @@
+package com.samplepackage
+
+object SampleName : SampleInterface.SampleNestedClass()
+
+interface SampleInterface {
+    open class SampleNestedClass
+}

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koparent/snippet/forkosourcedeclarationprovider/object-with-parent-interface-with-two-part-name-from-import.kttest
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koparent/snippet/forkosourcedeclarationprovider/object-with-parent-interface-with-two-part-name-from-import.kttest
@@ -1,0 +1,5 @@
+package com.samplepackage
+
+import com.lemonappdev.konsist.testdata.SampleParentInterfaceWithNestedDeclarations
+
+object SampleName : SampleParentInterfaceWithNestedDeclarations.SampleNestedInterface

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koparent/snippet/forkosourcedeclarationprovider/object-with-parent-interface-with-two-part-name-from-the-same-file.kttest
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koparent/snippet/forkosourcedeclarationprovider/object-with-parent-interface-with-two-part-name-from-the-same-file.kttest
@@ -1,0 +1,7 @@
+package com.samplepackage
+
+object SampleName : SampleInterface.SampleNestedInterface
+
+interface SampleInterface {
+    interface SampleNestedInterface
+}

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/testdata/TestData.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/testdata/TestData.kt
@@ -74,6 +74,7 @@ interface SampleParentInterface2
 
 interface SampleParentInterfaceWithNestedDeclarations {
     interface SampleNestedInterface
+
     open class SampleNestedClass
 }
 

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/testdata/TestData.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/testdata/TestData.kt
@@ -74,6 +74,7 @@ interface SampleParentInterface2
 
 interface SampleParentInterfaceWithNestedDeclarations {
     interface SampleNestedInterface
+    open class SampleNestedClass
 }
 
 interface SampleGenericSuperInterface<T>

--- a/lib/src/konsistTest/kotlin/com/lemonappdev/konsist/api/ApiKonsistTest.kt
+++ b/lib/src/konsistTest/kotlin/com/lemonappdev/konsist/api/ApiKonsistTest.kt
@@ -1,6 +1,5 @@
 package com.lemonappdev.konsist.api
 
-import com.lemonappdev.konsist.api.ext.list.withName
 import com.lemonappdev.konsist.api.ext.list.withNameEndingWith
 import com.lemonappdev.konsist.api.ext.list.withParameter
 import com.lemonappdev.konsist.api.ext.list.withProperty
@@ -20,11 +19,9 @@ class ApiKonsistTest {
 
     @Test
     fun `every api declaration has explicit return type`() {
-        Konsist
-            .scopeFromExternalDirectory("/Users/natalia/AndroidStudioProjects/ArtemisAgent")
-            .classes()
-            .withName("SimpleEventPacket")
-            .assertTrue { it.hasParentClass() }
+        apiPackageScope
+            .functions()
+            .assertTrue { it.hasReturnType() }
     }
 
     @Test

--- a/lib/src/konsistTest/kotlin/com/lemonappdev/konsist/api/ApiKonsistTest.kt
+++ b/lib/src/konsistTest/kotlin/com/lemonappdev/konsist/api/ApiKonsistTest.kt
@@ -1,5 +1,6 @@
 package com.lemonappdev.konsist.api
 
+import com.lemonappdev.konsist.api.ext.list.withName
 import com.lemonappdev.konsist.api.ext.list.withNameEndingWith
 import com.lemonappdev.konsist.api.ext.list.withParameter
 import com.lemonappdev.konsist.api.ext.list.withProperty
@@ -19,9 +20,10 @@ class ApiKonsistTest {
 
     @Test
     fun `every api declaration has explicit return type`() {
-        apiPackageScope
-            .functions()
-            .assertTrue { it.hasReturnType() }
+        Konsist
+            .scopeFromExternalDirectory("/Users/natalia/AndroidStudioProjects/ArtemisAgent")
+            .classes()
+            .withName("")
     }
 
     @Test

--- a/lib/src/konsistTest/kotlin/com/lemonappdev/konsist/api/ApiKonsistTest.kt
+++ b/lib/src/konsistTest/kotlin/com/lemonappdev/konsist/api/ApiKonsistTest.kt
@@ -23,7 +23,8 @@ class ApiKonsistTest {
         Konsist
             .scopeFromExternalDirectory("/Users/natalia/AndroidStudioProjects/ArtemisAgent")
             .classes()
-            .withName("")
+            .withName("SimpleEventPacket")
+            .assertTrue { it.hasParentClass() }
     }
 
     @Test

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/core/declaration/KoParentDeclarationCore.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/core/declaration/KoParentDeclarationCore.kt
@@ -116,13 +116,13 @@ internal class KoParentDeclarationCore(
         val isAlias = import?.alias != null
 
         (
-                import?.alias
-                    ?: getClass(innerName, fullyQualifiedName, isAlias, containingFile)
-                    ?: getInterface(innerName, fullyQualifiedName, isAlias, containingFile)
-                    ?: getTypeAlias(innerName, fullyQualifiedName, containingFile)
-                    ?: KoExternalDeclarationCore.getInstance(innerName, ktSuperTypeListEntry)
-                )
-                as? KoDeclarationCastProvider
+            import?.alias
+                ?: getClass(innerName, fullyQualifiedName, isAlias, containingFile)
+                ?: getInterface(innerName, fullyQualifiedName, isAlias, containingFile)
+                ?: getTypeAlias(innerName, fullyQualifiedName, containingFile)
+                ?: KoExternalDeclarationCore.getInstance(innerName, ktSuperTypeListEntry)
+        )
+            as? KoDeclarationCastProvider
     }
 
     override val name: String by lazy {

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/core/declaration/KoParentDeclarationCore.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/core/declaration/KoParentDeclarationCore.kt
@@ -95,17 +95,17 @@ internal class KoParentDeclarationCore(
                 .substringBefore("(")
                 .substringBefore("<")
 
-        val innerName = if (name.contains(".")) name.substringBeforeLast(".") else name
-        val outerName = if (name.contains(".")) name.substringAfterLast(".") else name
+        val outerName = if (name.contains(".")) name.substringBeforeLast(".") else name
+        val innerName = if (name.contains(".")) name.substringAfterLast(".") else name
 
         val import =
             containingFile
                 .imports
                 .firstOrNull { import ->
                     if (import.alias != null) {
-                        import.alias?.name == innerName
+                        import.alias?.name == outerName
                     } else {
-                        import.name.substringAfterLast(".") == outerName
+                        import.name.substringAfterLast(".") == outerName || import.name.endsWith(name)
                     }
                 }
 
@@ -116,13 +116,13 @@ internal class KoParentDeclarationCore(
         val isAlias = import?.alias != null
 
         (
-            import?.alias
-                ?: getClass(outerName, fullyQualifiedName, isAlias, containingFile)
-                ?: getInterface(outerName, fullyQualifiedName, isAlias, containingFile)
-                ?: getTypeAlias(outerName, fullyQualifiedName, containingFile)
-                ?: KoExternalDeclarationCore.getInstance(outerName, ktSuperTypeListEntry)
-        )
-            as? KoDeclarationCastProvider
+                import?.alias
+                    ?: getClass(innerName, fullyQualifiedName, isAlias, containingFile)
+                    ?: getInterface(innerName, fullyQualifiedName, isAlias, containingFile)
+                    ?: getTypeAlias(innerName, fullyQualifiedName, containingFile)
+                    ?: KoExternalDeclarationCore.getInstance(innerName, ktSuperTypeListEntry)
+                )
+                as? KoDeclarationCastProvider
     }
 
     override val name: String by lazy {


### PR DESCRIPTION
This PR fixes a bug in resolving parent declarations with complex names (e.g., `SampleInterface.SampleClass`) when they are imported into a file. Previously, instead of finding the correct declaration (e.g., `KoClassDeclaration`), the system would incorrectly return a `KoExternalDeclaration`.

Community: https://github.com/LemonAppDev/konsist/discussions/1616