### PR TITLE
KON-704 Add source declarations to `KoAnnotationDeclaration`

### DIFF
--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koannotation/KoAnnotationDeclarationForKoFullyQualifiedNameProviderTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koannotation/KoAnnotationDeclarationForKoFullyQualifiedNameProviderTest.kt
@@ -109,6 +109,20 @@ class KoAnnotationDeclarationForKoFullyQualifiedNameProviderTest {
     }
 
     @Test
+    fun `annotation-fully-qualified-name-with-import-alias`() {
+        // given
+        val sut =
+            getSnippetFile("annotation-fully-qualified-name-with-import-alias")
+                .functions()
+                .first()
+                .annotations
+                .first()
+
+        // then
+        sut.fullyQualifiedName shouldBeEqualTo "com.lemonappdev.konsist.testdata.SampleAnnotation"
+    }
+
+    @Test
     fun `annotation-in-file-fully-qualified-name`() {
         // given
         val sut =

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koannotation/KoAnnotationDeclarationForKoSourceDeclarationProviderTest.kt
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koannotation/KoAnnotationDeclarationForKoSourceDeclarationProviderTest.kt
@@ -1,0 +1,114 @@
+package com.lemonappdev.konsist.core.declaration.koannotation
+
+import com.lemonappdev.konsist.TestSnippetProvider.getSnippetKoScope
+import com.lemonappdev.konsist.api.declaration.KoClassDeclaration
+import com.lemonappdev.konsist.api.declaration.KoExternalDeclaration
+import com.lemonappdev.konsist.api.declaration.KoFunctionDeclaration
+import com.lemonappdev.konsist.api.declaration.KoInterfaceDeclaration
+import com.lemonappdev.konsist.api.declaration.KoObjectDeclaration
+import com.lemonappdev.konsist.api.declaration.KoPropertyDeclaration
+import com.lemonappdev.konsist.api.declaration.KoTypeAliasDeclaration
+import com.lemonappdev.konsist.api.declaration.type.KoKotlinTypeDeclaration
+import com.lemonappdev.konsist.api.ext.list.annotations
+import com.lemonappdev.konsist.api.provider.KoFullyQualifiedNameProvider
+import com.lemonappdev.konsist.externalsample.SampleExternalClass
+import com.lemonappdev.konsist.testdata.SampleAnnotation
+import com.lemonappdev.konsist.testdata.SampleClass
+import com.lemonappdev.konsist.testdata.SampleInterface
+import com.lemonappdev.konsist.testdata.SampleObject
+import org.amshove.kluent.assertSoftly
+import org.amshove.kluent.shouldBeEqualTo
+import org.amshove.kluent.shouldBeInstanceOf
+import org.amshove.kluent.shouldNotBeInstanceOf
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.Arguments.arguments
+import org.junit.jupiter.params.provider.MethodSource
+import kotlin.reflect.KClass
+
+class KoAnnotationDeclarationForKoSourceDeclarationProviderTest {
+    @ParameterizedTest
+    @MethodSource("provideValues")
+    fun `source declaration`(
+        fileName: String,
+        instanceOf: KClass<*>,
+        notInstanceOf: KClass<*>,
+        kClass: KClass<*>?,
+        fullyQualifiedName: String?,
+    ) {
+        // given
+        val sut =
+            getSnippetFile(fileName)
+                .classes()
+                .annotations
+                .first()
+
+        // then
+        assertSoftly(sut) {
+            sourceDeclaration shouldBeInstanceOf instanceOf
+            sourceDeclaration shouldNotBeInstanceOf notInstanceOf
+            hasSourceDeclaration {
+                (sourceDeclaration as? KoFullyQualifiedNameProvider)?.fullyQualifiedName == fullyQualifiedName
+            }.shouldBeEqualTo(true)
+            hasSourceDeclaration {
+                (sourceDeclaration as? KoFullyQualifiedNameProvider)?.fullyQualifiedName == "com.samplepackage.other"
+            }.shouldBeEqualTo(false)
+            kClass
+                ?.let { value -> hasSourceDeclarationOf(value) }
+                ?.shouldBeEqualTo(true)
+            hasSourceDeclarationOf(Char::class) shouldBeEqualTo false
+        }
+    }
+
+    private fun getSnippetFile(fileName: String) =
+        getSnippetKoScope("core/declaration/koannotation/snippet/forkosourcedeclarationprovider/", fileName)
+
+    companion object {
+        @Suppress("unused", "detekt.LongMethod")
+        @JvmStatic
+        fun provideValues() =
+            listOf(
+                arguments(
+                    "annotation-with-kotlin-source-declaration-with-default-import",
+                    KoKotlinTypeDeclaration::class,
+                    KoClassDeclaration::class,
+                    Deprecated::class,
+                    "kotlin.Deprecated",
+                ),
+                arguments(
+                    "annotation-with-kotlin-source-declaration-without-default-import",
+                    KoKotlinTypeDeclaration::class,
+                    KoClassDeclaration::class,
+                    Deprecated::class,
+                    "kotlin.Deprecated",
+                ),
+                arguments(
+                    "annotation-with-source-declaration-defined-in-the-file-with-package",
+                    KoClassDeclaration::class,
+                    KoInterfaceDeclaration::class,
+                    null,
+                    "com.samplepackage.SampleAnnotationFromFile",
+                ),
+                arguments(
+                    "annotation-with-source-declaration-defined-in-the-file-without-package",
+                    KoClassDeclaration::class,
+                    KoInterfaceDeclaration::class,
+                    null,
+                    "SampleAnnotationFromFile",
+                ),
+                arguments(
+                    "annotation-with-imported-source-declaration",
+                    KoClassDeclaration::class,
+                    KoInterfaceDeclaration::class,
+                    SampleAnnotation::class,
+                    "com.lemonappdev.konsist.testdata.SampleAnnotation",
+                ),
+                arguments(
+                    "annotation-with-source-declaration-defined-using-import-alias",
+                    KoClassDeclaration::class,
+                    KoInterfaceDeclaration::class,
+                    SampleAnnotation::class,
+                    "com.lemonappdev.konsist.testdata.SampleAnnotation",
+                ),
+            )
+    }
+}

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koannotation/snippet/forkofullyqualifiednameprovider/annotation-fully-qualified-name-with-import-alias.kttest
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koannotation/snippet/forkofullyqualifiednameprovider/annotation-fully-qualified-name-with-import-alias.kttest
@@ -1,0 +1,5 @@
+import com.lemonappdev.konsist.testdata.SampleAnnotation as AnnotationImportAlias
+
+@AnnotationImportAlias
+fun sampleFunction() {
+}

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koannotation/snippet/forkosourcedeclarationprovider/annotation-with-imported-source-declaration.kttest
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koannotation/snippet/forkosourcedeclarationprovider/annotation-with-imported-source-declaration.kttest
@@ -1,0 +1,4 @@
+import com.lemonappdev.konsist.testdata.SampleAnnotation
+
+@SampleAnnotation
+class SampleClass

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koannotation/snippet/forkosourcedeclarationprovider/annotation-with-kotlin-source-declaration-with-default-import.kttest
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koannotation/snippet/forkosourcedeclarationprovider/annotation-with-kotlin-source-declaration-with-default-import.kttest
@@ -1,0 +1,2 @@
+@Deprecated("")
+class SampleClass

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koannotation/snippet/forkosourcedeclarationprovider/annotation-with-kotlin-source-declaration-without-default-import.kttest
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koannotation/snippet/forkosourcedeclarationprovider/annotation-with-kotlin-source-declaration-without-default-import.kttest
@@ -1,0 +1,4 @@
+import kotlin.Deprecated
+
+@Deprecated("")
+class SampleClass

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koannotation/snippet/forkosourcedeclarationprovider/annotation-with-source-declaration-defined-in-the-file-with-package.kttest
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koannotation/snippet/forkosourcedeclarationprovider/annotation-with-source-declaration-defined-in-the-file-with-package.kttest
@@ -1,0 +1,6 @@
+package com.samplepackage
+
+@SampleAnnotationFromFile
+class SampleClass
+
+annotation class SampleAnnotationFromFile

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koannotation/snippet/forkosourcedeclarationprovider/annotation-with-source-declaration-defined-in-the-file-without-package.kttest
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koannotation/snippet/forkosourcedeclarationprovider/annotation-with-source-declaration-defined-in-the-file-without-package.kttest
@@ -1,0 +1,4 @@
+@SampleAnnotationFromFile
+class SampleClass
+
+annotation class SampleAnnotationFromFile

--- a/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koannotation/snippet/forkosourcedeclarationprovider/annotation-with-source-declaration-defined-using-import-alias.kttest
+++ b/lib/src/integrationTest/kotlin/com/lemonappdev/konsist/core/declaration/koannotation/snippet/forkosourcedeclarationprovider/annotation-with-source-declaration-defined-using-import-alias.kttest
@@ -1,0 +1,4 @@
+import com.lemonappdev.konsist.testdata.SampleAnnotation as AnnotationAliased
+
+@AnnotationAliased
+class SampleClass

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/api/declaration/KoAnnotationDeclaration.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/api/declaration/KoAnnotationDeclaration.kt
@@ -9,6 +9,7 @@ import com.lemonappdev.konsist.api.provider.KoModuleProvider
 import com.lemonappdev.konsist.api.provider.KoNameProvider
 import com.lemonappdev.konsist.api.provider.KoPathProvider
 import com.lemonappdev.konsist.api.provider.KoRepresentsTypeProvider
+import com.lemonappdev.konsist.api.provider.KoSourceDeclarationProvider
 import com.lemonappdev.konsist.api.provider.KoSourceSetProvider
 import com.lemonappdev.konsist.api.provider.KoTextProvider
 
@@ -27,4 +28,5 @@ interface KoAnnotationDeclaration :
     KoModuleProvider,
     KoSourceSetProvider,
     KoRepresentsTypeProvider,
-    KoTextProvider
+    KoTextProvider,
+    KoSourceDeclarationProvider

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/core/declaration/KoAnnotationDeclarationCore.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/core/declaration/KoAnnotationDeclarationCore.kt
@@ -3,6 +3,9 @@ package com.lemonappdev.konsist.core.declaration
 import com.lemonappdev.konsist.api.declaration.KoAnnotationDeclaration
 import com.lemonappdev.konsist.api.declaration.KoArgumentDeclaration
 import com.lemonappdev.konsist.api.declaration.KoBaseDeclaration
+import com.lemonappdev.konsist.api.declaration.KoImportAliasDeclaration
+import com.lemonappdev.konsist.api.declaration.KoSourceDeclaration
+import com.lemonappdev.konsist.api.provider.KoDeclarationCastProvider
 import com.lemonappdev.konsist.core.cache.KoDeclarationCache
 import com.lemonappdev.konsist.core.provider.KoArgumentProviderCore
 import com.lemonappdev.konsist.core.provider.KoBaseProviderCore
@@ -13,6 +16,7 @@ import com.lemonappdev.konsist.core.provider.KoModuleProviderCore
 import com.lemonappdev.konsist.core.provider.KoNameProviderCore
 import com.lemonappdev.konsist.core.provider.KoPathProviderCore
 import com.lemonappdev.konsist.core.provider.KoRepresentsTypeProviderCore
+import com.lemonappdev.konsist.core.provider.KoSourceDeclarationProviderCore
 import com.lemonappdev.konsist.core.provider.KoSourceSetProviderCore
 import com.lemonappdev.konsist.core.provider.KoTextProviderCore
 import org.jetbrains.kotlin.com.intellij.psi.PsiElement
@@ -22,7 +26,7 @@ import org.jetbrains.kotlin.psi.KtValueArgument
 import org.jetbrains.kotlin.psi.KtValueArgumentList
 
 internal class KoAnnotationDeclarationCore private constructor(
-    private val ktAnnotationEntry: KtAnnotationEntry,
+    override val ktAnnotationEntry: KtAnnotationEntry,
 ) : KoAnnotationDeclaration,
     KoBaseProviderCore,
     KoArgumentProviderCore,
@@ -34,7 +38,8 @@ internal class KoAnnotationDeclarationCore private constructor(
     KoModuleProviderCore,
     KoSourceSetProviderCore,
     KoRepresentsTypeProviderCore,
-    KoTextProviderCore {
+    KoTextProviderCore,
+    KoSourceDeclarationProviderCore {
     override val psiElement: PsiElement by lazy { ktAnnotationEntry }
 
     override val ktElement: KtElement by lazy { ktAnnotationEntry }
@@ -50,6 +55,14 @@ internal class KoAnnotationDeclarationCore private constructor(
             ?.filterIsInstance<KtValueArgument>()
             ?.map { KoArgumentDeclarationCore.getInstance(it, this) }
             .orEmpty()
+    }
+
+    override val sourceDeclaration: KoDeclarationCastProvider? by lazy {
+        if (super.sourceDeclaration is KoImportAliasDeclaration) {
+            super.sourceDeclaration?.asImportAliasDeclaration()?.sourceDeclaration
+        } else {
+            super.sourceDeclaration
+        }
     }
 
     override fun toString(): String = name

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/core/declaration/KoAnnotationDeclarationCore.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/core/declaration/KoAnnotationDeclarationCore.kt
@@ -58,6 +58,8 @@ internal class KoAnnotationDeclarationCore private constructor(
     }
 
     override val sourceDeclaration: KoDeclarationCastProvider? by lazy {
+        // When sourceDeclaration is an import alias, its sourceDeclaration refers to the import.
+        // The goal is to unwrap it and access the underlying base declaration directly.
         if (super.sourceDeclaration is KoImportAliasDeclaration) {
             super.sourceDeclaration?.asImportAliasDeclaration()?.sourceDeclaration
         } else {

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/core/declaration/KoAnnotationDeclarationCore.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/core/declaration/KoAnnotationDeclarationCore.kt
@@ -4,7 +4,6 @@ import com.lemonappdev.konsist.api.declaration.KoAnnotationDeclaration
 import com.lemonappdev.konsist.api.declaration.KoArgumentDeclaration
 import com.lemonappdev.konsist.api.declaration.KoBaseDeclaration
 import com.lemonappdev.konsist.api.declaration.KoImportAliasDeclaration
-import com.lemonappdev.konsist.api.declaration.KoSourceDeclaration
 import com.lemonappdev.konsist.api.provider.KoDeclarationCastProvider
 import com.lemonappdev.konsist.core.cache.KoDeclarationCache
 import com.lemonappdev.konsist.core.provider.KoArgumentProviderCore
@@ -65,6 +64,14 @@ internal class KoAnnotationDeclarationCore private constructor(
         } else {
             super.sourceDeclaration
         }
+    }
+
+    override val fullyQualifiedName: String? by lazy {
+        val import = containingFile
+            .imports
+            .firstOrNull { it.alias?.name == name }
+
+        import?.name ?: super<KoFullyQualifiedNameProviderCore>.fullyQualifiedName
     }
 
     override fun toString(): String = name

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/core/declaration/KoAnnotationDeclarationCore.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/core/declaration/KoAnnotationDeclarationCore.kt
@@ -67,9 +67,10 @@ internal class KoAnnotationDeclarationCore private constructor(
     }
 
     override val fullyQualifiedName: String? by lazy {
-        val import = containingFile
-            .imports
-            .firstOrNull { it.alias?.name == name }
+        val import =
+            containingFile
+                .imports
+                .firstOrNull { it.alias?.name == name }
 
         import?.name ?: super<KoFullyQualifiedNameProviderCore>.fullyQualifiedName
     }

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/KoSourceDeclarationProviderCore.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/KoSourceDeclarationProviderCore.kt
@@ -97,9 +97,9 @@ internal interface KoSourceDeclarationProviderCore :
 
     private fun isExtensionDeclaration(): Boolean =
         ktTypeReference?.isExtensionDeclaration() == true ||
-                ktNameReferenceExpression?.isExtensionDeclaration() == true ||
-                ktTypeProjection?.isExtensionDeclaration() == true ||
-                ktAnnotationEntry?.isExtensionDeclaration() == true
+            ktNameReferenceExpression?.isExtensionDeclaration() == true ||
+            ktTypeProjection?.isExtensionDeclaration() == true ||
+            ktAnnotationEntry?.isExtensionDeclaration() == true
 
     private fun getDeclarationWithfullyQualifiedName(declaration: KoBaseDeclaration): KoBaseDeclaration? =
         when {
@@ -121,8 +121,8 @@ internal interface KoSourceDeclarationProviderCore :
 
     override fun hasSourceDeclarationOf(kClass: KClass<*>): Boolean =
         sourceDeclaration?.hasClassDeclarationOf(kClass) == true ||
-                sourceDeclaration?.hasObjectDeclarationOf(kClass) == true ||
-                sourceDeclaration?.hasInterfaceDeclarationOf(kClass) == true ||
-                sourceDeclaration?.hasKotlinTypeDeclarationOf(kClass) == true ||
-                sourceDeclaration?.hasExternalDeclarationOf(kClass) == true
+            sourceDeclaration?.hasObjectDeclarationOf(kClass) == true ||
+            sourceDeclaration?.hasInterfaceDeclarationOf(kClass) == true ||
+            sourceDeclaration?.hasKotlinTypeDeclarationOf(kClass) == true ||
+            sourceDeclaration?.hasExternalDeclarationOf(kClass) == true
 }

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/KoSourceDeclarationProviderCore.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/core/provider/KoSourceDeclarationProviderCore.kt
@@ -10,6 +10,7 @@ import com.lemonappdev.konsist.core.declaration.private.KoFunctionTypeDeclaratio
 import com.lemonappdev.konsist.core.declaration.private.KoGenericTypeDeclarationCore
 import com.lemonappdev.konsist.core.ext.castToKoBaseDeclaration
 import com.lemonappdev.konsist.core.util.TypeUtil
+import org.jetbrains.kotlin.psi.KtAnnotationEntry
 import org.jetbrains.kotlin.psi.KtNameReferenceExpression
 import org.jetbrains.kotlin.psi.KtNullableType
 import org.jetbrains.kotlin.psi.KtTypeProjection
@@ -29,12 +30,14 @@ internal interface KoSourceDeclarationProviderCore :
         get() = null
     val ktTypeProjection: KtTypeProjection?
         get() = null
+    val ktAnnotationEntry: KtAnnotationEntry?
+        get() = null
 
     override val sourceDeclaration: KoDeclarationCastProvider?
         get() {
             val type =
                 TypeUtil.getBasicType(
-                    listOf(ktTypeReference, ktNameReferenceExpression, ktTypeProjection),
+                    listOf(ktTypeReference, ktNameReferenceExpression, ktTypeProjection, ktAnnotationEntry),
                     isExtensionDeclaration(),
                     getDeclarationWithfullyQualifiedName(containingDeclaration) ?: containingDeclaration,
                     containingFile,
@@ -94,8 +97,9 @@ internal interface KoSourceDeclarationProviderCore :
 
     private fun isExtensionDeclaration(): Boolean =
         ktTypeReference?.isExtensionDeclaration() == true ||
-            ktNameReferenceExpression?.isExtensionDeclaration() == true ||
-            ktTypeProjection?.isExtensionDeclaration() == true
+                ktNameReferenceExpression?.isExtensionDeclaration() == true ||
+                ktTypeProjection?.isExtensionDeclaration() == true ||
+                ktAnnotationEntry?.isExtensionDeclaration() == true
 
     private fun getDeclarationWithfullyQualifiedName(declaration: KoBaseDeclaration): KoBaseDeclaration? =
         when {
@@ -117,8 +121,8 @@ internal interface KoSourceDeclarationProviderCore :
 
     override fun hasSourceDeclarationOf(kClass: KClass<*>): Boolean =
         sourceDeclaration?.hasClassDeclarationOf(kClass) == true ||
-            sourceDeclaration?.hasObjectDeclarationOf(kClass) == true ||
-            sourceDeclaration?.hasInterfaceDeclarationOf(kClass) == true ||
-            sourceDeclaration?.hasKotlinTypeDeclarationOf(kClass) == true ||
-            sourceDeclaration?.hasExternalDeclarationOf(kClass) == true
+                sourceDeclaration?.hasObjectDeclarationOf(kClass) == true ||
+                sourceDeclaration?.hasInterfaceDeclarationOf(kClass) == true ||
+                sourceDeclaration?.hasKotlinTypeDeclarationOf(kClass) == true ||
+                sourceDeclaration?.hasExternalDeclarationOf(kClass) == true
 }

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/core/util/TypeUtil.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/core/util/TypeUtil.kt
@@ -22,6 +22,8 @@ import com.lemonappdev.konsist.core.model.getTypeAlias
 import com.lemonappdev.konsist.core.provider.KoTypeParameterProviderCore
 import org.jetbrains.kotlin.com.intellij.psi.PsiElement
 import org.jetbrains.kotlin.org.jline.utils.Log
+import org.jetbrains.kotlin.psi.KtAnnotationEntry
+import org.jetbrains.kotlin.psi.KtConstructorCalleeExpression
 import org.jetbrains.kotlin.psi.KtElement
 import org.jetbrains.kotlin.psi.KtFunctionType
 import org.jetbrains.kotlin.psi.KtNameReferenceExpression
@@ -86,6 +88,12 @@ object TypeUtil {
                         ?.children
                         ?.firstOrNull()
                 }
+            } else if (notNullTypes.filterIsInstance<KtAnnotationEntry>().isNotEmpty()) {
+                    notNullTypes
+                        .filterIsInstance<KtAnnotationEntry>()
+                        .firstOrNull()
+                        ?.children
+                        ?.firstOrNull()
             } else {
                 null
             }
@@ -211,6 +219,18 @@ object TypeUtil {
                     ?: getObject(typeText, fullyQualifiedName, false, containingFile)
                     ?: getTypeAlias(typeText, fullyQualifiedName, containingFile)
                     ?: KoExternalDeclarationCore.getInstance(typeText, nestedType)
+            }
+
+            nestedType is KtConstructorCalleeExpression && typeText != null -> {
+                if (isKotlinType(typeText)) {
+                    KoKotlinTypeDeclarationCore.getInstance(nestedType, parentDeclaration)
+                } else {
+                    getClass(typeText, fullyQualifiedName, false, containingFile)
+                        ?: getInterface(typeText, fullyQualifiedName, false, containingFile)
+                        ?: getObject(typeText, fullyQualifiedName, false, containingFile)
+                        ?: getTypeAlias(typeText, fullyQualifiedName, containingFile)
+                        ?: KoExternalDeclarationCore.getInstance(typeText, nestedType)
+                }
             }
 
             else -> null

--- a/lib/src/main/kotlin/com/lemonappdev/konsist/core/util/TypeUtil.kt
+++ b/lib/src/main/kotlin/com/lemonappdev/konsist/core/util/TypeUtil.kt
@@ -89,11 +89,11 @@ object TypeUtil {
                         ?.firstOrNull()
                 }
             } else if (notNullTypes.filterIsInstance<KtAnnotationEntry>().isNotEmpty()) {
-                    notNullTypes
-                        .filterIsInstance<KtAnnotationEntry>()
-                        .firstOrNull()
-                        ?.children
-                        ?.firstOrNull()
+                notNullTypes
+                    .filterIsInstance<KtAnnotationEntry>()
+                    .firstOrNull()
+                    ?.children
+                    ?.firstOrNull()
             } else {
                 null
             }


### PR DESCRIPTION
## Partially fixed bug: https://github.com/LemonAppDev/konsist/discussions/1715 (the second part will be fixed with this ticket https://lemonappdev.atlassian.net/browse/KON-703)

## Changes:
### 1. Reference to the source declaration is now available inside `KoAnnotationDeclaration`.

```kotlin
Konsist
   .scopeFromProduction()
   .classes()
   .annotations
   .assertTrue { it.sourceDeclaration?.hasNameContaining("Sample") }
```

Declarations can also be filtered based on whether their source declaration satisfies a given predicate.

```kotlin
Konsist
   .scopeFromProduction()
   .classes()
   .annotations
   .withSourceDeclaration { it.hasNameContaining("Sample") }
   .assertTrue { ... } 
```

### 2. ❗Breaking Api Change❗ - Changed `fullyQualifiedName` for an annotation defined through an import alias.

**Kotlin code:**
```kotlin
import com.domain.example.ExampleAnnotation as AnnotationAliased

@AnnotationAliased
class ExampleUseCase
```

**Konsist code:**
```kotlin
val annotationFullyQualifiedNames = Konsist
    .scopeFromProject()
    .classes()
    .withName("ExampleUseCase")
    .first()
    .annotations
    .map { it.fullyQualifiedName }
```

**Before:** `annotationFullyQualifiedNames` returns `["AnnotationAliased"]`
**After:** `annotationFullyQualifiedNames` returns `["com.domain.example.ExampleAnnotation"]`
