### PR TITLE
assertXXX can take a function with a StringBuilder allowing to dynami…

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,12 +23,12 @@ tests ([JUnit](https://junit.org/) / [Kotest](https://kotest.io/)).
 
 Gradle Kotlin:
 ```kotlin
-testImplementation("com.lemonappdev:konsist:0.17.3")
+testImplementation("com.lemonappdev:konsist:0.17.4")
 ```
 
 Gradle Groovy:
 ```groovy
-testImplementation "com.lemonappdev:konsist:0.17.3"
+testImplementation "com.lemonappdev:konsist:0.17.4"
 ```
 
 Maven:
@@ -36,7 +36,7 @@ Maven:
 <dependency>
 <groupId>com.lemonappdev</groupId>
 <artifactId>konsist</artifactId>
-<version>0.17.3</version>
+<version>0.17.4</version>
 <scope>test</scope>
 </dependency>
 ```

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,4 +3,4 @@ org.gradle.jvmargs=-Xms512M -Xmx4g -Dkotlin.daemon.jvm.options="-Xmx1g"
 org.gradle.parallel=true
 org.gradle.daemon=true
 
-konsist.version=0.17.3
+konsist.version=0.17.4

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/api/verify/KoDeclarationAndProviderAssert.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/api/verify/KoDeclarationAndProviderAssert.kt
@@ -20,6 +20,14 @@ import com.lemonappdev.konsist.core.verify.assert
  */
 fun <E : KoBaseProvider> E?.assertTrue(
     strict: Boolean = false,
+    testName: String? = null,
+    function: (E, StringBuilder) -> Boolean?,
+): Unit {
+    listOf(this).assert(strict, testName, function, positiveCheck = true)
+}
+
+fun <E : KoBaseProvider> E?.assertTrue(
+    strict: Boolean = false,
     additionalMessage: String? = null,
     testName: String? = null,
     function: (E) -> Boolean?,
@@ -42,6 +50,14 @@ fun <E : KoBaseProvider> E?.assertTrue(
  * @param function The predicate function that takes an element of type [E] and returns a [Boolean] value.
  *                If the function returns `true`, the element is considered invalid; otherwise, it's considered valid.
  */
+fun <E : KoBaseProvider> E?.assertFalse(
+    strict: Boolean = false,
+    testName: String? = null,
+    function: (E, StringBuilder) -> Boolean?,
+): Unit {
+    listOf(this).assert(strict, testName, function, positiveCheck = false)
+}
+
 fun <E : KoBaseProvider> E?.assertFalse(
     strict: Boolean = false,
     additionalMessage: String? = null,
@@ -69,6 +85,14 @@ fun <E : KoBaseProvider> E?.assertFalse(
  */
 fun <E : KoBaseProvider> List<E?>.assertTrue(
     strict: Boolean = false,
+    testName: String? = null,
+    function: (E, StringBuilder) -> Boolean?,
+): Unit {
+    assert(strict, testName, function, positiveCheck = true)
+}
+
+fun <E : KoBaseProvider> List<E?>.assertTrue(
+    strict: Boolean = false,
     additionalMessage: String? = null,
     testName: String? = null,
     function: (E) -> Boolean?,
@@ -91,6 +115,14 @@ fun <E : KoBaseProvider> List<E?>.assertTrue(
  * @param function The predicate function that takes an element of type [E] and returns a [Boolean] value.
  *                If the function returns `true`, the element is considered invalid; otherwise, it's considered valid.
  */
+fun <E : KoBaseProvider> List<E?>.assertFalse(
+    strict: Boolean = false,
+    testName: String? = null,
+    function: (E, StringBuilder) -> Boolean?,
+): Unit {
+    assert(strict, testName, function, positiveCheck = false)
+}
+
 fun <E : KoBaseProvider> List<E?>.assertFalse(
     strict: Boolean = false,
     additionalMessage: String? = null,
@@ -117,6 +149,14 @@ fun <E : KoBaseProvider> List<E?>.assertFalse(
  */
 fun <E : KoBaseProvider> Sequence<E?>.assertTrue(
     strict: Boolean = false,
+    testName: String? = null,
+    function: (E, StringBuilder) -> Boolean?,
+): Unit {
+    this.toList().assert(strict, testName, function, true)
+}
+
+fun <E : KoBaseProvider> Sequence<E?>.assertTrue(
+    strict: Boolean = false,
     additionalMessage: String? = null,
     testName: String? = null,
     function: (E) -> Boolean?,
@@ -139,6 +179,14 @@ fun <E : KoBaseProvider> Sequence<E?>.assertTrue(
  * @param function The predicate function that takes an element of type [E] and returns a [Boolean] value.
  *                If the function returns `true`, the element is considered invalid; otherwise, it's considered valid.
  */
+fun <E : KoBaseProvider> Sequence<E?>.assertFalse(
+    strict: Boolean = false,
+    testName: String? = null,
+    function: (E, StringBuilder) -> Boolean?,
+): Unit {
+    this.toList().assert(strict, testName, function, false)
+}
+
 fun <E : KoBaseProvider> Sequence<E?>.assertFalse(
     strict: Boolean = false,
     additionalMessage: String? = null,

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/core/verify/KoDeclarationAndProviderAssertCore.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/core/verify/KoDeclarationAndProviderAssertCore.kt
@@ -3,11 +3,7 @@ package com.lemonappdev.konsist.core.verify
 import com.lemonappdev.konsist.api.declaration.KoAnnotationDeclaration
 import com.lemonappdev.konsist.api.declaration.KoBaseDeclaration
 import com.lemonappdev.konsist.api.declaration.KoFileDeclaration
-import com.lemonappdev.konsist.api.provider.KoAnnotationProvider
-import com.lemonappdev.konsist.api.provider.KoBaseProvider
-import com.lemonappdev.konsist.api.provider.KoContainingDeclarationProvider
-import com.lemonappdev.konsist.api.provider.KoLocationProvider
-import com.lemonappdev.konsist.api.provider.KoNameProvider
+import com.lemonappdev.konsist.api.provider.*
 import com.lemonappdev.konsist.core.architecture.validator.ascii.AsciiTreeCreator
 import com.lemonappdev.konsist.core.architecture.validator.ascii.AsciiTreeNode
 import com.lemonappdev.konsist.core.exception.KoAssertionFailedException
@@ -18,11 +14,35 @@ import com.lemonappdev.konsist.core.util.HyperlinkUtil
 
 internal fun <E : KoBaseProvider> List<E?>.assert(
     strict: Boolean,
+    testName: String?,
+    function: (E, StringBuilder) -> Boolean?,
+    positiveCheck: Boolean,
+) {
+    val stringBuilder = StringBuilder()
+    val result =
+        assert(strict, testName, positiveCheck) { element ->
+            function(element, stringBuilder)
+        }
+    getResult(result.notSuppressedDeclarations, result.results, positiveCheck, result.localSuppressName, stringBuilder.toString())
+}
+
+internal fun <E : KoBaseProvider> List<E?>.assert(
+    strict: Boolean,
     additionalMessage: String?,
     testName: String?,
     function: (E) -> Boolean?,
     positiveCheck: Boolean,
 ) {
+    val result = assert(strict, testName, positiveCheck, function)
+    getResult(result.notSuppressedDeclarations, result.results, positiveCheck, result.localSuppressName, additionalMessage)
+}
+
+private fun <E : KoBaseProvider> List<E?>.assert(
+    strict: Boolean,
+    testName: String?,
+    positiveCheck: Boolean,
+    assertElement: (E) -> Boolean?,
+): AssertionResult<E> {
     var lastDeclaration: KoBaseProvider? = null
 
     try {
@@ -47,13 +67,13 @@ internal fun <E : KoBaseProvider> List<E?>.assert(
 
         val notSuppressedDeclarations = checkIfAnnotatedWithSuppress(this.filterNotNull(), localSuppressName)
 
-        val result =
+        val results =
             notSuppressedDeclarations.groupBy {
                 lastDeclaration = it
-                function(it) ?: positiveCheck
+                assertElement(it) ?: positiveCheck
             }
 
-        getResult(notSuppressedDeclarations, result, positiveCheck, localSuppressName, additionalMessage)
+        return AssertionResult(localSuppressName, notSuppressedDeclarations, results)
     } catch (e: KoException) {
         throw e
     } catch (
@@ -62,6 +82,12 @@ internal fun <E : KoBaseProvider> List<E?>.assert(
         throw KoInternalException(e.message.orEmpty(), e, lastDeclaration)
     }
 }
+
+private data class AssertionResult<E>(
+    val localSuppressName: String,
+    val notSuppressedDeclarations: List<E>,
+    val results: Map<Boolean, List<E>>,
+)
 
 internal fun <E : KoBaseProvider> List<E?>.assert(
     strict: Boolean,


### PR DESCRIPTION
Allow to call `assertXXX` with a
```
{ element, messageBuilder ->

}
```

To dynamically create the assertion result message.

For example:
```
Konsist
        .scopeFromPackage("$packageName..")
        .classes()
        .filter {
        }
        .assertTrue(
          testName = "bla bla",
        ) { classDeclaration, messageBuilder ->
            val ctorProperties = classDeclaration.primaryConstructor!!.parameters.mapTo(mutableSetOf()) { param -> param.name }
            val actualSettableClassProperties = classDeclaration.properties()
            val missingProperties = actualSettableClassProperties - copyProperties
            if (missingProperties.isNotEmpty()) {
              messageBuilder?.appendLine(
                "${classDeclaration.name} has ${missingProperties.size} copiable properties outside of its ctor:\n ${
                missingProperties.joinToString("\n") { "\t* $it" }
              }"
              )
              false
            } else true
          }
        }
```

will result in message:

```
Assert 'A data class implementing PermissionScopeCleanable and using properties not declared in the constructor should implements a custom copy method and declare it at the class level with @OverrideCopyFunctionName because these properties will not be copied with the generated default kotlin data class copy function' was violated (1 time).
MyClazz has 2 copiable properties outside of its ctor:
 	* plip
	* plop
```

In this case no 'additionalMessage' is taken.
Should add this feature keeping existing assertXXX calls